### PR TITLE
Add .settings in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ rpm-tmp.*
 /Debug
 .cproject
 .project
+.settings
 
 # OS X metafiles
 .DS_Store


### PR DESCRIPTION
It would be good to add .settings in .gitignore. Eclipse users will find it beneficial since it creates this directory automatically.