### PR TITLE
ALIROOT-7174, ATO-410-In ROOT6 TF1 does not inherit anymore from TFormula

### DIFF
--- a/STAT/AliTMinuitToolkit.cxx
+++ b/STAT/AliTMinuitToolkit.cxx
@@ -176,7 +176,7 @@ void  AliTMinuitToolkit::ClearData(){
   //   fCovar=0;
 }
 
-void  AliTMinuitToolkit::SetFitFunction(TFormula *const formula, Bool_t doReset) {
+void  AliTMinuitToolkit::SetFitFunction(TF1 *const formula, Bool_t doReset) {
   //
   fFormula=formula;
   if (doReset){
@@ -249,7 +249,7 @@ void AliTMinuitToolkit::FitterFCN(int &/*npar*/, double */*info*/, double &fchis
   //if (info) info[0]=fcnCounter;
   fcnCounter++;
   AliTMinuitToolkit * fitter = (AliTMinuitToolkit*)TVirtualFitter::GetFitter()->GetObjectFit();
-  TFormula *logLike=fitter->fLogLikelihoodFunction;
+  TF1 *logLike=fitter->fLogLikelihoodFunction;
   const Double_t* likeParam= (logLike!=NULL) ? logLike->GetParameters():NULL;
   fchisq = 0;
   const TMatrixD & variables= (*fitter->GetPoints());

--- a/STAT/AliTMinuitToolkit.h
+++ b/STAT/AliTMinuitToolkit.h
@@ -47,10 +47,10 @@ public:
   void TwoFoldCrossValidation(Int_t nIter, const char*reportName, Option_t *option=0);
   void MISAC(Int_t nFitPoints, Int_t nIter, const char*reportName, Option_t *option=0);
   // 
-  void SetFitFunction(TFormula *const formula, Bool_t doReset);
+  void SetFitFunction(TF1 *const formula, Bool_t doReset);
   void SetInitialParam(TMatrixD *const initialParam);  
   TMatrixD *  GetInitialParam() {return fInitialParam;}
-  void SetLogLikelihoodFunction(TFormula *logLikelihood){fLogLikelihoodFunction=logLikelihood;}
+  void SetLogLikelihoodFunction(TF1 *logLikelihood){fLogLikelihoodFunction=logLikelihood;}
   void SetFitAlgorithm(Char_t *const name) {fFitAlgorithm=name;};
   void SetMaxCalls(Int_t calls) {fMaxCalls = calls;};
   void SetTolerance(Double_t tol) {fPrecision = tol;};
@@ -61,8 +61,8 @@ public:
   //
   const TMatrixD * GetPoints() const {return fPoints;};
   const TMatrixD * GetValues() const {return fValues;};
-  TFormula * GetFormula() const {return fFormula;};
-  const TFormula *GetLogLikelihoodFunction() const { return fLogLikelihoodFunction;}
+  TF1 * GetFormula() const {return fFormula;};
+  const TF1 *GetLogLikelihoodFunction() const { return fLogLikelihoodFunction;}
   const TVectorD * GetParameters() const {return fParam;};
   const TVectorD * GetRMSEstimator() const {return fRMSEstimator;};
   const TMatrixD * GetCovarianceMatrix() const {return fCovar;};
@@ -91,8 +91,8 @@ private:
   //
   TTreeSRedirector *fStreamer;              // !pointer to the streamer
   Int_t             fVerbose;               // verbosity flag
-  TFormula        * fFormula;               // formula of the fitted function
-  TFormula        * fLogLikelihoodFunction; // Log likelihood (const)  function
+  TF1        * fFormula;               // formula of the fitted function
+  TF1        * fLogLikelihoodFunction; // Log likelihood (const)  function
   TString           fFitAlgorithm;          // fit algorithm for TMinuit: migrad, simplex, ...  
   //
   TMatrixD        * fPoints;             // !points -  IsOwner

--- a/STAT/test/AliTMinuitToolkitTestLinear.C
+++ b/STAT/test/AliTMinuitToolkitTestLinear.C
@@ -37,6 +37,8 @@ void AliTMinuitToolkitTestLinear(Int_t nIter, Int_t nDraw){
   // nIter=1000; nDraw=4;
   AliTMinuitToolkit::RegisterDefaultFitters();
   AliTMinuitToolkit::GetPredefinedFitter("pol1R")->SetStreamer("AliTMinuitToolkit_Pol1Rstreamer.root");
+  ((TFormula*)AliTMinuitToolkit::GetPredefinedFitter("pol1R")->GetLogLikelihoodFunction())->SetParameter(0,0.7);
+
   //
   //  
   TMatrixD &pInit = *((AliTMinuitToolkit::GetPredefinedFitter("pol1R")->GetInitialParam()));


### PR DESCRIPTION


## Problem description:
* In the AliTMinuitToolkit I needed n dimensional functional representation. Therefore I used the TFormula (generic ND I patched in ROOT ~ 13 year ago) instead of the TFx
* In user interface of drawing I need however TFx as the TFormula (in ROOT5) can not be drawn.
* In ROOT6 TF1 does not inherit from TFormula - therefore compilation breaks

## Temporary  fix (not  solution) of problem
* Replace TFormula with TF1
* !!!! Fix does not works for multidimension. Proper fix to be done soon