### PR TITLE
Distinguish particle/anpiparticle names (Geant4)

### DIFF
--- a/STEER/STEER/AliMC.cxx
+++ b/STEER/STEER/AliMC.cxx
@@ -332,9 +332,9 @@ void  AliMC::AddParticles()
 
   // Ps - hidden strange (s-sbar) pentaquarks
   TVirtualMC::GetMC()->DefineParticle( 9322134, "Ps_2100", kPTHadron, 2.1 ,  1.0, 1.6455e-23,"Hadron", 4.e-2, 3, -1, 0, 0, 0, 0, 0,  1, kTRUE);
-  TVirtualMC::GetMC()->DefineParticle(-9322134, "Ps_2100", kPTHadron, 2.1 , -1.0, 1.6455e-23,"Hadron", 4.e-2, 3, -1, 0, 0, 0, 0, 0, -1, kTRUE);
+  TVirtualMC::GetMC()->DefineParticle(-9322134, "AntiPs_2100", kPTHadron, 2.1 , -1.0, 1.6455e-23,"Hadron", 4.e-2, 3, -1, 0, 0, 0, 0, 0, -1, kTRUE);
   TVirtualMC::GetMC()->DefineParticle( 9322136, "Ps_2500", kPTHadron, 2.5 ,  1.0, 1.6455e-23,"Hadron", 4.e-2, 5, 1, 0, 0, 0, 0, 0,  1, kTRUE);
-  TVirtualMC::GetMC()->DefineParticle(-9322136, "Ps_2500", kPTHadron, 2.5 , -1.0, 1.6455e-23,"Hadron", 4.e-2, 5, 1, 0, 0, 0, 0, 0, -1, kTRUE);
+  TVirtualMC::GetMC()->DefineParticle(-9322136, "AntiPs_2500", kPTHadron, 2.5 , -1.0, 1.6455e-23,"Hadron", 4.e-2, 5, 1, 0, 0, 0, 0, 0, -1, kTRUE);
 
   Int_t psmode[6][3] = {0};
   Float_t psratio[6] = {0.f};


### PR DESCRIPTION
If we have particles with the same name twice, Geant4 produces fatal exception:
-------- EEEE ------- G4Exception-START -------- EEEE -------
*** G4Exception : PART122
      issued by : G4ParticleTable::Insert()
The particle Ps_2100  has already been registered in the Particle Table 
*** Fatal Exception *** core dump ***
-------- EEEE -------- G4Exception-END --------- EEEE -------
