### PR TITLE
Fixes to make the ITSU test work after ITS+MFT->ITSMT and migration to github migration

### DIFF
--- a/ITSMFT/ITS/itsuTestBench/rec.C
+++ b/ITSMFT/ITS/itsuTestBench/rec.C
@@ -16,6 +16,7 @@ void rec() {
   rec.SetRunMultFinder(kFALSE);   // to be implemented - CreateMultFinder
   rec.SetRunPlaneEff(kFALSE);     // to be implemented - CreateTrackleter
 
+  rec.SetDefaultStorage("local://$ALICE_ROOT_OCDB/OCDB");
   rec.SetSpecificStorage("GRP/GRP/Data",
 			 Form("local://%s",gSystem->pwd()));
   rec.SetSpecificStorage("ITS/Align/Data",

--- a/ITSMFT/ITS/itsuTestBench/sim.C
+++ b/ITSMFT/ITS/itsuTestBench/sim.C
@@ -1,12 +1,18 @@
 void sim(Int_t nev=3) {
 
+  printf("\n\nHERE>>\n");
+  
   gSystem->Exec(" rm itsSegmentations.root ");
+  gSystem->Load("libpythia6_4_25");   // Pythia 6.4
+
+  printf("\n\nHERE<<\n");
+  
   AliSimulation simulator;
   //  simulator.SetMakeSDigits("");
 
   //  simulator.SetMakeDigits("");
 
-  simulator.SetDefaultStorage("local://$ALICE_ROOT/OCDB");
+  simulator.SetDefaultStorage("local://$ALICE_ROOT_OCDB/OCDB");
   simulator.SetSpecificStorage("GRP/GRP/Data",
 			       Form("local://%s",gSystem->pwd()));
   simulator.SetSpecificStorage("ITS/Align/Data",

--- a/ITSMFT/ITS/rawconv/PixConv.h
+++ b/ITSMFT/ITS/rawconv/PixConv.h
@@ -109,19 +109,20 @@ public:
   unsigned long long   MakeLinkHeader(unsigned short link, unsigned short cycle);
   unsigned long long   MakeLinkTrailer(unsigned short link, unsigned short cycle);
   //
-protected:
+  void AddToBuffer(unsigned short v);
+  void AddToBuffer(unsigned char v);
+  void AddToBuffer(unsigned int v, int nbytes);
+  void AddToBuffer(unsigned long long v, int nbytes);
+  //
   struct PixLink {
     PixLink() {col=0; nextInRow=0;}
     short col;
     PixLink* nextInRow;
   };
   typedef struct PixLink PixLink_t;
+protected:
   //
   void ExpandBuffer(int add=1000);
-  void AddToBuffer(unsigned short v);
-  void AddToBuffer(unsigned char v);
-  void AddToBuffer(unsigned int v, int nbytes);
-  void AddToBuffer(unsigned long long v, int nbytes);
   void EraseInBuffer(int nbytes);
   //
   bool GetFromBuffer(unsigned char &v);

--- a/ITSMFT/ITS/rawconv/digits2raw.C
+++ b/ITSMFT/ITS/rawconv/digits2raw.C
@@ -10,7 +10,6 @@
 #include "AliLoader.h"
 #include "AliITSUGeomTGeo.h"
 #include "AliITSMFTSegmentationPix.h"
-#include "AliITSUSDigit.h"
 #include "AliITSMFTDigitPix.h"
 #include "AliITSMFTSensMap.h"
 #endif


### PR DESCRIPTION
1) Use $ALICE_ROOT_OCDB as default local OCDB
2) Eliminate ITSUDigit... frome headers, now ITS and MFT use common digits.
