### PR TITLE
cout/endl std namespace qualification was missing

### DIFF
--- a/FIT/FITsim/AliFITv7.cxx
+++ b/FIT/FITsim/AliFITv7.cxx
@@ -64,6 +64,9 @@
 #include "AliCDBEntry.h"
 #include "AliTrackReference.h"
 
+using std::cout;
+using std::endl;
+
 ClassImp(AliFITv7)
 
 //--------------------------------------------------------------------


### PR DESCRIPTION
Noticed it when trying to build AliRoot in O2 context.