### PR TITLE
CMakeLists.txt: Check for existing -std=c++11 / c++14 flag before add…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,14 +256,24 @@ else()
 
   # Enable C++11 by default if found in ROOT
   if(ROOT_HAS_CXX11 AND NOT DISABLE_CXX11)
-    message(STATUS "Enabling C++11")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    # Check whether C++11 flag is already in
+    if (${CMAKE_CXX_FLAGS} MATCHES "-std=c\\+\\+11") 
+      message(STATUS "C++11 already enabled")
+    else()
+      message(STATUS "Enabling C++11")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif()
   endif()
 
   # Enable C++14 by default if found in ROOT
   if(ROOT_HAS_CXX14 AND NOT DISABLE_CXX14)
-    message(STATUS "Enabling C++14")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+    # Check whether C++14 flag is already in
+    if (${CMAKE_CXX_FLAGS} MATCHES "-std=c\\+\\+14") 
+      message(STATUS "C++14 already enabled")
+    else()
+      message(STATUS "Enabling C++14")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+    endif()
   endif()
 
   # FTGL: prefer library from ROOT, look for both libFTGL and libftgl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,22 +256,16 @@ else()
 
   # Enable C++11 by default if found in ROOT
   if(ROOT_HAS_CXX11 AND NOT DISABLE_CXX11)
-    # Check whether C++11 flag is already in
-    if (${CMAKE_CXX_FLAGS} MATCHES "-std=c\\+\\+11") 
-      message(STATUS "C++11 already enabled")
-    else()
-      message(STATUS "Enabling C++11")
+    message(STATUS "Enabling C++11")
+    if (NOT ${CMAKE_CXX_FLAGS} MATCHES "-std=c\\+\\+11") 
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     endif()
   endif()
 
   # Enable C++14 by default if found in ROOT
   if(ROOT_HAS_CXX14 AND NOT DISABLE_CXX14)
-    # Check whether C++14 flag is already in
-    if (${CMAKE_CXX_FLAGS} MATCHES "-std=c\\+\\+14") 
-      message(STATUS "C++14 already enabled")
-    else()
-      message(STATUS "Enabling C++14")
+    message(STATUS "Enabling C++14")
+    if (NOT ${CMAKE_CXX_FLAGS} MATCHES "-std=c\\+\\+14") 
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
     endif()
   endif()


### PR DESCRIPTION
…ing it

Hello @ktf @dberzano ,

I realized that currently we compile AliRoot with two times the -std=c++11 flag. When I add output to the main CMakeLists.txt in the AliRoot source like

```
  # Enable C++11 by default if found in ROOT
  if(ROOT_HAS_CXX11 AND NOT DISABLE_CXX11)
    message(STATUS "Enabling C++11")
    message(STATUS "CMAKE_CXX_FLAGS before: ${CMAKE_CXX_FLAGS}")
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
    message(STATUS "CMAKE_CXX_FLAGS after: ${CMAKE_CXX_FLAGS}")
  endif()

```
One can see in the cmake stage that the -std=c++11 flag is already there in advance and is added a second time here. (I don't know where the first -std=c++11 comes from.)

> DEBUG:AliPhysics:0: -- ROOT was built with C++11 support
> DEBUG:AliPhysics:0: -- ROOT was not built with C++14 support
> DEBUG:AliPhysics:0: -- Enabling C++11
> DEBUG:AliPhysics:0: -- CMAKE_CXX_FLAGS before: -fPIC -g -O2 -std=c++11 
> DEBUG:AliPhysics:0: -- CMAKE_CXX_FLAGS after: -fPIC -g -O2 -std=c++11  -std=c++11

This PR checks whether the -std=c++11 is already in the flags before adding it. Same for C++14.

Cheers,
Hans

