### PR TITLE
Adding module structure for EMCAL documentation

### DIFF
--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerAlgorithm.h
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerAlgorithm.h
@@ -17,6 +17,7 @@ template<typename T> class AliEMCALTriggerDataGrid;
 /**
  * @class AliEMCALTriggerAlgorithm
  * @brief Base class for EMCAL Level1 trigger algorithms
+ * @ingroup EMCALTriggerBase
  */
 template<typename T>
 class AliEMCALTriggerAlgorithm : public TObject {

--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerBitConfig.h
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerBitConfig.h
@@ -18,6 +18,7 @@
 
 /**
  * \class AliEMCALTriggerBitConfig
+ * \ingroup EMCALTriggerBase
  * \brief Definition of trigger bit configurations
  *
  * Trigger bit configuration used in the trigger patch maker and by the trigger patches
@@ -84,6 +85,7 @@ protected:
 
 /**
  * \class AliEMCALTriggerBitConfigOld
+ * \ingroup EMCALTriggerBase
  * \brief Definition of old trigger bit configuration
  *
  * Definition of old trigger bit configuration:
@@ -101,6 +103,7 @@ public:
 
 /**
  * \class AliEMCALTriggerBitConfigNew
+ * \ingroup EMCALTriggerBase
  * \brief Definition of new trigger bit configuration
  *
  * Definition of new trigger bit configuration:

--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerChannelContainer.h
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerChannelContainer.h
@@ -8,6 +8,7 @@
 
 /**
  * @struct AliEmcalTriggerChannelContainer
+ * @ingroup EMCALTriggerBase
  * @brief Structure for position of trigger channels
  *
  * This structure is a container for trigger channels in col-row space with

--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerConstants.h
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerConstants.h
@@ -17,6 +17,7 @@ const Double_t kEMCL1ADCtoGeV = 0.07874;             ///< Conversion from EMCAL 
 
 /**
  * \enum EMCalTriggerType_t
+ * \ingroup EMCALTriggerBase
  * \brief Definition of different trigger patch types
  *
  * This enumeration defines the different trigger patch types

--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerDataGrid.h
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerDataGrid.h
@@ -10,6 +10,7 @@
 
 /**
  * \class AliEmcalTriggerDataGrid
+ * \ingroup EMCALTriggerBase
  * \brief Container for ADC / Amplitudes from the EMCAL triggers
  *
  * Dynamical-size container for ADC values from the FASTOR

--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerFastOR.h
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerFastOR.h
@@ -29,7 +29,8 @@ class AliEMCALGeometry;
 
 /**
  * @class AliEMCALTriggerFastOR
- * Trigger FastOR data struct
+ * @brief Trigger FastOR data struct
+ * @ingroup EMCALTriggerBase
  *
  */
 class AliEMCALTriggerFastOR {

--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerOnlineQAPP.h
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerOnlineQAPP.h
@@ -1,4 +1,5 @@
 /// \class AliEMCALTriggerOnlineQAPP
+/// \ingroup EMCALTriggerBase
 /// \brief Class to generate EMCal trigger QA plots in pp collisions
 ///
 /// This class generates QA plots for EMCal trigger in pp collisions

--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerOnlineQAPbPb.h
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerOnlineQAPbPb.h
@@ -22,6 +22,7 @@ class AliVCaloCells;
 
 /**
  * @class AliEMCALTriggerQAPbPb
+ * @ingroup EMCALTriggerBase
  * @brief Class to generate EMCal trigger QA plots in PbPb collision mode
  */
 

--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerPatchADCInfo.h
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerPatchADCInfo.h
@@ -8,6 +8,7 @@
 
 /**
  * @class AliEMCALTriggerPatchADCInfo
+ * @ingroup EMCALTriggerBase
  * @brief Helper class containing all ADC infos for a given trigger patch
  * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
  * @since Oct 13, 2016

--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerPatchFinder.h
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerPatchFinder.h
@@ -18,6 +18,7 @@ template<typename T> class AliEMCALTriggerAlgorithm;
 
 /**
  * @class AliEmcalTriggerPatchFinder
+ * @ingroup EMCALTriggerBase
  * @brief Steering class for patch finder
  *
  * This class steers the trigger patch finding by calling

--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerPatchInfo.h
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerPatchInfo.h
@@ -17,6 +17,7 @@ class TArrayI;
 
 /**
  * \class AliEMCALTriggerPatchInfo
+ * \ingroup EMCALTriggerBase
  * \brief Main data structure storing all relevant information of EMCAL/DCAL trigger patches
  * \author Jiri Kral <>, University of Jyv&aumlskul&auml
  * \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory

--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerQA.h
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerQA.h
@@ -23,6 +23,7 @@ class AliEMCALGeometry;
 
 /**
  * @class AliEMCALTriggerQA
+ * @ingroup EMCALTriggerBase
  * @brief Class to generate EMCal trigger QA plots
  */
 

--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerRawPatch.h
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerRawPatch.h
@@ -13,6 +13,7 @@
 
 /**
  * @class AliEMCALTriggerRawPatch
+ * @ingroup EMCALTriggerBase
  * @brief Raw patch information used inside the trigger maker kernel
  * for the offline trigger and trigger recalculator
  *

--- a/EMCAL/EMCALTriggerBase/doxymodules.h
+++ b/EMCAL/EMCALTriggerBase/doxymodules.h
@@ -1,0 +1,5 @@
+/**
+ * \defgroup EMCALTriggerBase
+ * \ingroup EMCAL
+ * \brief Tools for EMCAL trigger reconstruction and analysis, as stand-alone library
+ */

--- a/EMCAL/EMCALUtils/AliCaloConstants.h
+++ b/EMCAL/EMCALUtils/AliCaloConstants.h
@@ -23,6 +23,7 @@
 //_________________________________________
 ///
 /// \class AliCaloConstants.h
+/// \ingroup EMCALUtils
 /// \brief Constants used by HLT/Offline
 ///
 /// Constants used by the HLT ALICE Offline

--- a/EMCAL/EMCALUtils/AliEMCALCalibTimeDepCorrection.h
+++ b/EMCAL/EMCALUtils/AliEMCALCalibTimeDepCorrection.h
@@ -14,6 +14,7 @@ class TTree;
 ///////////////////////////////////////////////////////////////////////////////
 ///
 /// \class AliEMCALSuperModuleCalibTimeDepCorrection
+/// \ingroup EMCALUtils
 /// \brief Handle SM objects for temperature dependent corrections.
 ///
 /// \author:  David Silvermyr, <david.silvermyr@cern.ch>

--- a/EMCAL/EMCALUtils/AliEMCALEMCGeometry.h
+++ b/EMCAL/EMCALUtils/AliEMCALEMCGeometry.h
@@ -5,6 +5,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALEMCGeometry
+/// \ingroup EMCALUtils
 /// \brief EMCal geometry SM base, singleton
 ///
 /// Geometry class  for EMCAL : singleton

--- a/EMCAL/EMCALUtils/AliEMCALGeoParams.h
+++ b/EMCAL/EMCALUtils/AliEMCALGeoParams.h
@@ -4,7 +4,8 @@
  * See cxx source for full Copyright notice                               */
 
 ///////////////////////////////////////////////////////////////////////////////
-/// \class AliEMCALGeoParams                                                                          
+/// \class AliEMCALGeoParams
+/// \ingroup EMCALUtils
 /// \brief Class for holding various EMCAL basic parameters.
 ///
 /// * number of towers in each dimension per SuperModule

--- a/EMCAL/EMCALUtils/AliEMCALGeometry.h
+++ b/EMCAL/EMCALUtils/AliEMCALGeometry.h
@@ -5,6 +5,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALGeometry
+/// \ingroup EMCALUtils
 /// \brief EMCal geometry, singleton
 ///
 /// Geometry class  for EMCAL : singleton

--- a/EMCAL/EMCALUtils/AliEMCALPIDUtils.h
+++ b/EMCAL/EMCALUtils/AliEMCALPIDUtils.h
@@ -3,6 +3,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALPIDUtils
+/// \ingroup EMCALUtils
 /// \brief Compute cluster PID weights 
 ///
 ///   Compute PID weights for all the clusters that are in AliESDs.root file

--- a/EMCAL/EMCALUtils/AliEMCALRecoUtils.h
+++ b/EMCAL/EMCALUtils/AliEMCALRecoUtils.h
@@ -4,6 +4,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 ///
 /// \class AliEMCALRecoUtils
+/// \ingroup EMCALUtils
 /// \brief Some utilities for cluster and cell treatment.
 ///
 /// This class contains methods to correct and select the clusters and cells:

--- a/EMCAL/EMCALUtils/AliEMCALShishKebabTrd1Module.h
+++ b/EMCAL/EMCALUtils/AliEMCALShishKebabTrd1Module.h
@@ -6,6 +6,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALShishKebabTrd1Module
+/// \ingroup EMCALUtils
 /// \brief Main class for TRD1 geometry of Shish-Kebab case.
 ///
 /// Sep 20004 - Nov 2006; Apr 2010

--- a/EMCAL/EMCALUtils/AliEMCALTrack.h
+++ b/EMCAL/EMCALUtils/AliEMCALTrack.h
@@ -7,6 +7,7 @@
 //========================================================================  
 ///                       
 /// \class AliEMCALTrack 
+/// \ingroup EMCALUtils
 /// \brief Matched track to cluster handling.
 ///
 /// Implementation of a track to be used for EMCAL track matching, 

--- a/EMCAL/EMCALUtils/AliEMCALTriggerMapping.h
+++ b/EMCAL/EMCALUtils/AliEMCALTriggerMapping.h
@@ -6,6 +6,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 ///
 /// \class AliEMCALTriggerMapping
+/// \ingroup EMCALUtils
 /// \brief Trigger mapping methods, base class
 ///
 /// Trigger mapping base class

--- a/EMCAL/EMCALUtils/AliEMCALTriggerMappingV1.h
+++ b/EMCAL/EMCALUtils/AliEMCALTriggerMappingV1.h
@@ -6,6 +6,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 ///
 /// \class AliEMCALTriggerMappingV1
+/// \ingroup EMCALUtils
 /// \brief Trigger mapping methods, Run1
 ///
 /// Trigger mapping for Run1

--- a/EMCAL/EMCALUtils/AliEMCALTriggerMappingV2.h
+++ b/EMCAL/EMCALUtils/AliEMCALTriggerMappingV2.h
@@ -6,6 +6,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 ///
 /// \class AliEMCALTriggerMappingV2
+/// \ingroup EMCALUtils
 /// \brief Trigger mapping methods, base class
 ///
 /// Trigger mapping for Run2

--- a/EMCAL/EMCALUtils/doxymodules.h
+++ b/EMCAL/EMCALUtils/doxymodules.h
@@ -1,0 +1,5 @@
+/**
+ * \defgroup EMCALUtils
+ * \ingroup EMCAL
+ * \brief Various helpers and tools for EMCAL
+ */

--- a/EMCAL/EMCALbase/AliEMCALCalibData.h
+++ b/EMCAL/EMCALbase/AliEMCALCalibData.h
@@ -6,6 +6,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALCalibData
+/// \ingroup EMCALbase
 /// \brief Cell energy calibration factors container class 
 ///
 /// Channel energy calibration factors (ADC to GeV conversion) and pedestal, 

--- a/EMCAL/EMCALbase/AliEMCALCalibTime.h
+++ b/EMCAL/EMCALbase/AliEMCALCalibTime.h
@@ -6,6 +6,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALCalibTime
+/// \ingroup EMCALbase
 /// \brief Cell time shifts container class 
 ///
 /// Cell time shifts container class. Each channel is assigned by 4 parameters, 

--- a/EMCAL/EMCALbase/AliEMCALQAChecker.h
+++ b/EMCAL/EMCALbase/AliEMCALQAChecker.h
@@ -3,6 +3,7 @@
 
 //===============================================================
 /// \class AliEMCALQAChecker
+/// \ingroup EMCALbase
 /// \brief QA checker class
 ///
 ///  Checks the quality assurance. 

--- a/EMCAL/EMCALbase/AliEMCALRawUtils.h
+++ b/EMCAL/EMCALbase/AliEMCALRawUtils.h
@@ -6,6 +6,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALRawUtils
+/// \ingroup EMCALbase
 /// \brief Handling of raw data.
 ///
 ///  Utility Class for handling Raw data

--- a/EMCAL/EMCALbase/AliEMCALRecParam.h
+++ b/EMCAL/EMCALbase/AliEMCALRecParam.h
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------------
 ///
 /// \class AliEMCALRecParam
+/// \ingroup EMCALbase
 /// \brief Container of reconstruction parameters
 ///
 /// Container of EMCAL reconstruction parameters

--- a/EMCAL/EMCALbase/doxymodules.h
+++ b/EMCAL/EMCALbase/doxymodules.h
@@ -1,0 +1,5 @@
+/**
+ * \defgroup EMCALbase
+ * \ingroup EMCAL
+ * \brief EMCAL base classes
+ */

--- a/EMCAL/EMCALraw/AliEMCALRawResponse.h
+++ b/EMCAL/EMCALraw/AliEMCALRawResponse.h
@@ -20,6 +20,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALRawResponse
+/// \ingroup EMCALraw
 /// \brief Handling of digits to raw data transformation
 ///
 ///  Utility Class for handling simulated digits to Raw data generation

--- a/EMCAL/EMCALraw/doxymodules.h
+++ b/EMCAL/EMCALraw/doxymodules.h
@@ -1,0 +1,5 @@
+/**
+ * \defgroup EMCALraw
+ * \ingroup EMCAL
+ * \brief Classes and tools for EMCAL raw data reconstruction
+ */

--- a/EMCAL/EMCALrec/AliEMCALPID.h
+++ b/EMCAL/EMCALrec/AliEMCALPID.h
@@ -3,6 +3,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALPID
+/// \ingroup EMCALrec
 /// \brief Compute cluster PID weights 
 ///
 ///   Compute PID weights for all the clusters that are in AliESDs.root file

--- a/EMCAL/EMCALrec/AliEMCALQADataMakerRec.h
+++ b/EMCAL/EMCALrec/AliEMCALQADataMakerRec.h
@@ -3,6 +3,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALQADataMakerRec
+/// \ingroup EMCALrec
 /// \brief EMCal reconstruction QA
 ///
 /// Produces the data needed to calculate the quality assurance. 

--- a/EMCAL/EMCALrec/AliEMCALReconstructor.h
+++ b/EMCAL/EMCALrec/AliEMCALReconstructor.h
@@ -5,6 +5,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALReconstructor
+/// \ingroup EMCALrec
 /// \brief Wrapping class for EMCal reconstruction
 ///
 /// Wrapping class for EMCal reconstruction.

--- a/EMCAL/EMCALrec/AliEMCALTracker.h
+++ b/EMCAL/EMCALrec/AliEMCALTracker.h
@@ -6,6 +6,7 @@
 //=========================================================================
 ///                       
 /// \class AliEMCALTracker 
+/// \ingroup EMCALrec
 /// \brief Steer EMCal-Track matching
 ///
 /// Implementation of the track matching method between barrel tracks and

--- a/EMCAL/EMCALrec/doxymodules.h
+++ b/EMCAL/EMCALrec/doxymodules.h
@@ -1,0 +1,5 @@
+/**
+ * \defgroup EMCALrec
+ * \ingroup EMCAL
+ * \brief EMCAL reconstruction classes
+ */

--- a/EMCAL/EMCALsim/AliEMCALQADataMakerSim.h
+++ b/EMCAL/EMCALsim/AliEMCALQADataMakerSim.h
@@ -5,6 +5,7 @@
 
 //______________________________________________________________
 /// \class AliEMCALQADataMakerSim
+/// \ingroup EMCALsim
 /// \brief Simulation QA output maker
 ///
 /// Produces the data needed to calculate the quality assurance. 

--- a/EMCAL/EMCALsim/AliEMCALTriggerBoard.h
+++ b/EMCAL/EMCALsim/AliEMCALTriggerBoard.h
@@ -5,6 +5,7 @@
 
 //________________________________________________
 /// \class AliEMCALTriggerBoard
+/// \ingroup EMCALsim
 /// \brief EMCal trigger board super class
 ///
 /// EMCal trigger board super class

--- a/EMCAL/EMCALsim/AliEMCALTriggerElectronics.h
+++ b/EMCAL/EMCALsim/AliEMCALTriggerElectronics.h
@@ -5,6 +5,7 @@
 
 //________________________________________________
 /// \class AliEMCALTriggerElectronics
+/// \ingroup EMCALsim
 /// \brief EMCal trigger electronics manager L0/L1
 ///
 /// EMCal trigger electronics manager L0/L1

--- a/EMCAL/EMCALsim/AliEMCALTriggerPatch.h
+++ b/EMCAL/EMCALsim/AliEMCALTriggerPatch.h
@@ -5,6 +5,7 @@
 
 //________________________________________________
 /// \class AliEMCALTriggerPatch
+/// \ingroup EMCALsim
 /// \brief EMCal trigger patch implementation
 ///
 /// Patch object implementation: one patch is made of 

--- a/EMCAL/EMCALsim/AliEMCALTriggerSTU.h
+++ b/EMCAL/EMCALsim/AliEMCALTriggerSTU.h
@@ -5,6 +5,7 @@
 
 //________________________________________________
 /// \class AliEMCALTriggerSTU
+/// \ingroup EMCALsim
 /// \brief EMCal trigger STU handling
 ///
 /// Add description

--- a/EMCAL/EMCALsim/AliEMCALTriggerTRU.h
+++ b/EMCAL/EMCALsim/AliEMCALTriggerTRU.h
@@ -5,6 +5,7 @@
 
 //________________________________________________
 /// \class AliEMCALTriggerTRU
+/// \ingroup EMCALsim
 /// \brief EMCal trigger TRU handling
 ///
 /// Add description

--- a/EMCAL/EMCALsim/AliEMCALv0.h
+++ b/EMCAL/EMCALsim/AliEMCALv0.h
@@ -6,6 +6,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALv0
+/// \ingroup EMCALsim
 /// \brief EMCal simulation manager class v0
 ///
 /// Implementation version v0 of EMCAL Manager class

--- a/EMCAL/EMCALsim/AliEMCALv1.h
+++ b/EMCAL/EMCALsim/AliEMCALv1.h
@@ -6,6 +6,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALv1
+/// \ingroup EMCALsim
 /// \brief EMCal simulation manager class v1
 ///
 /// Implementation version v1 of EMCAL Manager class; 

--- a/EMCAL/EMCALsim/AliEMCALv2.h
+++ b/EMCAL/EMCALsim/AliEMCALv2.h
@@ -6,6 +6,7 @@
 
 //_________________________________________________________________________
 /// \class AliEMCALv2
+/// \ingroup EMCALsim
 /// \brief EMCal simulation manager class v2
 ///
 /// Implementation version v2 of EMCAL Manager class; SHASHLYK version

--- a/EMCAL/EMCALsim/doxymodules.h
+++ b/EMCAL/EMCALsim/doxymodules.h
@@ -1,0 +1,5 @@
+/**
+ * \defgroup EMCALsim
+ * \ingroup EMCAL
+ * \brief EMCAL simulation classes
+ */

--- a/EMCAL/doxymodules.h
+++ b/EMCAL/doxymodules.h
@@ -1,0 +1,4 @@
+/**
+ * \defgroup EMCAL
+ * \brief EMCAL classes for simulation, reconstruction, calibration and utilities
+ */


### PR DESCRIPTION
Classes documented already are put into submodules
according to libraries:
- EMCALbase
- EMCALraw
- EMCALrec
- EMCALsim
- EMCALTriggerBase
- EMCALUtils
A top-level module EMCAL groups all submodules. Classes
with fresh documentation will have to be added to the
submodules with the ingroup command.