### PR TITLE
No method Optimize in Root6

### DIFF
--- a/AD/ADrec/AliADReconstructor.cxx
+++ b/AD/ADrec/AliADReconstructor.cxx
@@ -48,6 +48,7 @@
 #include "AliADCalibData.h"
 #include "AliADRawStream.h"
 #include "AliADDecision.h"
+#include <RVersion.h>
 
 ClassImp(AliADReconstructor);
 
@@ -442,7 +443,9 @@ void AliADReconstructor::FillESD(TTree* digitsTree, TTree* /*clustersTree*/,AliE
 				       : NULL);
 	  correctedForSaturation  |= doExtrapolation[iClock];
 	  if (doExtrapolation[iClock]) {
+#if ROOT_VERSION_CODE < ROOT_VERSION(5,99,0)
 	    fExtrapolation->Optimize();
+#endif
 	    AliDebug(3, Form("Ch%02d bc%02d %d tail=%6.1f thr=%6.1f adc=%6.1f adcCorr=%7.1f",
 			     pmNumber, iClock, doExtrapolation[iClock], tail[pmNumber], extrapolationThresholds[iClock],
 			     adcPedSub[iClock], fExtrapolation->Eval(tail[pmNumber])));


### PR DESCRIPTION
The recent fix breaks the compilation with Root6, so I switched off the method Optimize. It is not available in Root6.