### PR TITLE
using -Werr -Wall for AD code

### DIFF
--- a/AD/ADbase/AliADCalibData.cxx
+++ b/AD/ADbase/AliADCalibData.cxx
@@ -35,37 +35,37 @@
 ClassImp(AliADCalibData);
 
 //________________________________________________________________
-AliADCalibData::AliADCalibData():
-  fLightYields(NULL),
-  fPMGainsA(NULL),
-  fPMGainsB(NULL),
-  fThrCalibA(NULL),
-  fThrCalibB(NULL),
-  fBBAThreshold(0),
-  fBBCThreshold(0) ,  
-  fBGAThreshold(0) ,  
-  fBGCThreshold(0) ,  
-  fBBAForBGThreshold(0) ,  
-  fBBCForBGThreshold(0) ,   
-  fMultADAThrLow(0) ,  
-  fMultADAThrHigh(0) , 
-  fMultADCThrLow(0) ,  
-  fMultADCThrHigh(0)
+AliADCalibData::AliADCalibData()
+  : fBBAThreshold(0)
+  , fBBCThreshold(0)
+  , fBGAThreshold(0)
+  , fBGCThreshold(0)
+  , fBBAForBGThreshold(0)
+  , fBBCForBGThreshold(0)
+  , fMultADAThrLow(0)
+  , fMultADAThrHigh(0)
+  , fMultADCThrLow(0)
+  , fMultADCThrHigh(0)
+  , fLightYields(NULL)
+  , fPMGainsA(NULL)
+  , fPMGainsB(NULL)
+  , fThrCalibA(NULL)
+  , fThrCalibB(NULL)
 {
   // default constructor
-  
+
   for(int t=0; t<16; t++) {
     fMeanHV[t]      = 1400.0;
-    fWidthHV[t]     = 0.0; 
+    fWidthHV[t]     = 0.0;
     fTimeOffset[t]  = 250.0;
     fTimeGain[t]    = 1.0;
     fDeadChannel[t]= kFALSE;
     fDiscriThr[t]  = 2.5;
   }
   for(int t=0; t<32; t++) {
-    fPedestal[t]    = 3.0;     
-    fSigma[t]       = 1.0;        
-    fADCmean[t]     = 0.0;      
+    fPedestal[t]    = 3.0;
+    fSigma[t]       = 1.0;
+    fADCmean[t]     = 0.0;
     fADCsigma[t]    = 0.0;
   }
   for(int i=0; i<kNCIUBoards ;i++) {
@@ -97,26 +97,26 @@ AliADCalibData::AliADCalibData():
 //________________________________________________________________
 void AliADCalibData::Reset()
 {
-  
+
 }
 
 //________________________________________________________________
-AliADCalibData::AliADCalibData(const char* name) :
-  fLightYields(NULL),
-  fPMGainsA(NULL),
-  fPMGainsB(NULL),
-  fThrCalibA(NULL),
-  fThrCalibB(NULL),
-  fBBAThreshold(0),
-  fBBCThreshold(0) ,  
-  fBGAThreshold(0) ,  
-  fBGCThreshold(0) ,  
-  fBBAForBGThreshold(0) ,  
-  fBBCForBGThreshold(0) ,   
-  fMultADAThrLow(0) ,  
-  fMultADAThrHigh(0) , 
-  fMultADCThrLow(0) ,  
-  fMultADCThrHigh(0)
+AliADCalibData::AliADCalibData(const char* name)
+  : fBBAThreshold(0)
+  , fBBCThreshold(0)
+  , fBGAThreshold(0)
+  , fBGCThreshold(0)
+  , fBBAForBGThreshold(0)
+  , fBBCForBGThreshold(0)
+  , fMultADAThrLow(0)
+  , fMultADAThrHigh(0)
+  , fMultADCThrLow(0)
+  , fMultADCThrHigh(0)
+  , fLightYields(NULL)
+  , fPMGainsA(NULL)
+  , fPMGainsB(NULL)
+  , fThrCalibA(NULL)
+  , fThrCalibB(NULL)
 {
   // Constructor
   TString namst = "Calib_";
@@ -125,16 +125,16 @@ AliADCalibData::AliADCalibData(const char* name) :
   SetTitle(namst.Data());
   for(int t=0; t<16; t++) {
     fMeanHV[t]      = 1500.0;
-    fWidthHV[t]     = 0.0; 
+    fWidthHV[t]     = 0.0;
     fTimeOffset[t]  = 5.0;
     fTimeGain[t]    = 1.0;
     fDeadChannel[t]= kFALSE;
     fDiscriThr[t]  = 2.5;
   }
   for(int t=0; t<32; t++) {
-    fPedestal[t]    = 0.0;     
-    fSigma[t]       = 0.0;        
-    fADCmean[t]     = 0.0;      
+    fPedestal[t]    = 0.0;
+    fSigma[t]       = 0.0;
+    fADCmean[t]     = 0.0;
     fADCsigma[t]    = 0.0;
   }
   for(int i=0; i<kNCIUBoards ;i++) {
@@ -164,53 +164,52 @@ AliADCalibData::AliADCalibData(const char* name) :
 }
 
 //________________________________________________________________
-AliADCalibData::AliADCalibData(const AliADCalibData& calibda) :
-  TNamed(calibda),
-  fLightYields(NULL),
-  fPMGainsA(NULL),
-  fPMGainsB(NULL),
-  fThrCalibA(NULL),
-  fThrCalibB(NULL)
+AliADCalibData::AliADCalibData(const AliADCalibData& calibda)
+  : TNamed(calibda)
+  , fLightYields(NULL)
+  , fPMGainsA(NULL)
+  , fPMGainsB(NULL)
+  , fThrCalibA(NULL)
+  , fThrCalibB(NULL)
 {
   // copy constructor
-
   SetName(calibda.GetName());
   SetTitle(calibda.GetName());
   fBBAThreshold = calibda.GetBBAThreshold();
-  fBBCThreshold = calibda.GetBBCThreshold();  
-  fBGAThreshold = calibda.GetBGAThreshold();  
-  fBGCThreshold = calibda.GetBGCThreshold();  
-  fBBAForBGThreshold = calibda.GetBBAForBGThreshold();  
-  fBBCForBGThreshold = calibda.GetBBCForBGThreshold();   
-  fMultADAThrLow = calibda.GetMultADAThrLow();  
+  fBBCThreshold = calibda.GetBBCThreshold();
+  fBGAThreshold = calibda.GetBGAThreshold();
+  fBGCThreshold = calibda.GetBGCThreshold();
+  fBBAForBGThreshold = calibda.GetBBAForBGThreshold();
+  fBBCForBGThreshold = calibda.GetBBCForBGThreshold();
+  fMultADAThrLow = calibda.GetMultADAThrLow();
   fMultADAThrHigh = calibda.GetMultADAThrHigh();
-  fMultADCThrLow = calibda.GetMultADCThrLow();  
+  fMultADCThrLow = calibda.GetMultADCThrLow();
   fMultADCThrHigh = calibda.GetMultADCThrHigh();
-  
-  for(int t=0; t<32; t++) { 
+
+  for(int t=0; t<32; t++) {
     fPedestal[t] = calibda.GetPedestal(t);
     fSigma[t]    = calibda.GetSigma(t);
     fADCmean[t]  = calibda.GetADCmean(t);
     fADCsigma[t] = calibda.GetADCsigma(t); }
-      
-  for(int t=0; t<16; t++) { 
+
+  for(int t=0; t<16; t++) {
     fMeanHV[t]       = calibda.GetMeanHV(t);
-    fWidthHV[t]      = calibda.GetWidthHV(t);        
+    fWidthHV[t]      = calibda.GetWidthHV(t);
     fTimeOffset[t]   = calibda.GetTimeOffset(t);
-    fTimeGain[t]     = calibda.GetTimeGain(t); 
+    fTimeGain[t]     = calibda.GetTimeGain(t);
     fDeadChannel[t]  = calibda.IsChannelDead(t);
     fDiscriThr[t]    = calibda.GetDiscriThr(t);
-  }  
-  
+  }
+
   for(int i=0; i<kNCIUBoards ;i++) {
     fTimeResolution[i]  = calibda.GetTimeResolution(i);
-    fWidthResolution[i] = calibda.GetWidthResolution(i);	  
+    fWidthResolution[i] = calibda.GetWidthResolution(i);
     fMatchWindow[i] = calibda.GetMatchWindow(i);
     fSearchWindow[i] = calibda.GetSearchWindow(i);
     fTriggerCountOffset[i] = calibda.GetTriggerCountOffset(i);
     fRollOver[i] = calibda.GetRollOver(i);
   }
-  
+
   for(int i=0; i<kNCIUBoards ;i++) {
     fClk1Win1[i] = calibda.GetClk1Win1(i);
     fClk1Win2[i] = calibda.GetClk1Win2(i);
@@ -235,40 +234,39 @@ AliADCalibData::AliADCalibData(const AliADCalibData& calibda) :
     fPedestalCutEven[j] = calibda.GetOnlinePedestal(1,j);
   }
   for(Int_t i = 0; i < 5; ++i) fTriggerSelected[i] = calibda.GetTriggerSelected(i);
-  
+
 }
 
 //________________________________________________________________
 AliADCalibData &AliADCalibData::operator =(const AliADCalibData& calibda)
 {
   // assignment operator
-
   SetName(calibda.GetName());
   SetTitle(calibda.GetName());
-  
+
   for(int t=0; t<32; t++) {
     fPedestal[t] = calibda.GetPedestal(t);
     fSigma[t]    = calibda.GetSigma(t);
     fADCmean[t]  = calibda.GetADCmean(t);
     fADCsigma[t] = calibda.GetADCsigma(t); }
-      
+
   for(int t=0; t<16; t++) {
     fMeanHV[t]       = calibda.GetMeanHV(t);
-    fWidthHV[t]      = calibda.GetWidthHV(t);        
+    fWidthHV[t]      = calibda.GetWidthHV(t);
     fTimeOffset[t]   = calibda.GetTimeOffset(t);
-    fTimeGain[t]     = calibda.GetTimeGain(t); 
+    fTimeGain[t]     = calibda.GetTimeGain(t);
     fDeadChannel[t]  = calibda.IsChannelDead(t);
     fDiscriThr[t]    = calibda.GetDiscriThr(t);
-  }   
+  }
   for(int i=0; i<kNCIUBoards ;i++) {
     fTimeResolution[i]  = calibda.GetTimeResolution(i);
-    fWidthResolution[i] = calibda.GetWidthResolution(i);	  
+    fWidthResolution[i] = calibda.GetWidthResolution(i);
     fMatchWindow[i] = calibda.GetMatchWindow(i);
     fSearchWindow[i] = calibda.GetSearchWindow(i);
     fTriggerCountOffset[i] = calibda.GetTriggerCountOffset(i);
     fRollOver[i] = calibda.GetRollOver(i);
   }
-  
+
   for(int i=0; i<kNCIUBoards ;i++) {
     fClk1Win1[i] = calibda.GetClk1Win1(i);
     fClk1Win2[i] = calibda.GetClk1Win2(i);
@@ -292,10 +290,9 @@ AliADCalibData &AliADCalibData::operator =(const AliADCalibData& calibda)
     fPedestalCutOdd[j] = calibda.GetOnlinePedestalCut(0,j);
     fPedestalCutEven[j] = calibda.GetOnlinePedestal(1,j);
   }
-  for(Int_t i = 0; i < 5; ++i) fTriggerSelected[i] = calibda.GetTriggerSelected(i); 
-   
+  for(Int_t i = 0; i < 5; ++i) fTriggerSelected[i] = calibda.GetTriggerSelected(i);
+
   return *this;
-  
 }
 
 //________________________________________________________________
@@ -304,14 +301,19 @@ AliADCalibData::~AliADCalibData()
   // destructor
   if (fLightYields)
     delete [] fLightYields;
+  fLightYields = NULL;
   if (fPMGainsA)
     delete [] fPMGainsA;
+  fPMGainsA = NULL;
   if (fPMGainsB)
     delete [] fPMGainsB;
+  fPMGainsB = NULL;
   if (fThrCalibA)
     delete [] fThrCalibA;
+  fThrCalibA = NULL;
   if (fThrCalibB)
     delete [] fThrCalibB;
+  fThrCalibB = NULL;
 }
 
 //________________________________________________________________
@@ -325,7 +327,7 @@ Float_t AliADCalibData::GetLightYields(Int_t channel)
     return fLightYields[channel];
   }
 
-  AliError(Form("Wrong channel index: %d",channel));
+  AliErrorF("Wrong channel index: %d",channel);
   return 0;
 }
 
@@ -372,7 +374,7 @@ Float_t AliADCalibData::GetGain(Int_t channel)
   // Argument passed is the PM number (aliroot numbering)
   if (!fPMGainsA) InitPMGains();
 
-  // High Voltage retrieval from Calibration Data Base:  
+  // High Voltage retrieval from Calibration Data Base:
   Float_t hv = fMeanHV[channel];
   Float_t gain = 0;
   if (hv>0)
@@ -387,7 +389,7 @@ Float_t AliADCalibData::GetADCperMIP(Int_t channel)
   // Argument passed is the PM number (aliroot numbering)
   if (!fPMGainsA) InitPMGains();
 
-  // High Voltage retrieval from Calibration Data Base:  
+  // High Voltage retrieval from Calibration Data Base:
   Float_t hv = fMeanHV[channel];
   Float_t ADCperMIP = 0;
   if (hv>0)
@@ -419,7 +421,7 @@ Float_t AliADCalibData::GetCalibDiscriThr(Int_t channel)
   // The method returns actual TDC discri threshold
   // extracted from the data.
   if (!fThrCalibA) InitCalibThresholds();
-  
+
   Float_t thr = GetDiscriThr(channel);
 
   Float_t calThr = fThrCalibA[channel]*thr + fThrCalibB[channel];
@@ -430,9 +432,9 @@ Float_t AliADCalibData::GetCalibDiscriThr(Int_t channel)
 void AliADCalibData::FillDCSData(AliADDataDCS * data){
   // Set all parameters from the data get by the shuttle
   TMap * params = data->GetFEEParameters();
-  TIter iter(params);	
+  TIter iter(params);
   TObjString* aliasName;
-	
+
   while ((  aliasName = (TObjString*) iter.Next() ))  {
     AliDCSValue* aValue = (AliDCSValue*) params->GetValue(aliasName);
     UInt_t val;
@@ -440,8 +442,8 @@ void AliADCalibData::FillDCSData(AliADDataDCS * data){
       val = aValue->GetUInt();
       SetParameter(aliasName->String(),val);
     }
-  }	
-	
+  }
+
   SetMeanHV(data->GetMeanHV());
   SetWidthHV(data->GetWidthHV());
   SetDeadMap(data->GetDeadMap());
@@ -449,21 +451,21 @@ void AliADCalibData::FillDCSData(AliADDataDCS * data){
 }
 //_____________________________________________________________________________
 void AliADCalibData::SetADCperMIP(Int_t nADCperMIP){
-  //Sets HV in a way to have uniform gains on PM according  
-  //to number of ADC per MIP 
+  //Sets HV in a way to have uniform gains on PM according
+  //to number of ADC per MIP
   if (!fPMGainsA) InitPMGains();
   Double_t hv = 0;
   for(Int_t channel = 0; channel<16; channel++){
     hv = TMath::Power(nADCperMIP,1/fPMGainsB[channel])*fPMGainsA[channel];
     SetMeanHV(hv,channel);
-    AliInfo(Form("HV on channel %d set to %f V",channel,hv));
+    AliInfoF("HV on channel %d set to %f V",channel,hv);
   }
 }
 
 //_____________________________________________________________________________
 void AliADCalibData::SetParameter(TString name, Int_t val){
   // Set given parameter
-	
+
   Int_t iBoard = -1;
   Int_t iChannel = -1;
 
@@ -475,7 +477,7 @@ void AliADCalibData::SetParameter(TString name, Int_t val){
   Char_t channel[2] ; channel[1] = '\0';
   channel[0] = paramName[paramName.Sizeof()-2];
   sscanf(channel,"%d",&iChannel);
-		
+
   if(name.Contains("TimeResolution")) SetTimeResolution((UShort_t) val,iBoard);
   else if(name.Contains("WidthResolution")) SetWidthResolution((UShort_t) val,iBoard);
   else if(name.Contains("MatchWindow")) SetMatchWindow((UInt_t) val,iBoard);
@@ -484,7 +486,7 @@ void AliADCalibData::SetParameter(TString name, Int_t val){
   else if(name.Contains("RollOver")) SetRollOver((UInt_t) val,iBoard);
   else if(name.Contains("DelayHit")) SetTimeOffset(0.01*(Float_t)val,iBoard,(iChannel-1));
   else if(name.Contains("DiscriThr")) SetDiscriThr(((Float_t)val-2040.)/112.,iBoard,(iChannel-1));
-		
+
   else if(name.Contains("DelayClk1Win1")) SetDelayClk1Win1((UShort_t) val,iBoard);
   else if(name.Contains("Clk1Win1")) SetClk1Win1((UShort_t) val,iBoard);
   else if(name.Contains("DelayClk1Win2")) SetDelayClk1Win2((UShort_t) val,iBoard);
@@ -515,8 +517,8 @@ void AliADCalibData::SetParameter(TString name, Int_t val){
   else if(name.Contains("PedEven")) SetOnlinePedestal((UShort_t) val, 0, iBoard, iChannel-1);
   else if(name.Contains("PedCutOdd")) SetOnlinePedestalCut((UShort_t) val, 1, iBoard, iChannel-1);
   else if(name.Contains("PedCutEven")) SetOnlinePedestalCut((UShort_t) val, 0, iBoard, iChannel-1);
-	
-  else AliError(Form("No Setter found for FEE parameter : %s",name.Data()));
+
+  else AliErrorF("No Setter found for FEE parameter : %s",name.Data());
   //
   delete nameSplit;
 }
@@ -536,35 +538,35 @@ void AliADCalibData::SetSigma(const Float_t* Sigma)
 }
 
 //________________________________________________________________
-void AliADCalibData::SetADCmean(const Float_t* ADCmean) 
+void AliADCalibData::SetADCmean(const Float_t* ADCmean)
 {
   if(ADCmean) for(int t=0; t<32; t++) fADCmean[t] = ADCmean[t];
   else for(int t=0; t<32; t++) fADCmean[t] = 0.0;
 }
 
 //________________________________________________________________
-void AliADCalibData::SetADCsigma(const Float_t* ADCsigma) 
+void AliADCalibData::SetADCsigma(const Float_t* ADCsigma)
 {
   if(ADCsigma) for(int t=0; t<32; t++) fADCsigma[t] = ADCsigma[t];
   else for(int t=0; t<32; t++) fADCsigma[t] = 0.0;
 }
 
 //________________________________________________________________
-void AliADCalibData::SetMeanHV(const Float_t* MeanHV) 
+void AliADCalibData::SetMeanHV(const Float_t* MeanHV)
 {
   if(MeanHV) for(int t=0; t<16; t++) fMeanHV[t] = MeanHV[t];
   else for(int t=0; t<16; t++) fMeanHV[t] = 0.0;
 }
 
 //________________________________________________________________
-void AliADCalibData::SetWidthHV(const Float_t* WidthHV) 
+void AliADCalibData::SetWidthHV(const Float_t* WidthHV)
 {
   if(WidthHV) for(int t=0; t<16; t++) fWidthHV[t] = WidthHV[t];
   else for(int t=0; t<16; t++) fWidthHV[t] = 0.0;
 }
 
 //________________________________________________________________
-void AliADCalibData::SetDeadMap(const Bool_t* deadMap) 
+void AliADCalibData::SetDeadMap(const Bool_t* deadMap)
 {
   if(deadMap) for(int t=0; t<16; t++) fDeadChannel[t] = deadMap[t];
   else for(int t=0; t<16; t++) fDeadChannel[t] = kFALSE;
@@ -580,13 +582,13 @@ void AliADCalibData::SetTimeOffset(Float_t val, Int_t board, Int_t channel)
 }
 
 //________________________________________________________________
-void AliADCalibData::SetTimeOffset(const Float_t* TimeOffset) 
+void AliADCalibData::SetTimeOffset(const Float_t* TimeOffset)
 {
   if(TimeOffset) for(int t=0; t<16; t++) fTimeOffset[t] = TimeOffset[t];
   else for(int t=0; t<16; t++) fTimeOffset[t] = 5.0;
 }
 //________________________________________________________________
-void AliADCalibData::SetTimeGain(const Float_t* TimeGain) 
+void AliADCalibData::SetTimeGain(const Float_t* TimeGain)
 {
   if(TimeGain) for(int t=0; t<16; t++) fTimeGain[t] = TimeGain[t];
   else for(int t=0; t<16; t++) fTimeGain[t] = 0.0;
@@ -596,7 +598,7 @@ void AliADCalibData::SetTimeResolution(UShort_t *resols){
   // Set Time Resolution of the TDC
   if(resols)  for(int t=0; t<kNCIUBoards; t++) SetTimeResolution(resols[t],t);
   else AliError("Time Resolution not defined.");
-	
+
 }
 //________________________________________________________________
 void AliADCalibData::SetTimeResolution(UShort_t resol, Int_t board)
@@ -629,14 +631,14 @@ void AliADCalibData::SetTimeResolution(UShort_t resol, Int_t board)
       fTimeResolution[board] = 12.5;
       break;
     }
-  } else AliError(Form("Board %d is not valid",board));
+  } else AliErrorF("Board %d is not valid",board);
 }
 //________________________________________________________________
 void AliADCalibData::SetWidthResolution(UShort_t *resols){
   // Set Time Width Resolution of the TDC
   if(resols)  for(int t=0; t<kNCIUBoards; t++) SetWidthResolution(resols[t],t);
   else AliError("Width Resolution not defined.");
-	
+
 }
 //________________________________________________________________
 void AliADCalibData::SetWidthResolution(UShort_t resol, Int_t board)
@@ -686,9 +688,9 @@ void AliADCalibData::SetWidthResolution(UShort_t resol, Int_t board)
     case 13:
       fWidthResolution[board] = 800.;
       break;
-				
+
     }
-  }else AliError(Form("Board %d is not valid",board));
+  }else AliErrorF("Board %d is not valid",board);
 }
 
 //________________________________________________________________
@@ -707,7 +709,7 @@ void AliADCalibData::SetMatchWindow(UInt_t window, Int_t board)
   // The units are 25ns
   if((board>=0) && (board<kNCIUBoards)) fMatchWindow[board] = window;
   else
-    AliError(Form("Board %d is not valid",board));
+    AliErrorF("Board %d is not valid",board);
 }
 
 //________________________________________________________________
@@ -726,7 +728,7 @@ void  AliADCalibData::SetSearchWindow(UInt_t window, Int_t board)
   // The units are 25ns
   if((board>=0) && (board<kNCIUBoards)) fSearchWindow[board] = window;
   else
-    AliError(Form("Board %d is not valid",board));
+    AliErrorF("Board %d is not valid",board);
 }
 
 //________________________________________________________________
@@ -745,7 +747,7 @@ void AliADCalibData::SetTriggerCountOffset(UInt_t offset, Int_t board)
   // The units are 25ns
   if((board>=0) && (board<kNCIUBoards)) fTriggerCountOffset[board] = offset;
   else
-    AliError(Form("Board %d is not valid",board));
+    AliErrorF("Board %d is not valid",board);
 }
 
 //________________________________________________________________
@@ -764,7 +766,7 @@ void AliADCalibData::SetRollOver(UInt_t offset, Int_t board)
   // The units are 25ns
   if((board>=0) && (board<kNCIUBoards)) fRollOver[board] = offset;
   else
-    AliError(Form("Board %d is not valid",board));
+    AliErrorF("Board %d is not valid",board);
 }
 
 //________________________________________________________________
@@ -779,7 +781,7 @@ void AliADCalibData::SetDiscriThr(Float_t thr, Int_t board, Int_t channel)
 }
 
 //________________________________________________________________
-void AliADCalibData::SetDiscriThr(const Float_t* thresholds) 
+void AliADCalibData::SetDiscriThr(const Float_t* thresholds)
 {
   // Set the TDC discriminator
   // threshold values expressed in units of ADC
@@ -791,11 +793,11 @@ void AliADCalibData::SetDiscriThr(const Float_t* thresholds)
 //________________________________________________________________
 void AliADCalibData::SetOnlinePedestalCut(UShort_t val,Int_t integrator, Int_t channel)
 {
-  // Set Pedestal Cut of individual channel 
+  // Set Pedestal Cut of individual channel
   if(channel>=0 && channel<16) {
     if(integrator) fPedestalCutOdd[channel] = val;
     else fPedestalCutEven[channel] = val;
-  } else AliError(Form("Impossible to write at : Channel %d",channel));
+  } else AliErrorF("Impossible to write at : Channel %d",channel);
 }
 //________________________________________________________________
 void AliADCalibData::SetOnlinePedestalCut(UShort_t val,Int_t integrator, Int_t board, Int_t channel)
@@ -811,21 +813,21 @@ void AliADCalibData::SetOnlinePedestalCut(UShort_t val,Int_t integrator, Int_t b
 //________________________________________________________________
 UShort_t AliADCalibData::GetOnlinePedestalCut(Int_t integrator, Int_t channel) const
 {
-  // Get Pedestal Cut of individual channel 
+  // Get Pedestal Cut of individual channel
   if(channel>=0 && channel<16) {
     if(integrator) return(fPedestalCutOdd[channel]);
     else return(fPedestalCutEven[channel]);
-  }else AliError(Form("Impossible to read at : Channel %d",channel));
+  }else AliErrorF("Impossible to read at : Channel %d",channel);
   return 0;
 }
 //________________________________________________________________
 void AliADCalibData::SetOnlinePedestal(UShort_t val, Int_t integrator, Int_t channel)
 {
-  // Set Pedestal of individual channel 
+  // Set Pedestal of individual channel
   if(channel>=0 && channel<16) {
     if(integrator) fPedestalOdd[channel] = val;
     else fPedestalEven[channel] = val;
-  } else AliError(Form("Impossible to write at : Channel %d ; Integrator %d ",channel,integrator));
+  } else AliErrorF("Impossible to write at : Channel %d ; Integrator %d ",channel,integrator);
 }
 //________________________________________________________________
 void AliADCalibData::SetOnlinePedestal(UShort_t val,Int_t integrator, Int_t board, Int_t channel)
@@ -841,11 +843,11 @@ void AliADCalibData::SetOnlinePedestal(UShort_t val,Int_t integrator, Int_t boar
 //________________________________________________________________
 UShort_t AliADCalibData::GetOnlinePedestal(Int_t integrator, Int_t channel) const
 {
-  // Get Pedestal of individual channel 
+  // Get Pedestal of individual channel
   if(channel>=0 && channel<16) {
     if(integrator) return(fPedestalOdd[channel]);
     else return(fPedestalEven[channel]);
-  } else AliError(Form("Impossible to read at : Channel %d",channel));
+  } else AliErrorF("Impossible to read at : Channel %d",channel);
   return 0;
 }
 //________________________________________________________________
@@ -853,14 +855,14 @@ void AliADCalibData::SetEnableCharge(Bool_t val, Int_t channel)
 {
   // Set the channels enabled for Charge triggers
   if(channel>=0 && channel<16) fEnableCharge[channel] = val;
-  else AliError(Form("Impossible to write at : Channel %d",channel));
+  else AliErrorF("Impossible to write at : Channel %d",channel);
 }
 //________________________________________________________________
 Bool_t AliADCalibData::GetEnableCharge(Int_t channel) const
 {
   // Get the channels enabled for Charge triggers
   if(channel>=0 && channel<16) return(fEnableCharge[channel]);
-  else AliError(Form("Impossible to read at : Channel %d",channel));
+  else AliErrorF("Impossible to read at : Channel %d",channel);
   return kFALSE;
 }
 //________________________________________________________________
@@ -868,14 +870,14 @@ void AliADCalibData::SetEnableTiming(Bool_t val, Int_t channel)
 {
   // Set the channels enabled for Timing triggers
   if(channel>=0 && channel<16) fEnableTiming[channel] = val;
-  else AliError(Form("Impossible to write at : Channel %d",channel));
+  else AliErrorF("Impossible to write at : Channel %d",channel);
 }
 //________________________________________________________________
 Bool_t AliADCalibData::GetEnableTiming(Int_t channel) const
 {
   // Get the channels enabled for Timing triggers
   if(channel>=0 && channel<16) return(fEnableTiming[channel]);
-  else AliError(Form("Impossible to read at : Channel %d",channel));
+  else AliErrorF("Impossible to read at : Channel %d",channel);
   return kFALSE;
 }
 //________________________________________________________________
@@ -884,7 +886,7 @@ void AliADCalibData::SetEnableCharge(Bool_t val,Int_t board, Int_t channel)
   Int_t ch = AliADCalibData::GetOfflineChannelNumber(board,channel);
   // Set the channels enabled for Charge triggers
   if(ch>=0) fEnableCharge[ch] = val;
-  else AliError(Form("Impossible to write at : Board %d ; Channel %d",board,channel));
+  else AliErrorF("Impossible to write at : Board %d ; Channel %d",board,channel);
 }
 //________________________________________________________________
 void AliADCalibData::SetEnableTiming(Bool_t val,Int_t board, Int_t channel)
@@ -892,14 +894,14 @@ void AliADCalibData::SetEnableTiming(Bool_t val,Int_t board, Int_t channel)
   Int_t ch = AliADCalibData::GetOfflineChannelNumber(board,channel);
   // Set the channels enabled for Timing triggers
   if(ch>=0) fEnableTiming[ch] = val;
-  else AliError(Form("Impossible to write at : Board %d ; Channel %d",board,channel));
+  else AliErrorF("Impossible to write at : Board %d ; Channel %d",board,channel);
 }
 //________________________________________________________________
 void AliADCalibData::SetTriggerSelected(UShort_t trigger, Int_t output)
 {
   // Set the trigger selected on the outputs to CTP
   if(output>=0 && output<5) fTriggerSelected[output] = trigger;
-  else AliError(Form("Trigger output number %d not valid",output));
+  else AliErrorF("Trigger output number %d not valid",output);
 }
 
 //________________________________________________________________
@@ -922,9 +924,9 @@ void AliADCalibData::SetClk1Win1(UShort_t clk, Int_t board)
   // Set Win clock of BB
   if((board>=0) && (board<kNCIUBoards)) {
     fClk1Win1[board] = clk;
-    if(!IsClkValid(clk)) AliWarning(Form("Profil Clock1 Win1 of board %d is not valid : %d",board,clk));
+    if(!IsClkValid(clk)) AliWarningF("Profil Clock1 Win1 of board %d is not valid : %d",board,clk);
   }else {
-    AliError(Form("Impossible to Write at Board %d",board));
+    AliErrorF("Impossible to Write at Board %d",board);
   }
 }
 //________________________________________________________________
@@ -933,9 +935,9 @@ void AliADCalibData::SetClk2Win1(UShort_t clk, Int_t board)
   // Set Win clock of BB
   if((board>=0) && (board<kNCIUBoards)) {
     fClk2Win1[board] = clk;
-    if(!IsClkValid(clk)) AliWarning(Form("Profil Clock2 Win1 of board %d is not valid : %d",board,clk));
+    if(!IsClkValid(clk)) AliWarningF("Profil Clock2 Win1 of board %d is not valid : %d",board,clk);
   }else {
-    AliError(Form("Impossible to Write at Board %d",board));
+    AliErrorF("Impossible to Write at Board %d",board);
   }
 }
 //________________________________________________________________
@@ -958,9 +960,9 @@ void AliADCalibData::SetClk1Win2(UShort_t clk, Int_t board)
   // Set Win clock of BG
   if((board>=0) && (board<kNCIUBoards)) {
     fClk1Win2[board] = clk;
-    if(!IsClkValid(clk)) AliWarning(Form("Profil Clock1 Win2 of board %d is not valid : %d",board,clk));
+    if(!IsClkValid(clk)) AliWarningF("Profil Clock1 Win2 of board %d is not valid : %d",board,clk);
   }else {
-    AliError(Form("Impossible to Write at Board %d",board));
+    AliErrorF("Impossible to Write at Board %d",board);
   }
 }
 //________________________________________________________________
@@ -969,9 +971,9 @@ void AliADCalibData::SetClk2Win2(UShort_t clk, Int_t board)
   // Set Win clock of BG
   if((board>=0) && (board<kNCIUBoards)) {
     fClk2Win2[board] = clk;
-    if(!IsClkValid(clk)) AliWarning(Form("Profil Clock2 Win2 of board %d is not valid : %d",board,clk));
+    if(!IsClkValid(clk)) AliWarningF("Profil Clock2 Win2 of board %d is not valid : %d",board,clk);
   }else {
-    AliError(Form("Impossible to Write at Board %d",board));
+    AliErrorF("Impossible to Write at Board %d",board);
   }
 }
 //________________________________________________________________
@@ -986,11 +988,11 @@ void AliADCalibData::SetDelayClk1Win1(UShort_t delay, Int_t board)
 {
   // Set Delay for Win clock of BB
   if(delay>1023){
-    AliWarning(Form("Profil Clock1 Win1 Delay of board %d should be less 1023 is currently %d. Truncated to the first 10 bits",board, delay));
+    AliWarningF("Profil Clock1 Win1 Delay of board %d should be less 1023 is currently %d. Truncated to the first 10 bits",board, delay);
     delay = delay & 0x3FF;
   }
   if((board>=0) && (board<kNCIUBoards))	fDelayClk1Win1[board] = delay;
-  else AliError(Form("Trying to write out of the array Board = %d",board));
+  else AliErrorF("Trying to write out of the array Board = %d",board);
 }
 //________________________________________________________________
 void AliADCalibData::SetDelayClk2Win1(UShort_t* delays)
@@ -1004,11 +1006,11 @@ void AliADCalibData::SetDelayClk2Win1(UShort_t delay, Int_t board)
 {
   // Set Delay for Win clock of BB
   if(delay>1023){
-    AliWarning(Form("Profil Clock2 Win1 Delay of board %d should be less 1023 is currently %d. Truncated to the first 10 bits",board, delay));
+    AliWarningF("Profil Clock2 Win1 Delay of board %d should be less 1023 is currently %d. Truncated to the first 10 bits",board, delay);
     delay = delay & 0x3FF;
   }
   if((board>=0) && (board<kNCIUBoards))	fDelayClk2Win1[board] = delay;
-  else AliError(Form("Trying to write out of the array Board = %d",board));
+  else AliErrorF("Trying to write out of the array Board = %d",board);
 }
 //________________________________________________________________
 void AliADCalibData::SetDelayClk1Win2(UShort_t* delays)
@@ -1022,11 +1024,11 @@ void AliADCalibData::SetDelayClk1Win2(UShort_t delay, Int_t board)
 {
   // Set Delay for Win clock of BG
   if(delay>1023){
-    AliWarning(Form("Profil Clock1 Win2 Delay of board %d should be less 1023 is currently %d. Truncated to the first 10 bits",board, delay));
+    AliWarningF("Profil Clock1 Win2 Delay of board %d should be less 1023 is currently %d. Truncated to the first 10 bits",board, delay);
     delay = delay & 0x3FF;
   }
   if((board>=0) && (board<kNCIUBoards))	fDelayClk1Win2[board] = delay;
-  else AliError(Form("Trying to write out of the array Board = %d",board));
+  else AliErrorF("Trying to write out of the array Board = %d",board);
 }
 //________________________________________________________________
 void AliADCalibData::SetDelayClk2Win2(UShort_t* delays)
@@ -1040,11 +1042,11 @@ void AliADCalibData::SetDelayClk2Win2(UShort_t delay, Int_t board)
 {
   // Set Delay for Win clock of BG
   if(delay>1023){
-    AliWarning(Form("Profil Clock2 Win2 Delay of board %d should be less 1023 is currently %d. Truncated to the first 10 bits",board, delay));
+    AliWarningF("Profil Clock2 Win2 Delay of board %d should be less 1023 is currently %d. Truncated to the first 10 bits",board, delay);
     delay = delay & 0x3FF;
   }
   if((board>=0) && (board<kNCIUBoards))	fDelayClk2Win2[board] = delay;
-  else AliError(Form("Trying to write out of the array Board = %d",board));
+  else AliErrorF("Trying to write out of the array Board = %d",board);
 }
 //________________________________________________________________
 void AliADCalibData::SetLatchWin1(UShort_t *latchs){
@@ -1058,9 +1060,9 @@ void AliADCalibData::SetLatchWin1(UShort_t latch, Int_t board)
   // Set Latch Win clock for BB
   if((board>=0) && (board<kNCIUBoards)) {
     fLatchWin1[board] = latch;
-    if(!IsClkValid(latch)) AliWarning(Form("Latch Win1 of board %d is not valid : %d",board,latch));
+    if(!IsClkValid(latch)) AliWarningF("Latch Win1 of board %d is not valid : %d",board,latch);
   }else {
-    AliError(Form("Impossible to Write at Board %d",board));
+    AliErrorF("Impossible to Write at Board %d",board);
   }
 }
 //________________________________________________________________
@@ -1075,9 +1077,9 @@ void AliADCalibData::SetLatchWin2(UShort_t latch, Int_t board)
   // Set Latch Win clock for BG
   if((board>=0) && (board<kNCIUBoards)) {
     fLatchWin2[board] = latch;
-    if(!IsClkValid(latch)) AliWarning(Form("Latch Win2 of board %d is not valid : %d",board,latch));
+    if(!IsClkValid(latch)) AliWarningF("Latch Win2 of board %d is not valid : %d",board,latch);
   }else {
-    AliError(Form("Impossible to Write at Board %d",board));
+    AliErrorF("Impossible to Write at Board %d",board);
   }
 }
 //________________________________________________________________
@@ -1092,9 +1094,9 @@ void AliADCalibData::SetResetWin1(UShort_t reset, Int_t board)
   // Set Reset Win clock for BB
   if((board>=0) && (board<kNCIUBoards)) {
     fResetWin1[board] = reset;
-    if(!IsClkValid(reset)) AliWarning(Form("Reset Win1 of board %d is not valid : %d",board,reset));
+    if(!IsClkValid(reset)) AliWarningF("Reset Win1 of board %d is not valid : %d",board,reset);
   }else {
-    AliError(Form("Impossible to Write at Board %d",board));
+    AliErrorF("Impossible to Write at Board %d",board);
   }
 }
 //________________________________________________________________
@@ -1109,9 +1111,9 @@ void AliADCalibData::SetResetWin2(UShort_t reset, Int_t board)
   // Set Reset Win clock for BG
   if((board>=0) && (board<kNCIUBoards)) {
     fResetWin2[board] = reset;
-    if(!IsClkValid(reset)) AliWarning(Form("Reset Win2 of board %d is not valid : %d",board,reset));
+    if(!IsClkValid(reset)) AliWarningF("Reset Win2 of board %d is not valid : %d",board,reset);
   }else {
-    AliError(Form("Impossible to Write at Board %d",board));
+    AliErrorF("Impossible to Write at Board %d",board);
   }
 }
 //________________________________________________________________
@@ -1119,14 +1121,14 @@ void AliADCalibData::SetPedestalSubtraction(Bool_t *peds){
   // Set Pedestal Subtraction Parameter
   if(peds)  for(int t=0; t<kNCIUBoards; t++) SetPedestalSubtraction(peds[t],t);
   else AliError("Pedestal Subtraction Not defined.");
-	
+
 }
 //________________________________________________________________
 void AliADCalibData::SetPedestalSubtraction(Bool_t ped, Int_t board)
 {
   // Set Pedestal Subtraction Parameter
   if((board>=0) && (board<kNCIUBoards)) fPedestalSubtraction[board] = ped;
-  else AliError(Form("Board %d is not valid",board));
+  else AliErrorF("Board %d is not valid",board);
 }
 
 //________________________________________________________________
@@ -1137,11 +1139,11 @@ Bool_t	AliADCalibData::IsClkValid(UShort_t clock) const {
   Short_t risingEdge = 0;
   Short_t fallingEdge = 0;
   for(int i=0 ; i<5 ; i++) word[i] = (clock >> i) & 0x1;
-	
+
   if(word[0] != word[4]){
     if(word[4]) fallingEdge++;
     else risingEdge++;
-  }	
+  }
   for(int i=1 ; i<5 ; i++){
     if(word[i] != word[i-1]) {
       if(word[i-1]) fallingEdge++;
@@ -1160,11 +1162,11 @@ Int_t AliADCalibData::GetOfflineChannelNumber(Int_t board, Int_t channel)
   // the FEE board and channel indexes
 
   if (board < 0 || board >= 2) {
-    AliErrorClass(Form("Wrong FEE board number: %d",board));
+    AliErrorClassF("Wrong FEE board number: %d",board);
     return -1;
   }
   if (channel < 0 || channel >= 8) {
-    AliErrorClass(Form("Wrong FEE channel number: %d",channel));
+    AliErrorClassF("Wrong FEE channel number: %d",channel);
     return -1;
   }
 
@@ -1179,7 +1181,7 @@ Int_t AliADCalibData::GetFEEChannelNumber(Int_t channel)
   // from offline channel index
   if (channel >= 0 && channel < 16) return ((kOnlineChannel[channel] % 8));
 
-  AliErrorClass(Form("Wrong channel index: %d",channel));
+  AliErrorClassF("Wrong channel index: %d",channel);
   return -1;
 }
 //________________________________________________________________
@@ -1191,19 +1193,19 @@ Int_t AliADCalibData::GetBoardNumber(Int_t channel)
   if (OnChannel >= 0 && OnChannel < 8) return (0);
   if (OnChannel >= 8 && OnChannel < 16) return (1);
 
-  AliErrorClass(Form("Wrong channel index: %d",channel));
+  AliErrorClassF("Wrong channel index: %d",channel);
   return -1;
 }
 //________________________________________________________________
 void AliADCalibData::PrintConfig()
 {
 
-  printf("\n");  
+  printf("\n");
   printf("======================================================\n");
   printf("=======================CCIU config====================\n");
   printf("======================================================\n");
-  printf("\n"); 
- 
+  printf("\n");
+
   printf("Selected triggers = ");
   for(Int_t i = 0; i<5 ; i++) printf("%d ",GetTriggerSelected(i));
   printf("\n");
@@ -1212,13 +1214,13 @@ void AliADCalibData::PrintConfig()
   printf("BGA thr = %d, BGC thr = %d\n",GetBGAThreshold(),GetBGCThreshold());
   printf("BBAforBG thr = %d, BBCforBG thr = %d\n",GetBBAForBGThreshold(),GetBBCForBGThreshold());
 
-  
-  printf("\n"); 
+
+  printf("\n");
   printf("======================================================\n");
   printf("=======================CIUs config====================\n");
   printf("======================================================\n");
   printf("\n");
- 
+
   for(Int_t CIUNumber = 0; CIUNumber < 2; ++CIUNumber) {
     printf("CIU= %d, Time Res= %f, Width Res= %f, RollOver= %d, TrigCountOffset= %d, SearchWin= %d, MatchWin= %d\n",
 	   CIUNumber,
@@ -1228,12 +1230,10 @@ void AliADCalibData::PrintConfig()
 	   GetTriggerCountOffset(CIUNumber),
 	   GetSearchWindow(CIUNumber),
 	   GetMatchWindow(CIUNumber));
-	   
-	  
   }
 
   printf("\n");
-  printf("=======================Trigger windows================\n"); 
+  printf("=======================Trigger windows================\n");
   printf("\n");
   Bool_t gatesOpen = kTRUE;
   for (Int_t CIUNumber = 0; CIUNumber < 2; ++CIUNumber) {
@@ -1250,13 +1250,13 @@ void AliADCalibData::PrintConfig()
       std::cout << "BB Delay1 = " <<GetDelayClk1Win1(CIUNumber)<< "  BG Delay1 = " <<GetDelayClk1Win2(CIUNumber)<<std::endl;
       std::cout << "BB Delay2 = " <<GetDelayClk2Win1(CIUNumber)<< "  BG Delay2 = " <<GetDelayClk2Win2(CIUNumber)<<std::endl;
       printf("\n");
-  
+
       AliADLogicalSignal clk1BB(GetClk1Win1(CIUNumber),GetDelayClk1Win1(CIUNumber),GetLatchWin1(CIUNumber),GetResetWin1(CIUNumber));
       AliADLogicalSignal clk2BB(GetClk2Win1(CIUNumber),GetDelayClk2Win1(CIUNumber),GetLatchWin1(CIUNumber),GetResetWin1(CIUNumber));
       AliADLogicalSignal *fBBGate = new AliADLogicalSignal(clk1BB & clk2BB);
-	
+
       std::cout<<"BB window = ["<<fBBGate->GetStartTime()<<" , "<<fBBGate->GetStopTime()<<"]"<<std::endl;
-	
+
       AliADLogicalSignal clk1BG(GetClk1Win2(CIUNumber),GetDelayClk1Win2(CIUNumber),GetLatchWin2(CIUNumber),GetResetWin2(CIUNumber));
       clk1BG.SetStartTime(clk1BG.GetStartTime()+2);
       clk1BG.SetStopTime(clk1BG.GetStopTime()+2);
@@ -1264,19 +1264,19 @@ void AliADCalibData::PrintConfig()
       clk2BG.SetStartTime(clk2BG.GetStartTime()-2);
       clk2BG.SetStopTime(clk2BG.GetStopTime()-2);
       AliADLogicalSignal *fBGGate = new AliADLogicalSignal(clk1BG & clk2BG);
-	
+
       std::cout<<"BG window = ["<<fBGGate->GetStartTime()<<" , "<<fBGGate->GetStopTime()<<"]"<<std::endl;
-      printf("\n");	  
+      printf("\n");
     }
   }
   else printf("Test window 25ns\n");
 
-  printf("\n");  
+  printf("\n");
   printf("======================================================\n");
   printf("====================Channels config===================\n");
   printf("======================================================\n");
-  printf("\n"); 
- 
+  printf("\n");
+
   for(Int_t pmNumber = 0; pmNumber < 16; ++pmNumber) {
     printf("ChOff = %d, ChOn = %d, HV = %.1f, MIP = %.1f ADC, Dead = %s, DelayHit = %.2f, Thr_DCS = %.1f, Thr_Calib = %.1f\n",
 	   pmNumber,
@@ -1289,7 +1289,7 @@ void AliADCalibData::PrintConfig()
 	   GetCalibDiscriThr(pmNumber)
 	   );
   }
-  
+
   printf("\n");
   printf("======================================================\n");
   printf("======================= Pedestal =====================\n");
@@ -1299,24 +1299,20 @@ void AliADCalibData::PrintConfig()
   for(Int_t pmNumber = 0; pmNumber < 16; ++pmNumber) {
     for(Int_t integrator = 0; integrator < 2; ++integrator){
       if(integrator == 0)printf("ChOff = %d, ChOn = %d, Int = %d, Pedestal = %.3f, Width = %3f,", pmNumber, kOnlineChannel[pmNumber],integrator, GetPedestal(pmNumber+16*integrator),GetSigma(pmNumber+16*integrator));
-      else printf(" Int = %d, Pedestal = %.3f, Width = %3f\n", integrator, GetPedestal(pmNumber+16*integrator),GetSigma(pmNumber+16*integrator));	
+      else printf(" Int = %d, Pedestal = %.3f, Width = %3f\n", integrator, GetPedestal(pmNumber+16*integrator),GetSigma(pmNumber+16*integrator));
     }
   }
-
-
-
 }
 
 //________________________________________________________________
 void AliADCalibData::PrintConfigShuttle()
 {
-
-  printf("\n");  
+  printf("\n");
   printf("======================================================\n");
   printf("=======================CCIU config====================\n");
   printf("======================================================\n");
-  printf("\n"); 
- 
+  printf("\n");
+
   printf("Selected triggers = ");
   for(Int_t i = 0; i<5 ; i++) printf("%d ",GetTriggerSelected(i));
   printf("\n");
@@ -1325,13 +1321,12 @@ void AliADCalibData::PrintConfigShuttle()
   printf("BGA thr = %d, BGC thr = %d\n",GetBGAThreshold(),GetBGCThreshold());
   printf("BBAforBG thr = %d, BBCforBG thr = %d\n",GetBBAForBGThreshold(),GetBBCForBGThreshold());
 
-  
-  printf("\n"); 
+  printf("\n");
   printf("======================================================\n");
   printf("=======================CIUs config====================\n");
   printf("======================================================\n");
   printf("\n");
- 
+
   for(Int_t CIUNumber = 0; CIUNumber < 2; ++CIUNumber) {
     printf("CIU= %d, Time Res= %f, Width Res= %f, RollOver= %d, TrigCountOffset= %d, SearchWin= %d, MatchWin= %d\n",
 	   CIUNumber,
@@ -1341,12 +1336,12 @@ void AliADCalibData::PrintConfigShuttle()
 	   GetTriggerCountOffset(CIUNumber),
 	   GetSearchWindow(CIUNumber),
 	   GetMatchWindow(CIUNumber));
-	   
-	  
+
+
   }
 
   printf("\n");
-  printf("=======================Trigger windows================\n"); 
+  printf("=======================Trigger windows================\n");
   printf("\n");
   Bool_t gatesOpen = kTRUE;
   for (Int_t CIUNumber = 0; CIUNumber < 2; ++CIUNumber) {
@@ -1361,17 +1356,17 @@ void AliADCalibData::PrintConfigShuttle()
       std::cout << "  R   " << std::bitset<5>(GetResetWin1(CIUNumber))<< "     R   " << std::bitset<5>(GetResetWin2(CIUNumber))<< std::endl;
       printf("\n");
       std::cout << "BB Delay1 = " <<GetDelayClk1Win1(CIUNumber)<< "  BG Delay1 = " <<GetDelayClk1Win2(CIUNumber)<<std::endl;
-      std::cout << "BB Delay2 = " <<GetDelayClk2Win1(CIUNumber)<< "  BG Delay2 = " <<GetDelayClk2Win2(CIUNumber)<<std::endl;  
+      std::cout << "BB Delay2 = " <<GetDelayClk2Win1(CIUNumber)<< "  BG Delay2 = " <<GetDelayClk2Win2(CIUNumber)<<std::endl;
     }
   }
   else printf("Test window 25ns\n");
 
-  printf("\n");  
+  printf("\n");
   printf("======================================================\n");
   printf("====================Channels config===================\n");
   printf("======================================================\n");
-  printf("\n"); 
- 
+  printf("\n");
+
   for(Int_t pmNumber = 0; pmNumber < 16; ++pmNumber) {
     printf("ChOff = %d, ChOn = %d, HV = %.1f, Dead = %s, DelayHit = %.2f, Thr_DCS = %.1f\n",
 	   pmNumber,
@@ -1382,7 +1377,7 @@ void AliADCalibData::PrintConfigShuttle()
 	   GetDiscriThr(pmNumber)
 	   );
   }
-  
+
   printf("\n");
   printf("======================================================\n");
   printf("======================= Pedestal =====================\n");
@@ -1392,8 +1387,7 @@ void AliADCalibData::PrintConfigShuttle()
   for(Int_t pmNumber = 0; pmNumber < 16; ++pmNumber) {
     for(Int_t integrator = 0; integrator < 2; ++integrator){
       if(integrator == 0)printf("ChOff = %d, ChOn = %d, Int = %d, Pedestal = %.3f, Width = %3f,", pmNumber, kOnlineChannel[pmNumber],integrator, GetPedestal(pmNumber+16*integrator),GetSigma(pmNumber+16*integrator));
-      else printf(" Int = %d, Pedestal = %.3f, Width = %3f\n", integrator, GetPedestal(pmNumber+16*integrator),GetSigma(pmNumber+16*integrator));	
+      else printf(" Int = %d, Pedestal = %.3f, Width = %3f\n", integrator, GetPedestal(pmNumber+16*integrator),GetSigma(pmNumber+16*integrator));
     }
   }
-
 }

--- a/AD/ADbase/AliADCalibData.h
+++ b/AD/ADbase/AliADCalibData.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 #ifndef ALIADCALIBDATA_H
 #define ALIADCALIBDATA_H
 
@@ -10,12 +11,12 @@
 class AliADDataDCS;
 
 
-class AliADCalibData: public TNamed {
+class AliADCalibData : public TNamed {
 
- public:
+public:
   AliADCalibData();
   AliADCalibData(const char* name);
-  
+
   AliADCalibData(const AliADCalibData &calibda);
   AliADCalibData& operator= (const AliADCalibData &calibda);
   virtual ~AliADCalibData();
@@ -33,12 +34,12 @@ class AliADCalibData: public TNamed {
   Float_t  GetADCsigma(Int_t channel)	const {return fADCsigma[channel];}
   Float_t* GetADCsigma()   const {return (float*)fADCsigma;}
   Float_t  GetMeanHV(Int_t channel)	const {return fMeanHV[channel];}
-  Float_t* GetMeanHV()   const {return (float*)fMeanHV;} 
+  Float_t* GetMeanHV()   const {return (float*)fMeanHV;}
   Float_t  GetWidthHV(Int_t channel)	const {return fWidthHV[channel];}
   Float_t* GetWidthHV()   const {return (float*)fWidthHV;}
   Bool_t   IsChannelDead(Int_t channel)	const {return fDeadChannel[channel];}
-  Bool_t*  GetDeadMap()   const {return (bool*)fDeadChannel;} 
-   
+  Bool_t*  GetDeadMap()   const {return (bool*)fDeadChannel;}
+
   Float_t  GetGain(Int_t channel);
   Float_t  GetADCperMIP(Int_t channel);
   Float_t  GetTimeOffset(Int_t channel)	const {return fTimeOffset[channel];}
@@ -64,7 +65,7 @@ class AliADCalibData: public TNamed {
   Float_t  GetDiscriThr(Int_t channel)	const {return fDiscriThr[channel];}
   Float_t* GetDiscriThr()   const {return (Float_t*)fDiscriThr;}
   Float_t  GetCalibDiscriThr(Int_t channel);
-  
+
   UShort_t * GetClk1Win1() const {return (UShort_t*)fClk1Win1;};
   UShort_t GetClk1Win1(Int_t board ) const {return ((board>=0 && board<kNCIUBoards)?fClk1Win1[board]:0);};
   UShort_t * GetClk2Win1() const {return (UShort_t*)fClk2Win1;};
@@ -79,22 +80,22 @@ class AliADCalibData: public TNamed {
   UShort_t GetDelayClk1Win1(Int_t board ) const {return ((board>=0 && board<kNCIUBoards)?fDelayClk1Win1[board]:0);};
   UShort_t * GetDelayClk2Win1() const {return (UShort_t*)fDelayClk2Win1;};
   UShort_t GetDelayClk2Win1(Int_t board ) const {return ((board>=0 && board<kNCIUBoards)?fDelayClk2Win1[board]:0);};
-  
+
   UShort_t * GetDelayClk1Win2() const {return (UShort_t*)fDelayClk1Win2;};
   UShort_t GetDelayClk1Win2(Int_t board ) const {return ((board>=0 && board<kNCIUBoards)?fDelayClk1Win2[board]:0);};
   UShort_t * GetDelayClk2Win2() const {return (UShort_t*)fDelayClk2Win2;};
   UShort_t GetDelayClk2Win2(Int_t board ) const {return ((board>=0 && board<kNCIUBoards)?fDelayClk2Win2[board]:0);};
-  
+
   UShort_t * GetLatchWin1() const {return (UShort_t*)fLatchWin1;};
   UShort_t GetLatchWin1(Int_t board ) const  {return ((board>=0 && board<kNCIUBoards)?fLatchWin1[board]:0);};
   UShort_t * GetLatchWin2() const {return (UShort_t*)fLatchWin2;};
   UShort_t GetLatchWin2(Int_t board ) const  {return ((board>=0 && board<kNCIUBoards)?fLatchWin2[board]:0);};
-  
+
   UShort_t * GetResetWin1() const {return (UShort_t*)fResetWin1;};
   UShort_t GetResetWin1(Int_t board ) const  {return ((board>=0 && board<kNCIUBoards)?fResetWin1[board]:0);};
   UShort_t * GetResetWin2() const {return (UShort_t*)fResetWin2;};
   UShort_t GetResetWin2(Int_t board ) const  {return ((board>=0 && board<kNCIUBoards)?fResetWin2[board]:0);};
-  
+
   Bool_t * GetPedestalSubtraction() const {return (Bool_t*) fPedestalSubtraction;};
   Bool_t GetPedestalSubtraction(Int_t board ) const  {return ((board>=0 && board<kNCIUBoards)?fPedestalSubtraction[board]:0);};
 
@@ -106,7 +107,7 @@ class AliADCalibData: public TNamed {
 
   UShort_t GetBBAForBGThreshold() const {return fBBAForBGThreshold;};
   UShort_t GetBBCForBGThreshold() const {return fBBCForBGThreshold;};
-  
+
   UShort_t GetMultADAThrLow() const {return fMultADAThrLow;};
   UShort_t GetMultADAThrHigh() const {return fMultADAThrHigh;};
 
@@ -114,7 +115,7 @@ class AliADCalibData: public TNamed {
   UShort_t GetMultADCThrHigh() const {return fMultADCThrHigh;};
 
   UShort_t GetTriggerSelected(Int_t output) const {return ((output>=0 && output<5)?fTriggerSelected[output]:0);};
-  
+
   Bool_t GetEnableCharge(Int_t channel) const;
   Bool_t GetEnableTiming(Int_t channel) const;
   UShort_t GetOnlinePedestal(Int_t integrator, Int_t channel) const;
@@ -124,7 +125,7 @@ class AliADCalibData: public TNamed {
   static Int_t GetBoardNumber(Int_t channel);
   static Int_t GetFEEChannelNumber(Int_t channel);
   static Int_t GetOfflineChannelNumber(Int_t board, Int_t channel);
-  
+
   Float_t  GetLightYields(Int_t channel);
 
   Float_t *GetPMGainsA() const { return fPMGainsA; }
@@ -135,21 +136,21 @@ class AliADCalibData: public TNamed {
   void     SetSigma(Float_t val, Int_t channel) {fSigma[channel]=val;}
   void     SetSigma(const Float_t* Sigma);
   void 	   SetADCmean(Float_t val, Int_t channel) {fADCmean[channel]=val;}
-  void 	   SetADCmean(const Float_t* ADCmean);  
+  void 	   SetADCmean(const Float_t* ADCmean);
   void 	   SetADCsigma(Float_t val, Int_t channel) {fADCsigma[channel]=val;}
   void 	   SetADCsigma(const Float_t* ADCsigma);
   void     SetMeanHV(Float_t val, Int_t channel) {fMeanHV[channel]=val;}
-  void     SetMeanHV(const Float_t* MeanHV);  
+  void     SetMeanHV(const Float_t* MeanHV);
   void     SetWidthHV(Float_t val, Int_t channel) {fWidthHV[channel]=val;}
-  void     SetWidthHV(const Float_t* WidthHV); 
+  void     SetWidthHV(const Float_t* WidthHV);
   void     SetDeadChannel(Bool_t val, Int_t channel) {fDeadChannel[channel]=val;}
-  void     SetDeadMap(const Bool_t* deadMap);  
-   
+  void     SetDeadMap(const Bool_t* deadMap);
+
   void     SetTimeOffset(Float_t val, Int_t board, Int_t channel);
   void     SetTimeOffset(const Float_t* TimeOffset);
   void     SetTimeGain(Float_t val, Int_t channel) {fTimeGain[channel]=val;}
   void     SetTimeGain(const Float_t* TimeGain);
-  
+
   void 	   SetParameter(TString name, Int_t val);
   void     SetTimeResolution(UShort_t *resols);
   void     SetTimeResolution(UShort_t resol, Int_t board);
@@ -167,42 +168,42 @@ class AliADCalibData: public TNamed {
 
   void     SetDiscriThr(Float_t thr, Int_t board, Int_t channel);
   void     SetDiscriThr(const Float_t* thresholds);
-  
+
   void	   SetADCperMIP(Int_t nADCperMIP);
 
   void SetClk1Win1(UShort_t* clks);
   void SetClk1Win1(UShort_t clk, Int_t board);
   void SetClk2Win1(UShort_t* clks);
   void SetClk2Win1(UShort_t clk, Int_t board);
-  
+
   void SetClk1Win2(UShort_t* clks);
   void SetClk1Win2(UShort_t clk, Int_t board);
   void SetClk2Win2(UShort_t* clks);
   void SetClk2Win2(UShort_t clk, Int_t board);
-  
+
   void SetDelayClk1Win1(UShort_t* delays);
   void SetDelayClk1Win1(UShort_t delay, Int_t board);
   void SetDelayClk2Win1(UShort_t* delays);
   void SetDelayClk2Win1(UShort_t delay, Int_t board);
-  
+
   void SetDelayClk1Win2(UShort_t* delays);
   void SetDelayClk1Win2(UShort_t delay, Int_t board);
   void SetDelayClk2Win2(UShort_t* delays);
   void SetDelayClk2Win2(UShort_t delay, Int_t board);
-  
+
   void SetLatchWin1(UShort_t *latchs);
   void SetLatchWin1(UShort_t latch, Int_t board);
   void SetLatchWin2(UShort_t *latchs);
   void SetLatchWin2(UShort_t latch, Int_t board);
-  
+
   void SetResetWin1(UShort_t *resets);
   void SetResetWin1(UShort_t reset, Int_t board);
   void SetResetWin2(UShort_t *resets);
   void SetResetWin2(UShort_t reset, Int_t board);
-  
+
   void SetPedestalSubtraction(Bool_t *peds);
   void SetPedestalSubtraction(Bool_t ped, Int_t board);
-  
+
   void SetBBAThreshold(UShort_t th) {fBBAThreshold = th;};
   void SetBBCThreshold(UShort_t th) {fBBCThreshold = th;};
 
@@ -211,16 +212,16 @@ class AliADCalibData: public TNamed {
 
   void SetBBAForBGThreshold(UShort_t th) {fBBAForBGThreshold = th;};
   void SetBBCForBGThreshold(UShort_t th) {fBBCForBGThreshold = th;};
-  
-  
+
+
   void SetMultADAThrLow(UShort_t th) {fMultADAThrLow = th;};
   void SetMultADAThrHigh(UShort_t th) {fMultADAThrHigh = th;};
-  
+
   void SetMultADCThrLow(UShort_t th) {fMultADCThrLow = th;};
   void SetMultADCThrHigh(UShort_t th) {fMultADCThrHigh = th;};
-  
+
   void SetTriggerSelected(UShort_t trigger, Int_t output);
-  
+
   void SetEnableCharge(Bool_t val, Int_t board, Int_t channel);
   void SetEnableTiming(Bool_t val, Int_t board, Int_t channel);
   void SetEnableCharge(Bool_t val, Int_t channel);
@@ -230,7 +231,7 @@ class AliADCalibData: public TNamed {
   void SetOnlinePedestal(UShort_t val, Int_t integrator, Int_t channel);
   void SetOnlinePedestalCut(UShort_t val, Int_t integrator, Int_t channel);
 
- protected:
+protected:
   void     InitLightYields();
   void     InitPMGains();
   void     InitCalibThresholds();
@@ -242,7 +243,7 @@ class AliADCalibData: public TNamed {
   Float_t  fADCsigma[32];     // ADC sigma values
   Float_t  fMeanHV[16];        // Mean PMT HV needed to compute MIP value
   Float_t  fWidthHV[16];       // Width of the PMT HV
-  
+
   Float_t  fTimeOffset[16];    // Time offsets of the TDC
   Float_t  fTimeGain[16];      // Gain factors of the TDC
   Bool_t   fDeadChannel[16];   // List of dead channels
@@ -253,7 +254,7 @@ class AliADCalibData: public TNamed {
   UInt_t   fSearchWindow[kNCIUBoards];// HPTDC search window (25ns units)
   UInt_t   fTriggerCountOffset[kNCIUBoards]; // HPTDC trigger count offset (25ns units)
   UInt_t   fRollOver[kNCIUBoards]; // HPTDC roll-over (25ns units)
-  
+
   UShort_t fClk1Win1[kNCIUBoards]; //Profil of the Clock 1  of the Window 1 (BB window)
   UShort_t fClk2Win1[kNCIUBoards]; //Profil of the Clock 2  of the Window 1 (BB window)
   UShort_t fClk1Win2[kNCIUBoards]; //Profil of the Clock 1  of the Window 2 (BG window)
@@ -297,4 +298,3 @@ class AliADCalibData: public TNamed {
 };
 
 #endif
-

--- a/AD/ADbase/AliADConst.h
+++ b/AD/ADbase/AliADConst.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 #ifndef ALIADCONST_H
 #define ALIADCONST_H
 
@@ -17,11 +18,10 @@ const Float_t kADPMTransparency = 0.25; // Transparency of the first dynode of t
 const Float_t kADPMNbOfSecElec = 6.0;   // Number of secondary electrons emitted from first dynode (per ph.e.)
 const Float_t kPhotoCathodeEfficiency = 0.18; // Photocathode efficiency
 const Int_t   kNCIUBoards = 2; //Number of CIU boards
-/*				    |------------Cside------------|----------Aside-------|   */	
+/*				    |------------Cside------------|----------Aside-------|   */
 const Int_t   kOfflineChannel[16] = {15, 11, 14, 10, 13, 9, 12, 8, 7, 3, 6, 2, 5, 1, 4, 0};
 /*	      Online->Offline								     */
 const Int_t   kOnlineChannel[16] =  {15, 13, 11, 9, 14, 12, 10, 8, 7, 5, 3, 1, 6, 4, 2, 0};
 /*	      Offline->Online								     */
 
 #endif
-

--- a/AD/ADbase/AliADDataDCS.cxx
+++ b/AD/ADbase/AliADDataDCS.cxx
@@ -36,78 +36,77 @@ class TDatime;
 // AliADDataDCS class
 // main aim to introduce the aliases for the AD DCS
 // data points to be then
-// stored in the OCDB, and to process them. 
+// stored in the OCDB, and to process them.
 // ProcessData() method called by ADPreprocessor
 
-ClassImp(AliADDataDCS)
+ClassImp(AliADDataDCS);
 
 //_____________________________________________________________________________
-AliADDataDCS::AliADDataDCS():
-	TObject(),
-	fRun(0),
-	fStartTime(0),
-	fEndTime(0),
-	fDaqStartTime(0),
-	fDaqEndTime(0),
-	fCtpStartTime(0),
-	fCtpEndTime(0),
-        fGraphs(NULL),
-	fFEEParameters(NULL),
-	fIsProcessed(kFALSE)
-
+AliADDataDCS::AliADDataDCS()
+  : TObject()
+  , fRun(0)
+  , fStartTime(0)
+  , fEndTime(0)
+  , fDaqStartTime(0)
+  , fDaqEndTime(0)
+  , fCtpStartTime(0)
+  , fCtpEndTime(0)
+  , fGraphs(NULL)
+  , fFEEParameters(NULL)
+  , fIsProcessed(kFALSE)
 {
   // Default constructor
-	for(int i=0;i<kNHvChannel;i++) {
-		fDeadChannel[i] = kFALSE;
-		fMeanHV[i]      = 100.0;
-		fWidthHV[i]     = 0.0; 
-		fHv[i]          = NULL;
-	}
+  for(int i=0;i<kNHvChannel;i++) {
+    fDeadChannel[i] = kFALSE;
+    fMeanHV[i]      = 100.0;
+    fWidthHV[i]     = 0.0;
+    fHv[i]          = NULL;
+  }
 }
 
 //_____________________________________________________________________________
-AliADDataDCS::AliADDataDCS(Int_t nRun, UInt_t startTime, UInt_t endTime, UInt_t daqStartTime, UInt_t daqEndTime, UInt_t ctpStartTime, UInt_t ctpEndTime):
-	TObject(),
-	fRun(nRun),
-	fStartTime(startTime),
-	fEndTime(endTime),
-	fDaqStartTime(daqStartTime),
-	fDaqEndTime(daqEndTime),
-	fCtpStartTime(ctpStartTime),
-	fCtpEndTime(ctpEndTime),
-	fGraphs(new TClonesArray("TGraph",kNGraphs)),
-	fFEEParameters(new TMap()),
-	fIsProcessed(kFALSE)
-
+AliADDataDCS::AliADDataDCS(Int_t nRun, UInt_t startTime, UInt_t endTime, UInt_t daqStartTime, UInt_t daqEndTime, UInt_t ctpStartTime, UInt_t ctpEndTime)
+  : TObject()
+  , fRun(nRun)
+  , fStartTime(startTime)
+  , fEndTime(endTime)
+  , fDaqStartTime(daqStartTime)
+  , fDaqEndTime(daqEndTime)
+  , fCtpStartTime(ctpStartTime)
+  , fCtpEndTime(ctpEndTime)
+  , fGraphs(new TClonesArray("TGraph",kNGraphs))
+  , fFEEParameters(new TMap())
+  , fIsProcessed(kFALSE)
 {
-
   // constructor with arguments
-  	for(int i=0;i<kNHvChannel;i++) {
-	 fDeadChannel[i] = kFALSE;        
-	 fMeanHV[i]      = 100.0;
-     fWidthHV[i]     = 0.0; 
-	}
-	AliInfo(Form("\n\tRun %d \n\tTime Created %s \n\tTime Completed %s \n\tDAQ start %s \n\tDAQ end %s \n\tCTP start %s \n\tCTP end %s   ", nRun,
-		TTimeStamp(startTime).AsString(),
-		TTimeStamp(endTime).AsString(),
-		TTimeStamp(daqStartTime).AsString(),
-		TTimeStamp(daqEndTime).AsString(),
-		TTimeStamp(ctpStartTime).AsString(),
-		TTimeStamp(ctpEndTime).AsString()
-		));
-	
-	fFEEParameters->SetOwnerValue();
-	Init();
+  for(int i=0;i<kNHvChannel;i++) {
+    fDeadChannel[i] = kFALSE;
+    fMeanHV[i]      = 100.0;
+    fWidthHV[i]     = 0.0;
+  }
+  AliInfoF("\n\tRun %d \n\tTime Created %s \n\tTime Completed %s \n\tDAQ start %s \n\tDAQ end %s \n\tCTP start %s \n\tCTP end %s   ", nRun,
+	       TTimeStamp(startTime).AsString(),
+	       TTimeStamp(endTime).AsString(),
+	       TTimeStamp(daqStartTime).AsString(),
+	       TTimeStamp(daqEndTime).AsString(),
+	       TTimeStamp(ctpStartTime).AsString(),
+	       TTimeStamp(ctpEndTime).AsString()
+	       );
 
+  fFEEParameters->SetOwnerValue();
+  Init();
 }
 
 //_____________________________________________________________________________
 AliADDataDCS::~AliADDataDCS() {
-
-  // destructor
-  fGraphs->Clear("C");
-  delete fFEEParameters;
-
+  if (fGraphs) {
+    fGraphs->Clear("C");
+    delete fGraphs;
+  }
+  fGraphs = NULL;
+  if (fFEEParameters)
+    delete fFEEParameters;
+  fFEEParameters = NULL;
 }
 
 //_____________________________________________________________________________
@@ -123,80 +122,81 @@ Bool_t AliADDataDCS::ProcessData(TMap& aliasMap){
 
   // starting loop on aliases
   for(int iAlias=0; iAlias<kNAliases; iAlias++){
-
     aliasArr = (TObjArray*) aliasMap.GetValue(fAliasNames[iAlias].Data());
     if(!aliasArr){
-      AliError(Form("Missing data points for alias %s!", fAliasNames[iAlias].Data()));
+      AliErrorF("Missing data points for alias %s!", fAliasNames[iAlias].Data());
       success = kFALSE;
       continue;
     }
 
     //Introduce(iAlias, aliasArr);
-    
+
     if(aliasArr->GetEntries()<2){
-      AliWarning(Form("Alias %s has just %d data points!",
-		    fAliasNames[iAlias].Data(),aliasArr->GetEntries()));
+      AliWarningF("Alias %s has just %d data points!",
+		      fAliasNames[iAlias].Data(),aliasArr->GetEntries());
     }
-    
+
     TIter iterarray(aliasArr);
-	
+
     if(iAlias<kNHvChannel){ // Treating HV values
-    	Int_t nentries = aliasArr->GetEntries();
+      Int_t nentries = aliasArr->GetEntries();
 
-    	Double_t *times = new Double_t[nentries];
-    	Double_t *values = new Double_t[nentries];
+      Double_t *times = new Double_t[nentries];
+      Double_t *values = new Double_t[nentries];
 
-    	UInt_t iValue=0;
-    	Float_t variation = 0.0;
+      UInt_t iValue=0;
+      Float_t variation = 0.0;
 
-    	while((aValue = (AliDCSValue*) iterarray.Next())) {
-			UInt_t currentTime = aValue->GetTimeStamp();
-			if(currentTime>fCtpEndTime) break;
+      while((aValue = (AliDCSValue*) iterarray.Next())) {
+	UInt_t currentTime = aValue->GetTimeStamp();
+	if(currentTime>fCtpEndTime) break;
 
-   			values[iValue] = aValue->GetFloat();
-   			times[iValue] = (Double_t) (currentTime);
-			
-			if(iValue>0) {
-				if(values[iValue-1]>0.) variation = TMath::Abs(values[iValue]-values[iValue-1])/values[iValue-1];
-				if(variation > 0.05) fDeadChannel[iAlias] = kTRUE;
-				}
-			fHv[iAlias]->Fill(values[iValue]);
-   			iValue++;
-    			}      
-    	CreateGraph(iAlias, iValue, times, values); // fill graphs 
+	values[iValue] = aValue->GetFloat();
+	times[iValue] = (Double_t) (currentTime);
 
-  	// calculate mean and rms of the first two histos
-	Int_t iChannel	   = iAlias;	
-	fMeanHV[iAlias]  = fHv[iAlias]->GetMean();
-	fWidthHV[iAlias] = fHv[iAlias]->GetRMS();
-
-    	delete[] values;
-    	delete[] times;	
+	if(iValue>0) {
+	  if(values[iValue-1]>0.) variation = TMath::Abs(values[iValue]-values[iValue-1])/values[iValue-1];
+	  if(variation > 0.05) fDeadChannel[iAlias] = kTRUE;
 	}
-      else if(iAlias >= kNHvChannel && iAlias<2*kNHvChannel){
-        Int_t nentries = aliasArr->GetEntries();
+	fHv[iAlias]->Fill(values[iValue]);
+	iValue++;
+      }
+      CreateGraph(iAlias, iValue, times, values); // fill graphs
 
-    	Double_t *times = new Double_t[nentries];
-    	Double_t *values = new Double_t[nentries];
-	UInt_t iValue=0;
-	
-	while((aValue = (AliDCSValue*) iterarray.Next())) {
-	               UInt_t currentTime = aValue->GetTimeStamp();
-	               if(currentTime>fCtpEndTime) break;
+      // calculate mean and rms of the first two histos
+      // Int_t iChannel	   = iAlias;  not used
+      fMeanHV[iAlias]  = fHv[iAlias]->GetMean();
+      fWidthHV[iAlias] = fHv[iAlias]->GetRMS();
 
-   	               values[iValue] = aValue->GetFloat();
-   	               times[iValue] = (Double_t) (currentTime);
-		       iValue++;
-	               }
-	CreateGraph(iAlias, iValue, times, values); // fill graphs
-        } 
-      else { // Treating FEE Parameters
-		AliDCSValue * lastVal = NULL;
-		while((aValue = (AliDCSValue*) iterarray.Next())) lastVal = aValue; // Take only the last value
-		fFEEParameters->Add(new TObjString(fAliasNames[iAlias].Data()),lastVal);
-	}      
+      delete [] values;
+      delete [] times;
+    }
+    else if(iAlias >= kNHvChannel && iAlias<2*kNHvChannel){
+      Int_t nentries = aliasArr->GetEntries();
+
+      Double_t *times = new Double_t[nentries];
+      Double_t *values = new Double_t[nentries];
+      UInt_t iValue=0;
+
+      while((aValue = (AliDCSValue*) iterarray.Next())) {
+        UInt_t currentTime = aValue->GetTimeStamp();
+        if(currentTime>fCtpEndTime) break;
+
+        values[iValue] = aValue->GetFloat();
+        times[iValue] = (Double_t) (currentTime);
+        iValue++;
+      }
+      CreateGraph(iAlias, iValue, times, values); // fill graphs
+      delete [] times;
+      delete [] values;
+    }
+    else { // Treating FEE Parameters
+      AliDCSValue * lastVal = NULL;
+      while((aValue = (AliDCSValue*) iterarray.Next())) lastVal = aValue; // Take only the last value
+      fFEEParameters->Add(new TObjString(fAliasNames[iAlias].Data()),lastVal);
+    }
   }
-  
+
   fIsProcessed=kTRUE;
 
   return success;
@@ -204,24 +204,23 @@ Bool_t AliADDataDCS::ProcessData(TMap& aliasMap){
 
 //_____________________________________________________________________________
 void AliADDataDCS::Init(){
-
   // initialization of aliases and DCS data
 
   TString sindex;
   int iAlias = 0;
-  
+
   for(int iPM = 0; iPM<16 ; iPM++){
-  		fAliasNames[iAlias] = Form("AD0/HV/PM%d",iPM);
-			
-		fHv[iAlias] = new TH1F(fAliasNames[iAlias].Data(),fAliasNames[iAlias].Data(), 3000, kHvMin, kHvMax);
-		fHv[iAlias]->GetXaxis()->SetTitle("Hv");
-		iAlias++;
+    fAliasNames[iAlias] = Form("AD0/HV/PM%d",iPM);
+
+    fHv[iAlias] = new TH1F(fAliasNames[iAlias].Data(),fAliasNames[iAlias].Data(), 3000, kHvMin, kHvMax);
+    fHv[iAlias]->GetXaxis()->SetTitle("Hv");
+    iAlias++;
   }
-  
+
   for(int iPM = 0; iPM<16 ; iPM++) fAliasNames[iAlias++] = Form("AD0/HV/Imon%d",iPM);
-  
+
   // CCIU Parameters
-	
+
   fAliasNames[iAlias++] = "AD0/FEE/CCIU/BBAThreshold";
   fAliasNames[iAlias++] = "AD0/FEE/CCIU/BBCThreshold";
   fAliasNames[iAlias++] = "AD0/FEE/CCIU/BGAThreshold";
@@ -233,62 +232,62 @@ void AliADDataDCS::Init(){
   fAliasNames[iAlias++] = "AD0/FEE/CCIU/MultADCThrLow";
   fAliasNames[iAlias++] = "AD0/FEE/CCIU/MultADCThrHigh";
   for(int i=1;i<=5;i++) {
-    	fAliasNames[iAlias] = "AD0/FEE/CCIU/TriggerSelect";
-    	fAliasNames[iAlias++] += Form("%d",i);
+    fAliasNames[iAlias] = "AD0/FEE/CCIU/TriggerSelect";
+    fAliasNames[iAlias++] += Form("%d",i);
   }
   //Trigger parameters
   for(int iCIU = 0; iCIU<2 ; iCIU++){
-  		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/Clk1Win1",iCIU);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/Clk1Win2",iCIU);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/Clk2Win1",iCIU);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/Clk2Win2",iCIU);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/DelayClk1Win1",iCIU);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/DelayClk1Win2",iCIU);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/DelayClk2Win1",iCIU);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/DelayClk2Win2",iCIU);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/LatchWin1",iCIU);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/LatchWin2",iCIU);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/ResetWin1",iCIU);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/ResetWin2",iCIU);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/PedestalSubtraction",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/Clk1Win1",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/Clk1Win2",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/Clk2Win1",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/Clk2Win2",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/DelayClk1Win1",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/DelayClk1Win2",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/DelayClk2Win1",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/DelayClk2Win2",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/LatchWin1",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/LatchWin2",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/ResetWin1",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/ResetWin2",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/PedestalSubtraction",iCIU);
   }
   for(int iCIU = 0; iCIU<2 ; iCIU++){
-	  for(int iCh=1;iCh<=8;iCh++){
-	    	fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/EnableCharge%d",iCIU,iCh);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/EnableTiming%d",iCIU,iCh);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/PedEven%d",iCIU,iCh);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/PedOdd%d",iCIU,iCh);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/PedCutEven%d",iCIU,iCh);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/PedCutOdd%d",iCIU,iCh);
-	  }
+    for(int iCh=1;iCh<=8;iCh++){
+      fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/EnableCharge%d",iCIU,iCh);
+      fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/EnableTiming%d",iCIU,iCh);
+      fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/PedEven%d",iCIU,iCh);
+      fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/PedOdd%d",iCIU,iCh);
+      fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/PedCutEven%d",iCIU,iCh);
+      fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/PedCutOdd%d",iCIU,iCh);
+    }
   }
- // Time Resolution Parameters	
+  // Time Resolution Parameters
   for(int iCIU = 0; iCIU<2 ; iCIU++){
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/TimeResolution",iCIU);
-		fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/WidthResolution",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/TimeResolution",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/WidthResolution",iCIU);
   }
   // HPTDC parameters
   for(int iCIU = 0; iCIU<2 ; iCIU++){
-	  	fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/MatchWindow",iCIU);
-	  	fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/SearchWindow",iCIU);
-	  	fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/TriggerCountOffset",iCIU);
-	  	fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/RollOver",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/MatchWindow",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/SearchWindow",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/TriggerCountOffset",iCIU);
+    fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/RollOver",iCIU);
   }
 
   for(int iCIU = 0; iCIU<2 ; iCIU++){
-	  for(int iCh=1;iCh<=8;iCh++){
-	    	fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/DelayHit%d",iCIU,iCh);
-	  }
+    for(int iCh=1;iCh<=8;iCh++){
+      fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/DelayHit%d",iCIU,iCh);
+    }
   }
 
   for(int iCIU = 0; iCIU<2 ; iCIU++){
-	  for(int iCh=1;iCh<=8;iCh++){
-	    	fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/DiscriThr%d",iCIU,iCh);
-	  }
+    for(int iCh=1;iCh<=8;iCh++){
+      fAliasNames[iAlias++] = Form("AD0/FEE/CIU%d/DiscriThr%d",iCIU,iCh);
+    }
   }
 
-  if(iAlias!=kNAliases) 
-  	      AliError(Form("Number of DCS Aliases defined not correct"));
+  if(iAlias!=kNAliases)
+    AliError("Number of DCS Aliases defined not correct");
 
 }
 
@@ -299,41 +298,37 @@ void AliADDataDCS::Introduce(UInt_t numAlias, const TObjArray* aliasArr)const
   // method to introduce new aliases
 
   int entries=aliasArr->GetEntries();
-  AliInfo(Form("************ Alias: %s **********",fAliasNames[numAlias].Data()));
-  AliInfo(Form("    	%d DP values collected",entries));
+  AliInfoF("************ Alias: %s **********",fAliasNames[numAlias].Data());
+  AliInfoF("    	%d DP values collected",entries);
 
 }
 
 //_____________________________________________________________________________
 void AliADDataDCS::CreateGraph(int i, int dim, const Double_t *x, const Double_t *y)
 {
-
-   // Create graphics
-   
-   TGraph *gr = new((*fGraphs)[fGraphs->GetEntriesFast()]) TGraph(dim, x, y);
-
-   gr->GetXaxis()->SetTimeDisplay(1);
-   gr->SetTitle(fAliasNames[i].Data());
-
+  // Create graphics
+  TGraph *gr = new((*fGraphs)[fGraphs->GetEntriesFast()]) TGraph(dim, x, y);
+  gr->GetXaxis()->SetTimeDisplay(1);
+  gr->SetTitle(fAliasNames[i].Data());
 }
 
 
 //_____________________________________________________________________________
-void AliADDataDCS::Draw(const Option_t* /*option*/)
+void AliADDataDCS::Draw(Option_t* /*option*/)
 {
-// Draw all histos and graphs
+  // Draw all histos and graphs
 
   if(!fIsProcessed) return;
 
   if(fGraphs->GetEntries()==0)  return;
-  
+
   TCanvas *cHV = new TCanvas("AD0_HV","AD0_HV");
   cHV->Divide(4,4);
-  
+
   for(int iPM = 0; iPM<16 ; iPM++){
-  	cHV->cd(iPM+1);
-  	((TGraph*) fGraphs->UncheckedAt(iPM))->SetMarkerStyle(20);
-  	((TGraph*) fGraphs->UncheckedAt(iPM))->Draw("ALP");	  		
-  	}
+    cHV->cd(iPM+1);
+    ((TGraph*) fGraphs->UncheckedAt(iPM))->SetMarkerStyle(20);
+    ((TGraph*) fGraphs->UncheckedAt(iPM))->Draw("ALP");
+  }
 }
 

--- a/AD/ADbase/AliADDataDCS.h
+++ b/AD/ADbase/AliADDataDCS.h
@@ -1,10 +1,11 @@
+// -*- C++ -*-
 #ifndef AliADDataDCS_H
 #define AliADDataDCS_H
 
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */
 
-#include <TObject.h> 
+#include <TObject.h>
 #include <TClonesArray.h>
 
 class TMap;
@@ -22,11 +23,11 @@ class AliADDataDCS : public TObject {
 public:
   enum {kNAliases=213,kNGraphs=32,kNHvChannel=16,kNLvChannel=4,kNCIUBoards = 2};
   enum {kHvMin=0, kHvMax=3000};
-  
+
   AliADDataDCS();
   AliADDataDCS(Int_t nRun, UInt_t timeCreated, UInt_t timeCompleted, UInt_t daqStart, UInt_t daqEnd, UInt_t ctpStart, UInt_t ctpEnd);
-  ~AliADDataDCS();
-  
+  virtual ~AliADDataDCS();
+
   void SetRun(Int_t run) {fRun = run;}
   void SetStartTime(Int_t startTime) {fStartTime = startTime;}
   void SetEndTime(Int_t endTime) {fEndTime = endTime;}
@@ -37,20 +38,20 @@ public:
   Int_t GetEndTime() const {return fEndTime;}
   Int_t GetDaqStartTime() const {return fDaqStartTime;}
   Int_t GetDaqEndTime() const {return fDaqEndTime;}
-  
+
   Bool_t ProcessData(TMap& aliasMap);
-  
-  const char* GetAliasName(Int_t pos) const 
-    {return pos<kNAliases ? fAliasNames[pos].Data() : 0;}
-  
-  void Draw(const Option_t* option);
-  
+
+  const char* GetAliasName(Int_t pos) const
+  {return pos<kNAliases ? fAliasNames[pos].Data() : 0;}
+
+  virtual void Draw(Option_t* option);
+
   Float_t* GetMeanHV()    const {return (float*)fMeanHV;}
   Float_t* GetWidthHV()   const {return (float*)fWidthHV;}
   Bool_t * GetDeadMap()   const {return (bool*)fDeadChannel;}
   TMap * GetFEEParameters() const {return fFEEParameters;};
   TClonesArray * GetGraphs() const {return fGraphs;};
-  
+
 private:
   AliADDataDCS(const AliADDataDCS&); // Not implemented
   AliADDataDCS& operator=(const AliADDataDCS&); // Not implemented
@@ -58,7 +59,7 @@ private:
   void Init();
   void Introduce(UInt_t numAlias, const TObjArray* aliasArr) const;
   void CreateGraph(int i, int dim, const Double_t *x, const Double_t *y);
-    
+
   Int_t fRun;       // Run number
   Int_t fStartTime; // start time (time created)
   Int_t fEndTime;   // end time (time completed)
@@ -66,17 +67,17 @@ private:
   UInt_t fDaqEndTime;   // DAQ end time
   UInt_t fCtpStartTime; // CTP start time
   UInt_t fCtpEndTime;   // CTP end time
-  
+
   TString fAliasNames[kNAliases];        // aliases for DCS data
   TClonesArray *fGraphs;		         // Array containing  graphics
   TH1F *fHv[kNHvChannel];                  // High Voltage histograms
   Float_t fMeanHV[kNHvChannel];            // High Voltage mean values
   Float_t fWidthHV[kNHvChannel];           // High Voltage widths
-  Bool_t  fDeadChannel[kNHvChannel];       // Dead Map 
+  Bool_t  fDeadChannel[kNHvChannel];       // Dead Map
   TMap * fFEEParameters;  // TMap holding the FEE parameters
-    
+
   Bool_t fIsProcessed;                   // bool to know processing status
-  
+
   ClassDef(AliADDataDCS, 7);
 };
 

--- a/AD/ADbase/AliADLoader.cxx
+++ b/AD/ADbase/AliADLoader.cxx
@@ -15,23 +15,22 @@
 const TString AliADLoader::fgkDefaultHitsFileName      = "AD.Hits.root";
 const TString AliADLoader::fgkDefaultDigitsFileName    = "AD.Digits.root";
 
-ClassImp(AliADLoader)
+ClassImp(AliADLoader);
 
 //_____________________________________________________________________________
 AliADLoader::AliADLoader()
-{ 
-   // Default constructor
+{
 }
 
 //_____________________________________________________________________________
 AliADLoader::AliADLoader(const Char_t *name,const Char_t *topfoldername)
-   :AliLoader(name,topfoldername)
+  : AliLoader(name,topfoldername)
 {
-   AliDebug( 1, Form("Name = %s; topfolder = %s", name, topfoldername) );
+  AliDebugF(1, "Name = %s; topfolder = %s", name, topfoldername);
 }
 
 //_____________________________________________________________________________
 AliADLoader::AliADLoader(const Char_t *name,TFolder *topfolder)
-   :AliLoader(name,topfolder)
+  : AliLoader(name,topfolder)
 {
 }

--- a/AD/ADbase/AliADLoader.h
+++ b/AD/ADbase/AliADLoader.h
@@ -1,33 +1,32 @@
+// -*- C++ -*-
 #ifndef ALIADLOADER_H
 #define ALIADLOADER_H
 
 /////////////////////////////////////////////////////////////////////
 //                                                                 //
-// Base class for ADloaders.                                       //                                          
+// Base class for ADloaders.                                       //
 // Loader provides base I/O facilities for standard data.          //
 // Each detector has a loader data member.                         //
-// Loader is always accessible via folder structure as well.       // 
+// Loader is always accessible via folder structure as well.       //
 //                                                                 //
 /////////////////////////////////////////////////////////////////////
 
 #include "AliLoader.h"
 
 class AliADLoader: public AliLoader {
-   
 public:
-                  AliADLoader();
-                  AliADLoader(const Char_t *name,const Char_t *topfoldername);
-                  AliADLoader(const Char_t *name,TFolder *topfolder);    
-    virtual      ~AliADLoader() {};
-    
-                  AliADLoader & operator = (const AliADLoader & ) {return *this;}
-    
-private:
-    static const TString fgkDefaultHitsFileName;      //! Default Name for hit file
-    static const TString fgkDefaultDigitsFileName;    //! Default Name for digit file
+  AliADLoader();
+  AliADLoader(const Char_t *name,const Char_t *topfoldername);
+  AliADLoader(const Char_t *name,TFolder *topfolder);
+  virtual ~AliADLoader() {};
 
-   ClassDef(AliADLoader,1)
-      
+  AliADLoader & operator=(const AliADLoader & ) {return *this;}
+
+private:
+  static const TString fgkDefaultHitsFileName;      //! Default Name for hit file
+  static const TString fgkDefaultDigitsFileName;    //! Default Name for digit file
+
+  ClassDef(AliADLoader,1);
 };
- 
+
 #endif

--- a/AD/ADbase/AliADLogicalSignal.cxx
+++ b/AD/ADbase/AliADLogicalSignal.cxx
@@ -26,121 +26,126 @@
 #include "AliLog.h"
 #include "AliADLogicalSignal.h"
 
-ClassImp(AliADLogicalSignal)
+ClassImp(AliADLogicalSignal);
 
 //_____________________________________________________________________________
-AliADLogicalSignal::AliADLogicalSignal() : TObject(), fStart(0.), fStop(0.)
+AliADLogicalSignal::AliADLogicalSignal()
+  : TObject()
+  , fStart(0.)
+  , fStop(0.)
 {
-	// Default constructor
+  // Default constructor
 }
 //_____________________________________________________________________________
-AliADLogicalSignal::AliADLogicalSignal(UShort_t profilClock, UInt_t delay, UInt_t latch, UInt_t reset) : TObject(), fStart(0.), fStop(0.)
+AliADLogicalSignal::AliADLogicalSignal(UShort_t profilClock, UInt_t delay, UInt_t latch, UInt_t reset)
+  : TObject()
+  , fStart(0.)
+  , fStop(0.)
 {
-	/*/
-	std::cout << "P " << std::bitset<5>(profilClock)<< std::endl;
-	std::cout << "L " << std::bitset<5>(latch)<< std::endl;
-	std::cout << "R " << std::bitset<5>(reset)<< std::endl;
-	std::cout << "Delay " <<delay<< std::endl;
-	/*/
+  /*/
+    std::cout << "P " << std::bitset<5>(profilClock)<< std::endl;
+    std::cout << "L " << std::bitset<5>(latch)<< std::endl;
+    std::cout << "R " << std::bitset<5>(reset)<< std::endl;
+    std::cout << "Delay " <<delay<< std::endl;
+    /*/
 
-	// Constructor using the profilClock and delay parameters comming from the FEE
-	Bool_t fClock[11];
-	Int_t fTimes[11];
-	Bool_t risingFound = kFALSE;
+  // Constructor using the profilClock and delay parameters comming from the FEE
+  Bool_t fClock[11];
+  Int_t fTimes[11];
+  Bool_t risingFound = kFALSE;
 
-	for(Int_t i=0; i<5; i++) {
-		fClock[i+1] = (profilClock >> (4-i)) & 0x1;
-		fClock[i+6] = (profilClock >> (4-i)) & 0x1;
-		}
-	fClock[0] = (profilClock >> 0) & 0x1;
+  for(Int_t i=0; i<5; i++) {
+    fClock[i+1] = (profilClock >> (4-i)) & 0x1;
+    fClock[i+6] = (profilClock >> (4-i)) & 0x1;
+  }
+  fClock[0] = (profilClock >> 0) & 0x1;
 
-	if(reset>latch) for(Int_t i=0; i<11; i++) fTimes[i] = -5+5*i;
-	if(reset<latch) for(Int_t i=0; i<11; i++) fTimes[i] = -30+5*i;
+  if(reset>latch) for(Int_t i=0; i<11; i++) fTimes[i] = -5+5*i;
+  if(reset<latch) for(Int_t i=0; i<11; i++) fTimes[i] = -30+5*i;
 
-	/*/
-	for(Int_t i=0; i<10; i++)std::cout<<fTimes[i]<<" ";
-	std::cout<<std::endl;
-	for(Int_t i=0; i<10; i++)std::cout<<fClock[i]<<" ";
-	std::cout<<std::endl;
-	/*/
+  /*/
+    for(Int_t i=0; i<10; i++)std::cout<<fTimes[i]<<" ";
+    std::cout<<std::endl;
+    for(Int_t i=0; i<10; i++)std::cout<<fClock[i]<<" ";
+    std::cout<<std::endl;
+    /*/
 
-	for(Int_t i=1; i<11; i++){
-		if(!risingFound && !fClock[i-1] && fClock[i]){
-			risingFound = kTRUE;
-			fStart = fTimes[i];
-			continue;
-			}
-		else if(risingFound && fClock[i-1] && !fClock[i]) {
-			fStop = fTimes[i];
-			break;
-			}
-		}
+  for(Int_t i=1; i<11; i++){
+    if(!risingFound && !fClock[i-1] && fClock[i]){
+      risingFound = kTRUE;
+      fStart = fTimes[i];
+      continue;
+    }
+    else if(risingFound && fClock[i-1] && !fClock[i]) {
+      fStop = fTimes[i];
+      break;
+    }
+  }
 
-	fStart += delay*1e-2; // Add 10 ps par register unit
-	fStop  += delay*1e-2;
+  fStart += delay*1e-2; // Add 10 ps par register unit
+  fStop  += delay*1e-2;
 }
 //_____________________________________________________________________________
-AliADLogicalSignal::AliADLogicalSignal(const AliADLogicalSignal &signal) :
-	TObject(), fStart(signal.fStart),
-	fStop(signal.fStop)
+AliADLogicalSignal::AliADLogicalSignal(const AliADLogicalSignal &signal)
+  : TObject()
+  , fStart(signal.fStart)
+  , fStop(signal.fStop)
 {
-	// Copy constructor
-}
-
-//_____________________________________________________________________________
-AliADLogicalSignal::~AliADLogicalSignal(){
-	// Destructor
 }
 
 //_____________________________________________________________________________
-AliADLogicalSignal& AliADLogicalSignal::operator =
-(const AliADLogicalSignal& signal)
+AliADLogicalSignal::~AliADLogicalSignal() {
+}
+
+//_____________________________________________________________________________
+AliADLogicalSignal& AliADLogicalSignal::operator=(const AliADLogicalSignal& signal)
 {
-	// Operator =
-        if(&signal == this) return *this;
-	fStart = signal.fStart;
-	fStop  = signal.fStop;
-	return *this;
+  // Operator =
+  if(&signal == this)
+    return *this;
+  fStart = signal.fStart;
+  fStop  = signal.fStop;
+  return *this;
 }
 
 //_____________________________________________________________________________
 AliADLogicalSignal AliADLogicalSignal::operator|(const AliADLogicalSignal& signal) const
 {
-	// Perform the Logical OR of two signals: C = A or B
-	if((fStart>signal.fStop) || (signal.fStart>fStop))
-		AliError(Form("Both signal do not superpose in time.\n  Start(A) = %f Stop(A) = %f\n   Start(B) = %f Stop(B) = %f",fStart, fStop, signal.fStart,signal.fStop));
+  // Perform the Logical OR of two signals: C = A or B
+  if((fStart>signal.fStop) || (signal.fStart>fStop))
+    AliErrorF("Both signal do not superpose in time.\n  Start(A) = %f Stop(A) = %f\n   Start(B) = %f Stop(B) = %f",fStart, fStop, signal.fStart,signal.fStop);
 
-	AliADLogicalSignal result;
-	if(fStart<signal.fStart) result.fStart = fStart;
-	else result.fStart = signal.fStart;
+  AliADLogicalSignal result;
+  if(fStart<signal.fStart) result.fStart = fStart;
+  else result.fStart = signal.fStart;
 
-	if(fStop>signal.fStop) result.fStop = fStop;
-	else result.fStop = signal.fStop;
+  if(fStop>signal.fStop) result.fStop = fStop;
+  else result.fStop = signal.fStop;
 
-	return result;
+  return result;
 }
 //_____________________________________________________________________________
 AliADLogicalSignal AliADLogicalSignal::operator&(const AliADLogicalSignal& signal) const
 {
-	// Perform the Logical AND of two signals: C = A and B
-	if((fStart>signal.fStop) || (signal.fStart>fStop))
-		AliError(Form("Both signal do not superpose in time.\n  Start(A) = %f Stop(A) = %f\n   Start(B) = %f Stop(B) = %f",fStart, fStop, signal.fStart,signal.fStop));
+  // Perform the Logical AND of two signals: C = A and B
+  if((fStart>signal.fStop) || (signal.fStart>fStop))
+    AliErrorF("Both signal do not superpose in time.\n  Start(A) = %f Stop(A) = %f\n   Start(B) = %f Stop(B) = %f",fStart, fStop, signal.fStart,signal.fStop);
 
-	AliADLogicalSignal result;
-	if(fStart>signal.fStart) result.fStart = fStart;
-	else result.fStart = signal.fStart;
+  AliADLogicalSignal result;
+  if(fStart>signal.fStart) result.fStart = fStart;
+  else result.fStart = signal.fStart;
 
-	if(fStop<signal.fStop) result.fStop = fStop;
-	else result.fStop = signal.fStop;
+  if(fStop<signal.fStop) result.fStop = fStop;
+  else result.fStop = signal.fStop;
 
-	return result;
+  return result;
 }
 
 //_____________________________________________________________________________
 Bool_t AliADLogicalSignal::IsInCoincidence(Float_t time) const
 {
-	// Check if a signal arriving at the time "time" is in coincidence with the logical signal
-	Bool_t result = kFALSE;
-	if((time>fStart) && (time<fStop)) result = kTRUE;
-	return result;
+  // Check if a signal arriving at the time "time" is in coincidence with the logical signal
+  Bool_t result = kFALSE;
+  if((time>fStart) && (time<fStop)) result = kTRUE;
+  return result;
 }

--- a/AD/ADbase/AliADLogicalSignal.h
+++ b/AD/ADbase/AliADLogicalSignal.h
@@ -1,19 +1,20 @@
+// -*- C++ -*-
 #ifndef ALIADLOGICALSIGNAL_H
 #define ALIADLOGICALSIGNAL_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights
- * reserved. 
+ * reserved.
  *
- * See cxx source for full Copyright notice                               
+ * See cxx source for full Copyright notice
  */
 
 
-// 
+//
 // Class AliADLogicalSignal
 // ---------------------------
-// Describes a logical signal in the electronics. 
+// Describes a logical signal in the electronics.
 // Use it to generate observation windows
 // which are used by AliADTriggerSimulator class
-// 
+//
 
 
 #include <TObject.h>
@@ -21,35 +22,30 @@
 
 class AliADLogicalSignal  : public TObject {
 public:
-	AliADLogicalSignal();
-	AliADLogicalSignal(UShort_t profilClock, UInt_t delay, UInt_t latch, UInt_t reset);
-	virtual ~AliADLogicalSignal();
-	AliADLogicalSignal(const AliADLogicalSignal &signal);
-	AliADLogicalSignal& operator= (const AliADLogicalSignal &signal);
-	AliADLogicalSignal operator& (const AliADLogicalSignal &signal) const;
-	AliADLogicalSignal operator| (const AliADLogicalSignal &signal) const;
-	// Print method
-	virtual void Print(Option_t* opt="") const { AliInfo(Form("\t%s -> Start %f Stop %f\n ",opt,fStart,fStop));}
-	
-	Float_t GetStartTime() const {return fStart;};
-	Float_t GetStopTime() const {return fStop;};
-	Float_t GetWidth() const {return (fStop - fStart);};
-	
-	void SetStartTime(Float_t time){fStart = time;};
-	void SetStopTime(Float_t time){fStop = time;};
-	
-	Bool_t IsInCoincidence(Float_t time) const;
-	
+  AliADLogicalSignal();
+  AliADLogicalSignal(UShort_t profilClock, UInt_t delay, UInt_t latch, UInt_t reset);
+  virtual ~AliADLogicalSignal();
+  AliADLogicalSignal(const AliADLogicalSignal &signal);
+  AliADLogicalSignal& operator= (const AliADLogicalSignal &signal);
+  AliADLogicalSignal operator& (const AliADLogicalSignal &signal) const;
+  AliADLogicalSignal operator| (const AliADLogicalSignal &signal) const;
+  // Print method
+  virtual void Print(Option_t* opt="") const { AliInfoF("\t%s -> Start %f Stop %f\n ",opt,fStart,fStop); }
+
+  Float_t GetStartTime() const {return fStart;};
+  Float_t GetStopTime() const {return fStop;};
+  Float_t GetWidth() const {return (fStop - fStart);};
+
+  void SetStartTime(Float_t time){fStart = time;};
+  void SetStopTime(Float_t time){fStop = time;};
+
+  Bool_t IsInCoincidence(Float_t time) const;
+
 private:
-	
-	Float_t fStart; // Start Time of the signal with respect to the LHC Clock
-	Float_t fStop;  // Stop Time of the signal with respect to the LHC Clock
-	
-	
-	ClassDef( AliADLogicalSignal, 1 )  
-	
+  Float_t fStart; // Start Time of the signal with respect to the LHC Clock
+  Float_t fStop;  // Stop Time of the signal with respect to the LHC Clock
+
+  ClassDef( AliADLogicalSignal, 1);
 };
 
 #endif // ALIADLOGICALSIGNAL_H
-
-

--- a/AD/ADbase/AliADPreprocessor.cxx
+++ b/AD/ADbase/AliADPreprocessor.cxx
@@ -13,162 +13,155 @@
 #include <TSystem.h>
 #include <TH1F.h>
 
-
 class Tlist;
 
 //
 //  This class is  a simple preprocessor for AD detector.
 //
-//  It gets High Voltage values for a given run from DCS and Pedestal values from DAQ 
+//  It gets High Voltage values for a given run from DCS and Pedestal values from DAQ
 //  and writes them as Calibration MetaData into OCDB/AD/Calib/Data
-//  It also retrieves FEE parameters from DCS archive   
-//  and writes them as Trigger MetaData into OCDB/AD/Trigger/Data 
+//  It also retrieves FEE parameters from DCS archive
+//  and writes them as Trigger MetaData into OCDB/AD/Trigger/Data
 //  (to be used for trigger simulation)
 //
 
-ClassImp(AliADPreprocessor)
+ClassImp(AliADPreprocessor);
 
 //______________________________________________________________________________________________
-AliADPreprocessor::AliADPreprocessor(AliShuttleInterface* shuttle) :
-	AliPreprocessor("AD0", shuttle),
-	fDCSData(0)
- 
+AliADPreprocessor::AliADPreprocessor(AliShuttleInterface* shuttle)
+  : AliPreprocessor("AD0", shuttle)
+  , fDCSData(NULL)
 {
-  // constructor  
-  
   AddRunType("STANDALONE_PULSER");
   AddRunType("STANDALONE_BC");
   AddRunType("PHYSICS");
   AddRunType("PEDESTAL");
-    
 }
 
 //______________________________________________________________________________________________
 AliADPreprocessor::~AliADPreprocessor()
 {
-  // destructor
-	delete fDCSData;
-	
+  delete fDCSData;
+  fDCSData = NULL;
 }
 
 //______________________________________________________________________________________________
 void AliADPreprocessor::Initialize(Int_t run, UInt_t startTime,
-	UInt_t endTime)
+				   UInt_t endTime)
 {
   // Creates AliADDataDCS object
+  AliPreprocessor::Initialize(run, startTime, endTime);
 
-   AliPreprocessor::Initialize(run, startTime, endTime);
-  
-   Log(Form("\n\tRun %d \n\tStartTime %s \n\tEndTime %s", run,
-		TTimeStamp(startTime).AsString(),
-		TTimeStamp(endTime).AsString()));
+  AliInfoF("\n\tRun %d \n\tStartTime %s \n\tEndTime %s", run,
+	   TTimeStamp(startTime).AsString(),
+	   TTimeStamp(endTime).AsString());
 
-   fRun       = run;
-   // fStartTime = startTime;
-   // fEndTime   = endTime;
-   fStartTime = GetStartTimeDCSQuery ();
-   fEndTime   = GetEndTimeDCSQuery ();
-   time_t daqStart = (time_t) (((TString)GetRunParameter("DAQ_time_start")).Atoi());
-   time_t daqEnd   = (time_t) (((TString)GetRunParameter("DAQ_time_end")).Atoi());
-   time_t ctpStart = (time_t) (((TString)GetRunParameter("TRGTimeStart")).Atoi());
-   time_t ctpEnd   = (time_t) (((TString)GetRunParameter("TRGTimeEnd")).Atoi());
-   
-	fDCSData      = new AliADDataDCS(fRun, fStartTime, fEndTime,(UInt_t)daqStart, (UInt_t)daqEnd,(UInt_t)ctpStart, (UInt_t)ctpEnd);	
-   
+  fRun       = run;
+  // fStartTime = startTime;
+  // fEndTime   = endTime;
+  fStartTime = GetStartTimeDCSQuery ();
+  fEndTime   = GetEndTimeDCSQuery ();
+  time_t daqStart = (time_t) (((TString)GetRunParameter("DAQ_time_start")).Atoi());
+  time_t daqEnd   = (time_t) (((TString)GetRunParameter("DAQ_time_end")).Atoi());
+  time_t ctpStart = (time_t) (((TString)GetRunParameter("TRGTimeStart")).Atoi());
+  time_t ctpEnd   = (time_t) (((TString)GetRunParameter("TRGTimeEnd")).Atoi());
+
+  fDCSData      = new AliADDataDCS(fRun, fStartTime, fEndTime,(UInt_t)daqStart, (UInt_t)daqEnd,(UInt_t)ctpStart, (UInt_t)ctpEnd);
+
 }
 
 //______________________________________________________________________________________________
 UInt_t AliADPreprocessor::Process(TMap* dcsAliasMap)
 {
-  // Fills data retrieved from DCS and DAQ into a AliADCalibData object and 
+  // Fills data retrieved from DCS and DAQ into a AliADCalibData object and
   // stores it into CalibrationDB
 
 
   // *** GET RUN TYPE ***
   TString runType = GetRunType();
   TString beamMode = GetRunParameter("LHCBeamMode");
-  Log(Form("Run type: %s, Beam mode: %s",runType.Data(), beamMode.Data()));
+  AliInfoF("Run type: %s, Beam mode: %s",runType.Data(), beamMode.Data());
 
 
-  // *** REFERENCE DATA *** 
-  
-  TString fileName; 
+  // *** REFERENCE DATA ***
+
+  TString fileName;
   AliADCalibData *calibData = new AliADCalibData();
-  
+
   // *************** HV From DCS ******************
   // Fills data into a AliADDataDCS object
   if(!dcsAliasMap) return 1;
 
- 	// The Processing of the DCS input data is forwarded to AliADDataDCS
+  // The Processing of the DCS input data is forwarded to AliADDataDCS
   if (!fDCSData->ProcessData(*dcsAliasMap)) return 1;
 
-	// Writes AD PMs HV values into AD calibration object and Timing resolution parameters
-  	calibData->FillDCSData(fDCSData);
-	
-	if(runType == "PHYSICS") ProcessTrendings();
-	   
-   // *************** From DAQ ******************
-   
-	TString sourcesId = "AD0da_results";
+  // Writes AD PMs HV values into AD calibration object and Timing resolution parameters
+  calibData->FillDCSData(fDCSData);
 
-	TList* sourceList = GetFileSources(kDAQ, sourcesId.Data());
-  	if (!sourceList)  {
-		Log(Form("No sources found for id %s", sourcesId.Data()));      		
-      		return 1; }
-	Log(Form("The following sources produced files with the id %s",sourcesId.Data()));
-	sourceList->Print();    
+  if(runType == "PHYSICS") ProcessTrendings();
 
-  	TIter iter(sourceList);
-  	TObjString *source;
-		
-	while((source=dynamic_cast<TObjString*> (iter.Next()))){
-  		fileName = GetFile(kDAQ, sourcesId.Data(), source->GetName());
-  		if (fileName.Length() > 0)
-    		Log(Form("Got the file %s, now we can extract some values.", fileName.Data()));
-		FILE *file;
-		if((file = fopen(fileName.Data(),"r")) == NULL){
-            	                   Log(Form("Cannot open file %s",fileName.Data()));
-	    	  	           return 1;}
-		Float_t pedMean[32], pedSigma[32], adcMean[32], adcSigma[32] ;
-		for(Int_t j=0; j<32; j++) {
-		  Int_t resScan = fscanf(file,"%f %f %f %f",
-					 &pedMean[j], &pedSigma[j], &adcMean[j], &adcSigma[j]);
-		  if (resScan != 4) Log(Form("Bad data in file %s !",fileName.Data()));
-		}
-		fclose(file);
-	    	
-		calibData->SetPedestal(pedMean);
-		calibData->SetSigma(pedSigma);
-		calibData->SetADCmean(adcMean);			
-		calibData->SetADCsigma(adcSigma);
-		}				
+  // *************** From DAQ ******************
 
-	delete source;      
-  
+  TString sourcesId = "AD0da_results";
+
+  TList* sourceList = GetFileSources(kDAQ, sourcesId.Data());
+  if (!sourceList)  {
+    AliInfoF("No sources found for id %s", sourcesId.Data());
+    return 1; }
+  AliInfoF("The following sources produced files with the id %s",sourcesId.Data());
+  sourceList->Print();
+
+  TIter iter(sourceList);
+  TObjString *source;
+
+  while((source=dynamic_cast<TObjString*> (iter.Next()))){
+    fileName = GetFile(kDAQ, sourcesId.Data(), source->GetName());
+    if (fileName.Length() > 0)
+      AliInfoF("Got the file %s, now we can extract some values.", fileName.Data());
+    FILE *file;
+    if((file = fopen(fileName.Data(),"r")) == NULL){
+      AliInfoF("Cannot open file %s",fileName.Data());
+      return 1;}
+    Float_t pedMean[32], pedSigma[32], adcMean[32], adcSigma[32] ;
+    for(Int_t j=0; j<32; j++) {
+      Int_t resScan = fscanf(file,"%f %f %f %f",
+			     &pedMean[j], &pedSigma[j], &adcMean[j], &adcSigma[j]);
+      if (resScan != 4) AliInfoF("Bad data in file %s !",fileName.Data());
+    }
+    fclose(file);
+
+    calibData->SetPedestal(pedMean);
+    calibData->SetSigma(pedSigma);
+    calibData->SetADCmean(adcMean);
+    calibData->SetADCsigma(adcSigma);
+  }
+
+  delete source;
+
   // Now we store the AD Calibration Object into CalibrationDB
 
   Bool_t resECal=kFALSE;
-  
+
   Bool_t result = 0;
   if(sourceList && sourceList->GetEntries()>0)
-  {
-  AliCDBMetaData metaData;
-  metaData.SetBeamPeriod(0);
-  metaData.SetResponsible("Michal Broz");
-  metaData.SetComment("This preprocessor fills an AliADCalibData object");
+    {
+      AliCDBMetaData metaData;
+      metaData.SetBeamPeriod(0);
+      metaData.SetResponsible("Michal Broz");
+      metaData.SetComment("This preprocessor fills an AliADCalibData object");
 
-  resECal = Store("Calib", "Data", calibData, &metaData, 0, kTRUE);
-  
-  }
+      resECal = Store("Calib", "Data", calibData, &metaData, 0, kTRUE);
+
+    }
   if(resECal==kFALSE ) result = 1;
-    
+
   if(runType == "PHYSICS" && beamMode != "NO BEAM") ProcessTimeSlewing();
-  
+
   if(sourceList && sourceList->GetEntries()>0) calibData->PrintConfigShuttle();
-  
+
   delete calibData;
-  delete sourceList; 
- 	
+  delete sourceList;
+
   return result;
 }
 
@@ -177,76 +170,72 @@ UInt_t AliADPreprocessor::ProcessTimeSlewing()
 {
 
   // *************** From DAQ ******************
-  TList *fListSplines = 0x0;
-  TString fileName; 
+  TList *fListSplines = NULL;
+  TString fileName;
   TString sourcesId = "AD0da_slewing";
 
   TList* sourceList = GetFileSources(kDAQ, sourcesId.Data());
   if (!sourceList)  {
-	  Log(Form("No sources found for id %s", sourcesId.Data()));			  
-          return 1; }
-  Log(Form("The following sources produced files with the id %s",sourcesId.Data()));
-  sourceList->Print();    
+    AliInfoF("No sources found for id %s", sourcesId.Data());
+    return 1; }
+  AliInfoF("The following sources produced files with the id %s",sourcesId.Data());
+  sourceList->Print();
 
   TIter iter(sourceList);
   TObjString *source;
-	  
+
   while((source=dynamic_cast<TObjString*> (iter.Next()))){
-	  fileName = GetFile(kDAQ, sourcesId.Data(), source->GetName());
-	  if (fileName.Length() > 0)
-	  Log(Form("Got the file %s, now we can extract some values.", fileName.Data()));
-	  TFile *f = TFile::Open(fileName);
-	  if(!f){
-        	Log(Form("Cannot open file %s",fileName.Data()));
-		return 1;}
-		
-	  fListSplines = (TList*)f->Get("fListSplines");
-	  if ( !fListSplines ) {
-	       Log("No Spline List in file");
-	       return 1;}
-	  f->Close();
-	  }				  
+    fileName = GetFile(kDAQ, sourcesId.Data(), source->GetName());
+    if (fileName.Length() > 0)
+      AliInfoF("Got the file %s, now we can extract some values.", fileName.Data());
+    TFile *f = TFile::Open(fileName);
+    if(!f){
+      AliInfoF("Cannot open file %s",fileName.Data());
+      return 1;}
+
+    fListSplines = (TList*)f->Get("fListSplines");
+    if ( !fListSplines ) {
+      Log("No Spline List in file");
+      return 1;}
+    f->Close();
+  }
 
   Bool_t result = 0;
   Bool_t resECal=kFALSE;
- 
+
   if(sourceList && sourceList->GetEntries()>0)
-  {
-  AliCDBMetaData metaData;
-  metaData.SetBeamPeriod(0);
-  metaData.SetResponsible("Michal Broz");
-  metaData.SetComment("This preprocessor fills an time slewing splines object");
+    {
+      AliCDBMetaData metaData;
+      metaData.SetBeamPeriod(0);
+      metaData.SetResponsible("Michal Broz");
+      metaData.SetComment("This preprocessor fills an time slewing splines object");
 
-  resECal = Store("Calib", "TimeSlewing", fListSplines, &metaData, 0, kTRUE);
-  }
+      resECal = Store("Calib", "TimeSlewing", fListSplines, &metaData, 0, kTRUE);
+    }
   if(resECal==kFALSE ) result = 1;
-  
-  delete sourceList;
-   
-  return result;
 
+  delete sourceList;
+
+  return result;
 }
 //______________________________________________________________________________________________
 UInt_t AliADPreprocessor::ProcessTrendings()
 {
-
   // *************** HV From DCS ******************
-  TClonesArray *fGraphs = 0x0;
-  fGraphs = fDCSData->GetGraphs();
-  
+  TClonesArray *fGraphs = fDCSData->GetGraphs();
+
   Bool_t result = 0;
   Bool_t resECal=kFALSE;
- 
-  if(fGraphs != 0x0){
-  AliCDBMetaData metaData;
-  metaData.SetBeamPeriod(0);
-  metaData.SetResponsible("Michal Broz");
-  metaData.SetComment("This preprocessor fills an object with PM V and I trends");
 
-  resECal = Store("Calib", "PMTrends", fGraphs, &metaData, 0, kFALSE);
+  if (fGraphs) {
+    AliCDBMetaData metaData;
+    metaData.SetBeamPeriod(0);
+    metaData.SetResponsible("Michal Broz");
+    metaData.SetComment("This preprocessor fills an object with PM V and I trends");
+
+    resECal = Store("Calib", "PMTrends", fGraphs, &metaData, 0, kFALSE);
   }
   if(resECal==kFALSE ) result = 1;
-     
-  return result;
 
+  return result;
 }

--- a/AD/ADbase/AliADPreprocessor.h
+++ b/AD/ADbase/AliADPreprocessor.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 #ifndef ALI_AD_PREPROCESSOR_H
 #define ALI_AD_PREPROCESSOR_H
 
@@ -6,30 +7,30 @@
 class  AliShuttleInterface;
 class  AliADDataDCS;
 
-//  AD Preprocessor  header 
+//  AD Preprocessor  header
 
 //  Calibration object from DCS and DAQ is written into  OCDB/AD/Calib/Data
 //  Calibration object from DAQ is written into OCDB/AD/Calib/TimeSlewing
 
 class AliADPreprocessor : public AliPreprocessor
 {
-  public:
-    AliADPreprocessor(AliShuttleInterface* shuttle);
-    virtual ~AliADPreprocessor();
-    virtual void Initialize(Int_t run, UInt_t startTime, UInt_t endTime);
+public:
+  AliADPreprocessor(AliShuttleInterface* shuttle);
+  virtual ~AliADPreprocessor();
+  virtual void Initialize(Int_t run, UInt_t startTime, UInt_t endTime);
 
-  protected:
-    virtual UInt_t Process(TMap* dcsAliasMap);
-    UInt_t ProcessTimeSlewing();
-    UInt_t ProcessTrendings();
+protected:
+  virtual UInt_t Process(TMap* dcsAliasMap);
+  UInt_t ProcessTimeSlewing();
+  UInt_t ProcessTrendings();
 
-    AliADDataDCS *fDCSData;    // CDB class that stores the calibration data
+  AliADDataDCS *fDCSData;    // CDB class that stores the calibration data
 
- private:
-    AliADPreprocessor(const AliADPreprocessor&); // Not implemented
-    AliADPreprocessor& operator=(const AliADPreprocessor&); // Not implemented
-    
-    ClassDef(AliADPreprocessor, 1);
+private:
+  AliADPreprocessor(const AliADPreprocessor&); // Not implemented
+  AliADPreprocessor& operator=(const AliADPreprocessor&); // Not implemented
+
+  ClassDef(AliADPreprocessor, 1);
 };
 
 #endif

--- a/AD/ADbase/AliADRawStream.cxx
+++ b/AD/ADbase/AliADRawStream.cxx
@@ -17,7 +17,7 @@
 ///
 /// This is a class for reading the AD DDL raw data
 /// The format of the raw data corresponds to the one
-/// implemented in AliADBuffer class. 
+/// implemented in AliADBuffer class.
 ///
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -26,22 +26,23 @@
 #include "AliLog.h"
 #include "AliDAQ.h"
 #include "AliADCalibData.h"
-ClassImp(AliADRawStream)
+
+ClassImp(AliADRawStream);
 
 //_____________________________________________________________________________
-AliADRawStream::AliADRawStream(AliRawReader* rawReader) :
-  fTrigger(0),
-  fTriggerMask(0),
-  fPosition(-1),
-  fRawReader(rawReader),
-  fData(NULL)
+AliADRawStream::AliADRawStream(AliRawReader* rawReader)
+  : fTrigger(0)
+  , fTriggerMask(0)
+  , fPosition(-1)
+  , fRawReader(rawReader)
+  , fData(NULL)
 {
   // create an object to read AD raw data
   //
   // select the raw data corresponding to
   // the AD detector id
   fRawReader->Reset();
-  AliDebug(1,Form("Selecting raw data for detector %d",AliDAQ::DetectorID("AD")));
+  AliDebugF(1, "Selecting raw data for detector %d", AliDAQ::DetectorID("AD"));
   fRawReader->Select("AD");
 
   // Initalize the containers
@@ -64,7 +65,6 @@ AliADRawStream::AliADRawStream(AliRawReader* rawReader) :
 //_____________________________________________________________________________
 AliADRawStream::~AliADRawStream()
 {
-  // destructor
 }
 
 //_____________________________________________________________________________
@@ -105,11 +105,11 @@ Bool_t AliADRawStream::Next()
 
   if (!fRawReader->ReadNextData(fData)) return kFALSE;
   if (fRawReader->GetDataSize() == 0) return kFALSE;
-     
+
   if (fRawReader->GetDataSize() != 5936) {
-     fRawReader->AddFatalErrorLog(kRawDataSizeErr,Form("size %d != 5936",fRawReader->GetDataSize()));
-     AliWarning(Form("Wrong AD raw data size: %d, expected 5936 bytes!",fRawReader->GetDataSize()));
-     return kFALSE;
+    fRawReader->AddFatalErrorLog(kRawDataSizeErr,Form("size %d != 5936",fRawReader->GetDataSize()));
+    AliWarningF("Wrong AD raw data size: %d, expected 5936 bytes!",fRawReader->GetDataSize());
+    return kFALSE;
   }
 
   fPosition = 0;
@@ -118,22 +118,21 @@ Bool_t AliADRawStream::Next()
   fTriggerMask = GetNextWord() & 0xffff;
 
   for(Int_t iScaler = 0; iScaler < kNScalers; iScaler++)
-     fScalers[iScaler] = GetNextWord();
+    fScalers[iScaler] = GetNextWord();
 
   for(Int_t iBunch = 0; iBunch < kNBunches; iBunch++)
-     fBunchNumbers[iBunch] = GetNextWord();
-  
+    fBunchNumbers[iBunch] = GetNextWord();
+
   Int_t iCIU=0;
-  for (Int_t  iV0CIU = 0; iV0CIU < 8; iV0CIU++) {
-    
+  for (Int_t iV0CIU = 0; iV0CIU < 8; iV0CIU++) {
+
     if(iV0CIU != 2 && iV0CIU != 5) {
       for(Int_t iWord = 0; iWord<182; iWord++) GetNextWord();
       continue;
-      	}
- 
-  // decoding of one Channel Interface Unit numbered iCIU - there are 8 channels per CIU (and 2 CIUs) :
-  
-    for (Int_t iChannel_Offset = iCIU*8; iChannel_Offset < (iCIU*8)+8; iChannel_Offset=iChannel_Offset+4) { 
+    }
+
+    // decoding of one Channel Interface Unit numbered iCIU - there are 8 channels per CIU (and 2 CIUs) :
+    for (Int_t iChannel_Offset = iCIU*8; iChannel_Offset < (iCIU*8)+8; iChannel_Offset=iChannel_Offset+4) {
       for(Int_t iChannel = iChannel_Offset; iChannel < iChannel_Offset+4; iChannel++) {
         for(Int_t iEvOfInt = 0; iEvOfInt < kNEvOfInt; iEvOfInt++) {
           UShort_t data = GetNextShort();
@@ -143,12 +142,12 @@ Bool_t AliADRawStream::Next()
       }
       for(Int_t iEvOfInt = 0; iEvOfInt < kNEvOfInt; iEvOfInt=iEvOfInt+2) {
         UShort_t data = GetNextShort();
-        for(Int_t iChannel = iChannel_Offset; iChannel < iChannel_Offset+4; iChannel++) {          
+        for(Int_t iChannel = iChannel_Offset; iChannel < iChannel_Offset+4; iChannel++) {
           fIsBB[iChannel][iEvOfInt] = (data >>  2*(iChannel-iChannel_Offset)) & 0x1;
-          fIsBG[iChannel][iEvOfInt] = (data >> (2*(iChannel-iChannel_Offset)+1)) & 0x1; 
-	  if(iEvOfInt < (kNEvOfInt - 1)) {      
-             fIsBB[iChannel][iEvOfInt+1] = (data >> (8+ 2*(iChannel-iChannel_Offset))) & 0x1;
-             fIsBG[iChannel][iEvOfInt+1] = (data >> (8+ 2*(iChannel-iChannel_Offset)+1)) & 0x1;
+          fIsBG[iChannel][iEvOfInt] = (data >> (2*(iChannel-iChannel_Offset)+1)) & 0x1;
+	  if(iEvOfInt < (kNEvOfInt - 1)) {
+	    fIsBB[iChannel][iEvOfInt+1] = (data >> (8+ 2*(iChannel-iChannel_Offset))) & 0x1;
+	    fIsBG[iChannel][iEvOfInt+1] = (data >> (8+ 2*(iChannel-iChannel_Offset)+1)) & 0x1;
 	  }
         }
       }
@@ -160,23 +159,23 @@ Bool_t AliADRawStream::Next()
           UShort_t data = GetNextShort();
           fChargeMB[iChannel][iBunch] = data & 0x3ff;
           fIsIntMB[iChannel][iBunch] = (data >> 10) & 0x1;
-        } 
+        }
       }
-   
+
       for(Int_t iBunch = 0; iBunch < kNBunches; iBunch=iBunch+2) {
         UShort_t data = GetNextShort();
-        for(Int_t iChannel = iChannel_Offset; iChannel < iChannel_Offset+4; iChannel++) {  
+        for(Int_t iChannel = iChannel_Offset; iChannel < iChannel_Offset+4; iChannel++) {
           fIsBBMB[iChannel][iBunch] = (data >>  2*iBunch) & 0x1;
           fIsBGMB[iChannel][iBunch] = (data >> (2*iBunch+1)) & 0x1;
 	  if(iBunch < (kNBunches - 1)) {
-             fIsBBMB[iChannel][iBunch+1] = (data >> (8+2*iBunch)) & 0x1;
-             fIsBGMB[iChannel][iBunch+1] = (data >> (8+2*iBunch+1)) & 0x1;
-	  }	  
+	    fIsBBMB[iChannel][iBunch+1] = (data >> (8+2*iBunch)) & 0x1;
+	    fIsBGMB[iChannel][iBunch+1] = (data >> (8+2*iBunch+1)) & 0x1;
+	  }
         }
       }
-  
+
       GetNextShort();
-   
+
       for(Int_t iChannel = iChannel_Offset; iChannel < iChannel_Offset+4; iChannel++) {
         fBBScalers[iChannel] = ((ULong64_t)GetNextWord()) << 32;
         fBBScalers[iChannel] |= GetNextWord();
@@ -184,19 +183,19 @@ Bool_t AliADRawStream::Next()
         fBGScalers[iChannel] |= GetNextWord();
       }
 
-    } 
+    }
 
-    for(Int_t iChannel = (iCIU*8) + 7; iChannel >= iCIU*8; iChannel--) { 
+    for(Int_t iChannel = (iCIU*8) + 7; iChannel >= iCIU*8; iChannel--) {
       UInt_t time = GetNextWord();
       fTime[iChannel]  = time & 0xfff;
       fWidth[iChannel] = ((time >> 12) & 0x7f); // HPTDC used in pairing mode
     }
     iCIU++;
     // End of decoding of one CIU card
-    //AliWarning(Form("Number of bytes used at end of reading CIU card number %d %d", iCIU+1, fPosition)); 
-    
+    //AliWarningF("Number of bytes used at end of reading CIU card number %d %d", iCIU+1, fPosition);
+
   } // end of decoding the eight CIUs
-    
+
   return kTRUE;
 }
 

--- a/AD/ADbase/AliADRawStream.h
+++ b/AD/ADbase/AliADRawStream.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 #ifndef ALIADRAWSTREAM_H
 #define ALIADRAWSTREAM_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
@@ -9,10 +10,10 @@
 /// The format of the raw data corresponds to the one
 /// implemented in AliADBuffer class.
 ///
-/// PLEASE NOTE that Int_t channel is here the FEE channel from 0 to 16 in the 
-/// not yet defined order which may be not the same order as the order 
+/// PLEASE NOTE that Int_t channel is here the FEE channel from 0 to 16 in the
+/// not yet defined order which may be not the same order as the order
 /// defined in aliroot by the naming and numbering conventions.
-/// Therefore one has to go from FEE_Channel to AliRoot_Channel using 
+/// Therefore one has to go from FEE_Channel to AliRoot_Channel using
 /// GetOfflineChannel(Int_t channel)  when going from Online to Offline !!!
 ///
 ///////////////////////////////////////////////////////////////////////////////
@@ -23,102 +24,100 @@
 class AliRawReader;
 
 class AliADRawStream: public TObject {
-  public :
-    AliADRawStream(AliRawReader* rawReader);
-    virtual ~AliADRawStream();
+public :
+  AliADRawStream(AliRawReader* rawReader);
+  virtual ~AliADRawStream();
 
-    virtual void      Reset();
-    virtual Bool_t    Next();
+  virtual void      Reset();
+  virtual Bool_t    Next();
 
-// Getters of various scalers and Minimum Bias flags :
+  // Getters of various scalers and Minimum Bias flags :
 
-   ULong64_t          GetBBScalers(Int_t channel) const  
-      { return        fBBScalers[channel]; }
-   ULong64_t          GetBGScalers(Int_t channel) const  
-      { return        fBGScalers[channel]; }
-   UInt_t             GetTriggerScalers(Int_t num_scaler) const 
-      { return        fScalers[num_scaler]; }
-   UInt_t             GetBunchNumbersMB(Int_t num_bunch) const 
-      { return        fBunchNumbers[num_bunch]; }
-   UShort_t           GetChargeMB(Int_t channel, Int_t num_bunch) const  
-      { return        fChargeMB[channel][num_bunch]; } 
-   Bool_t             GetIntMBFlag(Int_t channel, Int_t num_bunch) const   
-      { return        fIsIntMB[channel][num_bunch]; } 
-   Bool_t             GetBBMBFlag(Int_t channel, Int_t num_bunch) const   
-      { return        fIsBBMB[channel][num_bunch]; }  
-   Bool_t             GetBGMBFlag(Int_t channel, Int_t num_bunch) const   
-      { return        fIsBGMB[channel][num_bunch]; }      
-       
-// Getters of ADC signals, ADC pedestals, time information and corresponding flags :
+  ULong64_t          GetBBScalers(Int_t channel) const
+  { return        fBBScalers[channel]; }
+  ULong64_t          GetBGScalers(Int_t channel) const
+  { return        fBGScalers[channel]; }
+  UInt_t             GetTriggerScalers(Int_t num_scaler) const
+  { return        fScalers[num_scaler]; }
+  UInt_t             GetBunchNumbersMB(Int_t num_bunch) const
+  { return        fBunchNumbers[num_bunch]; }
+  UShort_t           GetChargeMB(Int_t channel, Int_t num_bunch) const
+  { return        fChargeMB[channel][num_bunch]; }
+  Bool_t             GetIntMBFlag(Int_t channel, Int_t num_bunch) const
+  { return        fIsIntMB[channel][num_bunch]; }
+  Bool_t             GetBBMBFlag(Int_t channel, Int_t num_bunch) const
+  { return        fIsBBMB[channel][num_bunch]; }
+  Bool_t             GetBGMBFlag(Int_t channel, Int_t num_bunch) const
+  { return        fIsBGMB[channel][num_bunch]; }
 
-    Short_t           GetADC(Int_t channel) const
-      { return TMath::MaxElement(kNEvOfInt, fADC[channel]); }    // maximum value instead of central clock
-//    { return fADC[channel][kNEvOfInt/2]; }
-            
-    Short_t           GetPedestal(Int_t channel, Int_t event) const
-      { return fADC[channel][20-event]; }
-    Bool_t            GetIntegratorFlag(Int_t channel, Int_t event) const
-      { return fIsInt[channel][20-event]; }
-    Bool_t            GetBBFlag(Int_t channel, Int_t event) const
-      { return fIsBB[channel][20-event]; } 
-    Bool_t            GetBGFlag(Int_t channel, Int_t event) const
-      { return fIsBG[channel][20-event]; }   
-    Short_t           GetTime(Int_t channel) const
-      { return fTime[channel]; }
-    Short_t           GetWidth(Int_t channel) const
-      { return fWidth[channel]; }
+  // Getters of ADC signals, ADC pedestals, time information and corresponding flags :
 
-    UShort_t          GetTriggerInputs() const
-      { return fTrigger; }
-    UShort_t          GetTriggerInputsMask() const
-      { return fTriggerMask; }
+  Short_t           GetADC(Int_t channel) const
+  { return TMath::MaxElement(kNEvOfInt, fADC[channel]); }    // maximum value instead of central clock
+  //    { return fADC[channel][kNEvOfInt/2]; }
 
-    enum EADRawDataParams {
-      kNChannels = 16, // number of electronic channels in AD (FEE numbering)
-      kNEvOfInt  = 21, // number of events of interest
-      kNScalers  = 16, // number of scalers
-      kNBunches  = 10  // number of bunches used in Minimum Bias information 
-    };
+  Short_t           GetPedestal(Int_t channel, Int_t event) const
+  { return fADC[channel][20-event]; }
+  Bool_t            GetIntegratorFlag(Int_t channel, Int_t event) const
+  { return fIsInt[channel][20-event]; }
+  Bool_t            GetBBFlag(Int_t channel, Int_t event) const
+  { return fIsBB[channel][20-event]; }
+  Bool_t            GetBGFlag(Int_t channel, Int_t event) const
+  { return fIsBG[channel][20-event]; }
+  Short_t           GetTime(Int_t channel) const
+  { return fTime[channel]; }
+  Short_t           GetWidth(Int_t channel) const
+  { return fWidth[channel]; }
 
-    enum EADRawStreamError {
-      kRawDataSizeErr = 1
-    };
+  UShort_t          GetTriggerInputs() const
+  { return fTrigger; }
+  UShort_t          GetTriggerInputsMask() const
+  { return fTriggerMask; }
 
-  private:
+  enum EADRawDataParams {
+    kNChannels = 16, // number of electronic channels in AD (FEE numbering)
+    kNEvOfInt  = 21, // number of events of interest
+    kNScalers  = 16, // number of scalers
+    kNBunches  = 10  // number of bunches used in Minimum Bias information
+  };
 
-    AliADRawStream(const AliADRawStream& stream);
-    AliADRawStream& operator = (const AliADRawStream& stream);
+  enum EADRawStreamError {
+    kRawDataSizeErr = 1
+  };
 
-    UInt_t GetNextWord();
-    UShort_t GetNextShort();
+private:
+  AliADRawStream(const AliADRawStream& stream);
+  AliADRawStream& operator = (const AliADRawStream& stream);
 
-    ULong64_t     fBBScalers[kNChannels];        // 'Beam-Beam' scalers for all channels
-    ULong64_t     fBGScalers[kNChannels];        // 'Beam-Gas' scalers for all channels
-    UInt_t        fScalers[kNScalers];           // Trigger scalers
-    UInt_t        fBunchNumbers[kNBunches];      // Bunch numbers for the previous 10 MB events
-    UShort_t      fChargeMB[kNChannels][kNBunches]; // ADC counts for all channels for the previous 10 MB events
-    Bool_t        fIsIntMB[kNChannels][kNBunches];  // 'Integrator' flag for all channels for the previous 10 MB events
-    Bool_t        fIsBBMB[kNChannels][kNBunches];   // 'Beam-Beam' flag for all channels for the previous 10 MB events
-    Bool_t        fIsBGMB[kNChannels][kNBunches];   // 'Beam-Gas' for all channels for the previous 10 MB events
+  UInt_t   GetNextWord();
+  UShort_t GetNextShort();
 
-    Short_t       fADC[kNChannels][kNEvOfInt];   // ADC counts for all channels and all events of interest
-    Bool_t        fIsInt[kNChannels][kNEvOfInt]; // 'Integrator' flag for all channels 
-    Bool_t        fIsBB[kNChannels][kNEvOfInt];  // 'Beam-Beam' flag for all channels
-    Bool_t        fIsBG[kNChannels][kNEvOfInt];  // 'Beam-Gas' flag for all channels
-    Short_t       fTime[kNChannels];             // leading time for all channels - from HPTDC - in HPTDC units
-    Short_t       fWidth[kNChannels];            // pulse width for all channels - from HPTDC - in HPTDC units
+  ULong64_t     fBBScalers[kNChannels];        // 'Beam-Beam' scalers for all channels
+  ULong64_t     fBGScalers[kNChannels];        // 'Beam-Gas' scalers for all channels
+  UInt_t        fScalers[kNScalers];           // Trigger scalers
+  UInt_t        fBunchNumbers[kNBunches];      // Bunch numbers for the previous 10 MB events
+  UShort_t      fChargeMB[kNChannels][kNBunches]; // ADC counts for all channels for the previous 10 MB events
+  Bool_t        fIsIntMB[kNChannels][kNBunches];  // 'Integrator' flag for all channels for the previous 10 MB events
+  Bool_t        fIsBBMB[kNChannels][kNBunches];   // 'Beam-Beam' flag for all channels for the previous 10 MB events
+  Bool_t        fIsBGMB[kNChannels][kNBunches];   // 'Beam-Gas' for all channels for the previous 10 MB events
 
-    UShort_t      fTrigger;        // AD trigger inputs
-    UShort_t      fTriggerMask;    // AD trigger inputs mask
+  Short_t       fADC[kNChannels][kNEvOfInt];   // ADC counts for all channels and all events of interest
+  Bool_t        fIsInt[kNChannels][kNEvOfInt]; // 'Integrator' flag for all channels
+  Bool_t        fIsBB[kNChannels][kNEvOfInt];  // 'Beam-Beam' flag for all channels
+  Bool_t        fIsBG[kNChannels][kNEvOfInt];  // 'Beam-Gas' flag for all channels
+  Short_t       fTime[kNChannels];             // leading time for all channels - from HPTDC - in HPTDC units
+  Short_t       fWidth[kNChannels];            // pulse width for all channels - from HPTDC - in HPTDC units
 
-    Int_t         fPosition;       // current position in the raw-data payload
-    
+  UShort_t      fTrigger;        // AD trigger inputs
+  UShort_t      fTriggerMask;    // AD trigger inputs mask
 
-    AliRawReader* fRawReader;      // object for reading the raw data
+  Int_t         fPosition;       // current position in the raw-data payload
 
-    UChar_t*      fData;           // pointer to raw data payload
+  AliRawReader* fRawReader;      // object for reading the raw data
 
-    ClassDef(AliADRawStream, 0) // class for reading AD DDL raw data
+  UChar_t*      fData;           // pointer to raw data payload
+
+  ClassDef(AliADRawStream, 0);   // class for reading AD DDL raw data
 };
 
 #endif

--- a/AD/ADbase/AliADSDigit.cxx
+++ b/AD/ADbase/AliADSDigit.cxx
@@ -15,28 +15,28 @@
 
 #include "AliADSDigit.h"
 
-ClassImp(AliADSDigit)
+ClassImp(AliADSDigit);
 
 //__________________________________________________________________________
 AliADSDigit::AliADSDigit()
-   :AliDigit(),
-    fPMNumber(0),
-    fNBins(0),
-    fCharges(NULL)
+  : AliDigit()
+  , fPMNumber(0)
+  , fNBins(0)
+  , fCharges(NULL)
 {
   // Standard default
   // constructor
 }
 
 //__________________________________________________________________________
-AliADSDigit::AliADSDigit(Int_t pmnumber,
-                         Int_t nbins,
+AliADSDigit::AliADSDigit(Int_t    pmnumber,
+                         Int_t    nbins,
                          Float_t *charges,
-                         Int_t *labels)
-  :AliDigit(),
-   fPMNumber(pmnumber),
-   fNBins(nbins),
-   fCharges(NULL)
+                         Int_t   *labels)
+  : AliDigit()
+  , fPMNumber(pmnumber)
+  , fNBins(nbins)
+  , fCharges(NULL)
 {
   // Constructor
   // Used in the digitizer
@@ -44,12 +44,10 @@ AliADSDigit::AliADSDigit(Int_t pmnumber,
   if (charges) {
     for(Int_t i = 0; i < fNBins; ++i)
       fCharges[i] = charges[i];
-  }
-  else {
+  } else {
     for(Int_t i = 0; i < fNBins; ++i)
       fCharges[i] = 0;
   }
-
   if (labels)
     for(Int_t iTrack = 0; iTrack < 3; ++iTrack) fTracks[iTrack] = labels[iTrack];
 }
@@ -59,10 +57,9 @@ AliADSDigit::~AliADSDigit()
 {
   // Destructor
   // Delete the charges array if it was allocated
-  if (fCharges) {
+  if (fCharges)
     delete [] fCharges;
-    fCharges = NULL;
-  }
+  fCharges = NULL;
 }
 
 void AliADSDigit::Clear(Option_t* )
@@ -72,8 +69,8 @@ void AliADSDigit::Clear(Option_t* )
   fCharges = NULL;
 }
 //__________________________________________________________________________
-void AliADSDigit::Print(const Option_t*) const
+void AliADSDigit::Print(Option_t*) const
 {
-    // Dumps digit object
-    Dump();
+  // Dumps digit object
+  Dump();
 }

--- a/AD/ADbase/AliADSDigit.h
+++ b/AD/ADbase/AliADSDigit.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 #ifndef ALIADSDIGIT_H
 #define ALIADSDIGIT_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
@@ -6,17 +7,16 @@
 #include "AliDigit.h"
 
 //_____________________________________________________________________________
-class AliADSDigit: public AliDigit  {
-
+class AliADSDigit: public AliDigit {
 public:
   AliADSDigit();
-  AliADSDigit(Int_t pmnumber,
-	      Int_t nbins,
+  AliADSDigit(Int_t    pmnumber,
+	      Int_t    nbins,
 	      Float_t *charges,
-	      Int_t *labels = 0);
+	      Int_t   *labels = NULL);
   virtual            ~AliADSDigit();
 
-  virtual void        Print(const Option_t* option="") const;
+  virtual void        Print(Option_t* option="") const;
 
   Int_t               PMNumber()   const {return fPMNumber;}
   Int_t               GetNBins()   const {return fNBins;}

--- a/AD/ADbase/AliADdigit.cxx
+++ b/AD/ADbase/AliADdigit.cxx
@@ -20,43 +20,42 @@ ClassImp(AliADdigit)
 
 //__________________________________________________________________________
 AliADdigit::AliADdigit()
-   :AliDigit(),
-    fPMNumber(0),
-    fTime(0.),
-    fWidth(0.),
-    fIntegrator(0),
-    fBBflag(0),
-    fBGflag(0)
-
+  : AliDigit()
+  , fPMNumber(0)
+  , fTime(0.)
+  , fWidth(0.)
+  , fIntegrator(0)
+  , fBBflag(0)
+  , fBGflag(0)
 {
   // Standard default
-  // constructor 
+  // constructor
   for(Int_t iClock = 0; iClock < kADNClocks; ++iClock) fChargeADC[iClock] = 0;
 }
 
 //__________________________________________________________________________
-AliADdigit::AliADdigit(Int_t   PMnumber, Float_t time, 
-                             Float_t width,
-			     Bool_t integrator,
-			     Short_t *chargeADC,
-			     Bool_t  BBflag,
-		  	     Bool_t  BGflag,
-			     Int_t *labels)
-:AliDigit(),
-fPMNumber(PMnumber),
-fTime(time),
-fWidth(width),
-fIntegrator(integrator),
-fBBflag(BBflag),
-fBGflag(BGflag)
-{  
+AliADdigit::AliADdigit(Int_t    PMnumber,
+		       Float_t  time,
+		       Float_t  width,
+		       Bool_t   integrator,
+		       Short_t *chargeADC,
+		       Bool_t   BBflag,
+		       Bool_t   BGflag,
+		       Int_t   *labels)
+  : AliDigit()
+  , fPMNumber(PMnumber)
+  , fTime(time)
+  , fWidth(width)
+  , fIntegrator(integrator)
+  , fBBflag(BBflag)
+  , fBGflag(BGflag)
+{
   // Constructor
   // Used in the digitizer
   if (chargeADC) {
     for(Int_t iClock = 0; iClock < kADNClocks; ++iClock)
       fChargeADC[iClock] = chargeADC[iClock];
-  }
-  else {
+  } else {
     for(Int_t iClock = 0; iClock < kADNClocks; ++iClock)
       fChargeADC[iClock] = 0;
   }
@@ -67,16 +66,14 @@ fBGflag(BGflag)
 //__________________________________________________________________________
 Bool_t AliADdigit::GetIntegratorFlag(Int_t clock)
 {
-if (clock >= 0 && clock < kADNClocks){
-	if(clock%2 == 0) return fIntegrator;
-	else return !fIntegrator;
-	}
-	
-else return kFALSE;
+  if (clock >= 0 && clock < kADNClocks) {
+    if(clock%2 == 0) return fIntegrator;
+    else return !fIntegrator;
+  } else return kFALSE;
 }
 //__________________________________________________________________________
-void AliADdigit::Print(const Option_t*) const
+void AliADdigit::Print(Option_t*) const
 {
-    // Dumps digit object
-    Dump();
+  // Dumps digit object
+  Dump();
 }

--- a/AD/ADbase/AliADdigit.h
+++ b/AD/ADbase/AliADdigit.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 #ifndef ALIADDIGIT_H
 #define ALIADDIGIT_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
@@ -9,43 +10,41 @@
 #include "AliADConst.h"
 
 //_____________________________________________________________________________
-class AliADdigit: public AliDigit  {
-
+class AliADdigit: public AliDigit {
 public:
-    AliADdigit();
-    AliADdigit(Int_t   PMnumber, Float_t time, 
-                  Float_t TimeWidth,
-		  Bool_t  Integrator,
-		  Short_t *chargeADC = 0,
-		  Bool_t  BBflag = kFALSE,
-		  Bool_t  BGflag = kFALSE,
-		  Int_t *labels = 0);
-    virtual ~AliADdigit() {};
-    virtual void Print(const Option_t* option="") const;
+  AliADdigit();
+  AliADdigit(Int_t   PMnumber, Float_t time,
+	     Float_t TimeWidth,
+	     Bool_t  Integrator,
+	     Short_t *chargeADC = NULL,
+	     Bool_t  BBflag = kFALSE,
+	     Bool_t  BGflag = kFALSE,
+	     Int_t  *labels = NULL);
+  virtual ~AliADdigit() {};
+  virtual void Print(Option_t* option="") const;
 
-    Int_t   PMNumber()   const {return fPMNumber;}    
-    Short_t ADC()        const {return fChargeADC[kADNClocks/2];}
-    Float_t Time()       const {return fTime;}
-    Float_t Width()      const {return fWidth;} 
-    Bool_t  Integrator() const {return fIntegrator;}
-    Short_t ChargeADC(Int_t clock) const {return (clock >= 0 && clock < kADNClocks) ? fChargeADC[clock] : 0;}
-    Bool_t  GetIntegratorFlag(Int_t clock);
-    Bool_t  GetBBflag()  const {return fBBflag;}
-    Bool_t  GetBGflag()  const {return fBGflag;}
-    void    SetBBflag(Bool_t bbFlag) {fBBflag = bbFlag;}
-    void    SetBGflag(Bool_t bgFlag) {fBGflag = bgFlag;}
-    
-  protected:
-    Int_t   fPMNumber;      // PhotoMultiplier number (0 to 16)
-    Float_t fTime;          // Time of Flight
-    Float_t fWidth;         // Width of the time distribution
-    Bool_t  fIntegrator;    // Integrator used in central clock
-    Short_t fChargeADC[kADNClocks]; // ADC samples as present in raw data
-    Bool_t  fBBflag;	    // BB flag in central clock
-    Bool_t  fBGflag;	    // BB flag in central clock
-    
+  Int_t   PMNumber()   const {return fPMNumber;}
+  Short_t ADC()        const {return fChargeADC[kADNClocks/2];}
+  Float_t Time()       const {return fTime;}
+  Float_t Width()      const {return fWidth;}
+  Bool_t  Integrator() const {return fIntegrator;}
+  Short_t ChargeADC(Int_t clock) const {return (clock >= 0 && clock < kADNClocks) ? fChargeADC[clock] : 0;}
+  Bool_t  GetIntegratorFlag(Int_t clock);
+  Bool_t  GetBBflag()  const {return fBBflag;}
+  Bool_t  GetBGflag()  const {return fBGflag;}
+  void    SetBBflag(Bool_t bbFlag) {fBBflag = bbFlag;}
+  void    SetBGflag(Bool_t bgFlag) {fBGflag = bgFlag;}
 
-  ClassDef(AliADdigit,1)  // AD Digit class
+protected:
+  Int_t   fPMNumber;      // PhotoMultiplier number (0 to 16)
+  Float_t fTime;          // Time of Flight
+  Float_t fWidth;         // Width of the time distribution
+  Bool_t  fIntegrator;    // Integrator used in central clock
+  Short_t fChargeADC[kADNClocks]; // ADC samples as present in raw data
+  Bool_t  fBBflag;	  // BB flag in central clock
+  Bool_t  fBGflag;	  // BG flag in central clock
+
+  ClassDef(AliADdigit,1); // AD Digit class
 };
 //typedef AliADdigit AliADdigit;
 #endif

--- a/AD/ADrec/AliADDecision.cxx
+++ b/AD/ADrec/AliADDecision.cxx
@@ -117,7 +117,6 @@ void AliADDecision::FillDecisions(AliESDAD *esdAD)
   Double_t timeBasicADA=0, timeBasicADC=0;
   Double_t weightBasicADA =0., weightBasicADC = 0.;
   UInt_t   ntimeBasicADA=0, ntimeBasicADC=0;
-  UInt_t   itimeBasicADA[8], itimeBasicADC[8];
 
   for (Int_t i = 0; i < 16; ++i) {
     Float_t adc = esdAD->GetAdc(i);
@@ -128,12 +127,10 @@ void AliADDecision::FillDecisions(AliESDAD *esdAD)
 	if (adc>1) timeErr = 1/adc;
 
 	if (i<8) {
-	  itimeBasicADC[ntimeBasicADC] = i;
 	  ntimeBasicADC++;
 	  timeBasicADC += time/(timeErr*timeErr);
 	  weightBasicADC += 1./(timeErr*timeErr);
 	} else {
-	  itimeBasicADA[ntimeBasicADA] = i-8;
 	  ntimeBasicADA++;
 	  timeBasicADA += time/(timeErr*timeErr);
 	  weightBasicADA += 1./(timeErr*timeErr);
@@ -266,14 +263,14 @@ void AliADDecision::FillDecisions(AliESDAD *esdAD)
   UInt_t aBBtriggerADC = 0; // bit mask for Beam-Beam trigger in ADC
   UInt_t aBGtriggerADC = 0; // bit mask for Beam-Gas trigger in ADC
 
-  for(Int_t i = 0; i < ntimeADA; ++i) {
+  for(UInt_t i = 0; i < ntimeADA; ++i) {
     if (esdAD->GetADADecision() == AliESDAD::kADBB)
       aBBtriggerADA |= (1 << (itimeADA[i]));
     else if (esdAD->GetADADecision() == AliESDAD::kADBG)
       aBGtriggerADA |= (1 << (itimeADA[i]));
   }
 
-  for(Int_t i = 0; i < ntimeADC; ++i) {
+  for(UInt_t i = 0; i < ntimeADC; ++i) {
     if (esdAD->GetADCDecision() == AliESDAD::kADBB)
       aBBtriggerADC |= (1 << (itimeADC[i]));
     else if (esdAD->GetADCDecision() == AliESDAD::kADBG)

--- a/AD/ADrec/AliADDecision.cxx
+++ b/AD/ADrec/AliADDecision.cxx
@@ -36,16 +36,16 @@
 #include "AliADReconstructor.h"
 
 //______________________________________________________________________
-ClassImp(AliADDecision)
+ClassImp(AliADDecision);
 
 //______________________________________________________________________
 
 AliADDecision::AliADDecision()
-:TObject(),
-  fADADist(0),
-  fADCDist(0),
-  fRecoParam(NULL),
-  fEarlyHitCutShape(NULL)
+  : TObject()
+  , fADADist(0)
+  , fADCDist(0)
+  , fRecoParam(NULL)
+  , fEarlyHitCutShape(NULL)
 {
   // Default constructor
   //AD has two layers, filling average
@@ -60,26 +60,25 @@ AliADDecision::AliADDecision()
   //fADCDist = 65.1917667655268360;
 
   fEarlyHitCutShape = new TF1("fEarlyHitCutShape", " [0]+(x>[2])*[1]*(x-[2])**2");
-
 }
 
 //______________________________________________________________________
 AliADDecision::~AliADDecision()
 {
-  // d-tor
-  delete fEarlyHitCutShape;
+  if (fEarlyHitCutShape)
+    delete fEarlyHitCutShape;
+  fEarlyHitCutShape = NULL;
 }
-
 
 //________________________________________________________________________________
 Double_t AliADDecision::GetZPosition(const char* symname)
 {
   // Get the global z coordinate of the given AD alignable volume
   //
-  Double_t *tr;
+  Double_t *tr=NULL;
   TGeoPNEntry *pne = gGeoManager->GetAlignableEntry(symname);
   if (!pne) {
-    AliFatalClass(Form("TGeoPNEntry with symbolic name %s does not exist!",symname));
+    AliFatalClassF("TGeoPNEntry with symbolic name %s does not exist!",symname);
     return 0;
   }
 
@@ -87,16 +86,15 @@ Double_t AliADDecision::GetZPosition(const char* symname)
   if(pnode){
     TGeoHMatrix* hm = pnode->GetMatrix();
     tr = hm->GetTranslation();
-  }else{
+  } else {
     const char* path = pne->GetTitle();
     if(!gGeoManager->cd(path)){
-      AliFatalClass(Form("Volume path %s not valid!",path));
+      AliFatalClassF("Volume path %s not valid!",path);
       return 0;
     }
     tr = gGeoManager->GetCurrentMatrix()->GetTranslation();
   }
   return tr[2];
-
 }
 
 //________________________________________________________________________________
@@ -134,8 +132,7 @@ void AliADDecision::FillDecisions(AliESDAD *esdAD)
 	  ntimeBasicADC++;
 	  timeBasicADC += time/(timeErr*timeErr);
 	  weightBasicADC += 1./(timeErr*timeErr);
-	}
-	else{
+	} else {
 	  itimeBasicADA[ntimeBasicADA] = i-8;
 	  ntimeBasicADA++;
 	  timeBasicADA += time/(timeErr*timeErr);
@@ -145,7 +142,6 @@ void AliADDecision::FillDecisions(AliESDAD *esdAD)
       }
     }
   } // end of loop over channels
-
 
   if(weightBasicADA > 1) timeBasicADA /= weightBasicADA;
   else timeBasicADA = -1024.;
@@ -189,7 +185,6 @@ void AliADDecision::FillDecisions(AliESDAD *esdAD)
 	}
       }
     }
-
   }
 
   //A-side
@@ -220,7 +215,6 @@ void AliADDecision::FillDecisions(AliESDAD *esdAD)
 	}
       }
     }
-
   }
 
   if(weightRobustADA > 1) timeRobustADA /= weightRobustADA;
@@ -290,6 +284,4 @@ void AliADDecision::FillDecisions(AliESDAD *esdAD)
   esdAD->SetBGtriggerADA(aBGtriggerADA);
   esdAD->SetBBtriggerADC(aBBtriggerADC);
   esdAD->SetBGtriggerADC(aBGtriggerADC);
-
-
 }

--- a/AD/ADrec/AliADDecision.h
+++ b/AD/ADrec/AliADDecision.h
@@ -1,10 +1,11 @@
+// -*- C++ -*-
 #ifndef ALIADDECISION_H
 #define ALIADDECISION_H
 
 ///_________________________________________________________________________
 ///
 ///  Auxiliary classs to compute the AD Trigger
-///_________________________________________________________________________   
+///_________________________________________________________________________
 
 #include <TObject.h>
 #include "AliLog.h"
@@ -18,33 +19,33 @@ class AliADRecoParam;
 
 class AliADDecision : public TObject
 {
- public:
+public:
   AliADDecision();   // constructor
-  virtual        ~AliADDecision();
+  virtual ~AliADDecision();
 
-   void FillDecisions(AliESDAD *esdAD);
-   Double_t GetZPosition(const char* symname);
+  void FillDecisions(AliESDAD *esdAD);
+  Double_t GetZPosition(const char* symname);
 
-   void SetRecoParam(const AliADRecoParam *param) { fRecoParam = param; }
-   const AliADRecoParam* GetRecoParam() const
-   {
-     if (!fRecoParam) {
-       AliError("Reco-param object is not set!");
-       return NULL;
-     }
-     return fRecoParam;
-   }
+  void SetRecoParam(const AliADRecoParam *param) { fRecoParam = param; }
+  const AliADRecoParam* GetRecoParam() const
+  {
+    if (!fRecoParam) {
+      AliError("Reco-param object is not set!");
+      return NULL;
+    }
+    return fRecoParam;
+  }
 
 private:
-   AliADDecision(const AliADDecision& mask);
-   AliADDecision& operator = (const AliADDecision& mask);
+  AliADDecision(const AliADDecision& mask);
+  AliADDecision& operator = (const AliADDecision& mask);
 
-   Float_t fADADist;     // Z position of ADA
-   Float_t fADCDist;     // Z position of ADC
-   const AliADRecoParam* fRecoParam; //! Pointer to AD reco-param object
-   TF1 *fEarlyHitCutShape; //! Shape of cut on early hits
+  Float_t fADADist;     // Z position of ADA
+  Float_t fADCDist;     // Z position of ADC
+  const AliADRecoParam* fRecoParam; //! Pointer to AD reco-param object
+  TF1 *fEarlyHitCutShape; //! Shape of cut on early hits
 
-   ClassDef( AliADDecision, 2)  // AD Offline trigger class
+  ClassDef( AliADDecision, 2);  // AD Offline trigger class
 };
 
 #endif // ALIADDECISION_H

--- a/AD/ADrec/AliADQAChecker.cxx
+++ b/AD/ADrec/AliADQAChecker.cxx
@@ -15,19 +15,19 @@
 
 
 /*
-  Checks the quality assurance. Under construction. 
+  Checks the quality assurance. Under construction.
   By comparing with reference data
 
 */
 
 // --- ROOT system ---
 #include <TClass.h>
-#include <TH2F.h> 
-#include <TH1D.h> 
-#include <TH1I.h> 
-#include <TIterator.h> 
-#include <TKey.h> 
-#include <TFile.h> 
+#include <TH2F.h>
+#include <TH1D.h>
+#include <TH1I.h>
+#include <TIterator.h>
+#include <TKey.h>
+#include <TFile.h>
 #include <TCanvas.h>
 #include <TPaveText.h>
 #include <TLatex.h>
@@ -50,726 +50,689 @@
 #include "AliADQAParam.h"
 
 
-ClassImp(AliADQAChecker)
+ClassImp(AliADQAChecker);
 
 //__________________________________________________________________
-AliADQAChecker::AliADQAChecker() : AliQACheckerBase("AD","AD Quality Assurance Data Checker"),
-  fLowEventCut(1000),
-  fORvsANDCut(0.2),
-  fBGvsBBCut(0.2),
-  fSatMed(0.1),
-  fSatHigh(0.3),
-  fSatHuge(0.5),
-  fMaxPedDiff(1),
-  fMaxPedWidth(1.5),
-  fChargeChannelZoomMin(0),
-  fChargeChannelZoomMax(50),
-  fTimeRatioBBZoomMin(170),
-  fTimeRatioBBZoomMax(210),
-  fTimeRatioBGZoomMin(50),
-  fTimeRatioBGZoomMax(90),
-  fChargeTrendMin(0),
-  fChargeTrendMax(1000),
-  fMaxNoTimeRate(10e-3),
-  fMaxNoFlagRate(10e-2),
-  fMaxBBVariation(5),
-  fMaxBGVariation(5),
-  fAsynchronBB(0.5),
-  fAsynchronBG(0.5)
+AliADQAChecker::AliADQAChecker()
+  : AliQACheckerBase("AD","AD Quality Assurance Data Checker")
+  , fLowEventCut(1000)
+  , fORvsANDCut(0.2)
+  , fBGvsBBCut(0.2)
+  , fSatMed(0.1)
+  , fSatHigh(0.3)
+  , fSatHuge(0.5)
+  , fMaxPedDiff(1)
+  , fMaxPedWidth(1.5)
+  , fChargeChannelZoomMin(0)
+  , fChargeChannelZoomMax(50)
+  , fTimeRatioBBZoomMin(170)
+  , fTimeRatioBBZoomMax(210)
+  , fTimeRatioBGZoomMin(50)
+  , fTimeRatioBGZoomMax(90)
+  , fChargeTrendMin(0)
+  , fChargeTrendMax(1000)
+  , fMaxNoTimeRate(10e-3)
+  , fMaxNoFlagRate(10e-2)
+  , fMaxBBVariation(5)
+  , fMaxBGVariation(5)
+  , fAsynchronBB(0.5)
+  , fAsynchronBG(0.5)
 {
-  
-  
 }
 
 //____________________________________________________________________________
 AliADQAParam* AliADQAChecker::GetQAParam() const
-
 {
   AliCDBManager *man = AliCDBManager::Instance();
-
-  AliCDBEntry *entry=0;
-
-  entry = man->Get("AD/Calib/QAParam");
+  AliCDBEntry *entry = man->Get("AD/Calib/QAParam");
   if(!entry)AliWarning("Load of QA param from default storage failed!");
- 
+
   // Retrieval of data in directory AD/Calib/QA:
 
   AliADQAParam *QAParam = 0;
-
   if (entry) QAParam = (AliADQAParam*) entry->GetObject();
   if (!QAParam)  AliFatal("No QA param from calibration database !");
 
   return QAParam;
 }
 //__________________________________________________________________
-void AliADQAChecker::Check(Double_t * check, AliQAv1::ALITASK_t index, TObjArray ** list, const AliDetectorRecoParam * /*recoParam*/) 
+void AliADQAChecker::Check(Double_t * check, AliQAv1::ALITASK_t index, TObjArray ** list, const AliDetectorRecoParam * /*recoParam*/)
 {
   // Main check function: Depending on the TASK, different checks will be applied
   // Check for missing channels and check on the trigger type for raw data
   // Check for missing disk or rings for esd (to be redone)
 
   for (Int_t specie = 0 ; specie < AliRecoParam::kNSpecies ; specie++) {
-    check[specie] = 1.0;    
-    if ( !AliQAv1::Instance()->IsEventSpecieSet(specie) ) 
+    check[specie] = 1.0;
+    if ( !AliQAv1::Instance()->IsEventSpecieSet(specie) )
       continue;
     if (index == AliQAv1::kRAW) {
       if (AliRecoParam::ConvertIndex(specie) == AliRecoParam::kCalib) check[specie] =  CheckPedestals(list[specie]);
       else check[specie] =  CheckRaws(list[specie]);
-    } 
-    else if (index == AliQAv1::kESD) {
+    } else if (index == AliQAv1::kESD) {
       check[specie] =  CheckEsds(list[specie]);
-    } 
+    }
   }
 }
 //_________________________________________________________________
 Double_t AliADQAChecker::CheckPedestals(TObjArray * list) const
 {
   //  Check on the QA histograms on the raw-data input list:
-
-Double_t test = 1.0;
-  if (list->GetEntries() == 0){  
+  Double_t test = 1.0;
+  if (list->GetEntries() == 0){
     AliWarning("There are no histograms to be checked");
-  }
-  else {
+  }  else {
     TH2F *hPedestalInt0  = (TH2F*)list->At(AliADQADataMakerRec::kPedestalInt0);
     if (!hPedestalInt0) {
       AliWarning("PedestalInt0 histogram is not found");
-    }
-    else {
-    	if(hPedestalInt0->GetListOfFunctions()->GetEntries()<1) hPedestalInt0->GetListOfFunctions()->Add(new TPaveText(0.15,0.63,0.85,0.85,"NDC"));
-    	for(Int_t i=0; i<hPedestalInt0->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hPedestalInt0->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hPedestalInt0->GetListOfFunctions()->At(i);
-      			QAbox->Clear();
-			if(hPedestalInt0->GetEntries() == 0){
-				QAbox->Clear();
-        			QAbox->SetFillColor(kYellow);
-        			QAbox->AddText("Is this AD pedestal run?");
-				}
-			else{
-    				TH1D *hPedestalSlice;
-				Int_t NbadChannels = 0;
-				TString badChannels = " ";
-    				for(Int_t i=0; i<16; i++){
-      					hPedestalSlice = hPedestalInt0->ProjectionY("hPedestalSlice",i+1,i+1);
-					Double_t RMS = hPedestalSlice->GetRMS();
-					if(RMS > fMaxPedWidth) {
-						test = 0.1;
-						if(NbadChannels == 0){
-							QAbox->SetFillColor(kRed);
-							QAbox->AddText("Noisy pedestal for channel ");
-							}
-						badChannels += i;
-						badChannels += ", ";
-						NbadChannels++;
-						}
-					if(NbadChannels != 0 && i==15) QAbox->AddText(badChannels.Data());
-					}
-				if(NbadChannels == 0){
-					QAbox->Clear();
-        				QAbox->SetFillColor(kGreen);
-        				QAbox->AddText("OK");
-					}
-				}		
-    			}
+    } else {
+      if(hPedestalInt0->GetListOfFunctions()->GetEntries()<1) hPedestalInt0->GetListOfFunctions()->Add(new TPaveText(0.15,0.63,0.85,0.85,"NDC"));
+      for(Int_t i=0; i<hPedestalInt0->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hPedestalInt0->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hPedestalInt0->GetListOfFunctions()->At(i);
+	  QAbox->Clear();
+	  if(hPedestalInt0->GetEntries() == 0){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kYellow);
+	    QAbox->AddText("Is this AD pedestal run?");
+	  } else {
+	    TH1D *hPedestalSlice;
+	    Int_t NbadChannels = 0;
+	    TString badChannels = " ";
+	    for(Int_t i=0; i<16; i++){
+	      hPedestalSlice = hPedestalInt0->ProjectionY("hPedestalSlice",i+1,i+1);
+	      Double_t RMS = hPedestalSlice->GetRMS();
+	      if(RMS > fMaxPedWidth) {
+		test = 0.1;
+		if(NbadChannels == 0){
+		  QAbox->SetFillColor(kRed);
+		  QAbox->AddText("Noisy pedestal for channel ");
 		}
-    	}
+		badChannels += i;
+		badChannels += ", ";
+		NbadChannels++;
+	      }
+	      if(NbadChannels != 0 && i==15) QAbox->AddText(badChannels.Data());
+	    }
+	    if(NbadChannels == 0){
+	      QAbox->Clear();
+	      QAbox->SetFillColor(kGreen);
+	      QAbox->AddText("OK");
+	    }
+	  }
+	}
+      }
+    }
     TH2F *hPedestalInt1  = (TH2F*)list->At(AliADQADataMakerRec::kPedestalInt1);
     if (!hPedestalInt1) {
       AliWarning("PedestalInt1 histogram is not found");
-    }
-    else {
-    	if(hPedestalInt1->GetListOfFunctions()->GetEntries()<1) hPedestalInt1->GetListOfFunctions()->Add(new TPaveText(0.15,0.63,0.85,0.85,"NDC"));
-    	for(Int_t i=0; i<hPedestalInt1->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hPedestalInt1->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hPedestalInt1->GetListOfFunctions()->At(i);
-      			QAbox->Clear();
-			if(hPedestalInt1->GetEntries() == 0){
-				QAbox->Clear();
-        			QAbox->SetFillColor(kYellow);
-        			QAbox->AddText("Is this AD pedestal run?");
-				}
-			else{
-    				TH1D *hPedestalSlice;
-				Int_t NbadChannels = 0;
-				TString badChannels = " ";
-    				for(Int_t i=0; i<16; i++){
-      					hPedestalSlice = hPedestalInt1->ProjectionY("hPedestalSlice",i+1,i+1);
-					Double_t RMS = hPedestalSlice->GetRMS();
-					if(RMS > fMaxPedWidth) {
-						test = 0.1;
-						if(NbadChannels == 0){
-							QAbox->SetFillColor(kRed);
-							QAbox->AddText("Noisy pedestal for channel ");
-							}
-						badChannels += i;
-						badChannels += ", ";
-						NbadChannels++;
-						}
-					if(NbadChannels != 0 && i==15) QAbox->AddText(badChannels.Data());
-					}
-				if(NbadChannels == 0){
-					QAbox->Clear();
-        				QAbox->SetFillColor(kGreen);
-        				QAbox->AddText("OK");
-					}
-				}		
-    			}
+    } else {
+      if(hPedestalInt1->GetListOfFunctions()->GetEntries()<1) hPedestalInt1->GetListOfFunctions()->Add(new TPaveText(0.15,0.63,0.85,0.85,"NDC"));
+      for(Int_t i=0; i<hPedestalInt1->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hPedestalInt1->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hPedestalInt1->GetListOfFunctions()->At(i);
+	  QAbox->Clear();
+	  if(hPedestalInt1->GetEntries() == 0){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kYellow);
+	    QAbox->AddText("Is this AD pedestal run?");
+	  } else {
+	    TH1D *hPedestalSlice;
+	    Int_t NbadChannels = 0;
+	    TString badChannels = " ";
+	    for(Int_t i=0; i<16; i++){
+	      hPedestalSlice = hPedestalInt1->ProjectionY("hPedestalSlice",i+1,i+1);
+	      Double_t RMS = hPedestalSlice->GetRMS();
+	      if(RMS > fMaxPedWidth) {
+		test = 0.1;
+		if(NbadChannels == 0){
+		  QAbox->SetFillColor(kRed);
+		  QAbox->AddText("Noisy pedestal for channel ");
 		}
-    	}
+		badChannels += i;
+		badChannels += ", ";
+		NbadChannels++;
+	      }
+	      if(NbadChannels != 0 && i==15) QAbox->AddText(badChannels.Data());
+	    }
+	    if(NbadChannels == 0){
+	      QAbox->Clear();
+	      QAbox->SetFillColor(kGreen);
+	      QAbox->AddText("OK");
+	    }
+	  }
+	}
+      }
+    }
   }
-  
-  return test ; 
+
+  return test ;
 }
 
 //_________________________________________________________________
 Double_t AliADQAChecker::CheckRaws(TObjArray * list) const
 {
-
   //  Check on the QA histograms on the raw-data input list:
-
   Double_t test = 1.0;
-  if (list->GetEntries() == 0){  
+  if (list->GetEntries() == 0){
     AliWarning("There are no histograms to be checked");
-  }
-  else {
+  } else {
     Float_t nEvents;
     TH1F *hChargeADA = (TH1F*)list->At(AliADQADataMakerRec::kChargeADA);
     if (!hChargeADA) {
       AliWarning("ChargeADA histogram is not found");
+    } else {
+      nEvents = hChargeADA->Integral(-1,-1);
+      if(hChargeADA->GetListOfFunctions()->GetEntries()<1) hChargeADA->GetListOfFunctions()->Add(new TPaveText(0.43,0.70,0.66,0.83,"NDC"));
+      for(Int_t i=0; i<hChargeADA->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hChargeADA->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hChargeADA->GetListOfFunctions()->At(i);
+
+	  TString meanChargeADA = " Mean charge ADA = ";
+	  meanChargeADA += TString::Format("%4.1f ", hChargeADA->GetMean());
+
+	  QAbox->Clear();
+	  QAbox->SetFillColor(kWhite);
+	  QAbox->SetTextColor(kBlue);
+	  QAbox->AddText(meanChargeADA.Data());
+	}
+      }
     }
-    else {
-    	nEvents = hChargeADA->Integral(-1,-1);
-    	if(hChargeADA->GetListOfFunctions()->GetEntries()<1) hChargeADA->GetListOfFunctions()->Add(new TPaveText(0.43,0.70,0.66,0.83,"NDC"));
-    	for(Int_t i=0; i<hChargeADA->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hChargeADA->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hChargeADA->GetListOfFunctions()->At(i);
-      			
-			TString meanChargeADA = " Mean charge ADA = ";
-			meanChargeADA += TString::Format("%4.1f ", hChargeADA->GetMean());
-			
-			QAbox->Clear();
-			QAbox->SetFillColor(kWhite);
-        		QAbox->SetTextColor(kBlue);
-			QAbox->AddText(meanChargeADA.Data());				
-    			}
-		}
-    	}
-	
+
     TH1F *hChargeADC = (TH1F*)list->At(AliADQADataMakerRec::kChargeADC);
     if (!hChargeADC) {
       AliWarning("ChargeADC histogram is not found");
+    } else {
+      if(hChargeADC->GetListOfFunctions()->GetEntries()<1) hChargeADC->GetListOfFunctions()->Add(new TPaveText(0.43,0.55,0.66,0.68,"NDC"));
+      for(Int_t i=0; i<hChargeADC->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hChargeADC->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hChargeADC->GetListOfFunctions()->At(i);
+
+	  TString meanChargeADC = " Mean charge ADC = ";
+	  meanChargeADC += TString::Format("%4.1f ", hChargeADC->GetMean());
+
+	  QAbox->Clear();
+	  QAbox->SetFillColor(kWhite);
+	  QAbox->SetTextColor(kRed);
+	  QAbox->AddText(meanChargeADC.Data());
+	}
+      }
     }
-    else {
-    	if(hChargeADC->GetListOfFunctions()->GetEntries()<1) hChargeADC->GetListOfFunctions()->Add(new TPaveText(0.43,0.55,0.66,0.68,"NDC"));
-    	for(Int_t i=0; i<hChargeADC->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hChargeADC->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hChargeADC->GetListOfFunctions()->At(i);
-      			
-			TString meanChargeADC = " Mean charge ADC = ";
-			meanChargeADC += TString::Format("%4.1f ", hChargeADC->GetMean());
-			
-			QAbox->Clear();
-			QAbox->SetFillColor(kWhite);
-        		QAbox->SetTextColor(kRed);
-			QAbox->AddText(meanChargeADC.Data());				
-    			}
-		}
-    	}
-	
-    Int_t nEventsADOR = 0;	
+
+    Int_t nEventsADOR = 0;
     TH1F *hTriggers = (TH1F*)list->At(AliADQADataMakerRec::kTriggers);
     if (!hTriggers) {
       AliWarning("Triggers histogram is not found");
+    } else {
+      nEventsADOR = hTriggers->GetBinContent(6);
+      if(hTriggers->GetListOfFunctions()->GetEntries()<1) hTriggers->GetListOfFunctions()->Add(new TPaveText(0.56,0.73,0.72,0.85,"NDC"));
+      for(Int_t i=0; i<hTriggers->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hTriggers->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hTriggers->GetListOfFunctions()->At(i);
+
+	  TString nEventsText = " Number of events = ";
+	  nEventsText += TString::Format("%.0f ", nEvents);
+
+	  QAbox->Clear();
+	  QAbox->SetFillColor(kWhite);
+	  QAbox->SetTextColor(kAzure-8);
+	  QAbox->AddText(nEventsText.Data());
+	}
+      }
     }
-    else {
-        nEventsADOR = hTriggers->GetBinContent(6);
-    	if(hTriggers->GetListOfFunctions()->GetEntries()<1) hTriggers->GetListOfFunctions()->Add(new TPaveText(0.56,0.73,0.72,0.85,"NDC"));
-    	for(Int_t i=0; i<hTriggers->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hTriggers->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hTriggers->GetListOfFunctions()->At(i);
-      			
-			TString nEventsText = " Number of events = ";
-			nEventsText += TString::Format("%.0f ", nEvents);
-			
-			QAbox->Clear();
-			QAbox->SetFillColor(kWhite);
-        		QAbox->SetTextColor(kAzure-8);
-			QAbox->AddText(nEventsText.Data());				
-    			}
-		}
-    	}
     TH1F *hFlagNoTime = (TH1F*)list->At(AliADQADataMakerRec::kFlagNoTime);
     if (!hFlagNoTime) {
       AliWarning("FlagNoTime histogram is not found");
+    } else {
+      if(hFlagNoTime->GetListOfFunctions()->GetEntries()<1) hFlagNoTime->GetListOfFunctions()->Add(new TPaveText(0.15,0.67,0.85,0.76,"NDC"));
+      for(Int_t i=0; i<hFlagNoTime->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hFlagNoTime->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hFlagNoTime->GetListOfFunctions()->At(i);
+
+	  TH1F *histoRate = (TH1F*)hFlagNoTime->Clone("histoRate");
+	  histoRate->Sumw2();
+	  if(nEvents != 0) histoRate->Scale(1/nEvents);
+	  Int_t NbadChannels = 0;
+	  TString badChannels = "No time rate too high, ch:";
+
+	  for(Int_t i=0; i<16; i++){
+	    if(histoRate->GetBinContent(i+1)>fMaxNoTimeRate) {
+	      test = 0.3;
+	      badChannels += i;
+	      badChannels += ", ";
+	      NbadChannels++;
+	    }
+	  }
+	  delete histoRate;
+	  if(NbadChannels != 0){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kRed);
+	    QAbox->AddText(badChannels.Data());
+	  } else {
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kGreen);
+	    QAbox->AddText("No time rate OK");
+	  }
+	}
+      }
     }
-    else {
-    	if(hFlagNoTime->GetListOfFunctions()->GetEntries()<1) hFlagNoTime->GetListOfFunctions()->Add(new TPaveText(0.15,0.67,0.85,0.76,"NDC"));
-    	for(Int_t i=0; i<hFlagNoTime->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hFlagNoTime->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hFlagNoTime->GetListOfFunctions()->At(i);
-      			
-			TH1F *histoRate = (TH1F*)hFlagNoTime->Clone("histoRate");
-			histoRate->Sumw2();
-			if(nEvents != 0) histoRate->Scale(1/nEvents);
-			Int_t NbadChannels = 0;
-			TString badChannels = "No time rate too high, ch:";
-			
-			for(Int_t i=0; i<16; i++){
-				if(histoRate->GetBinContent(i+1)>fMaxNoTimeRate) {
-					test = 0.3;
-					badChannels += i;
-					badChannels += ", ";
-					NbadChannels++;
-					}
-				}
-			delete histoRate;
-			if(NbadChannels != 0){
-				QAbox->Clear();
-				QAbox->SetFillColor(kRed); 
-				QAbox->AddText(badChannels.Data());
-				}
-			else{
-				QAbox->Clear();
-				QAbox->SetFillColor(kGreen);
-				QAbox->AddText("No time rate OK");				
-    				}
-			}
-    		}
-    	}
     TH1F *hTimeNoFlag = (TH1F*)list->At(AliADQADataMakerRec::kTimeNoFlag);
     if (!hTimeNoFlag) {
       AliWarning("TimeNoFlag histogram is not found");
     }
     else {
-    	if(hTimeNoFlag->GetListOfFunctions()->GetEntries()<1) hTimeNoFlag->GetListOfFunctions()->Add(new TPaveText(0.15,0.56,0.85,0.65,"NDC"));
-    	for(Int_t i=0; i<hTimeNoFlag->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hTimeNoFlag->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hTimeNoFlag->GetListOfFunctions()->At(i);
-      			
-			TH1F *histoRate = (TH1F*)hTimeNoFlag->Clone("histoRate");
-			histoRate->Sumw2();
-			if(nEvents != 0) histoRate->Scale(1/nEvents);
-			Int_t NbadChannels = 0;
-			TString badChannels = "No flag rate too high, ch: ";
-			
-			for(Int_t i=0; i<16; i++){
-				if(histoRate->GetBinContent(i+1)>fMaxNoFlagRate) {
-					test = 0.3;
-					badChannels += i;
-					badChannels += ", ";
-					NbadChannels++;
-					}
-				}
-			delete histoRate;
-			if(NbadChannels != 0){
-				QAbox->Clear();
-				QAbox->SetFillColor(kRed); 
-				QAbox->AddText(badChannels.Data());
-				}
-			else{
-				QAbox->Clear();
-				QAbox->SetFillColor(kGreen);
-				QAbox->AddText("No flag rate OK");				
-    				}
-			}
-    		}
-    	}
+      if(hTimeNoFlag->GetListOfFunctions()->GetEntries()<1) hTimeNoFlag->GetListOfFunctions()->Add(new TPaveText(0.15,0.56,0.85,0.65,"NDC"));
+      for(Int_t i=0; i<hTimeNoFlag->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hTimeNoFlag->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hTimeNoFlag->GetListOfFunctions()->At(i);
+
+	  TH1F *histoRate = (TH1F*)hTimeNoFlag->Clone("histoRate");
+	  histoRate->Sumw2();
+	  if(nEvents != 0) histoRate->Scale(1/nEvents);
+	  Int_t NbadChannels = 0;
+	  TString badChannels = "No flag rate too high, ch: ";
+
+	  for(Int_t i=0; i<16; i++){
+	    if(histoRate->GetBinContent(i+1)>fMaxNoFlagRate) {
+	      test = 0.3;
+	      badChannels += i;
+	      badChannels += ", ";
+	      NbadChannels++;
+	    }
+	  }
+	  delete histoRate;
+	  if(NbadChannels != 0){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kRed);
+	    QAbox->AddText(badChannels.Data());
+	  } else {
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kGreen);
+	    QAbox->AddText("No flag rate OK");
+	  }
+	}
+      }
+    }
     TH1F *hNEventsBBFlag = (TH1F*)list->At(AliADQADataMakerRec::kNEventsBBFlag);
     if (!hNEventsBBFlag) {
       AliWarning("NEventsBBFlag histogram is not found");
+    } else {
+      if(hNEventsBBFlag->GetListOfFunctions()->GetEntries()<1) hNEventsBBFlag->GetListOfFunctions()->Add(new TPaveText(0.15,0.67,0.85,0.76,"NDC"));
+      for(Int_t i=0; i<hNEventsBBFlag->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hNEventsBBFlag->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hNEventsBBFlag->GetListOfFunctions()->At(i);
+
+	  TH1F *histoRate = (TH1F*)hNEventsBBFlag->Clone("histoRate");
+	  histoRate->Sumw2();
+	  if(nEvents != 0) histoRate->Scale(1/nEvents);
+
+	  Float_t meanRateADA  = 0;
+	  Float_t meanRateADC  = 0;
+	  for(Int_t i=1; i<=8; i++){
+	    meanRateADC += histoRate->GetBinContent(i);
+	    meanRateADA += histoRate->GetBinContent(i+8);
+	  }
+	  meanRateADA = meanRateADA/8;
+	  meanRateADC = meanRateADC/8;
+	  Bool_t highVar = kFALSE;
+
+	  for(Int_t i=1; i<=8; i++){
+	    if(((TMath::Abs(histoRate->GetBinContent(i)-meanRateADC))>fMaxBBVariation) ||
+	       ((TMath::Abs(histoRate->GetBinContent(i+8)-meanRateADA))>fMaxBBVariation)){
+	      test = 0.7;
+	      highVar = kTRUE;
+	    }
+	  }
+	  delete histoRate;
+	  if(highVar){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kYellow);
+	    QAbox->AddText("BB rate variation too high");
+	  } else {
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kGreen);
+	    QAbox->AddText("BB rate variation OK");
+	  }
+	}
+      }
     }
-    else {
-    	if(hNEventsBBFlag->GetListOfFunctions()->GetEntries()<1) hNEventsBBFlag->GetListOfFunctions()->Add(new TPaveText(0.15,0.67,0.85,0.76,"NDC"));
-    	for(Int_t i=0; i<hNEventsBBFlag->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hNEventsBBFlag->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hNEventsBBFlag->GetListOfFunctions()->At(i);
-      			
-			TH1F *histoRate = (TH1F*)hNEventsBBFlag->Clone("histoRate");
-			histoRate->Sumw2();
-			if(nEvents != 0) histoRate->Scale(1/nEvents);
-			
-			Float_t meanRateADA  = 0;
-			Float_t meanRateADC  = 0;
-			for(Int_t i=1; i<=8; i++){
-				meanRateADC += histoRate->GetBinContent(i);
-				meanRateADA += histoRate->GetBinContent(i+8);
-				}
-			meanRateADA = meanRateADA/8;
-			meanRateADC = meanRateADC/8;
-			Bool_t highVar = kFALSE;
-			
-			for(Int_t i=1; i<=8; i++){
-				if(((TMath::Abs(histoRate->GetBinContent(i)-meanRateADC))>fMaxBBVariation) || 
-				   ((TMath::Abs(histoRate->GetBinContent(i+8)-meanRateADA))>fMaxBBVariation)){
-					test = 0.7;
-					highVar = kTRUE;
-					}
-				}
-			delete histoRate;
-			if(highVar){
-				QAbox->Clear();
-				QAbox->SetFillColor(kYellow); 
-				QAbox->AddText("BB rate variation too high");
-				}
-			else{
-				QAbox->Clear();
-				QAbox->SetFillColor(kGreen);
-				QAbox->AddText("BB rate variation OK");				
-    				}
-			}
-    		}
-    	}                                 
     TH1F *hNEventsBGFlag = (TH1F*)list->At(AliADQADataMakerRec::kNEventsBGFlag);
     if (!hNEventsBGFlag) {
       AliWarning("NEventsBGFlag histogram is not found");
+    } else {
+      if(hNEventsBGFlag->GetListOfFunctions()->GetEntries()<1) hNEventsBGFlag->GetListOfFunctions()->Add(new TPaveText(0.15,0.56,0.85,0.65,"NDC"));
+      for(Int_t i=0; i<hNEventsBGFlag->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hNEventsBGFlag->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hNEventsBGFlag->GetListOfFunctions()->At(i);
+
+	  TH1F *histoRate = (TH1F*)hNEventsBGFlag->Clone("histoRate");
+	  histoRate->Sumw2();
+	  if(nEvents != 0) histoRate->Scale(1/nEvents);
+
+	  Float_t meanRateADA  = 0;
+	  Float_t meanRateADC  = 0;
+	  for(Int_t i=1; i<=8; i++){
+	    meanRateADC += histoRate->GetBinContent(i);
+	    meanRateADA += histoRate->GetBinContent(i+8);
+	  }
+	  meanRateADA = meanRateADA/8;
+	  meanRateADC = meanRateADC/8;
+	  Bool_t highVar = kFALSE;
+
+	  for(Int_t i=1; i<=8; i++){
+	    if(((TMath::Abs(histoRate->GetBinContent(i)-meanRateADC))>fMaxBGVariation) ||
+	       ((TMath::Abs(histoRate->GetBinContent(i+8)-meanRateADA))>fMaxBGVariation)){
+	      test = 0.7;
+	      highVar = kTRUE;
+	    }
+	  }
+	  delete histoRate;
+	  if(highVar){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kYellow);
+	    QAbox->AddText("BG rate variation too high");
+	  }
+	  else{
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kGreen);
+	    QAbox->AddText("BG rate variation OK");
+	  }
+	}
+      }
     }
-    else {
-    	if(hNEventsBGFlag->GetListOfFunctions()->GetEntries()<1) hNEventsBGFlag->GetListOfFunctions()->Add(new TPaveText(0.15,0.56,0.85,0.65,"NDC"));
-    	for(Int_t i=0; i<hNEventsBGFlag->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hNEventsBGFlag->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hNEventsBGFlag->GetListOfFunctions()->At(i);
-      			
-			TH1F *histoRate = (TH1F*)hNEventsBGFlag->Clone("histoRate");
-			histoRate->Sumw2();
-			if(nEvents != 0) histoRate->Scale(1/nEvents);
-			
-			Float_t meanRateADA  = 0;
-			Float_t meanRateADC  = 0;
-			for(Int_t i=1; i<=8; i++){
-				meanRateADC += histoRate->GetBinContent(i);
-				meanRateADA += histoRate->GetBinContent(i+8);
-				}
-			meanRateADA = meanRateADA/8;
-			meanRateADC = meanRateADC/8;
-			Bool_t highVar = kFALSE;
-			
-			for(Int_t i=1; i<=8; i++){
-				if(((TMath::Abs(histoRate->GetBinContent(i)-meanRateADC))>fMaxBGVariation) || 
-				   ((TMath::Abs(histoRate->GetBinContent(i+8)-meanRateADA))>fMaxBGVariation)){
-					test = 0.7;
-					highVar = kTRUE;
-					}
-				}
-			delete histoRate;
-			if(highVar){
-				QAbox->Clear();
-				QAbox->SetFillColor(kYellow); 
-				QAbox->AddText("BG rate variation too high");
-				}
-			else{
-				QAbox->Clear();
-				QAbox->SetFillColor(kGreen);
-				QAbox->AddText("BG rate variation OK");				
-    				}
-			}
-    		}
-    	}                                                      
     TH2F *hChargeSaturation = (TH2F*)list->At(AliADQADataMakerRec::kChargeSaturation);
     if (!hChargeSaturation) {
       AliWarning("ChargeSaturation histogram is not found");
-    }
-    else {
-    	if(hChargeSaturation->GetListOfFunctions()->GetEntries()<1) hChargeSaturation->GetListOfFunctions()->Add(new TPaveText(0.11,0.40,0.89,0.65,"NDC"));
-    	for(Int_t i=0; i<hChargeSaturation->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hChargeSaturation->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hChargeSaturation->GetListOfFunctions()->At(i);
-      			QAbox->Clear();
+    } else {
+      if(hChargeSaturation->GetListOfFunctions()->GetEntries()<1) hChargeSaturation->GetListOfFunctions()->Add(new TPaveText(0.11,0.40,0.89,0.65,"NDC"));
+      for(Int_t i=0; i<hChargeSaturation->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hChargeSaturation->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hChargeSaturation->GetListOfFunctions()->At(i);
+	  QAbox->Clear();
 
-    			TH1D *hChargeSlice;
-			TString satText = "    ";
-			Char_t satValue[5];
-			Bool_t	medSat = kFALSE; 
-			Bool_t	highSat = kFALSE;
-			Bool_t	hugeSat = kFALSE;
-			
-    			for(Int_t i=0; i<16; i++){
-      				hChargeSlice = hChargeSaturation->ProjectionY("hChargeSlice",i+1,i+1);
-				Double_t saturation;
-				if(hChargeSlice->Integral() != 0) saturation = hChargeSlice->Integral(1000,1025)/hChargeSlice->Integral();
-				satText += TString::Format("%1.3f ", saturation);
-				satText +=" "; 
-				if(saturation > fSatMed && saturation < fSatHigh){
-					test = 0.7;
-					medSat = kTRUE;
-					}
-				if(saturation > fSatHigh && saturation < fSatHuge){
-					test = 0.3;
-					highSat = kTRUE;
-					}
-				if(saturation > fSatHuge){
-					test = 0.1;
-					hugeSat = kTRUE;
-					}
-				}
-			delete hChargeSlice;
-			if(!medSat && !highSat && !hugeSat){
-				QAbox->Clear();
-        			QAbox->SetFillColor(kGreen);
-        			QAbox->AddText("Saturation");
-				QAbox->AddText(satText.Data());
-				}
-			if(medSat && !highSat && !hugeSat){
-				QAbox->Clear();
-        			QAbox->SetFillColor(kYellow);
-        			QAbox->AddText("Saturation");
-				QAbox->AddText(satText.Data());
-				}
-			if(highSat && !hugeSat){
-				QAbox->Clear();
-        			QAbox->SetFillColor(kOrange);
-        			QAbox->AddText("Saturation");
-				QAbox->AddText(satText.Data());
-				}
-			if(hugeSat){
-				QAbox->Clear();
-        			QAbox->SetFillColor(kRed);
-        			QAbox->AddText("Saturation");
-				QAbox->AddText(satText.Data());
-				}		
-    			}
-		}
-    	}    
+	  TH1D *hChargeSlice;
+	  TString satText = "    ";
+	  // Char_t satValue[5]; not used
+	  Bool_t	medSat = kFALSE;
+	  Bool_t	highSat = kFALSE;
+	  Bool_t	hugeSat = kFALSE;
+
+	  for(Int_t i=0; i<16; i++){
+	    hChargeSlice = hChargeSaturation->ProjectionY("hChargeSlice",i+1,i+1);
+	    Double_t saturation=0.0;
+	    if(hChargeSlice->Integral() != 0) saturation = hChargeSlice->Integral(1000,1025)/hChargeSlice->Integral();
+	    satText += TString::Format("%1.3f ", saturation);
+	    satText +=" ";
+	    if(saturation > fSatMed && saturation < fSatHigh){
+	      test = 0.7;
+	      medSat = kTRUE;
+	    }
+	    if(saturation > fSatHigh && saturation < fSatHuge){
+	      test = 0.3;
+	      highSat = kTRUE;
+	    }
+	    if(saturation > fSatHuge){
+	      test = 0.1;
+	      hugeSat = kTRUE;
+	    }
+	  }
+	  delete hChargeSlice;
+	  if(!medSat && !highSat && !hugeSat){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kGreen);
+	    QAbox->AddText("Saturation");
+	    QAbox->AddText(satText.Data());
+	  }
+	  if(medSat && !highSat && !hugeSat){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kYellow);
+	    QAbox->AddText("Saturation");
+	    QAbox->AddText(satText.Data());
+	  }
+	  if(highSat && !hugeSat){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kOrange);
+	    QAbox->AddText("Saturation");
+	    QAbox->AddText(satText.Data());
+	  }
+	  if(hugeSat){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kRed);
+	    QAbox->AddText("Saturation");
+	    QAbox->AddText(satText.Data());
+	  }
+	}
+      }
+    }
     TH2F *hBBFlagVsClock = (TH2F*)list->At(AliADQADataMakerRec::kBBFlagVsClock);
     if (!hBBFlagVsClock) {
       AliWarning("BBFlagVsClock histogram is not found");
+    } else {
+      if(hBBFlagVsClock->GetListOfFunctions()->GetEntries()<1) hBBFlagVsClock->GetListOfFunctions()->Add(new TPaveText(0.30,0.15,0.70,0.37,"NDC"));
+      for(Int_t i=0; i<hBBFlagVsClock->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hBBFlagVsClock->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hBBFlagVsClock->GetListOfFunctions()->At(i);
+	  QAbox->Clear();
+
+	  TH1D *hClockSlice;
+	  Bool_t notConfgADA = kFALSE;
+	  Bool_t notConfgADC = kFALSE;
+	  Bool_t notSynchADA = kFALSE;
+	  Bool_t notSynchADC = kFALSE;
+
+	  for(Int_t i=0; i<16; i++){
+	    hClockSlice = hBBFlagVsClock->ProjectionY("hClockSlice",i+1,i+1);
+	    Double_t center = hClockSlice->GetBinContent(11);
+	    Double_t flagArray[21];
+	    for(Int_t iClock = 0; iClock<21; iClock++)flagArray[iClock] = hClockSlice->GetBinContent(iClock+1);
+	    Int_t maxClock = TMath::LocMax(21,flagArray);
+	    if(center == 0){
+	      if(i>7)notConfgADA = kTRUE;
+	      if(i<8)notConfgADC = kTRUE;
+	      continue;
+	    }
+	    if(maxClock != 10) {
+	      if(i>7)notSynchADA = kTRUE;
+	      if(i<8)notSynchADC = kTRUE;
+	    }
+	  }
+	  delete hClockSlice;
+	  if(notConfgADA || notConfgADC){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kViolet);
+	    if(notConfgADA)QAbox->AddText("ADA: dead channels!");
+	    if(!notConfgADA)QAbox->AddText("ADA ok");
+	    if(notConfgADC)QAbox->AddText("ADC: dead channels!");
+	    if(!notConfgADC)QAbox->AddText("ADC ok");
+	    if(notConfgADA && notConfgADC)QAbox->SetFillColor(kViolet);
+	  } else if(notSynchADA || notSynchADC){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kRed);
+	    if(notSynchADA)QAbox->AddText("ADA misconfigured!");
+	    if(!notSynchADA)QAbox->AddText("ADA ok");
+	    if(notSynchADC)QAbox->AddText("ADC misconfigured!");
+	    if(!notSynchADC)QAbox->AddText("ADC ok");
+	    if(notSynchADA && notSynchADC)QAbox->SetFillColor(kRed);
+	  } else {
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kGreen);
+	    QAbox->AddText("ADA ok");
+	    QAbox->AddText("ADC ok");
+	  }
+	}
+      }
     }
-    else {
-    	if(hBBFlagVsClock->GetListOfFunctions()->GetEntries()<1) hBBFlagVsClock->GetListOfFunctions()->Add(new TPaveText(0.30,0.15,0.70,0.37,"NDC"));
-    	for(Int_t i=0; i<hBBFlagVsClock->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hBBFlagVsClock->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hBBFlagVsClock->GetListOfFunctions()->At(i);
-      			QAbox->Clear();
-
-    			TH1D *hClockSlice;
-			Bool_t notConfgADA = kFALSE;
-			Bool_t notConfgADC = kFALSE;
-			Bool_t notSynchADA = kFALSE;
-			Bool_t notSynchADC = kFALSE;
-
-    			for(Int_t i=0; i<16; i++){
-      				hClockSlice = hBBFlagVsClock->ProjectionY("hClockSlice",i+1,i+1);
-				Double_t center = hClockSlice->GetBinContent(11);
-				Double_t flagArray[21];
-				for(Int_t iClock = 0; iClock<21; iClock++)flagArray[iClock] = hClockSlice->GetBinContent(iClock+1);
-				Int_t maxClock = TMath::LocMax(21,flagArray);
-				if(center == 0){
-					if(i>7)notConfgADA = kTRUE;
-					if(i<8)notConfgADC = kTRUE;
-					continue;
-					} 
-				if(maxClock != 10) {
-					if(i>7)notSynchADA = kTRUE;
-					if(i<8)notSynchADC = kTRUE;
-					}
-				}
-			delete hClockSlice;
-			if(notConfgADA || notConfgADC){
-				QAbox->Clear();
-        			QAbox->SetFillColor(kViolet);
-        			if(notConfgADA)QAbox->AddText("ADA: dead channels!");
-				if(!notConfgADA)QAbox->AddText("ADA ok");
-				if(notConfgADC)QAbox->AddText("ADC: dead channels!");
-				if(!notConfgADC)QAbox->AddText("ADC ok");
-				if(notConfgADA && notConfgADC)QAbox->SetFillColor(kViolet);
-				}
-				
-			else if(notSynchADA || notSynchADC){
-				QAbox->Clear();
-        			QAbox->SetFillColor(kRed);
-        			if(notSynchADA)QAbox->AddText("ADA misconfigured!");
-				if(!notSynchADA)QAbox->AddText("ADA ok");
-				if(notSynchADC)QAbox->AddText("ADC misconfigured!");
-				if(!notSynchADC)QAbox->AddText("ADC ok");
-				if(notSynchADA && notSynchADC)QAbox->SetFillColor(kRed);
-				}
-			else {
-				QAbox->Clear();
-        			QAbox->SetFillColor(kGreen);
-        			QAbox->AddText("ADA ok");
-				QAbox->AddText("ADC ok");
-				}				
-    			}
-		}
-    	} 
 
     TH2F *hBBFlagVsClock_ADOR = (TH2F*)list->At(AliADQADataMakerRec::kBBFlagVsClock_ADOR);
     if (!hBBFlagVsClock_ADOR) {
       AliWarning("BBFlagVsClock_ADOR histogram is not found");
-    }
-    else {
-    	if(hBBFlagVsClock_ADOR->GetListOfFunctions()->GetEntries()<1) hBBFlagVsClock_ADOR->GetListOfFunctions()->Add(new TPaveText(0.30,0.15,0.70,0.37,"NDC"));
-    	for(Int_t i=0; i<hBBFlagVsClock_ADOR->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hBBFlagVsClock_ADOR->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hBBFlagVsClock_ADOR->GetListOfFunctions()->At(i);
-      			QAbox->Clear();
+    } else {
+      if(hBBFlagVsClock_ADOR->GetListOfFunctions()->GetEntries()<1) hBBFlagVsClock_ADOR->GetListOfFunctions()->Add(new TPaveText(0.30,0.15,0.70,0.37,"NDC"));
+      for(Int_t i=0; i<hBBFlagVsClock_ADOR->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hBBFlagVsClock_ADOR->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hBBFlagVsClock_ADOR->GetListOfFunctions()->At(i);
+	  QAbox->Clear();
 
-    			TH1D *hClockSlice;
-			Bool_t notConfgADA = kFALSE;
-			Bool_t notConfgADC = kFALSE;
-			Bool_t notSynchADA = kFALSE;
-			Bool_t notSynchADC = kFALSE;
-			if(nEventsADOR<50){
-				QAbox->Clear();
-        			QAbox->SetFillColor(kYellow);
-        			QAbox->AddText("Low statistics");
-				}
-			else{
-    			  for(Int_t i=0; i<16; i++){
-      				  hClockSlice = hBBFlagVsClock_ADOR->ProjectionY("hClockSlice",i+1,i+1);
-				  Double_t center = hClockSlice->GetBinContent(11);
-				  Double_t flagArray[19];
-				  for(Int_t iClock = 1; iClock<20; iClock++)flagArray[iClock-1] = hClockSlice->GetBinContent(iClock+1);
-				  Int_t maxClock = TMath::LocMax(19,flagArray);
-				  if(center == 0){
-					if(i>7)notConfgADA = kTRUE;
-					if(i<8)notConfgADC = kTRUE;
-					continue;
-					} 
-				  if(maxClock != 9) {
-					if(i>7)notSynchADA = kTRUE;
-					if(i<8)notSynchADC = kTRUE;
-					}
-				  }
-			  delete hClockSlice;
-			  if(notConfgADA || notConfgADC){
-				  QAbox->Clear();
-        			  QAbox->SetFillColor(kViolet);
-        			  if(notConfgADA)QAbox->AddText("ADA: dead channels!");
-				  if(!notConfgADA)QAbox->AddText("ADA ok");
-				  if(notConfgADC)QAbox->AddText("ADC: dead channels!");
-				  if(!notConfgADC)QAbox->AddText("ADC ok");
-				  if(notConfgADA && notConfgADC)QAbox->SetFillColor(kViolet);
-				  }
-				
-			  else if(notSynchADA || notSynchADC){
-				  QAbox->Clear();
-        			  QAbox->SetFillColor(kRed);
-        			  if(notSynchADA)QAbox->AddText("ADA misconfigured!");
-				  if(!notSynchADA)QAbox->AddText("ADA ok");
-				  if(notSynchADC)QAbox->AddText("ADC misconfigured!");
-				  if(!notSynchADC)QAbox->AddText("ADC ok");
-				  if(notSynchADA && notSynchADC)QAbox->SetFillColor(kRed);
-				  }
-			  else {
-				  QAbox->Clear();
-        			  QAbox->SetFillColor(kGreen);
-        			  QAbox->AddText("ADA ok");
-				  QAbox->AddText("ADC ok");
-				  }				
-    			  }
-			}
-		}
-    	}     
+	  TH1D *hClockSlice;
+	  Bool_t notConfgADA = kFALSE;
+	  Bool_t notConfgADC = kFALSE;
+	  Bool_t notSynchADA = kFALSE;
+	  Bool_t notSynchADC = kFALSE;
+	  if(nEventsADOR<50){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kYellow);
+	    QAbox->AddText("Low statistics");
+	  } else {
+	    for(Int_t i=0; i<16; i++){
+	      hClockSlice = hBBFlagVsClock_ADOR->ProjectionY("hClockSlice",i+1,i+1);
+	      Double_t center = hClockSlice->GetBinContent(11);
+	      Double_t flagArray[19];
+	      for(Int_t iClock = 1; iClock<20; iClock++)flagArray[iClock-1] = hClockSlice->GetBinContent(iClock+1);
+	      Int_t maxClock = TMath::LocMax(19,flagArray);
+	      if(center == 0){
+		if(i>7)notConfgADA = kTRUE;
+		if(i<8)notConfgADC = kTRUE;
+		continue;
+	      }
+	      if(maxClock != 9) {
+		if(i>7)notSynchADA = kTRUE;
+		if(i<8)notSynchADC = kTRUE;
+	      }
+	    }
+	    delete hClockSlice;
+	    if(notConfgADA || notConfgADC){
+	      QAbox->Clear();
+	      QAbox->SetFillColor(kViolet);
+	      if(notConfgADA)QAbox->AddText("ADA: dead channels!");
+	      if(!notConfgADA)QAbox->AddText("ADA ok");
+	      if(notConfgADC)QAbox->AddText("ADC: dead channels!");
+	      if(!notConfgADC)QAbox->AddText("ADC ok");
+	      if(notConfgADA && notConfgADC)QAbox->SetFillColor(kViolet);
+	    } else if(notSynchADA || notSynchADC){
+	      QAbox->Clear();
+	      QAbox->SetFillColor(kRed);
+	      if(notSynchADA)QAbox->AddText("ADA misconfigured!");
+	      if(!notSynchADA)QAbox->AddText("ADA ok");
+	      if(notSynchADC)QAbox->AddText("ADC misconfigured!");
+	      if(!notSynchADC)QAbox->AddText("ADC ok");
+	      if(notSynchADA && notSynchADC)QAbox->SetFillColor(kRed);
+	    } else {
+	      QAbox->Clear();
+	      QAbox->SetFillColor(kGreen);
+	      QAbox->AddText("ADA ok");
+	      QAbox->AddText("ADC ok");
+	    }
+	  }
+	}
+      }
+    }
     TH2F *hPedestalDiffInt0  = (TH2F*)list->At(AliADQADataMakerRec::kPedestalDiffInt0);
     if (!hPedestalDiffInt0) {
       AliWarning("PedestalInt0 histogram is not found");
-    }
-    else {
-    	if(hPedestalDiffInt0->GetListOfFunctions()->GetEntries()<1) hPedestalDiffInt0->GetListOfFunctions()->Add(new TPaveText(0.15,0.63,0.85,0.85,"NDC"));
-    	for(Int_t i=0; i<hPedestalDiffInt0->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hPedestalDiffInt0->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hPedestalDiffInt0->GetListOfFunctions()->At(i);
-      			QAbox->Clear();
+    } else {
+      if(hPedestalDiffInt0->GetListOfFunctions()->GetEntries()<1) hPedestalDiffInt0->GetListOfFunctions()->Add(new TPaveText(0.15,0.63,0.85,0.85,"NDC"));
+      for(Int_t i=0; i<hPedestalDiffInt0->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hPedestalDiffInt0->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hPedestalDiffInt0->GetListOfFunctions()->At(i);
+	  QAbox->Clear();
 
-    			TH1D *hPedestalSlice;
-			Int_t NbadChannels = 0;
-			TString badChannels = " ";
-    			for(Int_t i=0; i<16; i++){
-      				hPedestalSlice = hPedestalDiffInt0->ProjectionY("hPedestalSlice",i+1,i+1);
-				Double_t mean = hPedestalSlice->GetMean();
-				if(TMath::Abs(mean)>fMaxPedDiff) {
-					test = 0.3;
-					if(NbadChannels == 0){
-						QAbox->SetFillColor(kYellow);
-						QAbox->AddText("Unstable pedestal for channel ");
-						}
-					badChannels += i;
-					badChannels += ", ";
-					NbadChannels++;
-					}
-				if(NbadChannels != 0 && i==15) QAbox->AddText(badChannels.Data());
-				}
-			delete hPedestalSlice;
-			if(NbadChannels == 0){
-				QAbox->Clear();
-        			QAbox->SetFillColor(kGreen);
-        			QAbox->AddText("OK");
-				}		
-    			}
-		}
-    	}
+	  TH1D *hPedestalSlice;
+	  Int_t NbadChannels = 0;
+	  TString badChannels = " ";
+	  for(Int_t i=0; i<16; i++){
+	    hPedestalSlice = hPedestalDiffInt0->ProjectionY("hPedestalSlice",i+1,i+1);
+	    Double_t mean = hPedestalSlice->GetMean();
+	    if(TMath::Abs(mean)>fMaxPedDiff) {
+	      test = 0.3;
+	      if(NbadChannels == 0){
+		QAbox->SetFillColor(kYellow);
+		QAbox->AddText("Unstable pedestal for channel ");
+	      }
+	      badChannels += i;
+	      badChannels += ", ";
+	      NbadChannels++;
+	    }
+	    if(NbadChannels != 0 && i==15) QAbox->AddText(badChannels.Data());
+	  }
+	  delete hPedestalSlice;
+	  if(NbadChannels == 0){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kGreen);
+	    QAbox->AddText("OK");
+	  }
+	}
+      }
+    }
     TH2F *hPedestalDiffInt1  = (TH2F*)list->At(AliADQADataMakerRec::kPedestalDiffInt1);
     if (!hPedestalDiffInt1) {
       AliWarning("PedestalInt1 histogram is not found");
-    }
-    else {
-    	if(hPedestalDiffInt1->GetListOfFunctions()->GetEntries()<1) hPedestalDiffInt1->GetListOfFunctions()->Add(new TPaveText(0.15,0.63,0.85,0.85,"NDC"));
-    	for(Int_t i=0; i<hPedestalDiffInt1->GetListOfFunctions()->GetEntries(); i++){
-     		TString funcName = hPedestalDiffInt1->GetListOfFunctions()->At(i)->ClassName();
-     		if(funcName.Contains("TPaveText")){
-      			TPaveText *QAbox = (TPaveText*)hPedestalDiffInt1->GetListOfFunctions()->At(i);
-      			QAbox->Clear();
+    } else {
+      if(hPedestalDiffInt1->GetListOfFunctions()->GetEntries()<1) hPedestalDiffInt1->GetListOfFunctions()->Add(new TPaveText(0.15,0.63,0.85,0.85,"NDC"));
+      for(Int_t i=0; i<hPedestalDiffInt1->GetListOfFunctions()->GetEntries(); i++){
+	TString funcName = hPedestalDiffInt1->GetListOfFunctions()->At(i)->ClassName();
+	if(funcName.Contains("TPaveText")){
+	  TPaveText *QAbox = (TPaveText*)hPedestalDiffInt1->GetListOfFunctions()->At(i);
+	  QAbox->Clear();
 
-    			TH1D *hPedestalSlice;
-			Int_t NbadChannels = 0;
-			TString badChannels = " ";
-    			for(Int_t i=0; i<16; i++){
-      				hPedestalSlice = hPedestalDiffInt1->ProjectionY("hPedestalSlice",i+1,i+1);
-				Double_t mean = hPedestalSlice->GetMean();
-				if(TMath::Abs(mean)>fMaxPedDiff) {
-					test = 0.3;
-					if(NbadChannels == 0){
-						QAbox->SetFillColor(kYellow);
-						QAbox->AddText("Unstable pedestal for channel ");
-						}
-					badChannels += i;
-					badChannels += ", ";
-					NbadChannels++;
-					}
-				if(NbadChannels != 0 && i==15) QAbox->AddText(badChannels.Data());
-				}
-			delete hPedestalSlice;
-			if(NbadChannels == 0){
-				QAbox->Clear();
-        			QAbox->SetFillColor(kGreen);
-        			QAbox->AddText("OK");
-				}		
-    			}
-		}
-    	}
-  } 
-  return test ;  
-}  
+	  TH1D *hPedestalSlice;
+	  Int_t NbadChannels = 0;
+	  TString badChannels = " ";
+	  for(Int_t i=0; i<16; i++){
+	    hPedestalSlice = hPedestalDiffInt1->ProjectionY("hPedestalSlice",i+1,i+1);
+	    Double_t mean = hPedestalSlice->GetMean();
+	    if(TMath::Abs(mean)>fMaxPedDiff) {
+	      test = 0.3;
+	      if(NbadChannels == 0){
+		QAbox->SetFillColor(kYellow);
+		QAbox->AddText("Unstable pedestal for channel ");
+	      }
+	      badChannels += i;
+	      badChannels += ", ";
+	      NbadChannels++;
+	    }
+	    if(NbadChannels != 0 && i==15) QAbox->AddText(badChannels.Data());
+	  }
+	  delete hPedestalSlice;
+	  if(NbadChannels == 0){
+	    QAbox->Clear();
+	    QAbox->SetFillColor(kGreen);
+	    QAbox->AddText("OK");
+	  }
+	}
+      }
+    }
+  }
+  return test ;
+}
 
 //_________________________________________________________________
 Double_t AliADQAChecker::CheckEsds(TObjArray * list) const
 {
-  
-//  check the ESDs for missing disk or ring
-//  printf(" Number of entries in ESD list = %d\n", list->GetEntries()); 
-//  list->Print();
+
+  //  check the ESDs for missing disk or ring
+  //  printf(" Number of entries in ESD list = %d\n", list->GetEntries());
+  //  list->Print();
 
   Double_t test     = 1.0;     // initialisation to OK
 
-  return test ; 
-} 
+  return test ;
+}
 
 //______________________________________________________________________________
-void AliADQAChecker::Init(const AliQAv1::DETECTORINDEX_t det) 
+void AliADQAChecker::Init(const AliQAv1::DETECTORINDEX_t det)
 {
   // intialises QA and QA checker settings
   fQAParam = (AliADQAParam*)GetQAParam();
@@ -792,19 +755,19 @@ void AliADQAChecker::Init(const AliQAv1::DETECTORINDEX_t det)
   fMaxBGVariation = fQAParam->GetMaxBGVariation();
   fAsynchronBB = fQAParam->GetAsynchronBB();
   fAsynchronBG = fQAParam->GetAsynchronBG();
-  
-  AliQAv1::Instance(det) ; 
-  Float_t * hiValue = new Float_t[AliQAv1::kNBIT] ; 
+
+  AliQAv1::Instance(det) ;
+  Float_t * hiValue = new Float_t[AliQAv1::kNBIT] ;
   Float_t * lowValue = new Float_t[AliQAv1::kNBIT] ;
-  lowValue[AliQAv1::kINFO]      = 0.5   ; 
-  hiValue[AliQAv1::kINFO]       = 1.0 ; 
-  lowValue[AliQAv1::kWARNING]   = 0.2 ; 
-  hiValue[AliQAv1::kWARNING]    = 0.5 ; 
-  lowValue[AliQAv1::kERROR]     = 0.0   ; 
-  hiValue[AliQAv1::kERROR]      = 0.2 ; 
-  lowValue[AliQAv1::kFATAL]     = -1.0   ; 
-  hiValue[AliQAv1::kFATAL]      = 0.0 ; 
-  SetHiLo(hiValue, lowValue) ; 
+  lowValue[AliQAv1::kINFO]      = 0.5   ;
+  hiValue[AliQAv1::kINFO]       = 1.0 ;
+  lowValue[AliQAv1::kWARNING]   = 0.2 ;
+  hiValue[AliQAv1::kWARNING]    = 0.5 ;
+  lowValue[AliQAv1::kERROR]     = 0.0   ;
+  hiValue[AliQAv1::kERROR]      = 0.2 ;
+  lowValue[AliQAv1::kFATAL]     = -1.0   ;
+  hiValue[AliQAv1::kFATAL]      = 0.0 ;
+  SetHiLo(hiValue, lowValue) ;
   delete [] hiValue;
   delete [] lowValue;
 }
@@ -812,7 +775,7 @@ void AliADQAChecker::Init(const AliQAv1::DETECTORINDEX_t det)
 //______________________________________________________________________________
 void AliADQAChecker::SetQA(AliQAv1::ALITASK_t index, Double_t * value) const
 {
-// sets the QA word according to return value of the Check
+  // sets the QA word according to return value of the Check
   AliQAv1 * qa = AliQAv1::Instance(index);
   for (Int_t specie = 0 ; specie < AliRecoParam::kNSpecies ; specie++) {
     qa->UnSet(AliQAv1::kFATAL, specie);
@@ -820,58 +783,58 @@ void AliADQAChecker::SetQA(AliQAv1::ALITASK_t index, Double_t * value) const
     qa->UnSet(AliQAv1::kERROR, specie);
     qa->UnSet(AliQAv1::kINFO, specie);
     if ( ! value ) { // No checker is implemented, set all QA to Fatal
-      qa->Set(AliQAv1::kFATAL, specie) ; 
+      qa->Set(AliQAv1::kFATAL, specie) ;
     } else {
-      if ( value[specie] >= fLowTestValue[AliQAv1::kFATAL] && value[specie] < fUpTestValue[AliQAv1::kFATAL] ) 
-        qa->Set(AliQAv1::kFATAL, specie) ; 
+      if ( value[specie] >= fLowTestValue[AliQAv1::kFATAL] && value[specie] < fUpTestValue[AliQAv1::kFATAL] )
+        qa->Set(AliQAv1::kFATAL, specie) ;
       else if ( value[specie] > fLowTestValue[AliQAv1::kERROR] && value[specie] <= fUpTestValue[AliQAv1::kERROR]  )
-        qa->Set(AliQAv1::kERROR, specie) ; 
+        qa->Set(AliQAv1::kERROR, specie) ;
       else if ( value[specie] > fLowTestValue[AliQAv1::kWARNING] && value[specie] <= fUpTestValue[AliQAv1::kWARNING]  )
         qa->Set(AliQAv1::kWARNING, specie) ;
-      else if ( value[specie] > fLowTestValue[AliQAv1::kINFO] && value[specie] <= fUpTestValue[AliQAv1::kINFO] ) 
-        qa->Set(AliQAv1::kINFO, specie) ; 	
+      else if ( value[specie] > fLowTestValue[AliQAv1::kINFO] && value[specie] <= fUpTestValue[AliQAv1::kINFO] )
+        qa->Set(AliQAv1::kINFO, specie) ;
     }
   }
 }
 
-//____________________________________________________________________________ 
-void AliADQAChecker::MakeImage( TObjArray ** list, AliQAv1::TASKINDEX_t task, AliQAv1::MODE_t mode) 
+//____________________________________________________________________________
+void AliADQAChecker::MakeImage( TObjArray ** list, AliQAv1::TASKINDEX_t task, AliQAv1::MODE_t mode)
 {
   // makes the QA image for sim and rec
   for (Int_t esIndex = 0; esIndex < AliRecoParam::kNSpecies; esIndex++) {
     if (! AliQAv1::Instance(AliQAv1::GetDetIndex(GetName()))->IsEventSpecieSet(AliRecoParam::ConvertIndex(esIndex)) || list[esIndex]->GetEntries() == 0) continue;
     Bool_t allHistosPresent = kTRUE;
-    
+
     Int_t histosToDraw[] = {AliADQADataMakerRec::kChargeADA,AliADQADataMakerRec::kChargeADC,AliADQADataMakerRec::kChargeEoI,AliADQADataMakerRec::kChargeEoIBB,AliADQADataMakerRec::kChargeEoIBG,
-		   AliADQADataMakerRec::kHPTDCTime,AliADQADataMakerRec::kHPTDCTimeBB,AliADQADataMakerRec::kHPTDCTimeBG,AliADQADataMakerRec::kWidth,
-		   AliADQADataMakerRec::kHPTDCTimeRebin,AliADQADataMakerRec::kHPTDCTimeRebinBB,AliADQADataMakerRec::kHPTDCTimeRebinBG,
-		   AliADQADataMakerRec::kBBFlagVsClock,AliADQADataMakerRec::kBBFlagVsClock_ADOR,AliADQADataMakerRec::kBGFlagVsClock,AliADQADataMakerRec::kBBFlagsPerChannel,AliADQADataMakerRec::kBGFlagsPerChannel,
-		   AliADQADataMakerRec::kChargeVsClockInt0,AliADQADataMakerRec::kChargeVsClockInt1,AliADQADataMakerRec::kMaxChargeClock,
-		   AliADQADataMakerRec::kNBBCoincADA,AliADQADataMakerRec::kNBBCoincADC,AliADQADataMakerRec::kNBGCoincADA,AliADQADataMakerRec::kNBGCoincADC,
-		   AliADQADataMakerRec::kPedestalDiffInt0,AliADQADataMakerRec::kPedestalDiffInt1,
-		   AliADQADataMakerRec::kChargeSaturation,
-		   AliADQADataMakerRec::kNBBCoincCorr,AliADQADataMakerRec::kNBGCoincCorr,
-		   AliADQADataMakerRec::kTriggers,AliADQADataMakerRec::kDecisions,
-		   AliADQADataMakerRec::kMeanTimeADA,AliADQADataMakerRec::kMeanTimeADC,AliADQADataMakerRec::kMeanTimeDiff,AliADQADataMakerRec::kMeanTimeCorr,AliADQADataMakerRec::kMeanTimeSumDiff,
-		   AliADQADataMakerRec::kPedestalInt0,AliADQADataMakerRec::kPedestalInt1,
-		   AliADQADataMakerRec::kNEventsBBFlag,AliADQADataMakerRec::kNEventsBGFlag,
-		   AliADQADataMakerRec::kFlagNoTime,AliADQADataMakerRec::kTimeNoFlag,
-		   AliADQADataMakerRec::kTimeSlewingADA,AliADQADataMakerRec::kTimeSlewingADC,
-		   AliADQADataMakerRec::kTrend_TriggerChargeQuantileADA,AliADQADataMakerRec::kTrend_TriggerChargeQuantileADC};
-		   
-    for(Int_t iHisto=0; iHisto<(&histosToDraw)[1]-histosToDraw; iHisto++)if(!list[esIndex]->At(histosToDraw[iHisto])) allHistosPresent = kFALSE; 
+			    AliADQADataMakerRec::kHPTDCTime,AliADQADataMakerRec::kHPTDCTimeBB,AliADQADataMakerRec::kHPTDCTimeBG,AliADQADataMakerRec::kWidth,
+			    AliADQADataMakerRec::kHPTDCTimeRebin,AliADQADataMakerRec::kHPTDCTimeRebinBB,AliADQADataMakerRec::kHPTDCTimeRebinBG,
+			    AliADQADataMakerRec::kBBFlagVsClock,AliADQADataMakerRec::kBBFlagVsClock_ADOR,AliADQADataMakerRec::kBGFlagVsClock,AliADQADataMakerRec::kBBFlagsPerChannel,AliADQADataMakerRec::kBGFlagsPerChannel,
+			    AliADQADataMakerRec::kChargeVsClockInt0,AliADQADataMakerRec::kChargeVsClockInt1,AliADQADataMakerRec::kMaxChargeClock,
+			    AliADQADataMakerRec::kNBBCoincADA,AliADQADataMakerRec::kNBBCoincADC,AliADQADataMakerRec::kNBGCoincADA,AliADQADataMakerRec::kNBGCoincADC,
+			    AliADQADataMakerRec::kPedestalDiffInt0,AliADQADataMakerRec::kPedestalDiffInt1,
+			    AliADQADataMakerRec::kChargeSaturation,
+			    AliADQADataMakerRec::kNBBCoincCorr,AliADQADataMakerRec::kNBGCoincCorr,
+			    AliADQADataMakerRec::kTriggers,AliADQADataMakerRec::kDecisions,
+			    AliADQADataMakerRec::kMeanTimeADA,AliADQADataMakerRec::kMeanTimeADC,AliADQADataMakerRec::kMeanTimeDiff,AliADQADataMakerRec::kMeanTimeCorr,AliADQADataMakerRec::kMeanTimeSumDiff,
+			    AliADQADataMakerRec::kPedestalInt0,AliADQADataMakerRec::kPedestalInt1,
+			    AliADQADataMakerRec::kNEventsBBFlag,AliADQADataMakerRec::kNEventsBGFlag,
+			    AliADQADataMakerRec::kFlagNoTime,AliADQADataMakerRec::kTimeNoFlag,
+			    AliADQADataMakerRec::kTimeSlewingADA,AliADQADataMakerRec::kTimeSlewingADC,
+			    AliADQADataMakerRec::kTrend_TriggerChargeQuantileADA,AliADQADataMakerRec::kTrend_TriggerChargeQuantileADC};
+
+    for(Int_t iHisto=0; iHisto<(&histosToDraw)[1]-histosToDraw; iHisto++)if(!list[esIndex]->At(histosToDraw[iHisto])) allHistosPresent = kFALSE;
     if(!allHistosPresent) continue;
     for(Int_t iHisto=0; iHisto<(&histosToDraw)[1]-histosToDraw; iHisto++)((TH1*)list[esIndex]->At(histosToDraw[iHisto]))->SetStats(kFALSE);
-           
-    const Char_t * title = Form("QA_%s_%s_%s", GetName(), AliQAv1::GetTaskName(task).Data(), AliRecoParam::GetEventSpecieName(esIndex)); 
-    
+
+    const Char_t * title = Form("QA_%s_%s_%s", GetName(), AliQAv1::GetTaskName(task).Data(), AliRecoParam::GetEventSpecieName(esIndex));
+
     if ( !fImage[esIndex] ) {
-    	if(AliRecoParam::ConvertIndex(esIndex) != AliRecoParam::kCalib) fImage[esIndex] = new TCanvas(title, title,2500,5500);
-	else fImage[esIndex] = new TCanvas(title, title,400,600);
-	}
-    
+      if(AliRecoParam::ConvertIndex(esIndex) != AliRecoParam::kCalib) fImage[esIndex] = new TCanvas(title, title,2500,5500);
+      else fImage[esIndex] = new TCanvas(title, title,400,600);
+    }
+
     fImage[esIndex]->cd();
-    
+
     const char* topT = Form("%s, %s, Run: %d", AliQAv1::GetTaskName(task).Data(), AliRecoParam::GetEventSpecieName(esIndex),AliQAChecker::Instance()->GetRunNumber());
     TLatex* topText = new TLatex(0.5, 0.99, topT);
     topText->SetTextAlign(23);
@@ -880,430 +843,424 @@ void AliADQAChecker::MakeImage( TObjArray ** list, AliQAv1::TASKINDEX_t task, Al
     topText->SetTextColor(kBlue+3);
     topText->SetNDC();
     topText->Draw();
-    
+
     //gStyle->SetOptStat(0);
     gStyle->SetLabelSize(1.1,"xyz");
-    gStyle->SetLabelFont(42,"xyz"); 
+    gStyle->SetLabelFont(42,"xyz");
     gStyle->SetLabelOffset(0.01,"xyz");
-    gStyle->SetTitleFont(42,"xyz");  
-    gStyle->SetTitleOffset(1.0,"xyz");  
-    gStyle->SetTitleSize(1.1,"xyz");  
-    
-    if(AliRecoParam::ConvertIndex(esIndex) != AliRecoParam::kCalib){
+    gStyle->SetTitleFont(42,"xyz");
+    gStyle->SetTitleOffset(1.0,"xyz");
+    gStyle->SetTitleSize(1.1,"xyz");
 
-    	TVirtualPad* pCharge = 0;
-    	TVirtualPad* pTime  = 0;
-    	TVirtualPad* pClockFg  = 0;
-	TVirtualPad* pClockCh  = 0;
-    	TVirtualPad* pCoinc  = 0;
-    	TVirtualPad* pPed  = 0;
-    	TVirtualPad* pMaxCh  = 0;
-	TVirtualPad* pMeanTime  = 0;
-    	TVirtualPad* pTrigger  = 0;
-	TVirtualPad* pChargeZoom = 0;
-	TVirtualPad* pTimeRatio = 0;
-	TVirtualPad* pDecision = 0;
-	TVirtualPad* pChargeTrend = 0;
-	
-	const UInt_t nRows = 11;
-	const UInt_t nLargeRows = 1;
-	Bool_t isLarge[] = {0,0,1,0,0,0,0,0,0,0,0};
-	const Double_t timesLarger = 1.5;
-	Double_t xRow[nRows];
-	xRow[0] = 0.95;
-	Double_t xStep = 0.95/((nRows-nLargeRows)+ timesLarger*nLargeRows);
-	for(Int_t iRow = 1; iRow<nRows; iRow++){
-		if(!isLarge[iRow-1]) xRow[iRow] = xRow[iRow-1]-xStep;
-		else xRow[iRow] = xRow[iRow-1]-timesLarger*xStep;
-		}
-	
-	UInt_t iRow = 0;	
+    if(AliRecoParam::ConvertIndex(esIndex) != AliRecoParam::kCalib) {
+      TVirtualPad* pCharge = 0;
+      TVirtualPad* pTime  = 0;
+      TVirtualPad* pClockFg  = 0;
+      // TVirtualPad* pClockCh  = 0; not used
+      TVirtualPad* pCoinc  = 0;
+      TVirtualPad* pPed  = 0;
+      TVirtualPad* pMaxCh  = 0;
+      TVirtualPad* pMeanTime  = 0;
+      TVirtualPad* pTrigger  = 0;
+      TVirtualPad* pChargeZoom = 0;
+      TVirtualPad* pTimeRatio = 0;
+      TVirtualPad* pDecision = 0;
+      TVirtualPad* pChargeTrend = 0;
 
-    	TPad* pCh = new TPad("Charge", "Charge Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
-    	fImage[esIndex]->cd();
-    	pCh->Draw();
-    	pCharge = pCh;
-	iRow++;
-	
-	TPad* pChZ = new TPad("ChargeZoom", "Charge Zoom Pad", 0.0, xRow[iRow+1], 1.0, xRow[iRow]);
-    	fImage[esIndex]->cd();
-    	pChZ->Draw();
-    	pChargeZoom = pChZ;
-	iRow++;
+      const UInt_t nRows = 11;
+      const UInt_t nLargeRows = 1;
+      Bool_t isLarge[] = {0,0,1,0,0,0,0,0,0,0,0};
+      const Double_t timesLarger = 1.5;
+      Double_t xRow[nRows];
+      xRow[0] = 0.95;
+      Double_t xStep = 0.95/((nRows-nLargeRows)+ timesLarger*nLargeRows);
+      for(Int_t iRow = 1; iRow<nRows; iRow++){
+	if(!isLarge[iRow-1]) xRow[iRow] = xRow[iRow-1]-xStep;
+	else xRow[iRow] = xRow[iRow-1]-timesLarger*xStep;
+      }
 
-    	TPad* pT = new TPad("Time", "Time Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
-    	fImage[esIndex]->cd();
-    	pT->Draw();
-    	pTime = pT;
-	iRow++;
-	
-	TPad* pTR = new TPad("TimeRatio", "Time Ratio Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
-    	fImage[esIndex]->cd();
-    	pTR->Draw();
-    	pTimeRatio = pTR;
-	iRow++;
-	
-	TPad* pMT = new TPad("Mean time", "Mean time Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
-    	fImage[esIndex]->cd();
-    	pMT->Draw();
-    	pMeanTime = pMT;
-	iRow++;
-    
-    	TPad* pClFg = new TPad("ClockFg", "ClockFg Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
-    	fImage[esIndex]->cd();
-    	pClFg->Draw();
-    	pClockFg = pClFg;
-	iRow++;
-	
-	TPad* pP = new TPad("Pedestal", "Pedestal Pad", 0, xRow[iRow+1], 0.5, xRow[iRow]);
-    	fImage[esIndex]->cd();
-    	pP->Draw();
-    	pPed = pP;
-    
-    	TPad* pM = new TPad("Max Charge", "Max Charge Pad", 0.5, xRow[iRow+1], 1.0, xRow[iRow]);
-    	fImage[esIndex]->cd();
-    	pM->Draw();
-    	pMaxCh = pM;
-	iRow++;
-    
-    	TPad* pCo = new TPad("Coincidences", "Coincidences Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
-    	fImage[esIndex]->cd();
-    	pCo->Draw();
-    	pCoinc = pCo;
-	iRow++;
-	
-        TPad* pTr = new TPad("Triggers", "Triggers Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
-    	fImage[esIndex]->cd();
-    	pTr->Draw();
-    	pTrigger = pTr;
-	iRow++;
+      UInt_t iRow = 0;
 
-	TPad* pD = new TPad("Decisions", "Decisions Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
-    	fImage[esIndex]->cd();
-    	pD->Draw();
-    	pDecision = pD;
-	iRow++;
-	
-	TPad* pCT = new TPad("Charge Trend", "Charge Trend Pad", 0, 0, 1.0, xRow[iRow]);
-    	fImage[esIndex]->cd();
-    	pCT->Draw();
-    	pChargeTrend = pCT;
+      TPad* pCh = new TPad("Charge", "Charge Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
+      fImage[esIndex]->cd();
+      pCh->Draw();
+      pCharge = pCh;
+      iRow++;
 
-    	pCharge->Divide(2, 1);
-	pChargeZoom->Divide(6, 1);
-    	pTime->Divide(4, 1);
-	pTimeRatio->Divide(4, 1);
-    	pClockFg->Divide(5, 1);
-    	pCoinc->Divide(4, 1);
-    	pPed->Divide(2, 1);
-	pMeanTime->Divide(4, 1);
-	pDecision->Divide(3, 1);
-	
-	Float_t nEvents = 0;
-    	TH1* histo = 0;
-	TH1* histoBlue = 0;
-	TH1* histoRed = 0;
-	TH1* histoNumerator = 0;
-	TH1* histoDenominator = 0;
-	TH1* histoRatio = 0;
-	TH2* histo2D = 0;
-	TH2* histo2DCopy = 0;
-       		
-	//Charge pad
-      	pCharge->cd(1);
-	gPad->SetLogy();
-	histoBlue=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kChargeADA);
-	nEvents = histoBlue->Integral(-1,-1);
-	histoRed=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kChargeADC);
-	Float_t max[2];
-	max[0] = histoBlue->GetBinContent(histoBlue->GetMaximumBin());
-	max[1] = histoRed->GetBinContent(histoRed->GetMaximumBin());
-	Float_t min[2];
-	min[0] = histoBlue->GetBinContent(histoBlue->GetMinimumBin());
-	min[1] = histoRed->GetBinContent(histoRed->GetMinimumBin());
-	
-	histoBlue->GetYaxis()->SetRangeUser(TMath::MinElement(2,min)+1 ,2*TMath::MaxElement(2,max));
-	histoBlue->DrawCopy();
-	histoRed->DrawCopy("same");
-	
-	TLegend *myLegend1 = new TLegend(0.70,0.67,0.97,0.82);
-	myLegend1->SetTextFont(42);
-  	myLegend1->SetBorderSize(0);
-  	myLegend1->SetFillStyle(0);
-  	myLegend1->SetFillColor(0);
-  	myLegend1->SetMargin(0.25);
-  	myLegend1->SetTextSize(0.05);
-  	myLegend1->SetEntrySeparation(0.5);
-	myLegend1->AddEntry(histoBlue,"ADA","l");
-	myLegend1->AddEntry(histoRed,"ADC","l");
-	myLegend1->Draw();
-	pCharge->cd(2);
-	gPad->SetLogz();
-	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kChargeEoIBB);
+      TPad* pChZ = new TPad("ChargeZoom", "Charge Zoom Pad", 0.0, xRow[iRow+1], 1.0, xRow[iRow]);
+      fImage[esIndex]->cd();
+      pChZ->Draw();
+      pChargeZoom = pChZ;
+      iRow++;
+
+      TPad* pT = new TPad("Time", "Time Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
+      fImage[esIndex]->cd();
+      pT->Draw();
+      pTime = pT;
+      iRow++;
+
+      TPad* pTR = new TPad("TimeRatio", "Time Ratio Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
+      fImage[esIndex]->cd();
+      pTR->Draw();
+      pTimeRatio = pTR;
+      iRow++;
+
+      TPad* pMT = new TPad("Mean time", "Mean time Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
+      fImage[esIndex]->cd();
+      pMT->Draw();
+      pMeanTime = pMT;
+      iRow++;
+
+      TPad* pClFg = new TPad("ClockFg", "ClockFg Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
+      fImage[esIndex]->cd();
+      pClFg->Draw();
+      pClockFg = pClFg;
+      iRow++;
+
+      TPad* pP = new TPad("Pedestal", "Pedestal Pad", 0, xRow[iRow+1], 0.5, xRow[iRow]);
+      fImage[esIndex]->cd();
+      pP->Draw();
+      pPed = pP;
+
+      TPad* pM = new TPad("Max Charge", "Max Charge Pad", 0.5, xRow[iRow+1], 1.0, xRow[iRow]);
+      fImage[esIndex]->cd();
+      pM->Draw();
+      pMaxCh = pM;
+      iRow++;
+
+      TPad* pCo = new TPad("Coincidences", "Coincidences Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
+      fImage[esIndex]->cd();
+      pCo->Draw();
+      pCoinc = pCo;
+      iRow++;
+
+      TPad* pTr = new TPad("Triggers", "Triggers Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
+      fImage[esIndex]->cd();
+      pTr->Draw();
+      pTrigger = pTr;
+      iRow++;
+
+      TPad* pD = new TPad("Decisions", "Decisions Pad", 0, xRow[iRow+1], 1.0, xRow[iRow]);
+      fImage[esIndex]->cd();
+      pD->Draw();
+      pDecision = pD;
+      iRow++;
+
+      TPad* pCT = new TPad("Charge Trend", "Charge Trend Pad", 0, 0, 1.0, xRow[iRow]);
+      fImage[esIndex]->cd();
+      pCT->Draw();
+      pChargeTrend = pCT;
+
+      pCharge->Divide(2, 1);
+      pChargeZoom->Divide(6, 1);
+      pTime->Divide(4, 1);
+      pTimeRatio->Divide(4, 1);
+      pClockFg->Divide(5, 1);
+      pCoinc->Divide(4, 1);
+      pPed->Divide(2, 1);
+      pMeanTime->Divide(4, 1);
+      pDecision->Divide(3, 1);
+
+      Float_t nEvents = 0;
+      TH1* histo = 0;
+      TH1* histoBlue = 0;
+      TH1* histoRed = 0;
+      // TH1* histoNumerator = 0; not used
+      TH1* histoDenominator = 0;
+      TH1* histoRatio = 0;
+      TH2* histo2D = 0;
+      TH2* histo2DCopy = 0;
+
+      //Charge pad
+      pCharge->cd(1);
+      gPad->SetLogy();
+      histoBlue=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kChargeADA);
+      nEvents = histoBlue->Integral(-1,-1);
+      histoRed=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kChargeADC);
+      Float_t max[2];
+      max[0] = histoBlue->GetBinContent(histoBlue->GetMaximumBin());
+      max[1] = histoRed->GetBinContent(histoRed->GetMaximumBin());
+      Float_t min[2];
+      min[0] = histoBlue->GetBinContent(histoBlue->GetMinimumBin());
+      min[1] = histoRed->GetBinContent(histoRed->GetMinimumBin());
+
+      histoBlue->GetYaxis()->SetRangeUser(TMath::MinElement(2,min)+1 ,2*TMath::MaxElement(2,max));
+      histoBlue->DrawCopy();
+      histoRed->DrawCopy("same");
+
+      TLegend *myLegend1 = new TLegend(0.70,0.67,0.97,0.82);
+      myLegend1->SetTextFont(42);
+      myLegend1->SetBorderSize(0);
+      myLegend1->SetFillStyle(0);
+      myLegend1->SetFillColor(0);
+      myLegend1->SetMargin(0.25);
+      myLegend1->SetTextSize(0.05);
+      myLegend1->SetEntrySeparation(0.5);
+      myLegend1->AddEntry(histoBlue,"ADA","l");
+      myLegend1->AddEntry(histoRed,"ADC","l");
+      myLegend1->Draw();
+      pCharge->cd(2);
+      gPad->SetLogz();
+      histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kChargeEoIBB);
+      histo->DrawCopy("COLZ");
+      //Zoommed charge pad
+      pChargeZoom->cd(5);
+      gPad->SetLogz();
+      histoRatio = (TH1*)histo->Clone("histoRatio");
+      histoRatio->GetYaxis()->SetRangeUser(fChargeChannelZoomMin,fChargeChannelZoomMax);
+      histoRatio->DrawCopy("COLZ");
+      pChargeZoom->cd(4);
+      gPad->SetLogz();
+      histoDenominator=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kChargeEoI);
+      histoDenominator->GetYaxis()->SetRangeUser(fChargeChannelZoomMin,fChargeChannelZoomMax);
+      histoDenominator->DrawCopy("COLZ");
+      pChargeZoom->cd(6);
+      gPad->SetLogz();
+      histoRatio->Divide(histoDenominator);
+      histoRatio->SetTitle("Ratio: w_BB_Flag/All");
+      histoRatio->DrawCopy("COLZ");
+
+      for(Int_t iHist = 0; iHist<3; iHist++){
+	pChargeZoom->cd(iHist+1);
+	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kChargeVsClockInt0+iHist);
+	if(iHist==2)gPad->SetLogz();
 	histo->DrawCopy("COLZ");
-	//Zoommed charge pad
-	pChargeZoom->cd(5);
+      }
+
+      //Time pad
+      for(Int_t iHist = 0; iHist<4; iHist++){
+	pTime->cd(iHist+1);
+	if(iHist==3)gPad->SetLogz();
+	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kHPTDCTime+iHist);
+	histo->DrawCopy("COLZ");
+      }
+      //Time ratio pad
+      pTimeRatio->cd(1);
+      //gPad->SetLogy();
+      histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kFlagNoTime);
+      histoBlue = (TH1*)histo->Clone("histoBlue");
+      if(nEvents != 0) histoBlue->Scale(1/nEvents);
+      histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kTimeNoFlag);
+      histoRed = (TH1*)histo->Clone("histoRed");
+      if(nEvents != 0) histoRed->Scale(1/nEvents);
+      max[0] = histoBlue->GetBinContent(histoBlue->GetMaximumBin());
+      max[1] = histoRed->GetBinContent(histoRed->GetMaximumBin());
+      histoBlue->GetYaxis()->SetRangeUser(0,2*TMath::MaxElement(2,max));
+      histoBlue->DrawCopy();
+      histoRed->DrawCopy("same");
+      TLegend *myLegend2 = new TLegend(0.15,0.78,0.85,0.88);
+      myLegend2->SetTextFont(42);
+      myLegend2->SetBorderSize(0);
+      myLegend2->SetFillStyle(0);
+      myLegend2->SetFillColor(0);
+      myLegend2->SetMargin(0.25);
+      myLegend2->SetTextSize(0.04);
+      myLegend2->SetEntrySeparation(0.5);
+      myLegend2->AddEntry(histoBlue,"Events with BB/BG flag but no time","l");
+      myLegend2->AddEntry(histoRed,"Events with time but no BB/BG flag","l");
+      myLegend2->Draw();
+
+      histoDenominator=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kHPTDCTimeRebin);
+
+      for(Int_t iHist = 1; iHist<3; iHist++){
+	pTimeRatio->cd(1+iHist);
 	gPad->SetLogz();
+	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kHPTDCTimeRebin + iHist);
 	histoRatio = (TH1*)histo->Clone("histoRatio");
-	histoRatio->GetYaxis()->SetRangeUser(fChargeChannelZoomMin,fChargeChannelZoomMax);
-	histoRatio->DrawCopy("COLZ");
-	pChargeZoom->cd(4);
-	gPad->SetLogz();
-	histoDenominator=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kChargeEoI);
-	histoDenominator->GetYaxis()->SetRangeUser(fChargeChannelZoomMin,fChargeChannelZoomMax);
-	histoDenominator->DrawCopy("COLZ");
-	pChargeZoom->cd(6);
-	gPad->SetLogz();
 	histoRatio->Divide(histoDenominator);
-	histoRatio->SetTitle("Ratio: w_BB_Flag/All");
+	if(iHist == 1)histoRatio->GetYaxis()->SetRangeUser(fTimeRatioBBZoomMin,fTimeRatioBBZoomMax);
+	if(iHist == 2)histoRatio->GetYaxis()->SetRangeUser(fTimeRatioBGZoomMin,fTimeRatioBGZoomMax);
 	histoRatio->DrawCopy("COLZ");
-	
-	for(Int_t iHist = 0; iHist<3; iHist++){
-		pChargeZoom->cd(iHist+1);
-		histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kChargeVsClockInt0+iHist);
-		if(iHist==2)gPad->SetLogz();
-		histo->DrawCopy("COLZ");
-		}
-	
-	//Time pad
-	for(Int_t iHist = 0; iHist<4; iHist++){
-		pTime->cd(iHist+1);
-		if(iHist==3)gPad->SetLogz();
-		histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kHPTDCTime+iHist);
-		histo->DrawCopy("COLZ");
-		}
-	//Time ratio pad
-	pTimeRatio->cd(1);
-	//gPad->SetLogy();
-	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kFlagNoTime);
-	histoBlue = (TH1*)histo->Clone("histoBlue");
-	if(nEvents != 0) histoBlue->Scale(1/nEvents);
-	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kTimeNoFlag);
-	histoRed = (TH1*)histo->Clone("histoRed");
-	if(nEvents != 0) histoRed->Scale(1/nEvents);
-	max[0] = histoBlue->GetBinContent(histoBlue->GetMaximumBin());
-	max[1] = histoRed->GetBinContent(histoRed->GetMaximumBin());
-	histoBlue->GetYaxis()->SetRangeUser(0,2*TMath::MaxElement(2,max));
-	histoBlue->DrawCopy();
-	histoRed->DrawCopy("same");
-	TLegend *myLegend2 = new TLegend(0.15,0.78,0.85,0.88);
-	myLegend2->SetTextFont(42);
-  	myLegend2->SetBorderSize(0);
-  	myLegend2->SetFillStyle(0);
-  	myLegend2->SetFillColor(0);
-  	myLegend2->SetMargin(0.25);
-  	myLegend2->SetTextSize(0.04);
-  	myLegend2->SetEntrySeparation(0.5);
-	myLegend2->AddEntry(histoBlue,"Events with BB/BG flag but no time","l");
-	myLegend2->AddEntry(histoRed,"Events with time but no BB/BG flag","l");
-	myLegend2->Draw();
+      }
+      pTimeRatio->cd(4);
+      //gPad->SetLogy();
+      histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kNEventsBBFlag);
+      histoBlue = (TH1*)histo->Clone("histoBlue");
+      histoBlue->Sumw2();
+      if(nEvents != 0) histoBlue->Scale(1/nEvents);
+      histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kNEventsBGFlag);
+      histoRed = (TH1*)histo->Clone("histoRed");
+      histoRed->Sumw2();
+      if(nEvents != 0) histoRed->Scale(1/nEvents);
 
-	histoDenominator=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kHPTDCTimeRebin);
-		
-	for(Int_t iHist = 1; iHist<3; iHist++){
-		pTimeRatio->cd(1+iHist);
-		gPad->SetLogz();
-		histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kHPTDCTimeRebin + iHist);
-		histoRatio = (TH1*)histo->Clone("histoRatio");
-		histoRatio->Divide(histoDenominator);
-		if(iHist == 1)histoRatio->GetYaxis()->SetRangeUser(fTimeRatioBBZoomMin,fTimeRatioBBZoomMax);
-		if(iHist == 2)histoRatio->GetYaxis()->SetRangeUser(fTimeRatioBGZoomMin,fTimeRatioBGZoomMax);
-		histoRatio->DrawCopy("COLZ");
-		}
-	pTimeRatio->cd(4);
-	//gPad->SetLogy();
-	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kNEventsBBFlag);
-	histoBlue = (TH1*)histo->Clone("histoBlue");
-	histoBlue->Sumw2();
-	if(nEvents != 0) histoBlue->Scale(1/nEvents);
-	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kNEventsBGFlag);
-	histoRed = (TH1*)histo->Clone("histoRed");
-	histoRed->Sumw2();
-	if(nEvents != 0) histoRed->Scale(1/nEvents);
-	
-	max[0] = histoBlue->GetBinContent(histoBlue->GetMaximumBin());
-	max[1] = histoRed->GetBinContent(histoRed->GetMaximumBin());
+      max[0] = histoBlue->GetBinContent(histoBlue->GetMaximumBin());
+      max[1] = histoRed->GetBinContent(histoRed->GetMaximumBin());
 
-	min[0] = histoBlue->GetBinContent(histoBlue->GetMinimumBin());
-	min[1] = histoRed->GetBinContent(histoRed->GetMinimumBin());
-	
-	histoBlue->GetYaxis()->SetRangeUser(0.8*TMath::MinElement(2,min),1.8*TMath::MaxElement(2,max));
-	histoBlue->DrawCopy("e");
-	//histoBlue->DrawCopy("esame");
-	//histoRed->DrawCopy("samehist");
-	histoRed->DrawCopy("esame");
-	TLegend *myLegend3 = new TLegend(0.15,0.78,0.85,0.88);
-	myLegend3->SetTextFont(42);
-  	myLegend3->SetBorderSize(0);
-  	myLegend3->SetFillStyle(0);
-  	myLegend3->SetFillColor(0);
-  	myLegend3->SetMargin(0.25);
-  	myLegend3->SetTextSize(0.04);
-  	myLegend3->SetEntrySeparation(0.5);
-	myLegend3->AddEntry(histoBlue,"Events with BB flag","l");
-	myLegend3->AddEntry(histoRed,"Events with BG flag","l");
-	myLegend3->Draw();
-		
-	//Clock Flags pad
-	for(Int_t iHist = 0; iHist<5; iHist++){
-		pClockFg->cd(iHist+1);
-		if(iHist>1)gPad->SetLogz();
-		histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kBBFlagVsClock+iHist);
-		histo->DrawCopy("COLZ");
-		}
-	
-	//Coincidences pad
-	for(Int_t iHist = 0; iHist<2; iHist++){
-		pCoinc->cd(iHist+1);
-		gPad->SetLogy();
-		histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kNBBCoincADC+2*iHist);
-		histo->DrawCopy();
-		histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kNBBCoincADA+2*iHist);
-		histo->DrawCopy("same");
-		myLegend1->Draw();
-		}
-	for(Int_t iHist = 0; iHist<2; iHist++){
-		pCoinc->cd(iHist+3);
-		gPad->SetLogz();
-		histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kNBBCoincCorr+iHist);
-		histo->DrawCopy("COLZ");
-		}
-	//Pedestal monitoring pad
-	for(Int_t iHist = 0; iHist<2; iHist++){
-		pPed->cd(iHist+1);
-		histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kPedestalDiffInt0+iHist);
-		histo->DrawCopy("COLZ");
-		}
-	//Saturation monitoring pad
-	pMaxCh->cd();
-	gPad->SetLogz();
-	histo2D=(TH2*)list[esIndex]->At(AliADQADataMakerRec::kChargeSaturation);
-	histo2DCopy = (TH2*)histo2D->Clone("histoBlue");
-	histo2DCopy->RebinY(64);
-	histo2DCopy->DrawCopy("COLZ");
+      min[0] = histoBlue->GetBinContent(histoBlue->GetMinimumBin());
+      min[1] = histoRed->GetBinContent(histoRed->GetMinimumBin());
 
-	//Trigger inputs pad
-	pTrigger->cd();
-	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kTriggers);
+      histoBlue->GetYaxis()->SetRangeUser(0.8*TMath::MinElement(2,min),1.8*TMath::MaxElement(2,max));
+      histoBlue->DrawCopy("e");
+      //histoBlue->DrawCopy("esame");
+      //histoRed->DrawCopy("samehist");
+      histoRed->DrawCopy("esame");
+      TLegend *myLegend3 = new TLegend(0.15,0.78,0.85,0.88);
+      myLegend3->SetTextFont(42);
+      myLegend3->SetBorderSize(0);
+      myLegend3->SetFillStyle(0);
+      myLegend3->SetFillColor(0);
+      myLegend3->SetMargin(0.25);
+      myLegend3->SetTextSize(0.04);
+      myLegend3->SetEntrySeparation(0.5);
+      myLegend3->AddEntry(histoBlue,"Events with BB flag","l");
+      myLegend3->AddEntry(histoRed,"Events with BG flag","l");
+      myLegend3->Draw();
+
+      //Clock Flags pad
+      for(Int_t iHist = 0; iHist<5; iHist++){
+	pClockFg->cd(iHist+1);
+	if(iHist>1)gPad->SetLogz();
+	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kBBFlagVsClock+iHist);
+	histo->DrawCopy("COLZ");
+      }
+
+      //Coincidences pad
+      for(Int_t iHist = 0; iHist<2; iHist++){
+	pCoinc->cd(iHist+1);
 	gPad->SetLogy();
-	histo->DrawCopy("HIST");
-	histo->DrawCopy("TEXT0SAME");
-	//Mean time pad
-	pMeanTime->cd(1);
-	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kMeanTimeADA);
-	histoBlue = (TH1*)histo->Clone("histoBlue");
-	
-	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kMeanTimeADC);
-	histoRed = (TH1*)histo->Clone("histoRed");
-	max[0] = histoBlue->GetBinContent(histoBlue->GetMaximumBin());
-	max[1] = histoRed->GetBinContent(histoRed->GetMaximumBin());
-	histoBlue->GetYaxis()->SetRangeUser(0,1.1*TMath::MaxElement(2,max));
-	histoBlue->DrawCopy();
-	histoRed->DrawCopy("same");
+	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kNBBCoincADC+2*iHist);
+	histo->DrawCopy();
+	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kNBBCoincADA+2*iHist);
+	histo->DrawCopy("same");
 	myLegend1->Draw();
-	for(Int_t iHist = 0; iHist<3; iHist++){
-		pMeanTime->cd(iHist+2);
-		gPad->SetLogz();
-		histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kMeanTimeDiff+iHist);
-		histo->DrawCopy("COLZ");
-		}
-	//Decisions pad
-	TH1D *hTimeSlice = 0x0;
-	TH1F *hMeanTimeVsChargeADA = new TH1F("hMeanTimeVsChargeADA","hMeanTimeVsChargeADA",200,-4,0);
-	
-	pDecision->cd(1);
+      }
+      for(Int_t iHist = 0; iHist<2; iHist++){
+	pCoinc->cd(iHist+3);
 	gPad->SetLogz();
-	histo2D=(TH2*)list[esIndex]->At(AliADQADataMakerRec::kTimeSlewingADA);
-	histo2DCopy = (TH2*)histo2D->Clone("histo2DCopy");
-	histo2DCopy->GetYaxis()->SetRangeUser(fTimeRatioBBZoomMin,fTimeRatioBBZoomMax);
-	histo2DCopy->SetTitle("Time slewing ADA");
-		
-	for(Int_t j=0; j<200;j++){
-  		hTimeSlice = histo2DCopy->ProjectionY("hTimeSlice",j+1,j+1);
-		if(hTimeSlice->GetEntries()<100 && j>100){
-			hMeanTimeVsChargeADA->SetBinContent(j+1,hMeanTimeVsChargeADA->GetBinContent(j));
-			hMeanTimeVsChargeADA->SetBinError(j+1,hMeanTimeVsChargeADA->GetBinError(j));
-			}
-		else{
-			hMeanTimeVsChargeADA->SetBinContent(j+1,hTimeSlice->GetMean());
-        		if(hTimeSlice->GetEntries()>0)hMeanTimeVsChargeADA->SetBinError(j+1,1/TMath::Power(hTimeSlice->GetEntries(),2));
-			}
-  		}
-  	TSpline3 *fTimeSlewingSplineADA = new TSpline3(hMeanTimeVsChargeADA);
-	fTimeSlewingSplineADA->SetLineWidth(3);
-	fTimeSlewingSplineADA->SetLineColor(kPink);
-		
-	histo2DCopy->DrawCopy("COLZ");
-	fTimeSlewingSplineADA->Draw("Psame");
-	delete hMeanTimeVsChargeADA;
-	
-	TH1F *hMeanTimeVsChargeADC = new TH1F("hMeanTimeVsChargeADC","hMeanTimeVsChargeADC",200,-4,0);
-	pDecision->cd(3);
-	gPad->SetLogz();
-	histo2D=(TH2*)list[esIndex]->At(AliADQADataMakerRec::kTimeSlewingADC);
-	histo2DCopy = (TH2*)histo2D->Clone("histo2DCopy");
-	histo2DCopy->GetYaxis()->SetRangeUser(fTimeRatioBBZoomMin,fTimeRatioBBZoomMax);
-	histo2DCopy->SetTitle("Time slewing ADC");
-		
-	for(Int_t j=0; j<200;j++){
-  		hTimeSlice = histo2DCopy->ProjectionY("hTimeSlice",j+1,j+1);
-		if(hTimeSlice->GetEntries()<100 && j>100){
-			hMeanTimeVsChargeADC->SetBinContent(j+1,hMeanTimeVsChargeADC->GetBinContent(j));
-			hMeanTimeVsChargeADC->SetBinError(j+1,hMeanTimeVsChargeADC->GetBinError(j));
-			}
-		else{
-			hMeanTimeVsChargeADC->SetBinContent(j+1,hTimeSlice->GetMean());
-        		if(hTimeSlice->GetEntries()>0)hMeanTimeVsChargeADC->SetBinError(j+1,1/TMath::Power(hTimeSlice->GetEntries(),2));
-			}
-  		}
-  	TSpline3 *fTimeSlewingSplineADC = new TSpline3(hMeanTimeVsChargeADC);
-	fTimeSlewingSplineADC->SetLineWidth(3);
-	fTimeSlewingSplineADC->SetLineColor(kPink);
-		
-	histo2DCopy->DrawCopy("COLZ");
-	fTimeSlewingSplineADC->Draw("Psame");
-	delete hMeanTimeVsChargeADC;
-	
+	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kNBBCoincCorr+iHist);
+	histo->DrawCopy("COLZ");
+      }
+      //Pedestal monitoring pad
+      for(Int_t iHist = 0; iHist<2; iHist++){
+	pPed->cd(iHist+1);
+	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kPedestalDiffInt0+iHist);
+	histo->DrawCopy("COLZ");
+      }
+      //Saturation monitoring pad
+      pMaxCh->cd();
+      gPad->SetLogz();
+      histo2D=(TH2*)list[esIndex]->At(AliADQADataMakerRec::kChargeSaturation);
+      histo2DCopy = (TH2*)histo2D->Clone("histoBlue");
+      histo2DCopy->RebinY(64);
+      histo2DCopy->DrawCopy("COLZ");
 
-	pDecision->cd(2);
-	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kDecisions);
-	histo->Draw("COLZTEXT");
-	
-	pChargeTrend->cd();
-	histoBlue = (TH1*)list[esIndex]->At(AliADQADataMakerRec::kTrend_TriggerChargeQuantileADA);
-	histoRed = (TH1*)list[esIndex]->At(AliADQADataMakerRec::kTrend_TriggerChargeQuantileADC);
-	histoBlue->GetYaxis()->SetRangeUser(fChargeTrendMin,fChargeTrendMax);
-	histoBlue->GetYaxis()->SetTitle("Quantile 0.9");
-	histoBlue->GetXaxis()->SetRange(1,histoBlue->GetNbinsX()-1);
-	histoBlue->DrawCopy();
-	histoRed->DrawCopy("same");
-	myLegend1->Draw();
+      //Trigger inputs pad
+      pTrigger->cd();
+      histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kTriggers);
+      gPad->SetLogy();
+      histo->DrawCopy("HIST");
+      histo->DrawCopy("TEXT0SAME");
+      //Mean time pad
+      pMeanTime->cd(1);
+      histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kMeanTimeADA);
+      histoBlue = (TH1*)histo->Clone("histoBlue");
+
+      histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kMeanTimeADC);
+      histoRed = (TH1*)histo->Clone("histoRed");
+      max[0] = histoBlue->GetBinContent(histoBlue->GetMaximumBin());
+      max[1] = histoRed->GetBinContent(histoRed->GetMaximumBin());
+      histoBlue->GetYaxis()->SetRangeUser(0,1.1*TMath::MaxElement(2,max));
+      histoBlue->DrawCopy();
+      histoRed->DrawCopy("same");
+      myLegend1->Draw();
+      for(Int_t iHist = 0; iHist<3; iHist++){
+	pMeanTime->cd(iHist+2);
+	gPad->SetLogz();
+	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kMeanTimeDiff+iHist);
+	histo->DrawCopy("COLZ");
+      }
+      //Decisions pad
+      TH1D *hTimeSlice = 0x0;
+      TH1F *hMeanTimeVsChargeADA = new TH1F("hMeanTimeVsChargeADA","hMeanTimeVsChargeADA",200,-4,0);
+
+      pDecision->cd(1);
+      gPad->SetLogz();
+      histo2D=(TH2*)list[esIndex]->At(AliADQADataMakerRec::kTimeSlewingADA);
+      histo2DCopy = (TH2*)histo2D->Clone("histo2DCopy");
+      histo2DCopy->GetYaxis()->SetRangeUser(fTimeRatioBBZoomMin,fTimeRatioBBZoomMax);
+      histo2DCopy->SetTitle("Time slewing ADA");
+
+      for(Int_t j=0; j<200;j++){
+	hTimeSlice = histo2DCopy->ProjectionY("hTimeSlice",j+1,j+1);
+	if(hTimeSlice->GetEntries()<100 && j>100){
+	  hMeanTimeVsChargeADA->SetBinContent(j+1,hMeanTimeVsChargeADA->GetBinContent(j));
+	  hMeanTimeVsChargeADA->SetBinError(j+1,hMeanTimeVsChargeADA->GetBinError(j));
+	} else {
+	  hMeanTimeVsChargeADA->SetBinContent(j+1,hTimeSlice->GetMean());
+	  if(hTimeSlice->GetEntries()>0)hMeanTimeVsChargeADA->SetBinError(j+1,1/TMath::Power(hTimeSlice->GetEntries(),2));
+	}
+      }
+      TSpline3 *fTimeSlewingSplineADA = new TSpline3(hMeanTimeVsChargeADA);
+      fTimeSlewingSplineADA->SetLineWidth(3);
+      fTimeSlewingSplineADA->SetLineColor(kPink);
+
+      histo2DCopy->DrawCopy("COLZ");
+      fTimeSlewingSplineADA->Draw("Psame");
+      delete hMeanTimeVsChargeADA;
+
+      TH1F *hMeanTimeVsChargeADC = new TH1F("hMeanTimeVsChargeADC","hMeanTimeVsChargeADC",200,-4,0);
+      pDecision->cd(3);
+      gPad->SetLogz();
+      histo2D=(TH2*)list[esIndex]->At(AliADQADataMakerRec::kTimeSlewingADC);
+      histo2DCopy = (TH2*)histo2D->Clone("histo2DCopy");
+      histo2DCopy->GetYaxis()->SetRangeUser(fTimeRatioBBZoomMin,fTimeRatioBBZoomMax);
+      histo2DCopy->SetTitle("Time slewing ADC");
+
+      for(Int_t j=0; j<200;j++){
+	hTimeSlice = histo2DCopy->ProjectionY("hTimeSlice",j+1,j+1);
+	if(hTimeSlice->GetEntries()<100 && j>100){
+	  hMeanTimeVsChargeADC->SetBinContent(j+1,hMeanTimeVsChargeADC->GetBinContent(j));
+	  hMeanTimeVsChargeADC->SetBinError(j+1,hMeanTimeVsChargeADC->GetBinError(j));
+	} else {
+	  hMeanTimeVsChargeADC->SetBinContent(j+1,hTimeSlice->GetMean());
+	  if(hTimeSlice->GetEntries()>0)hMeanTimeVsChargeADC->SetBinError(j+1,1/TMath::Power(hTimeSlice->GetEntries(),2));
+	}
+      }
+      TSpline3 *fTimeSlewingSplineADC = new TSpline3(hMeanTimeVsChargeADC);
+      fTimeSlewingSplineADC->SetLineWidth(3);
+      fTimeSlewingSplineADC->SetLineColor(kPink);
+
+      histo2DCopy->DrawCopy("COLZ");
+      fTimeSlewingSplineADC->Draw("Psame");
+      delete hMeanTimeVsChargeADC;
+
+
+      pDecision->cd(2);
+      histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kDecisions);
+      histo->Draw("COLZTEXT");
+
+      pChargeTrend->cd();
+      histoBlue = (TH1*)list[esIndex]->At(AliADQADataMakerRec::kTrend_TriggerChargeQuantileADA);
+      histoRed = (TH1*)list[esIndex]->At(AliADQADataMakerRec::kTrend_TriggerChargeQuantileADC);
+      histoBlue->GetYaxis()->SetRangeUser(fChargeTrendMin,fChargeTrendMax);
+      histoBlue->GetYaxis()->SetTitle("Quantile 0.9");
+      histoBlue->GetXaxis()->SetRange(1,histoBlue->GetNbinsX()-1);
+      histoBlue->DrawCopy();
+      histoRed->DrawCopy("same");
+      myLegend1->Draw();
+    } else {
+      TVirtualPad* pPed  = 0;
+      TH1* histo = 0;
+
+      TPad* pP = new TPad("Pedestal", "Pedestal Pad", 0.0, 0.1, 1.0, 0.95);
+      fImage[esIndex]->cd();
+      pP->Draw();
+      pPed = pP;
+      pPed->Divide(1, 2);
+
+      histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kPedestalInt0);
+      histo->SetStats(kFALSE);
+      pPed->cd(1);
+      histo->DrawCopy("colz");
+
+      histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kPedestalInt1);
+      histo->SetStats(kFALSE);
+      pPed->cd(2);
+      histo->DrawCopy("colz");
 
     }
-    else{
-	TVirtualPad* pPed  = 0;
-	TH1* histo = 0;
-	
-    	TPad* pP = new TPad("Pedestal", "Pedestal Pad", 0.0, 0.1, 1.0, 0.95);
-    	fImage[esIndex]->cd();
-    	pP->Draw();
-    	pPed = pP;
-	pPed->Divide(1, 2);
-	
-      	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kPedestalInt0);
-      	histo->SetStats(kFALSE);
-	pPed->cd(1);
-      	histo->DrawCopy("colz");
-	
-	histo=(TH1*)list[esIndex]->At(AliADQADataMakerRec::kPedestalInt1);
-      	histo->SetStats(kFALSE); 
-	pPed->cd(2);
-	histo->DrawCopy("colz");
 
-    }
-    
     //fImage[esIndex]->SaveAs(Form("QAsummary_%d_%d.png",AliQAChecker::Instance()->GetRunNumber(),esIndex));
-    //fImage[esIndex]->Print(Form("%s%s%d.%s", AliQAv1::GetImageFileName(), AliQAv1::GetModeName(mode), AliQAChecker::Instance()->GetRunNumber(), AliQAv1::GetImageFileFormat()), "ps"); 
+    //fImage[esIndex]->Print(Form("%s%s%d.%s", AliQAv1::GetImageFileName(), AliQAv1::GetModeName(mode), AliQAChecker::Instance()->GetRunNumber(), AliQAv1::GetImageFileFormat()), "ps");
   }
 }
- 

--- a/AD/ADrec/AliADQAChecker.cxx
+++ b/AD/ADrec/AliADQAChecker.cxx
@@ -219,7 +219,7 @@ Double_t AliADQAChecker::CheckRaws(TObjArray * list) const
   if (list->GetEntries() == 0){
     AliWarning("There are no histograms to be checked");
   } else {
-    Float_t nEvents;
+    Float_t nEvents = 0.0f;
     TH1F *hChargeADA = (TH1F*)list->At(AliADQADataMakerRec::kChargeADA);
     if (!hChargeADA) {
       AliWarning("ChargeADA histogram is not found");
@@ -874,7 +874,7 @@ void AliADQAChecker::MakeImage( TObjArray ** list, AliQAv1::TASKINDEX_t task, Al
       Double_t xRow[nRows];
       xRow[0] = 0.95;
       Double_t xStep = 0.95/((nRows-nLargeRows)+ timesLarger*nLargeRows);
-      for(Int_t iRow = 1; iRow<nRows; iRow++){
+      for(UInt_t iRow = 1; iRow<nRows; iRow++){
 	if(!isLarge[iRow-1]) xRow[iRow] = xRow[iRow-1]-xStep;
 	else xRow[iRow] = xRow[iRow-1]-timesLarger*xStep;
       }

--- a/AD/ADrec/AliADQAChecker.h
+++ b/AD/ADrec/AliADQAChecker.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 #ifndef ALIADQACHECKER_H
 #define ALIADQACHECKER_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
@@ -11,10 +12,10 @@
 */
 
 // --- ROOT system ---
-class TFile ; 
-class TH1F ; 
-class TH1I ; 
-class TObjArray ; 
+class TFile ;
+class TH1F ;
+class TH1I ;
+class TObjArray ;
 
 // --- Standard library ---
 
@@ -24,14 +25,13 @@ class TObjArray ;
 class AliADLoader;
 class AliCDBManager;
 class AliCDBStorage;
-class AliADQAParam; 
+class AliADQAParam;
 
 class AliADQAChecker: public AliQACheckerBase {
-
 public:
   AliADQAChecker();
-  virtual ~AliADQAChecker() {;} // destructor
-  
+  virtual ~AliADQAChecker() {} // destructor
+
   virtual void   Init(const AliQAv1::DETECTORINDEX_t det);
 
   AliADQAParam *GetQAParam() const;
@@ -43,17 +43,17 @@ public:
   void SetSatHugeCut(Double_t cut) {fSatHuge = cut;}
   void SetMaxPedDiffCut(Double_t cut) {fMaxPedDiff = cut;}
 
-protected:  
+protected:
   virtual void Check( Double_t * test, AliQAv1::ALITASK_t index, TObjArray ** list, const AliDetectorRecoParam * recoParam);
   Double_t CheckRaws(TObjArray * list) const;
   Double_t CheckPedestals(TObjArray * list) const;
   Double_t CheckEsds(TObjArray * list) const;
-  
-  virtual void   MakeImage( TObjArray ** list, AliQAv1::TASKINDEX_t task, AliQAv1::MODE_t mode) ;  
+
+  virtual void   MakeImage( TObjArray ** list, AliQAv1::TASKINDEX_t task, AliQAv1::MODE_t mode) ;
   virtual void SetQA(AliQAv1::ALITASK_t index, Double_t * value) const ;
-  
+
 private:
-  AliADQAChecker(const AliADQAChecker& qac); // cpy ctor   
+  AliADQAChecker(const AliADQAChecker& qac); // cpy ctor
   AliADQAChecker &operator=(const AliADQAChecker& qac); // assignment operator
 
   AliADQAParam *fQAParam;
@@ -73,15 +73,14 @@ private:
   Float_t fTimeRatioBGZoomMax; //Max for Zoom time/BG ratio
   Float_t fChargeTrendMin;
   Float_t fChargeTrendMax;
-  Float_t fMaxNoTimeRate; 
+  Float_t fMaxNoTimeRate;
   Float_t fMaxNoFlagRate;
   Float_t fMaxBBVariation;
   Float_t fMaxBGVariation;
   Float_t fAsynchronBB;
-  Float_t fAsynchronBG; 
+  Float_t fAsynchronBG;
 
-  ClassDef(AliADQAChecker,6)  // description 
-
+  ClassDef(AliADQAChecker,6);  // description
 };
 
 #endif // AliADQAChecker_H

--- a/AD/ADrec/AliADQADataMakerRec.cxx
+++ b/AD/ADrec/AliADQADataMakerRec.cxx
@@ -904,7 +904,7 @@ void AliADQADataMakerRec::MakeRaws(AliRawReader* rawReader)
     Bool_t flagBG[16];
     Float_t charge;
     Int_t  offlineCh;
-    Float_t adc[16], time[16], width[16], timeCorr[16], adcTrig[16];
+    Float_t adc[16], time[16], width[16], adcTrig[16];
     // Int_t  iPair=0; not used
 
     for(Int_t iChannel=0; iChannel<16; iChannel++) { // BEGIN : Loop over channels
@@ -993,8 +993,6 @@ void AliADQADataMakerRec::MakeRaws(AliRawReader* rawReader)
         }
       }
       // Fill HPTDC Time Histograms
-      timeCorr[offlineCh] = CorrectLeadingTime(offlineCh,time[offlineCh],adc[offlineCh]);
-
       if(time[offlineCh] > 1.e-6){
         FillRawsData(kWidthSlewing,width[offlineCh],adc[offlineCh]);
         Float_t timeErr = 1;

--- a/AD/ADrec/AliADQADataMakerRec.cxx
+++ b/AD/ADrec/AliADQADataMakerRec.cxx
@@ -14,20 +14,20 @@
  **************************************************************************/
 
 
-//  Produces the data needed to calculate the quality assurance 
+//  Produces the data needed to calculate the quality assurance
 //  All data must be mergeable objects
 //  Handles ESDs and Raws
 //  Histos defined will be used for Raw Data control and monitoring
 
 // --- ROOT system ---
 #include <TClonesArray.h>
-#include <TFile.h> 
-#include <TF1.h> 
-#include <TH1F.h> 
-#include <TH1I.h> 
-#include <TH2I.h> 
-#include <TH2F.h> 
-#include <TGraph.h> 
+#include <TFile.h>
+#include <TF1.h>
+#include <TH1F.h>
+#include <TH1I.h>
+#include <TH2I.h>
+#include <TH2F.h>
+#include <TGraph.h>
 #include <TParameter.h>
 #include <TTimeStamp.h>
 #include <TPaveText.h>
@@ -55,84 +55,88 @@
 #include "AliLHCClockPhase.h"
 #include "event.h"
 
-ClassImp(AliADQADataMakerRec)
-           
-//____________________________________________________________________________ 
-AliADQADataMakerRec::AliADQADataMakerRec() : 
-AliQADataMakerRec(AliQAv1::GetDetName(AliQAv1::kAD), "AD Quality Assurance Data Maker"),
-  fCalibData(0x0),
-  fRecoParam(0x0),
-  fQAParam(0x0),
-  fTrendingUpdateTime(0), 
-  fCycleStartTime(0), 
-  fCycleStopTime(0),
-  fADADist(56.7),
-  fADCDist(65.19),
-  fOldRun(0)
-    
-{
-  // Constructor
-   
-  AliDebug(AliQAv1::GetQADebugLevel(), "Construct AD QA Object");
+ClassImp(AliADQADataMakerRec);
 
-  for(Int_t i=0; i<16; i++){  
-    fEven[i] = 0;   
+//____________________________________________________________________________
+AliADQADataMakerRec::AliADQADataMakerRec()
+  : AliQADataMakerRec(AliQAv1::GetDetName(AliQAv1::kAD), "AD Quality Assurance Data Maker")
+  , fCalibData(NULL)
+  , fRecoParam(NULL)
+  , fQAParam(NULL)
+  , fTrendingUpdateTime(0)
+  , fCycleStartTime(0)
+  , fCycleStopTime(0)
+  , fADADist(56.7)
+  , fADCDist(65.19)
+  , fOldRun(0)
+{
+  AliDebug(AliQAv1::GetQADebugLevel(), "Construct AD QA Object");
+  for(Int_t i=0; i<16; i++){
+    fEven[i] = 0;
     fOdd[i]  = 0;
   }
-  
-  for(Int_t i=0; i<32; i++){  
-    fADCmean[i] = 0.0;   }	
+  for(Int_t i=0; i<32; i++){
+    fADCmean[i] = 0.0;
+  }
 }
 
-//____________________________________________________________________________ 
-AliADQADataMakerRec::AliADQADataMakerRec(const AliADQADataMakerRec& qadm) :
-  AliQADataMakerRec(),
-  fCalibData(0x0),
-  fRecoParam(0x0),
-  fQAParam(0x0),
-  fTrendingUpdateTime(0), 
-  fCycleStartTime(0), 
-  fCycleStopTime(0),
-  fADADist(56.7),
-  fADCDist(65.19),
-  fOldRun(0)
-  
+//____________________________________________________________________________
+AliADQADataMakerRec::AliADQADataMakerRec(const AliADQADataMakerRec& qadm)
+  : AliQADataMakerRec()
+  , fCalibData(NULL)
+  , fRecoParam(NULL)
+  , fQAParam(NULL)
+  , fTrendingUpdateTime(0)
+  , fCycleStartTime(0)
+  , fCycleStopTime(0)
+  , fADADist(56.7)
+  , fADCDist(65.19)
+  , fOldRun(0)
 {
-  // Copy constructor 
-  
-  SetName((const char*)qadm.GetName()) ; 
-  SetTitle((const char*)qadm.GetTitle()); 
+  SetName((const char*)qadm.GetName());
+  SetTitle((const char*)qadm.GetTitle());
+}
+
+AliADQADataMakerRec::~AliADQADataMakerRec()
+{
+  // if (fCalibData)
+  //   delete fCalibData;
+  // fCalibData = NULL;
+
+  // if (fRecoParam)
+  //   delete fRecoParam;
+  // fRecoParam = NULL;
+
+  // if (fQAParam)
+  //   delete fQAParam;
+  // fQAParam = NULL;
 }
 
 //__________________________________________________________________
-AliADQADataMakerRec& AliADQADataMakerRec::operator = (const AliADQADataMakerRec& qadm )
+AliADQADataMakerRec& AliADQADataMakerRec::operator=(const AliADQADataMakerRec& qadm )
 {
-  // Equal operator
-  
-  this->~AliADQADataMakerRec();
-  new(this) AliADQADataMakerRec(qadm);
+  if (this != &qadm) {
+    this->~AliADQADataMakerRec(); // here the object is not valid anymore!
+    new(this) AliADQADataMakerRec(qadm); // this is not exception safe!
+  }
   return *this;
 }
 
 //____________________________________________________________________________
 AliADCalibData* AliADQADataMakerRec::GetCalibData() const
-
 {
   AliCDBManager *man = AliCDBManager::Instance();
-
-  AliCDBEntry *entry=0;
-
-  entry = man->Get("AD/Calib/Data",fRun);
+  AliCDBEntry *entry = man->Get("AD/Calib/Data",fRun);
   if(!entry){
     AliWarning("Load of calibration data from default storage failed!");
     AliWarning("Calibration data will be loaded from local storage ($ALICE_ROOT)");
-	
+
     man->SetDefaultStorage("local://$ALICE_ROOT/OCDB");
     entry = man->Get("AD/Calib/Data",fRun);
   }
   // Retrieval of data in directory AD/Calib/Data:
 
-  AliADCalibData *calibdata = 0;
+  AliADCalibData *calibdata = NULL;
 
   if (entry) calibdata = (AliADCalibData*) entry->GetObject();
   if (!calibdata)  AliFatal("No calibration data from calibration database !");
@@ -141,219 +145,212 @@ AliADCalibData* AliADQADataMakerRec::GetCalibData() const
 }
 //____________________________________________________________________________
 AliADQAParam* AliADQADataMakerRec::GetQAParam() const
-
 {
   AliCDBManager *man = AliCDBManager::Instance();
-
-  AliCDBEntry *entry=0;
-
-  entry = man->Get("AD/Calib/QAParam",fRun);
+  AliCDBEntry *entry = man->Get("AD/Calib/QAParam",fRun);
   if(!entry){
     AliWarning("Load of QA param from default storage failed!");
     AliWarning("QA parameters will be loaded from local storage ($ALICE_ROOT)");
-	
+
     man->SetDefaultStorage("local://$ALICE_ROOT/OCDB");
     entry = man->Get("AD/Calib/QAParam",fRun);
   }
   // Retrieval of data in directory AD/Calib/QA:
-
   AliADQAParam *QAParam = 0;
-
   if (entry) QAParam = (AliADQAParam*) entry->GetObject();
-  if (!QAParam)  AliFatal("No QA param from calibration database !");
+  if (!QAParam) AliFatal("No QA param from calibration database !");
 
   return QAParam;
 }
-//____________________________________________________________________________ 
+//____________________________________________________________________________
 void AliADQADataMakerRec::StartOfDetectorCycle()
 {
   // Detector specific actions at start of cycle
-  
+
   // Reset of the histogram used - to have the trend versus time -
- 
   fCalibData = GetCalibData();
-  fQAParam = GetQAParam();
+  fQAParam   = GetQAParam();
   if(!fRecoParam)fRecoParam = (AliADRecoParam*)GetRecoParam();
-	
+
   TTimeStamp currentTime;
   fCycleStartTime = currentTime.GetSec();
- 
+
 }
-//____________________________________________________________________________ 
+//____________________________________________________________________________
 void AliADQADataMakerRec::EndOfDetectorCycle(AliQAv1::TASKINDEX_t task, TObjArray ** list)
 {
   // Detector specific actions at end of cycle
   // Does the QA checking
   ResetEventTrigClasses();
-  
+
   if(task == AliQAv1::kRAWS){
     TDatime currentTime;
     fCycleStopTime = currentTime.GetSecond();
-    
+
     if (fRun!=fOldRun){
-    ((TH1F*)GetRawsData(kTrend_TriggerChargeQuantileADA))->SetBins(1,0,1);
-    ((TH1F*)GetRawsData(kTrend_TriggerChargeQuantileADC))->SetBins(1,0,1);
-    fOldRun=fRun;
+      ((TH1F*)GetRawsData(kTrend_TriggerChargeQuantileADA))->SetBins(1,0,1);
+      ((TH1F*)GetRawsData(kTrend_TriggerChargeQuantileADC))->SetBins(1,0,1);
+      fOldRun=fRun;
     }
-    
+
     const Int_t nq = 1;
     const Double_t xq[nq] = {0.9};
     Double_t yq[nq] = {0.0};
     UInt_t currentBins = ((TH1F*)GetRawsData(kTrend_TriggerChargeQuantileADC))->GetNbinsX();
-    
+
     ((TH1F*)GetRawsData(kTrend_TriggerChargeQuantileADC))->SetBins(currentBins+1,0,currentBins+1);
     if(((TH1F*)GetRawsData(kChargeADC_PC))->Integral() != 0)((TH1F*)GetRawsData(kChargeADC_PC))->GetQuantiles(nq,yq,xq);
-    
+
     ((TH1F*)GetRawsData(kTrend_TriggerChargeQuantileADC))->SetBinContent(currentBins,yq[0]);
     ((TH1F*)GetRawsData(kTrend_TriggerChargeQuantileADC))->GetXaxis()->LabelsOption("v");
     if (currentBins%10 == 1)((TH1F*)GetRawsData(kTrend_TriggerChargeQuantileADC))->GetXaxis()->SetBinLabel(currentBins,Form("%d:%02d:%02d",currentTime.GetHour(),currentTime.GetMinute(),currentTime.GetSecond()));
     ((TH1F*)GetRawsData(kChargeADC_PC))->Reset("ICES");
-    
+
     ((TH1F*)GetRawsData(kTrend_TriggerChargeQuantileADA))->SetBins(currentBins+1,0,currentBins+1);
     if(((TH1F*)GetRawsData(kChargeADA_PC))->Integral() != 0)((TH1F*)GetRawsData(kChargeADA_PC))->GetQuantiles(1,yq,xq);
-    
+
     ((TH1F*)GetRawsData(kTrend_TriggerChargeQuantileADA))->SetBinContent(currentBins,yq[0]);
     ((TH1F*)GetRawsData(kTrend_TriggerChargeQuantileADA))->GetXaxis()->LabelsOption("v");
     if (currentBins%10 == 1)((TH1F*)GetRawsData(kTrend_TriggerChargeQuantileADA))->GetXaxis()->SetBinLabel(currentBins,Form("%d:%02d:%02d",currentTime.GetHour(),currentTime.GetMinute(),currentTime.GetSecond()));
     ((TH1F*)GetRawsData(kChargeADA_PC))->Reset("ICES");
-    
-    
+
+
     Int_t nCorrelation = 0;
     Int_t nPair = 1;
     for(Int_t i=0;i<8;i++){
-  	for(Int_t j=7;j>i;j--){
-  		if( (j - i) == 4){ 
-			Float_t Mean = ((TH1F*)GetRawsData(kNTimeDiffADC + nCorrelation))->GetMean();
-			Float_t RMS = ((TH1F*)GetRawsData(kNTimeDiffADC + nCorrelation))->GetRMS();
-			SetRawsDataBinContent(kPairTimeDiffMean,nPair,Mean);
-			SetRawsDataBinContent(kPairTimeDiffRMS,nPair,RMS);
-			nPair++;
-			}
-		 nCorrelation++;
-		}
-	}
+      for(Int_t j=7;j>i;j--){
+        if( (j - i) == 4){
+          Float_t Mean = ((TH1F*)GetRawsData(kNTimeDiffADC + nCorrelation))->GetMean();
+          Float_t RMS = ((TH1F*)GetRawsData(kNTimeDiffADC + nCorrelation))->GetRMS();
+          SetRawsDataBinContent(kPairTimeDiffMean,nPair,Mean);
+          SetRawsDataBinContent(kPairTimeDiffRMS,nPair,RMS);
+          nPair++;
+        }
+        nCorrelation++;
+      }
+    }
     nCorrelation = 0;
     for(Int_t i=0;i<8;i++){
-  	for(Int_t j=7;j>i;j--){
-  		if( (j - i) == 4){ 
-			Float_t Mean = ((TH1F*)GetRawsData(kNTimeDiffADA + nCorrelation))->GetMean();
-			Float_t RMS = ((TH1F*)GetRawsData(kNTimeDiffADA + nCorrelation))->GetRMS();
-			SetRawsDataBinContent(kPairTimeDiffMean,nPair,Mean);
-			SetRawsDataBinContent(kPairTimeDiffRMS,nPair,RMS);
-			nPair++;
-			}
-		 nCorrelation++;
-		}
-	}
-   
+      for(Int_t j=7;j>i;j--){
+        if( (j - i) == 4){
+          Float_t Mean = ((TH1F*)GetRawsData(kNTimeDiffADA + nCorrelation))->GetMean();
+          Float_t RMS = ((TH1F*)GetRawsData(kNTimeDiffADA + nCorrelation))->GetRMS();
+          SetRawsDataBinContent(kPairTimeDiffMean,nPair,Mean);
+          SetRawsDataBinContent(kPairTimeDiffRMS,nPair,RMS);
+          nPair++;
+        }
+        nCorrelation++;
+      }
+    }
 
-  for (Int_t specie = 0 ; specie < AliRecoParam::kNSpecies ; specie++) {
-    if (! IsValidEventSpecie(specie, list)) continue ;
-    SetEventSpecie(AliRecoParam::ConvertIndex(specie));
-    if(task == AliQAv1::kRAWS) {
-    	AliQAChecker::Instance()->Run(AliQAv1::kAD, task, list) ;
-    } else if (task == AliQAv1::kESDS) {
+
+    for (Int_t specie = 0 ; specie < AliRecoParam::kNSpecies ; specie++) {
+      if (! IsValidEventSpecie(specie, list)) continue ;
+      SetEventSpecie(AliRecoParam::ConvertIndex(specie));
+      if(task == AliQAv1::kRAWS) {
+        AliQAChecker::Instance()->Run(AliQAv1::kAD, task, list) ;
+      } else if (task == AliQAv1::kESDS) {
+      }
     }
+
   }
-  
-    }
-  
+
 }
 
-//____________________________________________________________________________ 
+//____________________________________________________________________________
 void AliADQADataMakerRec::InitESDs()
 {
-  const Bool_t expert   = kTRUE ; 
-  const Bool_t image    = kTRUE ; 
+  const Bool_t expert   = kTRUE ;
+  const Bool_t image    = kTRUE ;
 
-  TH1I * h0 = new TH1I("H1I_Cell_Multiplicity_ADA", "Cell Multiplicity in ADA;Multiplicity (Nb of Cell);Counts", 35, 0, 35) ;  
-  Add2ESDsList(h0, kCellMultiADA, !expert, image)  ;  
-                                                                                                        
-  TH1I * h1 = new TH1I("H1I_Cell_Multiplicity_ADC", "Cell Multiplicity in AD;Multiplicity (Nb of Cell);Counts", 35, 0, 35) ;  
-  Add2ESDsList(h1, kCellMultiADC, !expert, image)  ;  
-  
-  TH1F * h2 = new TH1F("H1D_BBFlag_Counters", "BB Flag Counters;Channel;Counts",16, 0, 16) ;  
-  Add2ESDsList(h2, kBBFlag, !expert, image)  ;  
-  
-  TH1F * h3 = new TH1F("H1D_BGFlag_Counters", "BG Flag Counters;Channel;Counts",16, 0, 16) ;  
-  Add2ESDsList(h3, kBGFlag, !expert, image)  ;  
-  
-  TH2F * h4 = new TH2F("H2D_Charge_Channel", "ADC Charge per channel;Channel;Charge (ADC counts)",16, 0, 16, 1024, 0, 1024) ;  
-  Add2ESDsList(h4, kChargeChannel, !expert, image)  ;  
-  
-  TH2F * h5 = new TH2F("H2D_Time_Channel", "Time per channel;Channel;Time (ns)",16,0,16, 1638, -79.980469, 79.980469);  
-  Add2ESDsList(h5, kTimeChannel, !expert, image)  ;  
-  
+  TH1I * h0 = new TH1I("H1I_Cell_Multiplicity_ADA", "Cell Multiplicity in ADA;Multiplicity (Nb of Cell);Counts", 35, 0, 35) ;
+  Add2ESDsList(h0, kCellMultiADA, !expert, image)  ;
+
+  TH1I * h1 = new TH1I("H1I_Cell_Multiplicity_ADC", "Cell Multiplicity in AD;Multiplicity (Nb of Cell);Counts", 35, 0, 35) ;
+  Add2ESDsList(h1, kCellMultiADC, !expert, image)  ;
+
+  TH1F * h2 = new TH1F("H1D_BBFlag_Counters", "BB Flag Counters;Channel;Counts",16, 0, 16) ;
+  Add2ESDsList(h2, kBBFlag, !expert, image)  ;
+
+  TH1F * h3 = new TH1F("H1D_BGFlag_Counters", "BG Flag Counters;Channel;Counts",16, 0, 16) ;
+  Add2ESDsList(h3, kBGFlag, !expert, image)  ;
+
+  TH2F * h4 = new TH2F("H2D_Charge_Channel", "ADC Charge per channel;Channel;Charge (ADC counts)",16, 0, 16, 1024, 0, 1024) ;
+  Add2ESDsList(h4, kChargeChannel, !expert, image)  ;
+
+  TH2F * h5 = new TH2F("H2D_Time_Channel", "Time per channel;Channel;Time (ns)",16,0,16, 1638, -79.980469, 79.980469);
+  Add2ESDsList(h5, kTimeChannel, !expert, image)  ;
+
   TH1F * h6 = new TH1F("H1D_ADA_Time", "Mean ADA Time;Time (ns);Counts",1638, -79.980469, 79.980469);
-  Add2ESDsList(h6,kESDADATime, !expert, image); 
-  
+  Add2ESDsList(h6,kESDADATime, !expert, image);
+
   TH1F * h7 = new TH1F("H1D_ADC_Time", "Mean ADC Time;Time (ns);Counts",1638, -79.980469, 79.980469);
-  Add2ESDsList(h7,kESDADCTime, !expert, image); 
-  
+  Add2ESDsList(h7,kESDADCTime, !expert, image);
+
   TH1F * h8 = new TH1F("H1D_Diff_Time", "Diff Time ADA - ADC;Diff Time ADA - ADC (ns);Counts",1000, -200., 200.);
-  Add2ESDsList(h8,kESDDiffTime, !expert, image); 
-  
+  Add2ESDsList(h8,kESDDiffTime, !expert, image);
+
   TH2F * h9 = new TH2F("H2D_ADA_TimeVsCharge", "TimeVsCharge ADA;Time (ns); Charge(ADC counts);Counts",1638, -79.980469, 79.980469,5000,0,5000);
   Add2ESDsList(h9,kESDADATimeVsCharge, !expert, image);
-  
+
   TH2F * h10 = new TH2F("H2D_ADC_TimeVsCharge", "TimeVsCharge ADC;Time (ns); Charge(ADC counts);Counts",1638, -79.980469, 79.980469,5000,0,5000);
   Add2ESDsList(h10,kESDADCTimeVsCharge, !expert, image);
-  
+
   TH2F * h11 = new TH2F("H2D_ADA_PairTimeSumDiff", "Pair Time Sum Vs Diff ADA; t1+t2 (ns); t1-t2 (ns);Counts",82, 79.980469, 160.058594,410, 0.000000, 40.039062);
   Add2ESDsList(h11,kESDADAPairTimeSumDiff, !expert, image);
-  
+
   TH2F * h12 = new TH2F("H2D_ADC_PairTimeSumDiff", "Pair Time Sum Vs Diff ADC; t1+t2 (ns); t1-t2 (ns);Counts",82, 79.980469, 160.058594,410, 0.000000, 40.039062);
   Add2ESDsList(h12,kESDADCPairTimeSumDiff, !expert, image);
-  
+
   //
-  ClonePerTrigClass(AliQAv1::kESDS); // this should be the last line	
+  ClonePerTrigClass(AliQAv1::kESDS); // this should be the last line
 }
 
-//____________________________________________________________________________ 
+//____________________________________________________________________________
 void AliADQADataMakerRec::InitDigits()
 {
-// create Digits histograms in Digits subdir
-  const Bool_t expert   = kTRUE ; 
-  const Bool_t image    = kTRUE ; 
+  // create Digits histograms in Digits subdir
+  const Bool_t expert   = kTRUE ;
+  const Bool_t image    = kTRUE ;
 
   // create Digits histograms in Digits subdir
-  TH1I * h0 = new TH1I("hDigitMultiplicity", "Digits multiplicity distribution in AD;# of Digits;Entries", 17,-0.5,16.5) ; 
+  TH1I * h0 = new TH1I("hDigitMultiplicity", "Digits multiplicity distribution in AD;# of Digits;Entries", 17,-0.5,16.5) ;
   h0->Sumw2() ;
   Add2DigitsList(h0, 0, !expert, image) ;
-     
-  TH2D * h1 = new TH2D("hDigitLeadingTimePerPM", "Leading time distribution per PM in AD;PM number;Leading Time [ns]",16,0,16, 3062, 0.976562, 300); 
+
+  TH2D * h1 = new TH2D("hDigitLeadingTimePerPM", "Leading time distribution per PM in AD;PM number;Leading Time [ns]",16,0,16, 3062, 0.976562, 300);
   h1->Sumw2() ;
-  Add2DigitsList(h1, 1, !expert, image) ; 
-  
-  TH2D * h2 = new TH2D("hDigitTimeWidthPerPM", "Time width distribution per PM in AD;PM number;Time width [ns]",16,0,16, 1000, 0, 100); 
+  Add2DigitsList(h1, 1, !expert, image) ;
+
+  TH2D * h2 = new TH2D("hDigitTimeWidthPerPM", "Time width distribution per PM in AD;PM number;Time width [ns]",16,0,16, 1000, 0, 100);
   h2->Sumw2() ;
   Add2DigitsList(h2, 2, !expert, image) ;
-  
+
   TH2I * h3 = new TH2I("hDigitChargePerClockPerPM", "Charge array per PM in AD;PM number; Clock",16,0,16,21, -10.5, 10.5);
   h3->Sumw2();
   Add2DigitsList(h3, 3, !expert, image) ;
-  
+
   TH1I * h4 = new TH1I("hDigitBBflagsAD","Number of BB flags in AD; # of BB flags; Entries",17,-0.5,16.5);
   h4->Sumw2();
   Add2DigitsList(h4, 4, !expert, image) ;
-  
+
   TH1I * h5 = new TH1I("hDigitBBflagsADA","Number of BB flags in ADA; # of BB flags; Entries",9,-0.5,8.5);
   h5->Sumw2();
   Add2DigitsList(h5, 5, !expert, image) ;
-  
+
   TH1I * h6 = new TH1I("hDigitBBflagsADC","Number of BB flags in ADC; # of BB flags; Entries",9,-0.5,8.5);
   h6->Sumw2();
   Add2DigitsList(h6, 6, !expert, image) ;
-  
+
   TH2D * h7 = new TH2D("hDigitTotalChargePerPM", "Total Charge per PM in AD;PM number; Charge [ADC counts]",16,0,16,10000,0,10000);
   h7->Sumw2();
   Add2DigitsList(h7, 7, !expert, image) ;
-  
+
   TH2I * h8 = new TH2I("hDigitMaxChargeClockPerPM", "Clock with maximum charge per PM in AD;PM number; Clock ",16,0,16,21, -10.5, 10.5);
   h8->Sumw2();
   Add2DigitsList(h8, 8, !expert, image) ;
-  
-   
+
+
   //
   ClonePerTrigClass(AliQAv1::kDIGITS); // this should be the last line
 }
@@ -361,101 +358,101 @@ void AliADQADataMakerRec::InitDigits()
 //____________________________________________________________________________
 void AliADQADataMakerRec::MakeDigits()
 {
- // makes data from Digits
+  // makes data from Digits
 
-  FillDigitsData(0,fDigitsArray->GetEntriesFast()) ; 
-  TIter next(fDigitsArray) ; 
-    AliADdigit *ADDigit ; 
-    Int_t nBBflagsADA = 0;
-    Int_t nBBflagsADC = 0;
-    
-    while ( (ADDigit = dynamic_cast<AliADdigit *>(next())) ) {
-         Int_t totCharge = 0;
-         Int_t   PMNumber  = ADDigit->PMNumber();
-	 if(PMNumber<8 && ADDigit->GetBBflag()) nBBflagsADC++;
-	 if(PMNumber>7 && ADDigit->GetBBflag()) nBBflagsADA++;
-	 
-	 Short_t adc[21];
-	 for(Int_t iClock=0; iClock<21; iClock++) { 
-	 adc[iClock]= ADDigit->ChargeADC(iClock);
-	 FillDigitsData(3, PMNumber,(float)iClock-10,(float)adc[iClock]);
-	 totCharge += adc[iClock];
-	 }
-	    
-         FillDigitsData(1,PMNumber,ADDigit->Time()); 
-	 FillDigitsData(2,PMNumber,ADDigit->Width());
-	 FillDigitsData(7,PMNumber,totCharge);
-	 FillDigitsData(8,PMNumber,TMath::LocMax(21,adc)-10); 
-	 
+  FillDigitsData(0,fDigitsArray->GetEntriesFast()) ;
+  TIter next(fDigitsArray) ;
+  AliADdigit *ADDigit ;
+  Int_t nBBflagsADA = 0;
+  Int_t nBBflagsADC = 0;
+
+  while ( (ADDigit = dynamic_cast<AliADdigit *>(next())) ) {
+    Int_t totCharge = 0;
+    Int_t   PMNumber  = ADDigit->PMNumber();
+    if(PMNumber<8 && ADDigit->GetBBflag()) nBBflagsADC++;
+    if(PMNumber>7 && ADDigit->GetBBflag()) nBBflagsADA++;
+
+    Short_t adc[21];
+    for(Int_t iClock=0; iClock<21; iClock++) {
+      adc[iClock]= ADDigit->ChargeADC(iClock);
+      FillDigitsData(3, PMNumber,(float)iClock-10,(float)adc[iClock]);
+      totCharge += adc[iClock];
     }
-    FillDigitsData(4,nBBflagsADA+nBBflagsADC);
-    FillDigitsData(5,nBBflagsADA);
-    FillDigitsData(6,nBBflagsADC);  
+
+    FillDigitsData(1,PMNumber,ADDigit->Time());
+    FillDigitsData(2,PMNumber,ADDigit->Width());
+    FillDigitsData(7,PMNumber,totCharge);
+    FillDigitsData(8,PMNumber,TMath::LocMax(21,adc)-10);
+
+  }
+  FillDigitsData(4,nBBflagsADA+nBBflagsADC);
+  FillDigitsData(5,nBBflagsADA);
+  FillDigitsData(6,nBBflagsADC);
 }
 
 //____________________________________________________________________________
 void AliADQADataMakerRec::MakeDigits(TTree* digitTree)
 {
   // makes data from Digit Tree
-	
-  if (fDigitsArray)
-    fDigitsArray->Clear() ; 
-  else 
-    fDigitsArray = new TClonesArray("AliADdigit", 1000) ; 
 
-    TBranch * branch = digitTree->GetBranch("ADDigit") ;
-    if ( ! branch ) {
-         AliWarning("AD branch in Digit Tree not found") ; 
-    } else {
-         branch->SetAddress(&fDigitsArray) ;
-         branch->GetEntry(0) ; 
-         MakeDigits() ; 
-    }
-    digitTree->ResetBranchAddress(branch);  
-    //
-    IncEvCountCycleDigits();
-    IncEvCountTotalDigits();
-    //    
+  if (fDigitsArray)
+    fDigitsArray->Clear() ;
+  else
+    fDigitsArray = new TClonesArray("AliADdigit", 1000) ;
+
+  TBranch * branch = digitTree->GetBranch("ADDigit") ;
+  if ( ! branch ) {
+    AliWarning("AD branch in Digit Tree not found") ;
+  } else {
+    branch->SetAddress(&fDigitsArray) ;
+    branch->GetEntry(0) ;
+    MakeDigits() ;
+  }
+  digitTree->ResetBranchAddress(branch);
+  //
+  IncEvCountCycleDigits();
+  IncEvCountTotalDigits();
+  //
 }
 
 //____________________________________________________________________________
 void AliADQADataMakerRec::MakeESDs(AliESDEvent* esd)
 {
-// Creates QA data from ESDs
-  
+  // Creates QA data from ESDs
+
   UInt_t eventType = esd->GetEventType();
 
   switch (eventType){
   case PHYSICS_EVENT:
     AliESDAD *esdAD=esd->GetADData();
-   
+
     if (!esdAD) break;
-		  
+
     FillESDsData(kCellMultiADA,esdAD->GetNbPMADA());
-    FillESDsData(kCellMultiADC,esdAD->GetNbPMADC());   
-	
+    FillESDsData(kCellMultiADC,esdAD->GetNbPMADC());
+
     for(Int_t i=0;i<16;i++) {
       FillESDsData(kChargeChannel,(Float_t) i,(Float_t) esdAD->GetAdc(i));
       if (i < 8) {
-	if(esdAD->BBTriggerADC(i)) {
-		FillESDsData(kBBFlag,(Float_t) i);
-		FillESDsData(kESDADCTimeVsCharge,esdAD->GetTime(i),esdAD->GetAdc(i));
-		}
-	if(esdAD->BGTriggerADC(i)) FillESDsData(kBGFlag,(Float_t) i);
-	
+        if(esdAD->BBTriggerADC(i)) {
+          FillESDsData(kBBFlag,(Float_t) i);
+          FillESDsData(kESDADCTimeVsCharge,esdAD->GetTime(i),esdAD->GetAdc(i));
+        }
+        if(esdAD->BGTriggerADC(i)) FillESDsData(kBGFlag,(Float_t) i);
+
       }
       else {
-	if(esdAD->BBTriggerADA(i-8)){ 
-		FillESDsData(kBBFlag,(Float_t) i); 
-		FillESDsData(kESDADATimeVsCharge,esdAD->GetTime(i),esdAD->GetAdc(i));
-		} 
-	if(esdAD->BGTriggerADA(i-8)) FillESDsData(kBGFlag,(Float_t) i);
-	
-      }		  	
+        if(esdAD->BBTriggerADA(i-8)){
+          FillESDsData(kBBFlag,(Float_t) i);
+          FillESDsData(kESDADATimeVsCharge,esdAD->GetTime(i),esdAD->GetAdc(i));
+        }
+        if(esdAD->BGTriggerADA(i-8)) FillESDsData(kBGFlag,(Float_t) i);
+
+      }
       Float_t time = (Float_t) esdAD->GetTime(i);
       FillESDsData(kTimeChannel,(Float_t) i,time);
     }
-    
+
     for (Int_t i = 0; i < 4; ++i) {
       Float_t time1 = esdAD->GetTime(i);
       Float_t time2 = esdAD->GetTime(i+4);
@@ -463,17 +460,17 @@ void AliADQADataMakerRec::MakeESDs(AliESDEvent* esd)
       Float_t timeDiff = TMath::Abs(time1-time2);
       Float_t timeSum = time1+time2;
       FillESDsData(kESDADCPairTimeSumDiff,timeSum,timeDiff);
-	}
-		
-     for (Int_t i = 8; i < 12; ++i) {
+    }
+
+    for (Int_t i = 8; i < 12; ++i) {
       Float_t time1 = esdAD->GetTime(i);
       Float_t time2 = esdAD->GetTime(i+4);
       if(time1<-1024.+1.e-6 || time2<-1024.+1.e-6) continue;
       Float_t timeDiff = TMath::Abs(time1-time2);
       Float_t timeSum = time1+time2;
       FillESDsData(kESDADAPairTimeSumDiff,timeSum,timeDiff);
-	}
-				
+    }
+
     Float_t timeADA = esdAD->GetADATime();
     Float_t timeADC = esdAD->GetADCTime();
     Float_t diffTime;
@@ -484,28 +481,28 @@ void AliADQADataMakerRec::MakeESDs(AliESDEvent* esd)
     FillESDsData(kESDADATime,timeADA);
     FillESDsData(kESDADCTime,timeADC);
     FillESDsData(kESDDiffTime,diffTime);
-		
+
     break;
-  }  
+  }
   //
   IncEvCountCycleESDs();
-  IncEvCountTotalESDs();  
-  // 
+  IncEvCountTotalESDs();
+  //
 }
 
-//____________________________________________________________________________ 
+//____________________________________________________________________________
 void AliADQADataMakerRec::InitRaws()
 {
   // Creates RAW histograms in Raws subdir
   if(!fRecoParam)fRecoParam = (AliADRecoParam*)GetRecoParam();
   if(!fQAParam) fQAParam = (AliADQAParam*)GetQAParam();
- 
-  const Bool_t expert   = kTRUE ; 
-  const Bool_t saveCorr = kTRUE ; 
-  const Bool_t image    = kTRUE ; 
+
+  const Bool_t expert   = kTRUE ;
+  const Bool_t saveCorr = kTRUE ;
+  const Bool_t image    = kTRUE ;
 
   const Int_t kNintegrator  =    2;
- 
+
   const Int_t kNTdcTimeBins  = fQAParam->GetNTdcTimeBins();
   const Float_t kTdcTimeMin    =  fQAParam->GetTdcTimeMin();
   const Float_t kTdcTimeMax    = fQAParam->GetTdcTimeMax();
@@ -517,128 +514,128 @@ void AliADQADataMakerRec::InitRaws()
   const Int_t kNTdcTimeRatioBins  = fQAParam->GetNTdcTimeRatioBins();
   const Float_t kTdcTimeRatioMin    =  fQAParam->GetTdcTimeRatioMin();
   const Float_t kTdcTimeRatioMax    = fQAParam->GetTdcTimeRatioMax();
-  
+
   const Int_t kNTdcWidthBins =  fQAParam->GetNTdcWidthBins();
   const Float_t kTdcWidthMin   =    fQAParam->GetTdcWidthMin();
   const Float_t kTdcWidthMax   =  fQAParam->GetTdcWidthMax();
-  
+
   const Int_t kNChargeChannelBins   =  fQAParam->GetNChargeChannelBins();
   const Int_t kChargeChannelMin   =  fQAParam->GetChargeChannelMin();
   const Int_t kChargeChannelMax   =  fQAParam->GetChargeChannelMax();
-  
+
   const Int_t kNChargeSideBins   = fQAParam->GetNChargeSideBins();
   const Int_t kChargeSideMin   = fQAParam->GetChargeSideMin();
   const Int_t kChargeSideMax   = fQAParam->GetChargeSideMax();
-  
+
   const Int_t kNChargeCorrBins   = fQAParam->GetNChargeCorrBins();
   const Int_t kChargeCorrMin   = fQAParam->GetChargeCorrMin();
   const Int_t kChargeCorrMax   = fQAParam->GetChargeCorrMax();
-     
-  const Int_t   kNPairTimeCorrBins = fQAParam->GetNPairTimeCorrBins(); 
+
+  const Int_t   kNPairTimeCorrBins = fQAParam->GetNPairTimeCorrBins();
   const Float_t kPairTimeCorrMin =  fQAParam->GetPairTimeCorrMin();
-  const Float_t kPairTimeCorrMax =  fQAParam->GetPairTimeCorrMax(); 
-   
+  const Float_t kPairTimeCorrMax =  fQAParam->GetPairTimeCorrMax();
+
   const Int_t kNPairTimeDiffBins = fQAParam->GetNPairTimeDiffBins();
   const Float_t kPairTimeDiffMin = fQAParam->GetPairTimeDiffMin();
-  const Float_t kPairTimeDiffMax = fQAParam->GetPairTimeDiffMax(); 
-  
+  const Float_t kPairTimeDiffMax = fQAParam->GetPairTimeDiffMax();
+
   const Int_t   kNMeanTimeCorrBins = fQAParam->GetNMeanTimeCorrBins();
   const Float_t kMeanTimeCorrMin =   fQAParam->GetMeanTimeCorrMin();
-  const Float_t kMeanTimeCorrMax =   fQAParam->GetMeanTimeCorrMax();    
-  
+  const Float_t kMeanTimeCorrMax =   fQAParam->GetMeanTimeCorrMax();
+
   const Int_t kNChannelBins  =   16;
   const Float_t kChannelMin    =    -0.5;
   const Float_t kChannelMax    =   15.5;
-  
+
   const Int_t kNPedestalBins =  40;
   const Float_t kPedestalMin   =    0;
-  const Float_t kPedestalMax   =  40; 
-  
+  const Float_t kPedestalMax   =  40;
+
   const Int_t kNPairBins  =   8;
   const Float_t kPairMin    =    -0.5;
   const Float_t kPairMax    =   7.5;
-  
+
   TH2I * h2i;
   TH2F * h2d;
   TH1I * h1i;
   TH1F * h1d;
 
   int iHisto =0;
-  
-  h1d = new TH1F("H1D_Trend_TriggerChargeQuantileADA","Trigger charge quantile",1, 0, 1) ;  
+
+  h1d = new TH1F("H1D_Trend_TriggerChargeQuantileADA","Trigger charge quantile",1, 0, 1) ;
   Add2RawsList(h1d,kTrend_TriggerChargeQuantileADA, !expert, image, saveCorr);   iHisto++;
   h1d->SetLineWidth(2);
   h1d->SetLineColor(kBlue);
-  
-  h1d = new TH1F("H1D_Charge_ADA_PC",Form("Total integrated [-%d,+%d] charge;Charge [ADC counts]",fRecoParam->GetNPreClocks(),fRecoParam->GetNPostClocks()), kNChargeSideBins, kChargeSideMin, kChargeSideMax) ;  
+
+  h1d = new TH1F("H1D_Charge_ADA_PC",Form("Total integrated [-%d,+%d] charge;Charge [ADC counts]",fRecoParam->GetNPreClocks(),fRecoParam->GetNPostClocks()), kNChargeSideBins, kChargeSideMin, kChargeSideMax) ;
   Add2RawsList(h1d,kChargeADA_PC, !expert, image, saveCorr);   iHisto++;
-  
-  h1d = new TH1F("H1D_Trend_TriggerChargeQuantileADC","Trigger charge quantile",1, 0, 1) ;  
+
+  h1d = new TH1F("H1D_Trend_TriggerChargeQuantileADC","Trigger charge quantile",1, 0, 1) ;
   Add2RawsList(h1d,kTrend_TriggerChargeQuantileADC, !expert, image, saveCorr);   iHisto++;
   h1d->SetLineWidth(2);
   h1d->SetLineColor(kRed);
-  
-  h1d = new TH1F("H1D_Charge_ADC_PC",Form("Total integrated [-%d,+%d] charge;Charge [ADC counts]",fRecoParam->GetNPreClocks(),fRecoParam->GetNPostClocks()), kNChargeSideBins, kChargeSideMin, kChargeSideMax) ;  
+
+  h1d = new TH1F("H1D_Charge_ADC_PC",Form("Total integrated [-%d,+%d] charge;Charge [ADC counts]",fRecoParam->GetNPreClocks(),fRecoParam->GetNPostClocks()), kNChargeSideBins, kChargeSideMin, kChargeSideMax) ;
   Add2RawsList(h1d,kChargeADC_PC, !expert, image, saveCorr);   iHisto++;
-  
- 
+
+
   // Creation of Cell Multiplicity Histograms
-  h1i = new TH1I("H1I_Multiplicity_ADA", "Number of channels with charge signal and time ADA;# of Channels;Entries", 9, -0.5, 8.5) ;  
+  h1i = new TH1I("H1I_Multiplicity_ADA", "Number of channels with charge signal and time ADA;# of Channels;Entries", 9, -0.5, 8.5) ;
   Add2RawsList(h1i,kMultiADA, expert, !image, !saveCorr);   iHisto++;
-  h1i = new TH1I("H1I_Multiplicity_ADC", "Number of channels with charge signal and time ADC;# of Channels;Entries", 9, -0.5, 8.5) ;  
+  h1i = new TH1I("H1I_Multiplicity_ADC", "Number of channels with charge signal and time ADC;# of Channels;Entries", 9, -0.5, 8.5) ;
   Add2RawsList(h1i,kMultiADC, expert, !image, !saveCorr);   iHisto++;
- 
+
   // Creation of Total Charge Histograms
-  h1d = new TH1F("H1D_Charge_ADA",Form("Total integrated [-%d,+%d] charge;Charge [ADC counts]",fRecoParam->GetNPreClocks(),fRecoParam->GetNPostClocks()), kNChargeSideBins, kChargeSideMin, kChargeSideMax) ;  
+  h1d = new TH1F("H1D_Charge_ADA",Form("Total integrated [-%d,+%d] charge;Charge [ADC counts]",fRecoParam->GetNPreClocks(),fRecoParam->GetNPostClocks()), kNChargeSideBins, kChargeSideMin, kChargeSideMax) ;
   Add2RawsList(h1d,kChargeADA, !expert, image, saveCorr);   iHisto++;
   h1d->SetLineWidth(2);
   h1d->SetLineColor(kBlue);
-  h1d = new TH1F("H1D_Charge_ADC",Form("Total integrated [-%d,+%d] charge;Charge [ADC counts]",fRecoParam->GetNPreClocks(),fRecoParam->GetNPostClocks()), kNChargeSideBins, kChargeSideMin, kChargeSideMax) ;  
+  h1d = new TH1F("H1D_Charge_ADC",Form("Total integrated [-%d,+%d] charge;Charge [ADC counts]",fRecoParam->GetNPreClocks(),fRecoParam->GetNPostClocks()), kNChargeSideBins, kChargeSideMin, kChargeSideMax) ;
   Add2RawsList(h1d,kChargeADC, !expert, image, saveCorr);   iHisto++;
   h1d->SetLineWidth(2);
   h1d->SetLineColor(kRed);
-  h1d = new TH1F("H1D_Charge_AD",Form("Total integrated [-%d,+%d] charge;Charge [ADC counts]",fRecoParam->GetNPreClocks(),fRecoParam->GetNPostClocks()), 2*kNChargeSideBins, kChargeSideMin, 1+2*kNChargeSideBins) ;  
+  h1d = new TH1F("H1D_Charge_AD",Form("Total integrated [-%d,+%d] charge;Charge [ADC counts]",fRecoParam->GetNPreClocks(),fRecoParam->GetNPostClocks()), 2*kNChargeSideBins, kChargeSideMin, 1+2*kNChargeSideBins) ;
   Add2RawsList(h1d,kChargeAD, !expert,  !image, !saveCorr);   iHisto++;
-   
 
-  // Creation of Charge EoI histogram 
+
+  // Creation of Charge EoI histogram
   h2d = new TH2F("H2D_ChargeEoI", Form("Integrated [-%d,+%d] charge;Channel Number;Charge [ADC counts]",fRecoParam->GetNPreClocks(),fRecoParam->GetNPostClocks())
-		 ,kNChannelBins, kChannelMin, kChannelMax, kNChargeChannelBins, kChargeChannelMin, kChargeChannelMax);
+                 ,kNChannelBins, kChannelMin, kChannelMax, kNChargeChannelBins, kChargeChannelMin, kChargeChannelMax);
   Add2RawsList(h2d,kChargeEoI, !expert, image, saveCorr); iHisto++;
-  
+
   h2d = new TH2F("H2D_ChargeEoIBB", Form("Integrated [-%d,+%d] charge w/ BB Flag condition;Channel Number;Charge [ADC counts]",fRecoParam->GetNPreClocks(),fRecoParam->GetNPostClocks())
-		 ,kNChannelBins, kChannelMin, kChannelMax, kNChargeChannelBins, kChargeChannelMin, kChargeChannelMax);
+                 ,kNChannelBins, kChannelMin, kChannelMax, kNChargeChannelBins, kChargeChannelMin, kChargeChannelMax);
   Add2RawsList(h2d,kChargeEoIBB, !expert, image, saveCorr); iHisto++;
-  
+
   h2d = new TH2F("H2D_ChargeEoIBG", Form("Integrated [-%d,+%d] charge w/ BG Flag condition;Channel Number;Charge [ADC counts]",fRecoParam->GetNPreClocks(),fRecoParam->GetNPostClocks())
-		 ,kNChannelBins, kChannelMin, kChannelMax, kNChargeChannelBins, kChargeChannelMin, kChargeChannelMax);
+                 ,kNChannelBins, kChannelMin, kChannelMax, kNChargeChannelBins, kChargeChannelMin, kChargeChannelMax);
   Add2RawsList(h2d,kChargeEoIBG, !expert, image, saveCorr); iHisto++;
 
 
   for(Int_t iInt=0;iInt<kNintegrator;iInt++){
-    // Creation of Pedestal histograms 
+    // Creation of Pedestal histograms
     h2i = new TH2I(Form("H2I_Pedestal_Int%d",iInt), Form("Pedestal (Int%d);Channel;Pedestal [ADC counts]",iInt)
-		   ,kNChannelBins, kChannelMin, kChannelMax,kNPedestalBins,kPedestalMin ,kPedestalMax );
+                   ,kNChannelBins, kChannelMin, kChannelMax,kNPedestalBins,kPedestalMin ,kPedestalMax );
     Add2RawsList(h2i,(iInt == 0 ? kPedestalInt0 : kPedestalInt1), expert, image, !saveCorr); iHisto++;
-    
-    h2d = new TH2F(Form("H2D_PedestalDiff_Int%d",iInt), Form("Pedestal difference Online - OCDB (Int%d);Channel; Pedestal Online - OCDB",iInt)
-		   ,kNChannelBins, kChannelMin, kChannelMax,81,-10.5,70.5);
-    Add2RawsList(h2d,(iInt == 0 ? kPedestalDiffInt0 : kPedestalDiffInt1), !expert, image, !saveCorr); iHisto++;
-	
 
-    // Creation of Charge EoI histograms 
+    h2d = new TH2F(Form("H2D_PedestalDiff_Int%d",iInt), Form("Pedestal difference Online - OCDB (Int%d);Channel; Pedestal Online - OCDB",iInt)
+                   ,kNChannelBins, kChannelMin, kChannelMax,81,-10.5,70.5);
+    Add2RawsList(h2d,(iInt == 0 ? kPedestalDiffInt0 : kPedestalDiffInt1), !expert, image, !saveCorr); iHisto++;
+
+
+    // Creation of Charge EoI histograms
     h2i = new TH2I(Form("H2I_ChargeEoI_Int%d",iInt), Form("Maximum charge per clock (Int%d);Channel;Charge [ADC counts]",iInt)
-		   ,kNChannelBins, kChannelMin, kChannelMax, 1025, 0, 1025);
-    Add2RawsList(h2i,(iInt == 0 ? kChargeEoIInt0 : kChargeEoIInt1), !expert, image, saveCorr); iHisto++;  
+                   ,kNChannelBins, kChannelMin, kChannelMax, 1025, 0, 1025);
+    Add2RawsList(h2i,(iInt == 0 ? kChargeEoIInt0 : kChargeEoIInt1), !expert, image, saveCorr); iHisto++;
   }
-  
+
   h2i = new TH2I("H2I_ChargeSaturation", "Maximum charge per clock, both Ints;Channel;Charge [ADC counts]",kNChannelBins, kChannelMin, kChannelMax, 1024, 1, 1025);
-  Add2RawsList(h2i,kChargeSaturation, !expert, image, saveCorr); iHisto++;	
-  
-  // Creation of Time histograms 
+  Add2RawsList(h2i,kChargeSaturation, !expert, image, saveCorr); iHisto++;
+
+  // Creation of Time histograms
   h2i = new TH2I("H2I_Width", "HPTDC Width;Channel;Width [ns]",kNChannelBins, kChannelMin, kChannelMax, kNTdcWidthBins, kTdcWidthMin, kTdcWidthMax);
   Add2RawsList(h2i,kWidth, expert, image, saveCorr); iHisto++;
-  
+
   h2i = new TH2I("H2I_Width_BB", "HPTDC Width w/ BB Flag condition;Channel;Width [ns]",kNChannelBins, kChannelMin, kChannelMax, kNTdcWidthBins, kTdcWidthMin, kTdcWidthMax);
   Add2RawsList(h2i,kWidthBB, expert, !image, !saveCorr); iHisto++;
 
@@ -648,98 +645,98 @@ void AliADQADataMakerRec::InitRaws()
 
   h2i = new TH2I("H2I_HPTDCTime", "HPTDC Time;Channel;Leading Time [ns]",kNChannelBins, kChannelMin, kChannelMax, kNTdcTimeBins, kTdcTimeMin, kTdcTimeMax);
   Add2RawsList(h2i,kHPTDCTime, !expert, image, saveCorr); iHisto++;
-  
+
   h2i = new TH2I("H2I_HPTDCTime_BB", "HPTDC Time w/ BB Flag condition;Channel;Leading Time [ns]",kNChannelBins, kChannelMin, kChannelMax, kNTdcTimeBinsFlag, kTdcTimeMinBBFlag, kTdcTimeMaxBBFlag);
   Add2RawsList(h2i,kHPTDCTimeBB, !expert, image, !saveCorr); iHisto++;
 
   h2i = new TH2I("H2I_HPTDCTime_BG", "HPTDC Time w/ BG Flag condition;Channel;Leading Time [ns]",kNChannelBins, kChannelMin, kChannelMax, kNTdcTimeBinsFlag, kTdcTimeMinBGFlag, kTdcTimeMaxBGFlag);
   Add2RawsList(h2i,kHPTDCTimeBG, !expert, image, !saveCorr); iHisto++;
-  
+
   //With wide binning for ratio
   h2d = new TH2F("H2D_HPTDCTimeRebin", "HPTDC Time;Channel;Leading Time [ns]",kNChannelBins, kChannelMin, kChannelMax, kNTdcTimeRatioBins, kTdcTimeRatioMin, kTdcTimeRatioMax);
   Add2RawsList(h2d,kHPTDCTimeRebin, !expert, image, saveCorr); iHisto++;
-  
+
   h2d = new TH2F("H2D_HPTDCTimeRebin_BB", "Ratio Time w_BB_Flag/All ;Channel;Leading Time [ns]",kNChannelBins, kChannelMin, kChannelMax, kNTdcTimeRatioBins, kTdcTimeRatioMin, kTdcTimeRatioMax);
   Add2RawsList(h2d,kHPTDCTimeRebinBB, !expert, image, !saveCorr); iHisto++;
 
   h2d = new TH2F("H2D_HPTDCTimeRebin_BG", "Ratio Time w_BG_Flag/All;Channel;Leading Time [ns]",kNChannelBins, kChannelMin, kChannelMax, kNTdcTimeRatioBins, kTdcTimeRatioMin, kTdcTimeRatioMax);
   Add2RawsList(h2d,kHPTDCTimeRebinBG, !expert, image, !saveCorr); iHisto++;
 
-  //Mean time histograms	
+  //Mean time histograms
   h1d = new TH1F("H1D_MeanTimeADA", "Mean Time;Mean time [ns];Counts",kNTdcTimeBins, kTdcTimeMin, kTdcTimeMax);
   Add2RawsList(h1d,kMeanTimeADA, expert, !image, !saveCorr); iHisto++;
   h1d->SetLineWidth(2);
   h1d->SetLineColor(kBlue);
-	
+
   h1d = new TH1F("H1D_MeanTimeADC", "Mean Time;Mean time [ns];Counts",kNTdcTimeBins, kTdcTimeMin, kTdcTimeMax);
   Add2RawsList(h1d,kMeanTimeADC, expert, !image, !saveCorr); iHisto++;
   h1d->SetLineWidth(2);
   h1d->SetLineColor(kRed);
-	
+
   h1d = new TH1F("H1D_MeanTimeDifference","Mean Time Difference ADA-ADC ;AD Mean time t_{A} - t_{C} [ns];Counts",1024,-150,150);
   Add2RawsList(h1d,kMeanTimeDiff, expert, !image, !saveCorr); iHisto++;
 
-  h2d = new TH2F("H2D_MeanTimeCorr", "AD Mean time t_{A} vs t_{C};Mean time ADA [ns];Mean time ADC [ns]", kNMeanTimeCorrBins,kMeanTimeCorrMin,kMeanTimeCorrMax,kNMeanTimeCorrBins, kMeanTimeCorrMin,kMeanTimeCorrMax) ;  
+  h2d = new TH2F("H2D_MeanTimeCorr", "AD Mean time t_{A} vs t_{C};Mean time ADA [ns];Mean time ADC [ns]", kNMeanTimeCorrBins,kMeanTimeCorrMin,kMeanTimeCorrMax,kNMeanTimeCorrBins, kMeanTimeCorrMin,kMeanTimeCorrMax) ;
   Add2RawsList(h2d,kMeanTimeCorr, expert, !image, !saveCorr);   iHisto++;
- 
-  h2d = new TH2F("H2D_MeanTimeSumDiff", "AD Mean time t_{A} - t_{C} vs t_{A} + t_{C}; AD Mean time t_{A} - t_{C} [ns];AD Mean time t_{A} + t_{C} [ns]", 307, -150.000000, 149.804688, 410, 200.0, 600.390625);  
+
+  h2d = new TH2F("H2D_MeanTimeSumDiff", "AD Mean time t_{A} - t_{C} vs t_{A} + t_{C}; AD Mean time t_{A} - t_{C} [ns];AD Mean time t_{A} + t_{C} [ns]", 307, -150.000000, 149.804688, 410, 200.0, 600.390625);
   Add2RawsList(h2d,kMeanTimeSumDiff, expert, !image, !saveCorr);   iHisto++;
- 
+
   //Slewing histograms
-  h2d = new TH2F("H2D_TimeSlewingADA", "Time Vs Charge ADA;Log10(1/Charge) [ADC counts]; Leading Time[ns]", 200,-4,0, kNTdcTimeBins, kTdcTimeMin, kTdcTimeMax);  
+  h2d = new TH2F("H2D_TimeSlewingADA", "Time Vs Charge ADA;Log10(1/Charge) [ADC counts]; Leading Time[ns]", 200,-4,0, kNTdcTimeBins, kTdcTimeMin, kTdcTimeMax);
   Add2RawsList(h2d,kTimeSlewingADA, expert, !image, !saveCorr);   iHisto++;
-  
-  h2d = new TH2F("H2D_TimeSlewingADC", "Time Vs Charge ADC;Log10(1/Charge) [ADC counts]; Leading Time[ns]", 200,-4,0, kNTdcTimeBins, kTdcTimeMin, kTdcTimeMax) ;  
+
+  h2d = new TH2F("H2D_TimeSlewingADC", "Time Vs Charge ADC;Log10(1/Charge) [ADC counts]; Leading Time[ns]", 200,-4,0, kNTdcTimeBins, kTdcTimeMin, kTdcTimeMax) ;
   Add2RawsList(h2d,kTimeSlewingADC, expert, !image, !saveCorr);   iHisto++;
-  
-  h2d = new TH2F("H2D_WidthSlewing", "Width Vs Charge ;Time Width [ns];Charge [ADC counts]", kNTdcWidthBins, kTdcWidthMin, kTdcWidthMax, kNChargeCorrBins, kChargeCorrMin, kChargeCorrMax) ;  
+
+  h2d = new TH2F("H2D_WidthSlewing", "Width Vs Charge ;Time Width [ns];Charge [ADC counts]", kNTdcWidthBins, kTdcWidthMin, kTdcWidthMax, kNChargeCorrBins, kChargeCorrMin, kChargeCorrMax) ;
   Add2RawsList(h2d,kWidthSlewing, expert, !image, !saveCorr);   iHisto++;
-  
+
   //Creation of pair coincidence histograms
-  h1i = new TH1I("H1I_MultiBBCoincidence_ADA", "Number of BB flag coincidences;# of BB Coincidences;Entries", 5, -0.5, 4.5) ;  
+  h1i = new TH1I("H1I_MultiBBCoincidence_ADA", "Number of BB flag coincidences;# of BB Coincidences;Entries", 5, -0.5, 4.5) ;
   Add2RawsList(h1i,kNBBCoincADA, !expert, image, saveCorr);   iHisto++;
   h1i->SetLineWidth(2);
   h1i->SetLineColor(kBlue);
   h1i->GetXaxis()->SetNdivisions(505);
-  h1i = new TH1I("H1I_MultiBBCoincidence_ADC", "Number of BB flag coincidences;# of BB Coincidences;Entries", 5, -0.5, 4.5) ;  
+  h1i = new TH1I("H1I_MultiBBCoincidence_ADC", "Number of BB flag coincidences;# of BB Coincidences;Entries", 5, -0.5, 4.5) ;
   Add2RawsList(h1i,kNBBCoincADC, !expert, image, saveCorr);   iHisto++;
   h1i->SetLineWidth(2);
   h1i->SetLineColor(kRed);
   h1i->GetXaxis()->SetNdivisions(505);
-  
-  h1i = new TH1I("H1I_MultiBGCoincidence_ADA", "Number of BG flag coincidences;# of BG Coincidences;Entries", 5, -0.5, 4.5) ;  
+
+  h1i = new TH1I("H1I_MultiBGCoincidence_ADA", "Number of BG flag coincidences;# of BG Coincidences;Entries", 5, -0.5, 4.5) ;
   Add2RawsList(h1i,kNBGCoincADA, !expert, image, saveCorr);   iHisto++;
   h1i->SetLineWidth(2);
   h1i->SetLineColor(kBlue);
   h1i->GetXaxis()->SetNdivisions(505);
-  h1i = new TH1I("H1I_MultiBGCoincidence_ADC", "Number of BG flag coincidences;# of BG Coincidences;Entries", 5, -0.5, 4.5) ;  
+  h1i = new TH1I("H1I_MultiBGCoincidence_ADC", "Number of BG flag coincidences;# of BG Coincidences;Entries", 5, -0.5, 4.5) ;
   Add2RawsList(h1i,kNBGCoincADC, !expert, image, saveCorr);   iHisto++;
   h1i->SetLineWidth(2);
   h1i->SetLineColor(kRed);
   h1i->GetXaxis()->SetNdivisions(505);
-  
+
   h2i = new TH2I("H2I_BBCoincCorr", "Number of BB flag coincidences;# of BB Coincidences ADA;# of BB Coincidences ADC",5, -0.5, 4.5, 5, -0.5, 4.5);
   Add2RawsList(h2i,kNBBCoincCorr, !expert, image, !saveCorr); iHisto++;
   h2i->GetXaxis()->SetNdivisions(505);
   h2i->GetYaxis()->SetNdivisions(505);
-  
+
   h2i = new TH2I("H2I_BGCoincCorr", "Number of BG flag coincidences;# of BG Coincidences ADA;# of BG Coincidences ADC",5, -0.5, 4.5, 5, -0.5, 4.5);
   Add2RawsList(h2i,kNBGCoincCorr, !expert, image, !saveCorr); iHisto++;
   h2i->GetXaxis()->SetNdivisions(505);
   h2i->GetYaxis()->SetNdivisions(505);
-  
-  h1d = new TH1F("H1D_NEventsBBFlag", "Number of events with a BB/BG flag per channel;# of Channels;Event rate", kNChannelBins, kChannelMin, kChannelMax);  
+
+  h1d = new TH1F("H1D_NEventsBBFlag", "Number of events with a BB/BG flag per channel;# of Channels;Event rate", kNChannelBins, kChannelMin, kChannelMax);
   Add2RawsList(h1d,kNEventsBBFlag, expert, image, saveCorr);   iHisto++;
   h1d->SetLineWidth(3);
   h1d->SetLineColor(kBlue);
-  
-  h1d = new TH1F("H1D_NEventsBGFlag", "Number of events with a BB/BG flag per channel;# of Channels;Event rate", kNChannelBins, kChannelMin, kChannelMax);  
+
+  h1d = new TH1F("H1D_NEventsBGFlag", "Number of events with a BB/BG flag per channel;# of Channels;Event rate", kNChannelBins, kChannelMin, kChannelMax);
   Add2RawsList(h1d,kNEventsBGFlag, expert, image, saveCorr);   iHisto++;
   h1d->SetLineWidth(3);
   h1d->SetLineColor(kRed);
 
   //Creation of trigger histogram
-  h1d = new TH1F("H1D_Trigger_Type", "AD0 Trigger Type;;Counts", 11,0 ,11) ;  
+  h1d = new TH1F("H1D_Trigger_Type", "AD0 Trigger Type;;Counts", 11,0 ,11) ;
   Add2RawsList(h1d,kTriggers, !expert, image, saveCorr);   iHisto++;
   h1d->SetFillColor(kAzure-8);
   h1d->SetLineWidth(2);
@@ -756,8 +753,8 @@ void AliADQADataMakerRec::InitRaws()
   h1d->GetXaxis()->SetBinLabel(9, "UGC & UBA");
   h1d->GetXaxis()->SetBinLabel(10, "UGA || UGC");
   h1d->GetXaxis()->SetBinLabel(11, "(UGA & UBC) || (UGC & UBA)");
-  
-  h2d = new TH2F("H2D_Decision", "AD Decision; ADA; ADC", 4,0 ,4,4,0,4) ;  
+
+  h2d = new TH2F("H2D_Decision", "AD Decision; ADA; ADC", 4,0 ,4,4,0,4) ;
   Add2RawsList(h2d,kDecisions, !expert, image, saveCorr);   iHisto++;
   h2d->SetOption("coltext");
   h2d->GetXaxis()->SetLabelSize(0.06);
@@ -776,89 +773,89 @@ void AliADQADataMakerRec::InitRaws()
   //Creation of debug histograms
   h1d = new TH1F("H1D_Pair_TimeDiffMean","Time difference mean for coincidence pair [ns];Pair number;Time mean [ns]",kNPairBins, kPairMin, kPairMax);
   Add2RawsList(h1d,kPairTimeDiffMean, expert, !image, !saveCorr); iHisto++;
-  
+
   h1d = new TH1F("H1D_Pair_TimeDiffRMS","Time difference RMS for coincidence pair [ns];Pair number;Time RMS [ns]",kNPairBins, kPairMin, kPairMax);
   Add2RawsList(h1d,kPairTimeDiffRMS, expert, !image, !saveCorr); iHisto++;
 
   //Creation of Clock histograms
   h2d = new TH2F("H2D_BBFlagVsClock", "BB-Flags vs LHC-Clock(All events);Channel;LHC Clocks",kNChannelBins, kChannelMin, kChannelMax,21, -10.5, 10.5 );
   Add2RawsList(h2d,kBBFlagVsClock, !expert, image, saveCorr); iHisto++;
-  
+
   h2d = new TH2F("H2D_BBFlagVsClock_ADOR", "BB-Flags vs LHC-Clock(AD-OR);Channel;LHC Clocks",kNChannelBins, kChannelMin, kChannelMax,21, -10.5, 10.5 );
   Add2RawsList(h2d,kBBFlagVsClock_ADOR, !expert, image, saveCorr); iHisto++;
-	
+
   h2d = new TH2F("H2D_BGFlagVsClock", "BG-Flags vs LHC-Clock;Channel;LHC Clocks",kNChannelBins, kChannelMin, kChannelMax,21, -10.5, 10.5 );
   Add2RawsList(h2d,kBGFlagVsClock, !expert, image, saveCorr); iHisto++;
- 
+
   for(Int_t iInt=0;iInt<kNintegrator;iInt++){
-  	h2d = new TH2F(Form("H2D_ChargeVsClock_Int%d",iInt), Form("Charge Versus LHC-Clock (Int%d);Channel;LHCClock;Charge [ADC counts]",iInt),kNChannelBins, kChannelMin, kChannelMax,21, -10.5, 10.5 );
-  	Add2RawsList(h2d,(iInt == 0 ? kChargeVsClockInt0 : kChargeVsClockInt1 ), expert, image, saveCorr); iHisto++;
-	}
-	
+    h2d = new TH2F(Form("H2D_ChargeVsClock_Int%d",iInt), Form("Charge Versus LHC-Clock (Int%d);Channel;LHCClock;Charge [ADC counts]",iInt),kNChannelBins, kChannelMin, kChannelMax,21, -10.5, 10.5 );
+    Add2RawsList(h2d,(iInt == 0 ? kChargeVsClockInt0 : kChargeVsClockInt1 ), expert, image, saveCorr); iHisto++;
+  }
+
   h2d = new TH2F("H2D_MaxChargeVsClock", "Maximum Charge Versus LHC-Clock;Channel;LHC Clocks",kNChannelBins, kChannelMin, kChannelMax,21, -10.5, 10.5 );
   Add2RawsList(h2d,kMaxChargeClock, !expert, image, saveCorr); iHisto++;
-  
+
   h2d = new TH2F("H2D_BBFlagPerChannel", "BB-Flags Versus Channel;Channel;BB Flags Count",kNChannelBins, kChannelMin, kChannelMax,22,-0.5,21.5);
   Add2RawsList(h2d,kBBFlagsPerChannel, expert, !image, saveCorr); iHisto++;
-  
+
   h2d = new TH2F("H2D_BGFlagPerChannel", "BG-Flags Versus Channel;Channel;BG Flags Count",kNChannelBins, kChannelMin, kChannelMax,22,-0.5,21.5);
   Add2RawsList(h2d,kBGFlagsPerChannel, expert, !image, saveCorr); iHisto++;
-  
+
   h1d = new TH1F("H1D_FlagNoTime", "No Flag-No Time events;Channel;Event rate",kNChannelBins, kChannelMin, kChannelMax);
   Add2RawsList(h1d,kFlagNoTime, !expert, image, saveCorr); iHisto++;
   h1d->SetLineWidth(3);
   h1d->SetLineColor(kBlue);
-  
+
   h1d = new TH1F("H1D_TimeNoFlag", "No Flag-No Time events;Channel;Event rate",kNChannelBins, kChannelMin, kChannelMax);
   Add2RawsList(h1d,kTimeNoFlag, !expert, image, saveCorr); iHisto++;
   h1d->SetLineWidth(3);
   h1d->SetLineColor(kRed);
-  
+
   //Correlation histograms
   Int_t nCorrelation = 0;
   for(Int_t i=0;i<8;i++){
-  	for(Int_t j=7;j>i;j--){
-  		h2d = new TH2F(Form("ChargeCorr/H2D_kNChargeCorrADA_%d_%d",i,j),Form("Charge Correlation ADA module%d - module%d",i,j),kNChargeCorrBins, kChargeCorrMin, kChargeCorrMax,kNChargeCorrBins, kChargeCorrMin, kChargeCorrMax);
-		Add2RawsList(h2d,kNChargeCorrADA+nCorrelation, expert, !image, !saveCorr); iHisto++; nCorrelation++;
-		}
-	}
+    for(Int_t j=7;j>i;j--){
+      h2d = new TH2F(Form("ChargeCorr/H2D_kNChargeCorrADA_%d_%d",i,j),Form("Charge Correlation ADA module%d - module%d",i,j),kNChargeCorrBins, kChargeCorrMin, kChargeCorrMax,kNChargeCorrBins, kChargeCorrMin, kChargeCorrMax);
+      Add2RawsList(h2d,kNChargeCorrADA+nCorrelation, expert, !image, !saveCorr); iHisto++; nCorrelation++;
+    }
+  }
   nCorrelation = 0;
   for(Int_t i=0;i<8;i++){
-  	for(Int_t j=7;j>i;j--){
-  		h2d = new TH2F(Form("ChargeCorr/H2D_kNChargeCorrADC_%d_%d",i,j),Form("Charge Correlation ADC module%d - module%d",i,j),kNChargeCorrBins, kChargeCorrMin, kChargeCorrMax,kNChargeCorrBins, kChargeCorrMin, kChargeCorrMax);
-		Add2RawsList(h2d,kNChargeCorrADC+nCorrelation, expert, !image, !saveCorr); iHisto++; nCorrelation++;
-		}
-	}
+    for(Int_t j=7;j>i;j--){
+      h2d = new TH2F(Form("ChargeCorr/H2D_kNChargeCorrADC_%d_%d",i,j),Form("Charge Correlation ADC module%d - module%d",i,j),kNChargeCorrBins, kChargeCorrMin, kChargeCorrMax,kNChargeCorrBins, kChargeCorrMin, kChargeCorrMax);
+      Add2RawsList(h2d,kNChargeCorrADC+nCorrelation, expert, !image, !saveCorr); iHisto++; nCorrelation++;
+    }
+  }
   nCorrelation = 0;
   for(Int_t i=0;i<8;i++){
-  	for(Int_t j=7;j>i;j--){
-  		h2d = new TH2F(Form("TimeCorr/H2D_kNTimeCorrADA_%d_%d",i,j),Form("Time Correlation ADA module%d - module%d",i,j),kNPairTimeCorrBins,kPairTimeCorrMin,kPairTimeCorrMax,kNPairTimeCorrBins,kPairTimeCorrMin,kPairTimeCorrMax);
-		Add2RawsList(h2d,kNTimeCorrADA+nCorrelation, expert, !image, !saveCorr); iHisto++; nCorrelation++;
-		}
-	}
+    for(Int_t j=7;j>i;j--){
+      h2d = new TH2F(Form("TimeCorr/H2D_kNTimeCorrADA_%d_%d",i,j),Form("Time Correlation ADA module%d - module%d",i,j),kNPairTimeCorrBins,kPairTimeCorrMin,kPairTimeCorrMax,kNPairTimeCorrBins,kPairTimeCorrMin,kPairTimeCorrMax);
+      Add2RawsList(h2d,kNTimeCorrADA+nCorrelation, expert, !image, !saveCorr); iHisto++; nCorrelation++;
+    }
+  }
   nCorrelation = 0;
   for(Int_t i=0;i<8;i++){
-  	for(Int_t j=7;j>i;j--){
-  		h2d = new TH2F(Form("TimeCorr/H2D_kNTimeCorrADC_%d_%d",i,j),Form("Time Correlation ADC module%d - module%d",i,j),kNPairTimeCorrBins,kPairTimeCorrMin,kPairTimeCorrMax,kNPairTimeCorrBins,kPairTimeCorrMin,kPairTimeCorrMax);
-		Add2RawsList(h2d,kNTimeCorrADC+nCorrelation, expert, !image, !saveCorr); iHisto++; nCorrelation++;
-		}
-	}
+    for(Int_t j=7;j>i;j--){
+      h2d = new TH2F(Form("TimeCorr/H2D_kNTimeCorrADC_%d_%d",i,j),Form("Time Correlation ADC module%d - module%d",i,j),kNPairTimeCorrBins,kPairTimeCorrMin,kPairTimeCorrMax,kNPairTimeCorrBins,kPairTimeCorrMin,kPairTimeCorrMax);
+      Add2RawsList(h2d,kNTimeCorrADC+nCorrelation, expert, !image, !saveCorr); iHisto++; nCorrelation++;
+    }
+  }
   nCorrelation = 0;
   for(Int_t i=0;i<8;i++){
-  	for(Int_t j=7;j>i;j--){
-  		h1d = new TH1F(Form("TimeDiff/H1D_kNTimeDiffADA_%d_%d",i,j),Form("Time Difference ADA module%d - module%d",i,j),kNPairTimeDiffBins,kPairTimeDiffMin,kPairTimeDiffMax);
-		Add2RawsList(h1d,kNTimeDiffADA+nCorrelation, expert, !image, !saveCorr); iHisto++; nCorrelation++;
-		}
-	}
+    for(Int_t j=7;j>i;j--){
+      h1d = new TH1F(Form("TimeDiff/H1D_kNTimeDiffADA_%d_%d",i,j),Form("Time Difference ADA module%d - module%d",i,j),kNPairTimeDiffBins,kPairTimeDiffMin,kPairTimeDiffMax);
+      Add2RawsList(h1d,kNTimeDiffADA+nCorrelation, expert, !image, !saveCorr); iHisto++; nCorrelation++;
+    }
+  }
   nCorrelation = 0;
   for(Int_t i=0;i<8;i++){
-  	for(Int_t j=7;j>i;j--){
-  		h1d = new TH1F(Form("TimeDiff/H1D_kNTimeDiffADC_%d_%d",i,j),Form("Time Difference ADC module%d - module%d",i,j),kNPairTimeDiffBins,kPairTimeDiffMin,kPairTimeDiffMax);
-		Add2RawsList(h1d,kNTimeDiffADC+nCorrelation, expert, !image, !saveCorr); iHisto++; nCorrelation++;
-		}
-	}
-  
-  AliDebug(AliQAv1::GetQADebugLevel(), Form("%d Histograms has been added to the Raws List",iHisto));
+    for(Int_t j=7;j>i;j--){
+      h1d = new TH1F(Form("TimeDiff/H1D_kNTimeDiffADC_%d_%d",i,j),Form("Time Difference ADC module%d - module%d",i,j),kNPairTimeDiffBins,kPairTimeDiffMin,kPairTimeDiffMax);
+      Add2RawsList(h1d,kNTimeDiffADC+nCorrelation, expert, !image, !saveCorr); iHisto++; nCorrelation++;
+    }
+  }
+
+  AliDebugF(AliQAv1::GetQADebugLevel(), "%d Histograms has been added to the Raws List",iHisto);
   //
   ClonePerTrigClass(AliQAv1::kRAWS); // this should be the last line
 }
@@ -867,20 +864,20 @@ void AliADQADataMakerRec::InitRaws()
 void AliADQADataMakerRec::MakeRaws(AliRawReader* rawReader)
 {
   // Fills histograms with Raws, computes average ADC values dynamically (pedestal subtracted)
-                  
-					  
+
+
   // Check id histograms already created for this Event Specie
   if ( ! GetRawsData(kPedestalInt0) )
     InitRaws() ;
 
-  rawReader->Reset() ; 
-  AliADRawStream* rawStream  = new AliADRawStream(rawReader); 
-  if(!(rawStream->Next())){ delete rawStream; rawStream = 0x0; return;}  
- 
+  rawReader->Reset() ;
+  AliADRawStream* rawStream  = new AliADRawStream(rawReader);
+  if(!(rawStream->Next())){ delete rawStream; rawStream = NULL; return;}
+
   eventTypeType eventType = rawReader->GetType();
 
-  Int_t    mulADA = 0 ; 
-  Int_t    mulADC = 0 ; 
+  Int_t    mulADA = 0 ;
+  Int_t    mulADC = 0 ;
   Double_t timeADA =0., timeADC = 0.;
   Double_t weightADA =0., weightADC = 0.;
   UInt_t   itimeADA=0, itimeADC=0;
@@ -888,90 +885,90 @@ void AliADQADataMakerRec::MakeRaws(AliRawReader* rawReader)
   Double_t chargeTrigADA=0., chargeTrigADC=0.;
 
   Double_t diffTime=-100000, sumTime = -10000;
-  
-  Int_t	   pBBmulADA = 0;
-  Int_t	   pBBmulADC = 0;
-  Int_t	   pBGmulADA = 0;
-  Int_t	   pBGmulADC = 0;
-  Double_t pDiffTime =-100000.;
 
-  
+  Int_t    pBBmulADA = 0;
+  Int_t    pBBmulADC = 0;
+  Int_t    pBGmulADA = 0;
+  Int_t    pBGmulADC = 0;
+  // Double_t pDiffTime =-100000.; not used
+
+
   switch (eventType){
   case PHYSICS_EVENT:
-  
+
     Int_t  iFlag=0;
     Int_t  pedestal;
     Float_t OCDBdiff;
     Int_t  integrator[16];
-    Bool_t flagBB[16];	 
-    Bool_t flagBG[16];	 
+    Bool_t flagBB[16];
+    Bool_t flagBG[16];
     Float_t charge;
     Int_t  offlineCh;
-    Float_t adc[16], time[16], width[16], timeCorr[16], adcTrig[16]; 
-    Int_t  iPair=0;
+    Float_t adc[16], time[16], width[16], timeCorr[16], adcTrig[16];
+    // Int_t  iPair=0; not used
 
     for(Int_t iChannel=0; iChannel<16; iChannel++) { // BEGIN : Loop over channels
-		   
+
       offlineCh = kOfflineChannel[iChannel];
-		   
+
       // Fill Pedestal histograms
-      iFlag = 0;   
+      iFlag = 0;
       for(Int_t j=0; j<=20; j++) {
-	if((rawStream->GetBGFlag(iChannel,j) || rawStream->GetBBFlag(iChannel,j))) iFlag++;
+        if((rawStream->GetBGFlag(iChannel,j) || rawStream->GetBBFlag(iChannel,j))) iFlag++;
       }
 
       if(iFlag == 0){ //No Flag found
-	for(Int_t j=11; j<=17; j++){
-	  pedestal= (Int_t) rawStream->GetPedestal(iChannel, j);
-	  integrator[offlineCh] = rawStream->GetIntegratorFlag(iChannel, j);
-	  OCDBdiff = pedestal - fCalibData->GetPedestal(offlineCh+16*integrator[offlineCh]);
+        for(Int_t j=11; j<=17; j++){
+          pedestal= (Int_t) rawStream->GetPedestal(iChannel, j);
+          integrator[offlineCh] = rawStream->GetIntegratorFlag(iChannel, j);
+          OCDBdiff = pedestal - fCalibData->GetPedestal(offlineCh+16*integrator[offlineCh]);
 
-	  FillRawsData((integrator[offlineCh] == 0 ? kPedestalInt0 : kPedestalInt1),offlineCh,pedestal);
-	  FillRawsData((integrator[offlineCh] == 0 ? kPedestalDiffInt0 : kPedestalDiffInt1),offlineCh,OCDBdiff);
-	}
+          FillRawsData((integrator[offlineCh] == 0 ? kPedestalInt0 : kPedestalInt1),offlineCh,pedestal);
+          FillRawsData((integrator[offlineCh] == 0 ? kPedestalDiffInt0 : kPedestalDiffInt1),offlineCh,OCDBdiff);
+        }
       }
       // Fill Charge EoI histograms
-	   
+
       adc[offlineCh]    = 0.0;
       adcTrig[offlineCh] = 0.0;
-      // Search for the maximum charge in the train of 21 LHC clocks 
+      // Search for the maximum charge in the train of 21 LHC clocks
       // regardless of the integrator which has been operated:
       Float_t maxadc = 0;
       Int_t imax = -1;
       Float_t adcPedSub[21];
       for(Int_t iClock=0; iClock<21; iClock++){
-	Bool_t iIntegrator = rawStream->GetIntegratorFlag(iChannel,iClock);
-	Int_t k = offlineCh+16*iIntegrator;
+        Bool_t iIntegrator = rawStream->GetIntegratorFlag(iChannel,iClock);
+        Int_t k = offlineCh+16*iIntegrator;
 
-	adcPedSub[iClock] = rawStream->GetPedestal(iChannel,iClock) - fCalibData->GetPedestal(k);
-	if(adcPedSub[iClock] <= fRecoParam->GetNSigmaPed()*fCalibData->GetSigma(k)) {
-	  adcPedSub[iClock] = 0;
-	  continue;
-	}
-	
-	if(iClock < fRecoParam->GetStartClock() || iClock > fRecoParam->GetEndClock()) continue;
-	if(adcPedSub[iClock] > maxadc) {
-	  maxadc = adcPedSub[iClock];
-	  imax   = iClock;
-	}
+        adcPedSub[iClock] = rawStream->GetPedestal(iChannel,iClock) - fCalibData->GetPedestal(k);
+        if(adcPedSub[iClock] <= fRecoParam->GetNSigmaPed()*fCalibData->GetSigma(k)) {
+          adcPedSub[iClock] = 0;
+          continue;
+        }
+
+        if(iClock < fRecoParam->GetStartClock() || iClock > fRecoParam->GetEndClock()) continue;
+        if(adcPedSub[iClock] > maxadc) {
+          maxadc = adcPedSub[iClock];
+          imax   = iClock;
+        }
       }
       adcTrig[offlineCh] = adcPedSub[10];
       if (imax != -1) {
-	Int_t start = imax - fRecoParam->GetNPreClocks();
-	if (start < 0) start = 0;
-	Int_t end = imax + fRecoParam->GetNPostClocks();
-	if (end > 20) end = 20;
-	for(Int_t iClock = start; iClock <= end; iClock++) {
-	  adc[offlineCh] += adcPedSub[iClock];
-	}
-	charge = rawStream->GetPedestal(iChannel,imax); // Charge at the maximum
+        Int_t start = imax - fRecoParam->GetNPreClocks();
+        if (start < 0) start = 0;
+        Int_t end = imax + fRecoParam->GetNPostClocks();
+        if (end > 20) end = 20;
+        for(Int_t iClock = start; iClock <= end; iClock++) {
+          adc[offlineCh] += adcPedSub[iClock];
+        }
+        charge = rawStream->GetPedestal(iChannel,imax); // Charge at the maximum
       }
-      else charge = -1024;		
-      
+      else charge = -1024;
+
       if(charge != -1024) FillRawsData(kMaxChargeClock,offlineCh,imax-10);
-       
+
       integrator[offlineCh] = rawStream->GetIntegratorFlag(iChannel,imax);
-      
+
       Int_t board = AliADCalibData::GetBoardNumber(offlineCh);
       time[offlineCh] = rawStream->GetTime(iChannel)*fCalibData->GetTimeResolution(board);
       width[offlineCh] = rawStream->GetWidth(iChannel)*fCalibData->GetWidthResolution(board);
@@ -982,143 +979,143 @@ void AliADQADataMakerRec::MakeRaws(AliRawReader* rawReader)
       FillRawsData(kChargeSaturation,offlineCh,charge);
 
       Float_t sigma = fCalibData->GetSigma(offlineCh+16*integrator[offlineCh]);
-		  
-      if((adc[offlineCh] > fRecoParam->GetNSigmaPed()*sigma) && !(time[offlineCh] <1.e-6)){ 
-	if(offlineCh<8) {
-	  mulADC++;
-	  chargeADC += adc[offlineCh];
-	  chargeTrigADC += adcTrig[offlineCh];
-	  
-	} else {
-	  mulADA++;
-	  chargeADA += adc[offlineCh];
-	  chargeTrigADA += adcTrig[offlineCh];
-	}
+
+      if((adc[offlineCh] > fRecoParam->GetNSigmaPed()*sigma) && !(time[offlineCh] <1.e-6)){
+        if(offlineCh<8) {
+          mulADC++;
+          chargeADC += adc[offlineCh];
+          chargeTrigADC += adcTrig[offlineCh];
+
+        } else {
+          mulADA++;
+          chargeADA += adc[offlineCh];
+          chargeTrigADA += adcTrig[offlineCh];
+        }
       }
       // Fill HPTDC Time Histograms
       timeCorr[offlineCh] = CorrectLeadingTime(offlineCh,time[offlineCh],adc[offlineCh]);
-   
+
       if(time[offlineCh] > 1.e-6){
         FillRawsData(kWidthSlewing,width[offlineCh],adc[offlineCh]);
-	Float_t timeErr = 1;
-	if (adc[offlineCh]>1) timeErr = 1/adc[offlineCh];
+        Float_t timeErr = 1;
+        if (adc[offlineCh]>1) timeErr = 1/adc[offlineCh];
 
-	if (offlineCh<8) {
-	    itimeADC++;
-	    timeADC += time[offlineCh]/(timeErr*timeErr);
-	    weightADC += 1./(timeErr*timeErr); 
-      	    if (adc[offlineCh]>1) FillRawsData(kTimeSlewingADC,TMath::Log10(1.0/adc[offlineCh]),time[offlineCh]);
-	  }
-	else{
-	    itimeADA++;
-	    timeADA += time[offlineCh]/(timeErr*timeErr);
-	    weightADA += 1./(timeErr*timeErr);
-	    if (adc[offlineCh]>1) FillRawsData(kTimeSlewingADA,TMath::Log10(1.0/adc[offlineCh]),time[offlineCh]);
-	  }
-	
+        if (offlineCh<8) {
+          itimeADC++;
+          timeADC += time[offlineCh]/(timeErr*timeErr);
+          weightADC += 1./(timeErr*timeErr);
+          if (adc[offlineCh]>1) FillRawsData(kTimeSlewingADC,TMath::Log10(1.0/adc[offlineCh]),time[offlineCh]);
+        }
+        else{
+          itimeADA++;
+          timeADA += time[offlineCh]/(timeErr*timeErr);
+          weightADA += 1./(timeErr*timeErr);
+          if (adc[offlineCh]>1) FillRawsData(kTimeSlewingADA,TMath::Log10(1.0/adc[offlineCh]),time[offlineCh]);
+        }
+
       }
-      
+
       // Fill Flag and Charge Versus LHC-Clock histograms
       Int_t nbbFlag = 0;
       Int_t nbgFlag = 0;
       flagBB[offlineCh] = rawStream->GetBBFlag(iChannel,10);
       flagBG[offlineCh] = rawStream->GetBGFlag(iChannel,10);
-      
+
       for(Int_t iEvent=0; iEvent<21; iEvent++){
-	charge = rawStream->GetPedestal(iChannel,iEvent);
-	Int_t intgr = rawStream->GetIntegratorFlag(iChannel,iEvent);
-	Bool_t bbFlag	  = rawStream->GetBBFlag(iChannel,iEvent);
-	Bool_t bgFlag	  = rawStream->GetBGFlag(iChannel,iEvent);
-	if(bbFlag) nbbFlag++;
-	if(bgFlag) nbgFlag++;
-	
-	FillRawsData((intgr == 0 ? kChargeVsClockInt0 : kChargeVsClockInt1 ), offlineCh,(float)iEvent-10,(float)charge);
-	FillRawsData(kBBFlagVsClock, offlineCh,(float)iEvent-10,(float)bbFlag);
-	FillRawsData(kBGFlagVsClock, offlineCh,(float)iEvent-10,(float)bgFlag);
-	
+        charge = rawStream->GetPedestal(iChannel,iEvent);
+        Int_t intgr = rawStream->GetIntegratorFlag(iChannel,iEvent);
+        Bool_t bbFlag     = rawStream->GetBBFlag(iChannel,iEvent);
+        Bool_t bgFlag     = rawStream->GetBGFlag(iChannel,iEvent);
+        if(bbFlag) nbbFlag++;
+        if(bgFlag) nbgFlag++;
+
+        FillRawsData((intgr == 0 ? kChargeVsClockInt0 : kChargeVsClockInt1 ), offlineCh,(float)iEvent-10,(float)charge);
+        FillRawsData(kBBFlagVsClock, offlineCh,(float)iEvent-10,(float)bbFlag);
+        FillRawsData(kBGFlagVsClock, offlineCh,(float)iEvent-10,(float)bgFlag);
+
       }
       FillRawsData(kBBFlagsPerChannel, offlineCh,nbbFlag);
       FillRawsData(kBGFlagsPerChannel, offlineCh,nbgFlag);
       //if((nbbFlag+nbgFlag)>0 && time[offlineCh]<1e-6)FillRawsData(kFlagNoTime,offlineCh);
       //if((nbbFlag+nbgFlag)==0 && time[offlineCh]>1e-6)FillRawsData(kTimeNoFlag,offlineCh);
-      
+
       if((flagBB[offlineCh] || flagBG[offlineCh]) && time[offlineCh]<1e-6)FillRawsData(kFlagNoTime,offlineCh);
       if((!flagBB[offlineCh] && !flagBG[offlineCh]) && time[offlineCh]>1e-6)FillRawsData(kTimeNoFlag,offlineCh);
-      
+
       FillRawsData(kHPTDCTime,offlineCh,time[offlineCh]);
       FillRawsData(kHPTDCTimeRebin,offlineCh,time[offlineCh]);
       FillRawsData(kWidth,offlineCh,width[offlineCh]);
       if(flagBB[offlineCh]) {
-      //if(nbbFlag > 0){
-	FillRawsData(kHPTDCTimeBB,offlineCh,time[offlineCh]);
-	FillRawsData(kHPTDCTimeRebinBB,offlineCh,time[offlineCh]);
-	FillRawsData(kWidthBB,offlineCh,width[offlineCh]);
-	FillRawsData(kChargeEoIBB,offlineCh,adc[offlineCh]);
-	FillRawsData(kNEventsBBFlag,offlineCh);
+        //if(nbbFlag > 0){
+        FillRawsData(kHPTDCTimeBB,offlineCh,time[offlineCh]);
+        FillRawsData(kHPTDCTimeRebinBB,offlineCh,time[offlineCh]);
+        FillRawsData(kWidthBB,offlineCh,width[offlineCh]);
+        FillRawsData(kChargeEoIBB,offlineCh,adc[offlineCh]);
+        FillRawsData(kNEventsBBFlag,offlineCh);
       }
       if(flagBG[offlineCh]) {
-      //if(nbgFlag > 0){
-	FillRawsData(kHPTDCTimeBG,offlineCh,time[offlineCh]);
-	FillRawsData(kHPTDCTimeRebinBG,offlineCh,time[offlineCh]);
-	FillRawsData(kWidthBG,offlineCh,width[offlineCh]);
-	FillRawsData(kChargeEoIBG,offlineCh,adc[offlineCh]);
-	FillRawsData(kNEventsBGFlag,offlineCh);
+        //if(nbgFlag > 0){
+        FillRawsData(kHPTDCTimeBG,offlineCh,time[offlineCh]);
+        FillRawsData(kHPTDCTimeRebinBG,offlineCh,time[offlineCh]);
+        FillRawsData(kWidthBG,offlineCh,width[offlineCh]);
+        FillRawsData(kChargeEoIBG,offlineCh,adc[offlineCh]);
+        FillRawsData(kNEventsBGFlag,offlineCh);
       }
-      
+
 
     }// END of Loop over channels
-    
+
     //Correlation Cside
     Int_t nCorrelation = 0;
     for(Int_t iChannel=0; iChannel<8; iChannel++) {
-    	for(Int_t jChannel=7; jChannel>iChannel; jChannel--) {
-		FillRawsData(kNChargeCorrADC+nCorrelation,adc[iChannel],adc[jChannel]);
-		FillRawsData(kNTimeCorrADC+nCorrelation,time[iChannel],time[jChannel]);
-		if(time[iChannel]>1e-6 && time[jChannel]>1e-6) FillRawsData(kNTimeDiffADC+nCorrelation,time[iChannel]-time[jChannel]);
-		nCorrelation++;
-		}
-	}
+      for(Int_t jChannel=7; jChannel>iChannel; jChannel--) {
+        FillRawsData(kNChargeCorrADC+nCorrelation,adc[iChannel],adc[jChannel]);
+        FillRawsData(kNTimeCorrADC+nCorrelation,time[iChannel],time[jChannel]);
+        if(time[iChannel]>1e-6 && time[jChannel]>1e-6) FillRawsData(kNTimeDiffADC+nCorrelation,time[iChannel]-time[jChannel]);
+        nCorrelation++;
+      }
+    }
     //Correlation Aside
     nCorrelation = 0;
     for(Int_t iChannel=8; iChannel<16; iChannel++) {
-    	for(Int_t jChannel=15; jChannel>iChannel; jChannel--) {
-		FillRawsData(kNChargeCorrADA+nCorrelation,adc[iChannel],adc[jChannel]);
-		FillRawsData(kNTimeCorrADA+nCorrelation,time[iChannel],time[jChannel]);
-		if(time[iChannel]>1e-6 && time[jChannel]>1e-6) FillRawsData(kNTimeDiffADA+nCorrelation,time[iChannel]-time[jChannel]);
-		nCorrelation++;
-		}
-    	}
-		
-    for(Int_t iChannel=0; iChannel<4; iChannel++) {//Loop over pairs of pads
-    	//Enable time is used to turn off the coincidence 
-    	if((!fCalibData->GetEnableTiming(iChannel) || flagBB[iChannel]) && (!fCalibData->GetEnableTiming(iChannel+4) || flagBB[iChannel+4])) pBBmulADC++;
-	if((!fCalibData->GetEnableTiming(iChannel) || flagBG[iChannel]) && (!fCalibData->GetEnableTiming(iChannel+4) || flagBG[iChannel+4])) pBGmulADC++;
+      for(Int_t jChannel=15; jChannel>iChannel; jChannel--) {
+        FillRawsData(kNChargeCorrADA+nCorrelation,adc[iChannel],adc[jChannel]);
+        FillRawsData(kNTimeCorrADA+nCorrelation,time[iChannel],time[jChannel]);
+        if(time[iChannel]>1e-6 && time[jChannel]>1e-6) FillRawsData(kNTimeDiffADA+nCorrelation,time[iChannel]-time[jChannel]);
+        nCorrelation++;
+      }
+    }
 
-	if((!fCalibData->GetEnableTiming(iChannel+8) || flagBB[iChannel+8]) && (!fCalibData->GetEnableTiming(iChannel+12) || flagBB[iChannel+12])) pBBmulADA++;
-	if((!fCalibData->GetEnableTiming(iChannel+8) || flagBG[iChannel+8]) && (!fCalibData->GetEnableTiming(iChannel+12) || flagBG[iChannel+12])) pBGmulADA++;
-	}
-					
+    for(Int_t iChannel=0; iChannel<4; iChannel++) {//Loop over pairs of pads
+      //Enable time is used to turn off the coincidence
+      if((!fCalibData->GetEnableTiming(iChannel) || flagBB[iChannel]) && (!fCalibData->GetEnableTiming(iChannel+4) || flagBB[iChannel+4])) pBBmulADC++;
+      if((!fCalibData->GetEnableTiming(iChannel) || flagBG[iChannel]) && (!fCalibData->GetEnableTiming(iChannel+4) || flagBG[iChannel+4])) pBGmulADC++;
+
+      if((!fCalibData->GetEnableTiming(iChannel+8) || flagBB[iChannel+8]) && (!fCalibData->GetEnableTiming(iChannel+12) || flagBB[iChannel+12])) pBBmulADA++;
+      if((!fCalibData->GetEnableTiming(iChannel+8) || flagBG[iChannel+8]) && (!fCalibData->GetEnableTiming(iChannel+12) || flagBG[iChannel+12])) pBGmulADA++;
+    }
+
     FillRawsData(kNBBCoincADA,pBBmulADA);
     FillRawsData(kNBBCoincADC,pBBmulADC);
     FillRawsData(kNBGCoincADA,pBGmulADA);
     FillRawsData(kNBGCoincADC,pBGmulADC);
     FillRawsData(kNBBCoincCorr,pBBmulADA,pBBmulADC);
     FillRawsData(kNBGCoincCorr,pBGmulADA,pBGmulADC);
-    
+
     for(Int_t iChannel=0; iChannel<16; iChannel++) {
-    	for(Int_t iEvent=0; iEvent<21; iEvent++){
-		offlineCh = kOfflineChannel[iChannel];
-		Bool_t bbFlag = rawStream->GetBBFlag(iChannel,iEvent);
-		if(pBBmulADA>0 || pBBmulADC>0)FillRawsData(kBBFlagVsClock_ADOR, offlineCh,(float)iEvent-10,(float)bbFlag);
-		}
-	}
-    
+      for(Int_t iEvent=0; iEvent<21; iEvent++){
+        offlineCh = kOfflineChannel[iChannel];
+        Bool_t bbFlag = rawStream->GetBBFlag(iChannel,iEvent);
+        if(pBBmulADA>0 || pBBmulADC>0)FillRawsData(kBBFlagVsClock_ADOR, offlineCh,(float)iEvent-10,(float)bbFlag);
+      }
+    }
+
     //Triggers
     Bool_t UBA = kFALSE;
     Bool_t UBC = kFALSE;
     Bool_t UGA = kFALSE;
     Bool_t UGC = kFALSE;
-    
+
     if(pBBmulADA>=fCalibData->GetBBAThreshold()) UBA = kTRUE;
     if(pBBmulADC>=fCalibData->GetBBCThreshold()) UBC = kTRUE;
     if(pBGmulADA>=fCalibData->GetBGAThreshold()) UGA = kTRUE;
@@ -1135,21 +1132,21 @@ void AliADQADataMakerRec::MakeRaws(AliRawReader* rawReader)
     if(UGC && UBA) FillRawsData(kTriggers,8);
     if(UGA || UGC) FillRawsData(kTriggers,9);
     if((UGA && UBC) || (UGC && UBA)) FillRawsData(kTriggers,10);
-    	
+
     //Average times
-    if(weightADA>1) timeADA /= weightADA; 
+    if(weightADA>1) timeADA /= weightADA;
     else timeADA = -1024.;
     if(weightADC>1) timeADC /= weightADC;
     else timeADC = -1024.;
     if(timeADA<1.e-6 || timeADC<1.e-6) {
-    	diffTime = -1024.;
-	sumTime = -1024;
-	}
+      diffTime = -1024.;
+      sumTime = -1024;
+    }
     else {
-    	diffTime = timeADA - timeADC;
-	sumTime = timeADA + timeADC;
-	}
-    	
+      diffTime = timeADA - timeADC;
+      sumTime = timeADA + timeADC;
+    }
+
     FillRawsData(kMeanTimeADA,timeADA);
     FillRawsData(kMeanTimeADC,timeADC);
     FillRawsData(kMeanTimeDiff,diffTime);
@@ -1164,35 +1161,35 @@ void AliADQADataMakerRec::MakeRaws(AliRawReader* rawReader)
     FillRawsData(kChargeAD,chargeADA + chargeADC);
     if(mulADA!=0)FillRawsData(kChargeADA_PC,chargeTrigADA/mulADA);
     if(mulADC!=0)FillRawsData(kChargeADC_PC,chargeTrigADA/mulADC);
-    
+
     //Decisions
     Int_t windowOffset = (fCalibData->GetTriggerCountOffset(0) - 3242)*25;
     Int_t ADADecision=0;
-    Int_t ADCDecision=0; 
+    Int_t ADCDecision=0;
 
     if(timeADA > (fADADist - windowOffset + 5*fRecoParam->GetTimeWindowBBALow()) && timeADA < (fADADist - windowOffset  + 5*fRecoParam->GetTimeWindowBBAUp())) ADADecision=1;
     else if(timeADA > (-fADADist - windowOffset + 5*fRecoParam->GetTimeWindowBGALow()) && timeADA < (-fADADist - windowOffset + 5*fRecoParam->GetTimeWindowBGAUp())) ADADecision=2;
     else if(timeADA>-1024.+1.e-6) ADADecision=3;
     else ADADecision=0;
-    
+
     if(timeADC > (fADCDist - windowOffset + 5*fRecoParam->GetTimeWindowBBCLow()) && timeADC < (fADCDist - windowOffset + 5*fRecoParam->GetTimeWindowBBCUp())) ADCDecision=1;
     else if(timeADC > (-fADCDist - windowOffset + 5*fRecoParam->GetTimeWindowBGCLow()) && timeADC < (-fADCDist - windowOffset + 5*fRecoParam->GetTimeWindowBGCUp())) ADCDecision=2;
     else if(timeADC>-1024.+1.e-6) ADCDecision=3;
     else ADCDecision=0;
 
     FillRawsData(kDecisions,ADADecision,ADCDecision);
-    
+
     break;
-  } // END of SWITCH : EVENT TYPE 
-	 
-  delete rawStream; rawStream = 0x0;      
+  } // END of SWITCH : EVENT TYPE
+
+  delete rawStream; rawStream = NULL;
   //
   IncEvCountCycleRaws();
   IncEvCountTotalRaws();
   //
 }
 
-//____________________________________________________________________________ 
+//____________________________________________________________________________
 Float_t AliADQADataMakerRec::CorrectLeadingTime(Int_t /*i*/, Float_t time, Float_t adc) const
 {
   // Correct the leading time
@@ -1204,12 +1201,11 @@ Float_t AliADQADataMakerRec::CorrectLeadingTime(Int_t /*i*/, Float_t time, Float
 
   // Slewing correction
   //time -= fTimeSlewing->Eval(adc);
-  
-   // Channel alignment and general offset subtraction
+
+  // Channel alignment and general offset subtraction
   //  time -= fHptdcOffset[i];
   //AliInfo(Form("time-offset %f", time));
-  
+
 
   return time;
 }
-

--- a/AD/ADrec/AliADQADataMakerRec.h
+++ b/AD/ADrec/AliADQADataMakerRec.h
@@ -1,18 +1,19 @@
+// -*- C++ -*-
 #ifndef ALIADQADATAMAKERREC_H
 #define ALIADQADATAMAKERREC_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */
 
 
-//  Produces the data needed to calculate the quality assurance  
+//  Produces the data needed to calculate the quality assurance
 //  All data must be mergeable objects
 //  Handles ESDs and RAWs
 //  Histos will be used for Raw Data control and monitoring
 
 // --- ROOT system ---
-class TH1F; 
-class TH1I; 
-class TObjArray; 
+class TH1F;
+class TH1I;
+class TObjArray;
 
 // --- Standard library ---
 
@@ -25,83 +26,81 @@ class AliADCalibData;
 class AliADRecoParam;
 class AliADQAParam;
 
-class AliADQADataMakerRec: public AliQADataMakerRec {
-
+class AliADQADataMakerRec : public AliQADataMakerRec {
 public:
   // Histograms for Raw data control
   enum HRawType_t {
-  		   kChargeADA,kChargeADC,kChargeEoI,kChargeEoIBB,kChargeEoIBG,
-		   kHPTDCTime,kHPTDCTimeBB,kHPTDCTimeBG,kWidth,
-		   kHPTDCTimeRebin,kHPTDCTimeRebinBB,kHPTDCTimeRebinBG,
-		   kBBFlagVsClock,kBBFlagVsClock_ADOR,kBGFlagVsClock,kBBFlagsPerChannel,kBGFlagsPerChannel,
-		   kChargeVsClockInt0,kChargeVsClockInt1,kMaxChargeClock,
-		   kNBBCoincADA,kNBBCoincADC,kNBGCoincADA,kNBGCoincADC,
-		   kPedestalDiffInt0,kPedestalDiffInt1,
-		   kChargeEoIInt0,kChargeEoIInt1,kChargeSaturation,
-		   kNBBCoincCorr,kNBGCoincCorr,
-		   kTriggers,kDecisions,
-		   kMeanTimeADA,kMeanTimeADC,kMeanTimeDiff,kMeanTimeCorr,kMeanTimeSumDiff,
-		   kPedestalInt0,kPedestalInt1,
-		   kNEventsBBFlag,kNEventsBGFlag,
-		   kFlagNoTime,kTimeNoFlag,
-		   kWidthBB,kWidthBG,
-		   kTimeSlewingADA,kTimeSlewingADC,kWidthSlewing,
-		   kMultiADA,kMultiADC,kChargeAD, 
-		   
-		   kChargeADA_PC,kChargeADC_PC,
-		   kTrend_TriggerChargeQuantileADA,kTrend_TriggerChargeQuantileADC,
-		   
-		   kPairTimeDiffMean,kPairTimeDiffRMS,
-		   kNChargeCorrADA,
-		   kNChargeCorrADC = kNChargeCorrADA + 28,
-		   kNTimeCorrADA = kNChargeCorrADC + 28,
-		   kNTimeCorrADC = kNTimeCorrADA + 28,
-		   kNTimeDiffADA = kNTimeCorrADC + 28,
-		   kNTimeDiffADC = kNTimeDiffADA + 28};
-		   
-		   
+    kChargeADA,kChargeADC,kChargeEoI,kChargeEoIBB,kChargeEoIBG,
+    kHPTDCTime,kHPTDCTimeBB,kHPTDCTimeBG,kWidth,
+    kHPTDCTimeRebin,kHPTDCTimeRebinBB,kHPTDCTimeRebinBG,
+    kBBFlagVsClock,kBBFlagVsClock_ADOR,kBGFlagVsClock,kBBFlagsPerChannel,kBGFlagsPerChannel,
+    kChargeVsClockInt0,kChargeVsClockInt1,kMaxChargeClock,
+    kNBBCoincADA,kNBBCoincADC,kNBGCoincADA,kNBGCoincADC,
+    kPedestalDiffInt0,kPedestalDiffInt1,
+    kChargeEoIInt0,kChargeEoIInt1,kChargeSaturation,
+    kNBBCoincCorr,kNBGCoincCorr,
+    kTriggers,kDecisions,
+    kMeanTimeADA,kMeanTimeADC,kMeanTimeDiff,kMeanTimeCorr,kMeanTimeSumDiff,
+    kPedestalInt0,kPedestalInt1,
+    kNEventsBBFlag,kNEventsBGFlag,
+    kFlagNoTime,kTimeNoFlag,
+    kWidthBB,kWidthBG,
+    kTimeSlewingADA,kTimeSlewingADC,kWidthSlewing,
+    kMultiADA,kMultiADC,kChargeAD,
+
+    kChargeADA_PC,kChargeADC_PC,
+    kTrend_TriggerChargeQuantileADA,kTrend_TriggerChargeQuantileADC,
+
+    kPairTimeDiffMean,kPairTimeDiffRMS,
+    kNChargeCorrADA,
+    kNChargeCorrADC = kNChargeCorrADA + 28,
+    kNTimeCorrADA = kNChargeCorrADC + 28,
+    kNTimeCorrADC = kNTimeCorrADA + 28,
+    kNTimeDiffADA = kNTimeCorrADC + 28,
+    kNTimeDiffADC = kNTimeDiffADA + 28};
+
+
   enum HESDType_t {kCellMultiADA,kCellMultiADC,
 		   kBBFlag,kBGFlag,kChargeChannel,kTimeChannel,
 		   kESDADATime,kESDADCTime,kESDDiffTime,kESDADATimeVsCharge,kESDADCTimeVsCharge,
 		   kESDADAPairTimeSumDiff,kESDADCPairTimeSumDiff};
-	
+
 public:
-  AliADQADataMakerRec() ;            // constructor
-  AliADQADataMakerRec(const AliADQADataMakerRec& qadm) ;   
+  AliADQADataMakerRec();
+  AliADQADataMakerRec(const AliADQADataMakerRec& qadm) ;
   AliADQADataMakerRec& operator = (const AliADQADataMakerRec& qadm) ;
-  virtual ~AliADQADataMakerRec() {;} // destructor
+  virtual ~AliADQADataMakerRec();
   AliADCalibData *GetCalibData() const;
   AliADQAParam *GetQAParam() const;
-  virtual void   InitRaws() ; 
-  
-protected: 
+  virtual void   InitRaws() ;
+
+protected:
   AliADCalibData *fCalibData;        //! calibration data
-  AliADRecoParam *fRecoParam;
-  AliADQAParam *fQAParam;
-   
+  AliADRecoParam *fRecoParam;        //
+  AliADQAParam   *fQAParam;          //
+
 private:
   virtual void   EndOfDetectorCycle(AliQAv1::TASKINDEX_t task, TObjArray ** list) ;
-  virtual void   InitESDs() ; 
-  virtual void   InitDigits();  
+  virtual void   InitESDs() ;
+  virtual void   InitDigits();
   virtual void   MakeESDs(AliESDEvent * esd) ;
   virtual void   MakeRaws(AliRawReader* rawReader) ;
-  virtual void   MakeDigits() ; 
-  virtual void   MakeDigits(TTree* digitTree) ; 
-  virtual void   StartOfDetectorCycle() ; 
+  virtual void   MakeDigits() ;
+  virtual void   MakeDigits(TTree* digitTree) ;
+  virtual void   StartOfDetectorCycle() ;
   Float_t CorrectLeadingTime(Int_t i, Float_t time, Float_t adc) const;
-  
+
   Int_t   fEven[16];                  // even charge integrators
   Int_t   fOdd[16];                   // odd charge intergators
   Float_t fADCmean[32];               // mean adc per integrator
-  size_t fTrendingUpdateTime;         // trending histos update time
-  UInt_t fCycleStartTime;             // timestamp of QA start-of-cycle
-  UInt_t fCycleStopTime;              // timestamp of QA end-of-cycle		      
+  size_t  fTrendingUpdateTime;        // trending histos update time
+  UInt_t  fCycleStartTime;            // timestamp of QA start-of-cycle
+  UInt_t  fCycleStopTime;             // timestamp of QA end-of-cycle
   Float_t fADADist;     	      // Z position of ADA
   Float_t fADCDist;     	      // Z position of ADC
-  UInt_t fOldRun;
+  UInt_t  fOldRun;
 
-  ClassDef(AliADQADataMakerRec,4)  // description 
-
-};
+  ClassDef(AliADQADataMakerRec,4);    // description
+} ;
 
 #endif // AliADQADATAMAKERREC_H

--- a/AD/ADrec/AliADQADataMakerRec.h
+++ b/AD/ADrec/AliADQADataMakerRec.h
@@ -98,7 +98,7 @@ private:
   UInt_t  fCycleStopTime;             // timestamp of QA end-of-cycle
   Float_t fADADist;     	      // Z position of ADA
   Float_t fADCDist;     	      // Z position of ADC
-  UInt_t  fOldRun;
+  Int_t   fOldRun;
 
   ClassDef(AliADQADataMakerRec,4);    // description
 } ;

--- a/AD/ADrec/AliADQAParam.cxx
+++ b/AD/ADrec/AliADQAParam.cxx
@@ -12,73 +12,66 @@
  * about the suitability of this software for any purpose. It is          *
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
- 
+
+#include <TNamed.h>
 #include "AliADQAParam.h"
 
-ClassImp(AliADQAParam)
+ClassImp(AliADQAParam);
 
 //_____________________________________________________________________________
-AliADQAParam::AliADQAParam():
-  fNTdcTimeBins(3062),
-  fTdcTimeMin(0.976562),
-  fTdcTimeMax(300.0),
-  fNTdcTimeBinsFlag(410),
-  fTdcTimeMinBGFlag(50.0),
-  fTdcTimeMaxBGFlag(90.039062),
-  fTdcTimeMinBBFlag(170.0),
-  fTdcTimeMaxBBFlag(210.039062),
-  fNTdcTimeRatioBins(300),
-  fTdcTimeRatioMin(1),
-  fTdcTimeRatioMax(301),
-  fNTdcWidthBins(153),
-  fTdcWidthMin(2.343750),
-  fTdcWidthMax(121.875000),
-  fNChargeChannelBins(1000),
-  fChargeChannelMin(0),
-  fChargeChannelMax(1000),
-  fChargeChannelZoomMin(0),
-  fChargeChannelZoomMax(50),
-  fNChargeSideBins(500),
-  fChargeSideMin(1),
-  fChargeSideMax(5000),
-  fNChargeCorrBins(101),
-  fChargeCorrMin(1),
-  fChargeCorrMax(1001),
-  fNPairTimeCorrBins(306), 
-  fPairTimeCorrMin(0.976562),
-  fPairTimeCorrMax(299.804688),
-  fNPairTimeDiffBins(154), 
-  fPairTimeDiffMin(-15.039062),
-  fPairTimeDiffMax(15.039062),
-  fNMeanTimeCorrBins(306), 
-  fMeanTimeCorrMin(50.976562),
-  fMeanTimeCorrMax(349.804688),
-  fChargeTrendMin(0),
-  fChargeTrendMax(1000),
-  fSatMed(0.1),
-  fSatHigh(0.3),
-  fSatHuge(0.5),
-  fMaxPedDiff(1),
-  fMaxPedWidth(1.5),
-  fMaxNoTimeRate(10e-4),
-  fMaxNoFlagRate(10e-3),
-  fMaxBBVariation(0.1),
-  fMaxBGVariation(0.1),
-  fAsynchronBB(0.5),
-  fAsynchronBG(0.5)
-  
-   	
-
+AliADQAParam::AliADQAParam()
+  : TNamed("AliADQAParam", "AD QA parameters")
+  , fNTdcTimeBins(3062)
+  , fTdcTimeMin(0.976562)
+  , fTdcTimeMax(300.0)
+  , fNTdcTimeBinsFlag(410)
+  , fTdcTimeMinBBFlag(170.0)
+  , fTdcTimeMaxBBFlag(210.039062)
+  , fTdcTimeMinBGFlag(50.0)
+  , fTdcTimeMaxBGFlag(90.039062)
+  , fNTdcTimeRatioBins(300)
+  , fTdcTimeRatioMin(1)
+  , fTdcTimeRatioMax(301)
+  , fNTdcWidthBins(153)
+  , fTdcWidthMin(2.343750)
+  , fTdcWidthMax(121.875000)
+  , fNChargeChannelBins(1000)
+  , fChargeChannelMin(0)
+  , fChargeChannelMax(1000)
+  , fChargeChannelZoomMin(0)
+  , fChargeChannelZoomMax(50)
+  , fNChargeSideBins(500)
+  , fChargeSideMin(1)
+  , fChargeSideMax(5000)
+  , fNChargeCorrBins(101)
+  , fChargeCorrMin(1)
+  , fChargeCorrMax(1001)
+  , fChargeTrendMin(0)
+  , fChargeTrendMax(1000)
+  , fNPairTimeCorrBins(306)
+  , fPairTimeCorrMin(0.976562)
+  , fPairTimeCorrMax(299.804688)
+  , fNPairTimeDiffBins(154)
+  , fPairTimeDiffMin(-15.039062)
+  , fPairTimeDiffMax(15.039062)
+  , fNMeanTimeCorrBins(306)
+  , fMeanTimeCorrMin(50.976562)
+  , fMeanTimeCorrMax(349.804688)
+  , fSatMed(0.1)
+  , fSatHigh(0.3)
+  , fSatHuge(0.5)
+  , fMaxPedDiff(1)
+  , fMaxPedWidth(1.5)
+  , fMaxNoTimeRate(10e-4)
+  , fMaxNoFlagRate(10e-3)
+  , fMaxBBVariation(0.1)
+  , fMaxBGVariation(0.1)
+  , fAsynchronBB(0.5)
+  , fAsynchronBG(0.5)
 {
-  //
-  // constructor
-  //
 }
 
 //_____________________________________________________________________________
-AliADQAParam::~AliADQAParam() 
+AliADQAParam::~AliADQAParam()
 {
-  //
-  // destructor
-  //  
 }

--- a/AD/ADrec/AliADQAParam.h
+++ b/AD/ADrec/AliADQAParam.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 /**************************************************************************
  * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  *                                                                        *
@@ -20,10 +21,10 @@
 
 class AliADQAParam : public TNamed
 {
- public: 
+public:
   AliADQAParam();
   virtual ~AliADQAParam();
-  
+
   //HPTDC time
   void SetNTdcTimeBins (Int_t val) { fNTdcTimeBins = val; }
   void SetTdcTimeMin (Float_t val) { fTdcTimeMin = val; }
@@ -59,32 +60,32 @@ class AliADQAParam : public TNamed
   //Pair time correlation
   void SetNPairTimeCorrBins(Int_t val) { fNPairTimeCorrBins = val;}
   void SetPairTimeCorrMin(Float_t val) { fPairTimeCorrMin = val;}
-  void SetPairTimeCorrMax(Float_t val) { fPairTimeCorrMax = val;} 
+  void SetPairTimeCorrMax(Float_t val) { fPairTimeCorrMax = val;}
   //Pair time diference
   void SetNPairTimeDiffBins(Int_t val) { fNPairTimeDiffBins = val;}
   void SetPairTimeDiffMin(Float_t val) { fPairTimeDiffMin = val;}
-  void SetPairTimeDiffMax(Float_t val) { fPairTimeDiffMax = val;} 
+  void SetPairTimeDiffMax(Float_t val) { fPairTimeDiffMax = val;}
   //Mean time correlation
   void SetNMeanTimeCorrBins(Int_t val) { fNMeanTimeCorrBins = val;}
   void SetMeanTimeCorrMin(Float_t val) { fMeanTimeCorrMin = val;}
-  void SetMeanTimeCorrMax(Float_t val) { fMeanTimeCorrMax = val;} 
+  void SetMeanTimeCorrMax(Float_t val) { fMeanTimeCorrMax = val;}
   //Charge trends
   void SetChargeTrendMin(Float_t val) {fChargeTrendMin = val;}
   void SetChargeTrendMax(Float_t val) {fChargeTrendMax = val;}
-  
+
   //QA checker limits
   void SetSatMed(Float_t val) {fSatMed = val;}
   void SetSatHigh(Float_t val) {fSatHigh = val;}
-  void SetSatHuge(Float_t val) {fSatHuge = val;} 
-  
-  void SetMaxPedDiff(Int_t val) {fMaxPedDiff = val;} 
-  void SetMaxPedWidth(Float_t val) {fMaxPedWidth = val;} 
-  
+  void SetSatHuge(Float_t val) {fSatHuge = val;}
+
+  void SetMaxPedDiff(Int_t val) {fMaxPedDiff = val;}
+  void SetMaxPedWidth(Float_t val) {fMaxPedWidth = val;}
+
   void SetMaxNoTimeRate(Float_t val) {fMaxNoTimeRate = val;}
   void SetMaxNoFlagRate(Float_t val) {fMaxNoFlagRate = val;}
   void SetMaxBBVariation(Float_t val) {fMaxBBVariation = val;}
   void SetMaxBGVariation(Float_t val) {fMaxBGVariation = val;}
-  
+
   void SetAsynchronBB(Float_t val) {fAsynchronBB = val;}
   void SetAsynchronBG(Float_t val) {fAsynchronBG = val;}
 
@@ -120,14 +121,14 @@ class AliADQAParam : public TNamed
   Int_t GetNChargeCorrBins() const { return fNChargeCorrBins; }
   Int_t GetChargeCorrMin() const { return fChargeCorrMin; }
   Int_t GetChargeCorrMax() const { return fChargeCorrMax; }
-  //Pair time correlation 
+  //Pair time correlation
   Int_t GetNPairTimeCorrBins() const { return fNPairTimeCorrBins;}
   Float_t GetPairTimeCorrMin() const { return fPairTimeCorrMin;}
-  Float_t GetPairTimeCorrMax() const { return fPairTimeCorrMax;} 
+  Float_t GetPairTimeCorrMax() const { return fPairTimeCorrMax;}
   //Pair time difference
   Int_t GetNPairTimeDiffBins() const { return fNPairTimeDiffBins;}
   Float_t GetPairTimeDiffMin() const { return fPairTimeDiffMin;}
-  Float_t GetPairTimeDiffMax() const { return fPairTimeDiffMax;} 
+  Float_t GetPairTimeDiffMax() const { return fPairTimeDiffMax;}
   //Mean time correlation
   Int_t  GetNMeanTimeCorrBins() const { return fNMeanTimeCorrBins;}
   Float_t GetMeanTimeCorrMin() const { return fMeanTimeCorrMin;}
@@ -135,36 +136,36 @@ class AliADQAParam : public TNamed
   //Charge trends
   Float_t GetChargeTrendMin() const {return fChargeTrendMin;}
   Float_t GetChargeTrendMax() const {return fChargeTrendMax;}
-  
+
   //QA checker limits
   Float_t GetSatMed() const {return fSatMed;}
   Float_t GetSatHigh() const {return fSatHigh;}
-  Float_t GetSatHuge() const {return fSatHuge;} 
-  
-  Int_t GetMaxPedDiff() const {return fMaxPedDiff;} 
+  Float_t GetSatHuge() const {return fSatHuge;}
+
+  Int_t GetMaxPedDiff() const {return fMaxPedDiff;}
   Float_t GetMaxPedWidth() const {return fMaxPedWidth;}
-  
+
   Float_t GetMaxNoTimeRate() const {return fMaxNoTimeRate;}
   Float_t GetMaxNoFlagRate() const {return fMaxNoFlagRate;}
   Float_t GetMaxBBVariation() const {return fMaxBBVariation;}
   Float_t GetMaxBGVariation() const {return fMaxBGVariation;}
-  
+
   Float_t GetAsynchronBB() const {return fAsynchronBB;}
   Float_t GetAsynchronBG() const {return fAsynchronBG;}
 
- private:
- 
+private:
+
   //QA histogram bins and limits
   Int_t	fNTdcTimeBins;	//Time bining
-  Float_t fTdcTimeMin;	
+  Float_t fTdcTimeMin;
   Float_t fTdcTimeMax;
   Int_t	fNTdcTimeBinsFlag;	//Time bining with BB/BG flag
-  Float_t fTdcTimeMinBBFlag;	
+  Float_t fTdcTimeMinBBFlag;
   Float_t fTdcTimeMaxBBFlag;
-  Float_t fTdcTimeMinBGFlag;	
+  Float_t fTdcTimeMinBGFlag;
   Float_t fTdcTimeMaxBGFlag;
   Int_t	fNTdcTimeRatioBins;	//Time ratio w_flag/All bining
-  Float_t fTdcTimeRatioMin;	
+  Float_t fTdcTimeRatioMin;
   Float_t fTdcTimeRatioMax;
   Int_t fNTdcWidthBins; //Width binning
   Float_t fTdcWidthMin;
@@ -182,36 +183,35 @@ class AliADQAParam : public TNamed
   Int_t fChargeCorrMax;
   Float_t fChargeTrendMin;
   Float_t fChargeTrendMax;
-  
-  Int_t   fNPairTimeCorrBins; 
+
+  Int_t   fNPairTimeCorrBins;
   Float_t fPairTimeCorrMin;
-  Float_t fPairTimeCorrMax; 
-   
-  Int_t   fNPairTimeDiffBins; 
+  Float_t fPairTimeCorrMax;
+
+  Int_t   fNPairTimeDiffBins;
   Float_t fPairTimeDiffMin;
   Float_t fPairTimeDiffMax;
-  
-  Int_t   fNMeanTimeCorrBins; 
+
+  Int_t   fNMeanTimeCorrBins;
   Float_t fMeanTimeCorrMin;
   Float_t fMeanTimeCorrMax;
-  
+
   //QA checker limits
   Float_t fSatMed;
   Float_t fSatHigh;
   Float_t fSatHuge;
-  
+
   Int_t fMaxPedDiff;
   Float_t fMaxPedWidth;
-  
+
   Float_t fMaxNoTimeRate;
   Float_t fMaxNoFlagRate;
   Float_t fMaxBBVariation;
   Float_t fMaxBGVariation;
-  
+
   Float_t fAsynchronBB;
   Float_t fAsynchronBG;
-  
 
-  ClassDef(AliADQAParam,5)
+  ClassDef(AliADQAParam,5);
 };
 #endif

--- a/AD/ADrec/AliADRecoParam.cxx
+++ b/AD/ADrec/AliADRecoParam.cxx
@@ -12,46 +12,40 @@
  * about the suitability of this software for any purpose. It is          *
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
- 
+
 #include "AliLog.h"
 
 #include "AliADRecoParam.h"
 
-ClassImp(AliADRecoParam)
+ClassImp(AliADRecoParam);
 
 //_____________________________________________________________________________
-AliADRecoParam::AliADRecoParam() : AliDetectorRecoParam(),
-  fNSigmaPed(2.0),
-  fStartClock(8),
-  fEndClock(12),
-  fNPreClocks(1),
-  fNPostClocks(2),
-  fTailBegin(16),
-  fTailEnd(20),
-  fAdcThresHold(1.0),
-  fTimeWindowBBALow(-9.5),
-  fTimeWindowBBAUp(22.5),
-  fTimeWindowBGALow(-2.5),
-  fTimeWindowBGAUp(5.0),
-  fTimeWindowBBCLow(-2.5),
-  fTimeWindowBBCUp(22.5),
-  fTimeWindowBGCLow(-2.5),
-  fTimeWindowBGCUp(2.5),
-  fMaxResid(5.0),
-  fResidRise(0.02)		
-
+AliADRecoParam::AliADRecoParam()
+  : AliDetectorRecoParam()
+  , fNSigmaPed(2.0)
+  , fStartClock(8)
+  , fEndClock(12)
+  , fNPreClocks(1)
+  , fNPostClocks(2)
+  , fTailBegin(16)
+  , fTailEnd(20)
+  , fAdcThresHold(1.0)
+  , fTimeWindowBBALow(-9.5)
+  , fTimeWindowBBAUp(22.5)
+  , fTimeWindowBGALow(-2.5)
+  , fTimeWindowBGAUp(5.0)
+  , fTimeWindowBBCLow(-2.5)
+  , fTimeWindowBBCUp(22.5)
+  , fTimeWindowBGCLow(-2.5)
+  , fTimeWindowBGCUp(2.5)
+  , fMaxResid(5.0)
+  , fResidRise(0.02)
 {
-  //
-  // constructor
-  //
   SetName("AD");
   SetTitle("AD");
 }
 
 //_____________________________________________________________________________
-AliADRecoParam::~AliADRecoParam() 
+AliADRecoParam::~AliADRecoParam()
 {
-  //
-  // destructor
-  //  
 }

--- a/AD/ADrec/AliADRecoParam.h
+++ b/AD/ADrec/AliADRecoParam.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 /**************************************************************************
  * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  *                                                                        *
@@ -20,10 +21,10 @@
 
 class AliADRecoParam : public AliDetectorRecoParam
 {
- public: 
+public:
   AliADRecoParam();
   virtual ~AliADRecoParam();
-  
+
   void SetNSigmaPed(Float_t nSigma) { fNSigmaPed = nSigma; }
   void SetStartClock(Int_t start) { fStartClock = start; }
   void SetEndClock(Int_t end) {fEndClock = end; }
@@ -59,12 +60,12 @@ class AliADRecoParam : public AliDetectorRecoParam
   Float_t  GetTimeWindowBGCLow() const { return fTimeWindowBGCLow; }
   Float_t  GetTimeWindowBGCUp () const { return fTimeWindowBGCUp ; }
   Float_t  GetMaxResid () const { return fMaxResid; }
-  Float_t  GetResidRise () const { return fResidRise; } 
+  Float_t  GetResidRise () const { return fResidRise; }
 
   Int_t    GetTailBegin() const { return fTailBegin; }
   Int_t    GetTailEnd()   const { return fTailEnd;   }
-  
- private:
+
+private:
 
   Float_t fNSigmaPed;  // Number of pedestal sigmas for adc cut
   Int_t fStartClock;   // Start clock for max adc search
@@ -73,7 +74,7 @@ class AliADRecoParam : public AliDetectorRecoParam
   Int_t fNPostClocks;  // Number of post-clocks used in adc charge sum
   Int_t fTailBegin;    // tail charge begin (BC)
   Int_t fTailEnd;      // tail charge end (BC)
-  
+
   // Cuts used in the trigger mask creation
   Float_t fAdcThresHold;      // Threshold on the ADC
   Float_t fTimeWindowBBALow;  // BBA window (lower cut)
@@ -86,7 +87,7 @@ class AliADRecoParam : public AliDetectorRecoParam
   Float_t fTimeWindowBGCUp;   // BGC window (upper cut)
   Float_t fMaxResid;   	      // Maximum residual of a single channel time
   Float_t fResidRise;	      // Rise of the early hit cut
-  
-  ClassDef(AliADRecoParam, 5)
+
+  ClassDef(AliADRecoParam, 5);
 };
 #endif

--- a/AD/ADrec/AliADReconstructor.cxx
+++ b/AD/ADrec/AliADReconstructor.cxx
@@ -440,12 +440,12 @@ void AliADReconstructor::FillESD(TTree* digitsTree, TTree* /*clustersTree*/,AliE
 				       : NULL);
 	  correctedForSaturation  |= doExtrapolation[iClock];
 	  if (doExtrapolation[iClock]) {
-#if ROOT_VERSION_CODE < ROOT_VERSION(5,99,0)
+#if ROOT_VERSION_CODE < ROOT_VERSION(5,99,0) // ROOT version <6
 	    fExtrapolation->Optimize();
 #endif
-	    AliDebug(3, Form("Ch%02d bc%02d %d tail=%6.1f thr=%6.1f adc=%6.1f adcCorr=%7.1f",
-			     pmNumber, iClock, doExtrapolation[iClock], tail[pmNumber], extrapolationThresholds[iClock],
-			     adcPedSub[iClock], fExtrapolation->Eval(tail[pmNumber])));
+	    AliDebugF(3, "Ch%02d bc%02d %d tail=%6.1f thr=%6.1f adc=%6.1f adcCorr=%7.1f",
+		      pmNumber, iClock, doExtrapolation[iClock], tail[pmNumber], extrapolationThresholds[iClock],
+		      adcPedSub[iClock], fExtrapolation->Eval(tail[pmNumber]));
 	  }
 
 	  adc[pmNumber] += chargeEqualizationFactor*((doExtrapolation[iClock] && tail[pmNumber] > extrapolationThresholds[iClock])

--- a/AD/ADrec/AliADReconstructor.cxx
+++ b/AD/ADrec/AliADReconstructor.cxx
@@ -128,28 +128,28 @@ void AliADReconstructor::SetOption(Option_t* opt)
     }
   }
   delete oa;
-  AliInfo(Form("opt='%s'  fCorrectForSaturation: %s", opt, fCorrectForSaturation ? "ON" : "OFF"));
+  AliInfoF("opt='%s' fCorrectForSaturation: %s", opt, fCorrectForSaturation ? "ON" : "OFF");
 }
 //________________________________________________________________________________
 Double_t AliADReconstructor::GetZPosition(const char* symname)
 {
   // Get the global z coordinate of the given AD alignable volume
   //
-  Double_t *tr;
+  Double_t *tr = NULL;
   TGeoPNEntry *pne = gGeoManager->GetAlignableEntry(symname);
   if (!pne) {
-    AliFatalClass(Form("TGeoPNEntry with symbolic name %s does not exist!", symname));
+    AliFatalClassF("TGeoPNEntry with symbolic name %s does not exist!", symname);
     return 0;
   }
 
   TGeoPhysicalNode *pnode = pne->GetPhysicalNode();
-  if (NULL != pnode) {
+  if (pnode) {
     TGeoHMatrix* hm = pnode->GetMatrix();
     tr = hm->GetTranslation();
   } else {
     const char* path = pne->GetTitle();
     if (!gGeoManager->cd(path)) {
-      AliFatalClass(Form("Volume path %s not valid!", path));
+      AliFatalClassF("Volume path %s not valid!", path);
       return 0;
     }
     tr = gGeoManager->GetCurrentMatrix()->GetTranslation();
@@ -162,7 +162,7 @@ Double_t AliADReconstructor::GetZPosition(const char* symname)
 AliADReconstructor& AliADReconstructor::operator = (const AliADReconstructor&)
 {
   // assignment operator
-  Fatal("operator =",  "assignment operator not implemented");
+  AliFatal("assignment operator not implemented");
   return *this;
 }
 
@@ -170,9 +170,9 @@ AliADReconstructor& AliADReconstructor::operator = (const AliADReconstructor&)
 AliADReconstructor::~AliADReconstructor()
 {
   // destructor
-  delete fESDAD;
-  delete fESDADfriend;
-  delete fDigitsArray;
+  delete fESDAD;       fESDAD       = NULL;
+  delete fESDADfriend; fESDADfriend = NULL;
+  delete fDigitsArray; fDigitsArray = NULL;
 }
 
 //_____________________________________________________________________________
@@ -217,12 +217,12 @@ UShort_t MakeTriggerFlags(Bool_t UBA, Bool_t UBC,
 void AliADReconstructor::ConvertDigits(AliRawReader* rawReader, TTree* digitsTree) const
 {
   // converts RAW to digits
-  if (NULL == digitsTree) {
+  if (!digitsTree) {
     AliError("No digits tree!");
     return;
   }
 
-  if (NULL == fDigitsArray)
+  if (!fDigitsArray)
     fDigitsArray = new TClonesArray("AliADdigit", 16);
   digitsTree->Branch("ADDigit", &fDigitsArray);
 
@@ -425,13 +425,10 @@ void AliADReconstructor::FillESD(TTree* digitsTree, TTree* /*clustersTree*/,AliE
 	for (Int_t iClock=end+1; iClock<kADNClocks; ++iClock)
 	  tailComplement[pmNumber] += adcPedSub[iClock];
 
-	if (fCorrectForSaturation) {
-	  f_Int0->Clear("C");
-	  f_Int1->Clear("C");
+	if (fCorrectForSaturation)
 	  fSaturationCorrection->GetEntry(pmNumber);
-	}
 
-	AliDebug(3, Form("pmNumber=%d offlineCh=%d onlineCh=%d isPileUp=%d", pmNumber, chOffline, chOnline, isPileUp));
+	AliDebugF(3, "pmNumber=%d offlineCh=%d onlineCh=%d isPileUp=%d", pmNumber, chOffline, chOnline, isPileUp);
 	adc[pmNumber] = 0.0f;
 	for (Int_t iClock=start; iClock<=end; ++iClock) {
 	  const Bool_t iIntegrator = ((iClock%2) == 0 ? integrator : !integrator);
@@ -462,36 +459,36 @@ void AliADReconstructor::FillESD(TTree* digitsTree, TTree* /*clustersTree*/,AliE
 	  tail[pmNumber] *= -1;
       }
 
-      AliDebug(3, Form("ADreco: GetRecoParam()->GetNPreClocks()=%d, GetRecoParam()->GetNPostClocks()=%d imax=%d maxadc=%.1f adc[%2d]=%.1f tail[%2d]=%.1f tailC=%.1f",
-		       GetRecoParam()->GetNPreClocks(),
-		       GetRecoParam()->GetNPostClocks(),
-		       imax,
-		       maxadc,
-		       pmNumber,
-		       adc[pmNumber],
-		       pmNumber,
-		       tail[pmNumber],
-		       tailComplement[pmNumber]));
+      AliDebugF(3, "ADreco: GetRecoParam()->GetNPreClocks()=%d, GetRecoParam()->GetNPostClocks()=%d imax=%d maxadc=%.1f adc[%2d]=%.1f tail[%2d]=%.1f tailC=%.1f",
+		GetRecoParam()->GetNPreClocks(),
+		GetRecoParam()->GetNPostClocks(),
+		imax,
+		maxadc,
+		pmNumber,
+		adc[pmNumber],
+		pmNumber,
+		tail[pmNumber],
+		tailComplement[pmNumber]);
 
       // MIP multiplicity
       const Float_t adcPerMIP = const_cast<AliADCalibData*>(fCalibData)->GetADCperMIP(pmNumber);
       mult[pmNumber] = (adcPerMIP != 0 ? adc[pmNumber]/adcPerMIP : 0.0f);
 
       if (adc[pmNumber] > 0) {
-	AliDebug(1, Form("PM = %d ADC = %.2f (%.2f) TDC %.2f (%.2f)   Int %d (%d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d)    %.2f %.2f   %.2f %.2f    %d %d",
-			 pmNumber,  adc[pmNumber],
-			 digit->ChargeADC(11)+digit->ChargeADC(10)+digit->ChargeADC(9)+digit->ChargeADC(8)+
-			 digit->ChargeADC(7)+digit->ChargeADC(6)+digit->ChargeADC(5)+digit->ChargeADC(4)-
-			 4.*fCalibData->GetPedestal(pmNumber)-4.*fCalibData->GetPedestal(pmNumber+16),
-			 digit->Time(), time[pmNumber],
-			 integrator,
-			 digit->ChargeADC(0), digit->ChargeADC(1), digit->ChargeADC(2), digit->ChargeADC(3), digit->ChargeADC(4), digit->ChargeADC(5), digit->ChargeADC(6), digit->ChargeADC(7),
-			 digit->ChargeADC(8), digit->ChargeADC(9), digit->ChargeADC(10),
-			 digit->ChargeADC(11), digit->ChargeADC(12),
-			 digit->ChargeADC(13), digit->ChargeADC(14), digit->ChargeADC(15), digit->ChargeADC(16), digit->ChargeADC(17), digit->ChargeADC(18), digit->ChargeADC(19), digit->ChargeADC(20),
-			 fCalibData->GetPedestal(pmNumber), fCalibData->GetSigma(pmNumber),
-			 fCalibData->GetPedestal(pmNumber+16), fCalibData->GetSigma(pmNumber+16),
-			 aBBflag[pmNumber], aBGflag[pmNumber]));
+	AliDebugF(1, "PM = %d ADC = %.2f (%.2f) TDC %.2f (%.2f)   Int %d (%d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d)    %.2f %.2f   %.2f %.2f    %d %d",
+		  pmNumber,  adc[pmNumber],
+		  digit->ChargeADC(11)+digit->ChargeADC(10)+digit->ChargeADC(9)+digit->ChargeADC(8)+
+		  digit->ChargeADC(7)+digit->ChargeADC(6)+digit->ChargeADC(5)+digit->ChargeADC(4)-
+		  4.*fCalibData->GetPedestal(pmNumber)-4.*fCalibData->GetPedestal(pmNumber+16),
+		  digit->Time(), time[pmNumber],
+		  integrator,
+		  digit->ChargeADC(0), digit->ChargeADC(1), digit->ChargeADC(2), digit->ChargeADC(3), digit->ChargeADC(4), digit->ChargeADC(5), digit->ChargeADC(6), digit->ChargeADC(7),
+		  digit->ChargeADC(8), digit->ChargeADC(9), digit->ChargeADC(10),
+		  digit->ChargeADC(11), digit->ChargeADC(12),
+		  digit->ChargeADC(13), digit->ChargeADC(14), digit->ChargeADC(15), digit->ChargeADC(16), digit->ChargeADC(17), digit->ChargeADC(18), digit->ChargeADC(19), digit->ChargeADC(20),
+		  fCalibData->GetPedestal(pmNumber), fCalibData->GetSigma(pmNumber),
+		  fCalibData->GetPedestal(pmNumber+16), fCalibData->GetSigma(pmNumber+16),
+		  aBBflag[pmNumber], aBGflag[pmNumber]);
       };
 
       // Fill ESD friend object
@@ -501,6 +498,11 @@ void AliADReconstructor::FillESD(TTree* digitsTree, TTree* /*clustersTree*/,AliE
       }
       fESDADfriend->SetTime (pmNumber, digit->Time());
       fESDADfriend->SetWidth(pmNumber, digit->Width());
+
+      if (fCorrectForSaturation) {
+	f_Int0->Delete(); // TF1 does not implement TObject::Clear()
+	f_Int1->Delete();
+      }
     } // end of loop over digits
   } // end of loop over events in digits tree
 
@@ -557,13 +559,13 @@ void AliADReconstructor::FillESD(TTree* digitsTree, TTree* /*clustersTree*/,AliE
   offlineDecision.SetRecoParam(GetRecoParam());
   offlineDecision.FillDecisions(fESDAD);
 
-  if (NULL != esd) {
-    AliDebug(1, Form("Writing AD data to ESD tree"));
+  if (esd) {
+    AliDebug(1, "Writing AD data to ESD tree");
     esd->SetADData(fESDAD);
 
     AliESDfriend *fr = dynamic_cast<AliESDfriend*>(esd->FindListObject("AliESDfriend"));
-    if (NULL != fr) {
-      AliDebug(1, Form("Writing AD friend data to ESD tree"));
+    if (fr) {
+      AliDebug(1, "Writing AD friend data to ESD tree");
       fr->SetADfriend(fESDADfriend);
     }
   }
@@ -578,9 +580,9 @@ const AliADCalibData* AliADReconstructor::GetCalibData() const
   AliCDBEntry *entry = man->Get("AD/Calib/Data");
   const AliADCalibData *calibdata = NULL;
 
-  if (NULL != entry)
+  if (entry)
     calibdata = dynamic_cast<const AliADCalibData*>(entry->GetObject());
-  if (NULL == calibdata)
+  if (!calibdata)
     AliFatal("No calibration data from calibration database !");
 
   return calibdata;
@@ -593,9 +595,9 @@ void AliADReconstructor::GetTimeSlewingSplines()
   AliCDBEntry *entry = man->Get("AD/Calib/TimeSlewing");
   TList *fListSplines = NULL;
 
-  if (NULL != entry)
+  if (entry)
     fListSplines = dynamic_cast<TList*>(entry->GetObject());
-  if (NULL == fListSplines)
+  if (!fListSplines)
     AliFatal("No time slewing correction from calibration database !");
 
   for (Int_t i=0; i<16; ++i)
@@ -648,7 +650,7 @@ void AliADReconstructor::GetCollisionMode()
     fBeamEnergy = 0.;
   }
 
-  AliDebug(1, Form("\n ++++++ Beam type and collision mode retrieved as %s %d @ %1.3f GeV ++++++\n\n", beamType.Data(), fCollisionMode, fBeamEnergy));
+  AliDebugF(1, "\n ++++++ Beam type and collision mode retrieved as %s %d @ %1.3f GeV ++++++\n\n", beamType.Data(), fCollisionMode, fBeamEnergy);
 }
 //____________________________________________________________________________
 Float_t AliADReconstructor::CorrectLeadingTime(Int_t i, Float_t time, Float_t adc) const

--- a/AD/ADrec/AliADReconstructor.h
+++ b/AD/ADrec/AliADReconstructor.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 #ifndef ALIADRECONSTRUCTOR_H
 #define ALIADRECONSTRUCTOR_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved.*/
@@ -31,29 +32,33 @@ public:
   AliADReconstructor();
   virtual ~AliADReconstructor();
   virtual void   Init();
-  
-  virtual void   Reconstruct(AliRawReader* /*rawReader*/, 
+
+  virtual void   Reconstruct(AliRawReader* /*rawReader*/,
 		             TTree* /*clustersTree*/) const {
-    AliError("Method not implemented"); return;};
+    AliError("Method not implemented");
+    return;
+  }
   virtual void   Reconstruct(TTree*, TTree*) const {return;};
-  
-  virtual void   FillESD(TTree* digitsTree, TTree* /*clustersTree*/, 
+
+  virtual void   FillESD(TTree* digitsTree, TTree* /*clustersTree*/,
 			 AliESDEvent* esd) const;
 
-  virtual void   FillESD(AliRawReader* /*rawReader*/, TTree* /*clustersTree*/, 
-			 AliESDEvent* /*esd*/) const { 
-    AliError("Method not implemented"); return;};
-  
+  virtual void   FillESD(AliRawReader* /*rawReader*/, TTree* /*clustersTree*/,
+			 AliESDEvent* /*esd*/) const {
+    AliError("Method not implemented");
+    return;
+  }
+
   virtual Bool_t HasDigitConversion() const { return kTRUE; }
   virtual void ConvertDigits(AliRawReader* rawReader, TTree* digitsTree) const;
 
   static const AliADRecoParam* GetRecoParam() { return dynamic_cast<const AliADRecoParam*>(AliReconstructor::GetRecoParam(14)); }
 
-  AliCDBStorage     *SetStorage(const char* uri);
+  AliCDBStorage* SetStorage(const char* uri);
   void GetCollisionMode();
   Double_t GetZPosition(const char* symname);
 
-  const AliADCalibData *GetCalibData() const; 
+  const AliADCalibData* GetCalibData() const;
   void GetTimeSlewingSplines();
   Float_t CorrectLeadingTime(Int_t i, Float_t time, Float_t adc) const;
 
@@ -62,12 +67,12 @@ public:
 
   void SetOption(Option_t *opt);
 
-  AliESDAD*    GetESDAD() { return fESDAD; }
+  AliESDAD* GetESDAD() { return fESDAD; }
 
 protected:
-  AliESDAD       *fESDAD;       // AD ESD object 
+  AliESDAD       *fESDAD;       // AD ESD object
   AliESDEvent    *fESD;         // ESD object
-  AliESDADfriend *fESDADfriend; // AD ESDfriend object  
+  AliESDADfriend *fESDADfriend; // AD ESDfriend object
 
 private:
   AliADReconstructor(const AliADReconstructor &reconstructor); //Not implemented
@@ -85,7 +90,7 @@ private:
 
   Bool_t                fCorrectForSaturation;  //
 
-  ClassDef(AliADReconstructor, 5)  // class for the AD reconstruction
+  ClassDef(AliADReconstructor, 5);  // class for the AD reconstruction
 };
 
 #endif

--- a/AD/ADrec/AliADTrending.cxx
+++ b/AD/ADrec/AliADTrending.cxx
@@ -119,8 +119,8 @@ void AliADTrending::PrintEntry(UInt_t entry)
   if(entry>=fNEntries){
     AliErrorF("maximum entry is %d\n",fNEntries-1);
   } else {
-    AliInfoF("Entry %d @ %f : %f %f %f %f %f %f %f %f \n",entry, fTime[entry],
-	     fData[0][entry],fData[1][entry],fData[2][entry],fData[3][entry],fData[4][entry],fData[5][entry],fData[6][entry],fData[7][entry]);
+    AliInfoF("Entry %d @ %f : %f %f %f %f\n",entry, fTime[entry],
+	     fData[0][entry],fData[1][entry],fData[2][entry],fData[3][entry]);
   }
 }
 

--- a/AD/ADrec/AliADTrending.cxx
+++ b/AD/ADrec/AliADTrending.cxx
@@ -13,13 +13,13 @@
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
 
-// 
+//
 // Class AliADTrending
 // ---------------------------
-// 
-//  class used in QA to publish variables evolution versus time in AMORE. 
+//
+//  class used in QA to publish variables evolution versus time in AMORE.
 //  These histo are the one which will be looked at by QA Shifter
-// 
+//
 #include "TGraph.h"
 #include "TMultiGraph.h"
 #include "TLegend.h"
@@ -28,120 +28,124 @@
 #include "AliLog.h"
 #include "AliADTrending.h"
 
-ClassImp(AliADTrending)
+ClassImp(AliADTrending);
 
 //_____________________________________________________________________________
-AliADTrending::AliADTrending() : TH1(), fNEntries(0), fMultiGraphs(NULL)
+AliADTrending::AliADTrending()
+  : TH1()
+  , fNEntries(0)
+  , fMultiGraphs(NULL)
 {
-	// Default constructor
-	for(int i=0; i<4;i++) fGraphs[i] = NULL;
-	for (int i = 0; i < kDataSize; i++) {
-		fTime[i] = 0;
-		for (int j = 0; j < 4; j++) {
-		  fData[j][i] = 0;
-		}
-	}
+  // Default constructor
+  for(int i=0; i<4;i++) fGraphs[i] = NULL;
+  for (int i = 0; i < kDataSize; i++) {
+    fTime[i] = 0;
+    for (int j = 0; j < 4; j++) {
+      fData[j][i] = 0;
+    }
+  }
 }
 //_____________________________________________________________________________
-AliADTrending::AliADTrending(const char* name, const char* title) : TH1(), fNEntries(0), fMultiGraphs(NULL)
+AliADTrending::AliADTrending(const char* name, const char* title)
+  : TH1()
+  , fNEntries(0)
+  , fMultiGraphs(NULL)
 {
-	SetName(name);
-	SetTitle(title);
-	for(int i=0; i<4;i++) fGraphs[i] = NULL;
-	for (int i = 0; i < kDataSize; i++) {
-		fTime[i] = 0;
-		for (int j = 0; j < 4; j++) {
-		  fData[j][i] = 0;
-		}
-	}
+  SetName(name);
+  SetTitle(title);
+  for(int i=0; i<4;i++) fGraphs[i] = NULL;
+  for (int i = 0; i < kDataSize; i++) {
+    fTime[i] = 0;
+    for (int j = 0; j < 4; j++) {
+      fData[j][i] = 0;
+    }
+  }
 }
 //_____________________________________________________________________________
-AliADTrending::AliADTrending(const AliADTrending &trend) : 
-	TH1(), fNEntries(trend.fNEntries), fMultiGraphs(NULL)
+AliADTrending::AliADTrending(const AliADTrending &trend)
+  : TH1()
+  , fNEntries(trend.fNEntries)
+  , fMultiGraphs(NULL)
 {
-	// Copy constructor
-	for(int i=0; i<4;i++) fGraphs[i] = NULL;
-	SetName(trend.GetName());
-	SetTitle(trend.GetTitle());
-	for (int i = 0; i < kDataSize; i++) {
-		fTime[i] = trend.fTime[i];
-		for (int j = 0; j < 4; j++) {
-			fData[j][i] = trend.fData[j][i];
-		}
-	}
+  // Copy constructor
+  for(int i=0; i<4;i++) fGraphs[i] = NULL;
+  SetName(trend.GetName());
+  SetTitle(trend.GetTitle());
+  for (int i = 0; i < kDataSize; i++) {
+    fTime[i] = trend.fTime[i];
+    for (int j = 0; j < 4; j++) {
+      fData[j][i] = trend.fData[j][i];
+    }
+  }
 }
 
 //_____________________________________________________________________________
 AliADTrending::~AliADTrending(){
-  for (Int_t i=0; i<4; ++i) delete fGraphs[i];
+  for (Int_t i=0; i<4; ++i) {
+    delete fGraphs[i];
+    fGraphs[i] = NULL;
+  }
   delete fMultiGraphs;
+  fMultiGraphs = NULL;
 }
-// -----------------------------------------------------------------			
+// -----------------------------------------------------------------
 void AliADTrending::AddEntry(Double_t * data, UInt_t time)
 {
-
-	if(fNEntries<kDataSize){
-		for (int i = 0; i < 4; i++)
-		{
-			fData[i][fNEntries] = data[i];
-			fTime[fNEntries] = (double) time;
-		}
-		fNEntries++;	
-	}else{
-
-		for (int i = 0; i < kDataSize-1; i++){
-			fTime[i] = fTime[i+1];
-			for (int ich = 0; ich < 4; ich++){		
-				fData[ich][i] = fData[ich][i+1];
-			}	
-		}
-		for (int i = 0; i < 4; i++)
-		{
-			fData[i][fNEntries-1] = data[i];
-			fTime[fNEntries-1] = (double) time;
-		}
-		
-	}
-// 	printf("sizeof UInt_t Double_t %d %d\n",sizeof(UInt_t),sizeof(Double_t));
-// 	printf("Add Entry %d @ %f : %f %f %f %f %f %f %f %f \n",fNEntries,fTime[fNEntries-1], 
-// 		data[0],data[1],data[2],data[3],data[4],data[5],data[6],data[7]);
-}			
-// -----------------------------------------------------------------			
+  if(fNEntries<kDataSize){
+    for (int i = 0; i < 4; i++) {
+      fData[i][fNEntries] = data[i];
+      fTime[fNEntries] = (double) time;
+    }
+    fNEntries++;
+  } else {
+    for (int i = 0; i < kDataSize-1; i++) {
+      fTime[i] = fTime[i+1];
+      for (int ich = 0; ich < 4; ich++){
+	fData[ich][i] = fData[ich][i+1];
+      }
+    }
+    for (int i = 0; i < 4; i++) {
+      fData[i][fNEntries-1] = data[i];
+      fTime[fNEntries-1] = (double) time;
+    }
+  }
+  // 	printf("sizeof UInt_t Double_t %d %d\n",sizeof(UInt_t),sizeof(Double_t));
+  // 	printf("Add Entry %d @ %f : %f %f %f %f %f %f %f %f \n",fNEntries,fTime[fNEntries-1],
+  // 		data[0],data[1],data[2],data[3],data[4],data[5],data[6],data[7]);
+}
+// -----------------------------------------------------------------
 void AliADTrending::PrintEntry(UInt_t entry)
 {
+  if(entry>=fNEntries){
+    AliErrorF("maximum entry is %d\n",fNEntries-1);
+  } else {
+    AliInfoF("Entry %d @ %f : %f %f %f %f %f %f %f %f \n",entry, fTime[entry],
+	     fData[0][entry],fData[1][entry],fData[2][entry],fData[3][entry],fData[4][entry],fData[5][entry],fData[6][entry],fData[7][entry]);
+  }
+}
 
-	if(entry>=fNEntries){
-		AliError(Form("maximum entry is %d\n",fNEntries-1));
-	}else{
-		AliInfo(Form("Entry %d @ %f : %f %f %f %f %f %f %f %f \n",entry, fTime[entry],
-			fData[0][entry],fData[1][entry],fData[2][entry],fData[3][entry],fData[4][entry],fData[5][entry],fData[6][entry],fData[7][entry]));
+// -----------------------------------------------------------------
+void AliADTrending::Draw(Option_t *){
+  fMultiGraphs = new TMultiGraph();
+  fMultiGraphs->SetTitle(GetTitle());
 
-	}
-}			
+  for(int i=0;i<4;i++) {
+    fGraphs[i] = new TGraph(GetNEntries(), GetTime(), GetChannel(i));
+    fGraphs[i]->SetLineWidth(2);
+    //fGraphs[i]->SetLineColor(i<4 ? i+1 : i -3);
+    //fGraphs[i]->SetLineStyle(i<4 ? 1 : 2);
+    fMultiGraphs->Add(fGraphs[i]);
+  }
 
-// -----------------------------------------------------------------			
-void AliADTrending::Draw(Option_t *option){
-    TString opt = option;	
-	fMultiGraphs = new TMultiGraph();
-	fMultiGraphs->SetTitle(GetTitle());
-	
-	for(int i=0;i<4;i++) {
-		fGraphs[i] = new TGraph(GetNEntries(), GetTime(), GetChannel(i));
-		fGraphs[i]->SetLineWidth(2);
-		//fGraphs[i]->SetLineColor(i<4 ? i+1 : i -3);
-		//fGraphs[i]->SetLineStyle(i<4 ? 1 : 2);
-	 	fMultiGraphs->Add(fGraphs[i]);
-	}
+  fMultiGraphs->Draw("AL");
+  fMultiGraphs->GetXaxis()->SetTimeDisplay(1);
+  fMultiGraphs->GetXaxis()->SetNdivisions(505,kFALSE);
+  fMultiGraphs->Draw("AL");
+  TLegend * legend = new TLegend(0.7,0.65,0.86,0.88);
+  legend->AddEntry(fGraphs[0],"ADA - Layer0","l");
+  legend->AddEntry(fGraphs[1],"ADA - Layer1","l");
+  legend->AddEntry(fGraphs[2],"ADC - Layer0","l");
+  legend->AddEntry(fGraphs[3],"ADC - Layer1","l");
 
-	fMultiGraphs->Draw("AL");
-	fMultiGraphs->GetXaxis()->SetTimeDisplay(1);
-	fMultiGraphs->GetXaxis()->SetNdivisions(505,kFALSE);
-	fMultiGraphs->Draw("AL");
-	TLegend * legend = new TLegend(0.7,0.65,0.86,0.88);
-	legend->AddEntry(fGraphs[0],"ADA - Layer0","l");
-	legend->AddEntry(fGraphs[1],"ADA - Layer1","l");
-	legend->AddEntry(fGraphs[2],"ADC - Layer0","l");
-	legend->AddEntry(fGraphs[3],"ADC - Layer1","l");
-
-	legend->Draw();
+  legend->Draw();
 }

--- a/AD/ADrec/AliADTrending.h
+++ b/AD/ADrec/AliADTrending.h
@@ -1,19 +1,20 @@
+// -*- C++ -*-
 #ifndef ALIADTRENDING_H
 #define ALIADTRENDING_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights
- * reserved. 
+ * reserved.
  *
- * See cxx source for full Copyright notice                               
+ * See cxx source for full Copyright notice
  */
 
 
-// 
+//
 // Class AliADTrending
 // ---------------------------
-// 
-//  class used in QA to publish variables evolution versus time in AMORE. 
+//
+//  class used in QA to publish variables evolution versus time in AMORE.
 //  These histo are the one which will be looked at by QA Shifter
-// 
+//
 
 
 #include <TH1.h>
@@ -23,32 +24,30 @@ class TMultiGraph;
 
 class AliADTrending  : public TH1 {
 public:
-	AliADTrending();
-	AliADTrending(const char* name, const char* title);
-	virtual ~AliADTrending();
-	AliADTrending(const AliADTrending &trend);
-		
-	Double_t * GetTime(){return fTime;};
-	Double_t * GetChannel(Int_t i){return fData[i];};
-	Double_t  GetLastTime(){return fTime[fNEntries-1];};
-	Double_t  GetLastChannel(Int_t i){return fData[i][fNEntries];};
-	UInt_t GetNEntries(){return fNEntries;};
-	void AddEntry(Double_t * data, UInt_t time);
-	void PrintEntry(UInt_t entry);	
-	virtual void Draw(Option_t  *option="");
+  AliADTrending();
+  AliADTrending(const char* name, const char* title);
+  virtual ~AliADTrending();
+  AliADTrending(const AliADTrending &trend);
+
+  Double_t * GetTime(){return fTime;};
+  Double_t * GetChannel(Int_t i){return fData[i];};
+  Double_t  GetLastTime(){return fTime[fNEntries-1];};
+  Double_t  GetLastChannel(Int_t i){return fData[i][fNEntries];};
+  UInt_t GetNEntries(){return fNEntries;};
+  void AddEntry(Double_t * data, UInt_t time);
+  void PrintEntry(UInt_t entry);
+  virtual void Draw(Option_t  *option="");
 
 private:
-	
-	AliADTrending& operator= (const AliADTrending & /*trend*/); // Not implemented
-	enum{kDataSize = 500};
-	Double_t fData[4][kDataSize];
-	Double_t fTime[kDataSize];
-	UInt_t fNEntries;
-	TMultiGraph *fMultiGraphs;
-	TGraph * fGraphs[4];
-	
-	ClassDef( AliADTrending, 2 )  
-	
+  AliADTrending& operator= (const AliADTrending & /*trend*/); // Not implemented
+  enum{kDataSize = 500};
+  Double_t fData[4][kDataSize];
+  Double_t fTime[kDataSize];
+  UInt_t fNEntries;
+  TMultiGraph *fMultiGraphs;
+  TGraph * fGraphs[4];
+
+  ClassDef( AliADTrending, 2 );
 };
 
 #endif // ALIADTRENDING_H

--- a/AD/ADrec/AliADTrigger.cxx
+++ b/AD/ADrec/AliADTrigger.cxx
@@ -21,7 +21,6 @@
 // Its create and Set  Inputs of the CTP
 //
 
-
 #include <TClonesArray.h>
 #include <TTree.h>
 
@@ -36,87 +35,83 @@
 #include "AliADTriggerSimulator.h"
 
 //______________________________________________________________________
-ClassImp(AliADTrigger)
+ClassImp(AliADTrigger);
 
 //______________________________________________________________________
 
-AliADTrigger::AliADTrigger():AliTriggerDetector()
+AliADTrigger::AliADTrigger()
+  : AliTriggerDetector()
 {
-   SetName("AD");
-   CreateInputs();
+  SetName("AD");
+  CreateInputs();
 }
 //______________________________________________________________________
 void AliADTrigger::CreateInputs()
 {
-   // Do not create inputs again!!
-   if( fInputs.GetEntriesFast() > 0 ) return;
+  // Do not create inputs again!!
+  if (fInputs.GetEntriesFast() > 0) return;
 
-   fInputs.AddLast( new AliTriggerInput( "AD_BBA_AND_BBC", "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "AD_BBA_OR_BBC","AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "AD_BGA_AND_BBC",  "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "0UGA",   "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "AD_BGC_AND_BBA", "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "0UGC",   "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "AD_CTA1_AND_CTC1",   "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "AD_CTA1_OR_CTC1",   "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "AD_CTA2_AND_CTC2",   "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "AD_CTA2_OR_CTC2",   "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "AD_MTA_AND_MTC",   "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "AD_MTA_OR_MTC",   "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "0UBA",   "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "0UBC",   "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "AD_BGA_OR_BGC",   "AD", 0 ) );
-   fInputs.AddLast( new AliTriggerInput( "AD_BEAMGAS",   "AD", 0 ) );
+  fInputs.AddLast(new AliTriggerInput("AD_BBA_AND_BBC",   "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("AD_BBA_OR_BBC",    "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("AD_BGA_AND_BBC",   "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("0UGA",             "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("AD_BGC_AND_BBA",   "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("0UGC",             "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("AD_CTA1_AND_CTC1", "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("AD_CTA1_OR_CTC1",  "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("AD_CTA2_AND_CTC2", "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("AD_CTA2_OR_CTC2",  "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("AD_MTA_AND_MTC",   "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("AD_MTA_OR_MTC",    "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("0UBA",             "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("0UBC",             "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("AD_BGA_OR_BGC",    "AD", 0));
+  fInputs.AddLast(new AliTriggerInput("AD_BEAMGAS",       "AD", 0));
 }
 
 //______________________________________________________________________
 void AliADTrigger::Trigger()
 {
   //  ********** Get run loader for the current event **********
-   AliRunLoader* runLoader = AliRunLoader::Instance();
+  AliRunLoader* runLoader = AliRunLoader::Instance();
 
-   AliLoader* loader = runLoader->GetLoader( "ADLoader" );
+  AliLoader* loader = runLoader->GetLoader( "ADLoader" );
 
-   if(!loader) {
-      AliError("Can not get AD loader");
-      return;
-   }
-   loader->LoadDigits("update");
-   TTree* ADDigitsTree = loader->TreeD();
+  if(!loader) {
+    AliError("Can not get AD loader");
+    return;
+  }
+  loader->LoadDigits("update");
+  TTree* ADDigitsTree = loader->TreeD();
 
-   if (!ADDigitsTree) {
-      AliError("Can not get the AD digit tree");
-      return;
-   }
-   TClonesArray* ADDigits = NULL;
-   TBranch* digitBranch = ADDigitsTree->GetBranch("ADDigit");
-   digitBranch->SetAddress(&ADDigits);
-   
-   AliADTriggerSimulator * triggerSimulator = new AliADTriggerSimulator(ADDigitsTree,ADDigits);
-   triggerSimulator->Run();
-	
-   loader->WriteDigits("OVERWRITE");  
-   loader->UnloadDigits();     
+  if (!ADDigitsTree) {
+    AliError("Can not get the AD digit tree");
+    return;
+  }
+  TClonesArray* ADDigits = NULL;
+  TBranch* digitBranch = ADDigitsTree->GetBranch("ADDigit");
+  digitBranch->SetAddress(&ADDigits);
 
-   if(triggerSimulator->GetBBAandBBC())   SetInput( "AD_BBA_AND_BBC" );
-   if(triggerSimulator->GetBBAorBBC())      SetInput( "AD_BBA_OR_BBC" );
-   if(triggerSimulator->GetBGAandBBC())   SetInput( "AD_BGA_AND_BBC" );
-   if(triggerSimulator->GetBGA())         SetInput( "0UGA" );
-   if(triggerSimulator->GetBGCandBBA())   SetInput( "AD_BGC_AND_BBA" );
-   if(triggerSimulator->GetBGC())         SetInput( "0UGC" );
-   if(triggerSimulator->GetCTA1andCTC1())   SetInput( "AD_CTA1_AND_CTC1" );
-   if(triggerSimulator->GetCTA1orCTC1())   SetInput( "AD_CTA1_OR_CTC1" );
-   if(triggerSimulator->GetCTA2andCTC2())   SetInput( "AD_CTA2_AND_CTC2" );
-   if(triggerSimulator->GetCTA1orCTC1())   SetInput( "AD_CTA1_OR_CTC1" );
-   if(triggerSimulator->GetMTAandMTC())   SetInput( "AD_MTA_AND_MTC" );
-   if(triggerSimulator->GetMTAorMTC())      SetInput( "AD_MTA_OR_MTC" );
-   if(triggerSimulator->GetBBA())         SetInput( "0UBA" );
-   if(triggerSimulator->GetBBC())         SetInput( "0UBC" );
-   if(triggerSimulator->GetBGAorBGC())      SetInput( "AD_BGA_OR_BGC" );
-   if(triggerSimulator->GetBeamGas())      SetInput( "AD_BEAMGAS" );
+  AliADTriggerSimulator * triggerSimulator = new AliADTriggerSimulator(ADDigitsTree,ADDigits);
+  triggerSimulator->Run();
 
-  return;
+  loader->WriteDigits("OVERWRITE");
+  loader->UnloadDigits();
+
+  if (triggerSimulator->GetBBAandBBC())   SetInput("AD_BBA_AND_BBC");
+  if (triggerSimulator->GetBBAorBBC())    SetInput("AD_BBA_OR_BBC");
+  if (triggerSimulator->GetBGAandBBC())   SetInput("AD_BGA_AND_BBC");
+  if (triggerSimulator->GetBGA())         SetInput("0UGA");
+  if (triggerSimulator->GetBGCandBBA())   SetInput("AD_BGC_AND_BBA");
+  if (triggerSimulator->GetBGC())         SetInput("0UGC");
+  if (triggerSimulator->GetCTA1andCTC1()) SetInput("AD_CTA1_AND_CTC1");
+  if (triggerSimulator->GetCTA1orCTC1())  SetInput("AD_CTA1_OR_CTC1");
+  if (triggerSimulator->GetCTA2andCTC2()) SetInput("AD_CTA2_AND_CTC2");
+  if (triggerSimulator->GetCTA1orCTC1())  SetInput("AD_CTA1_OR_CTC1");
+  if (triggerSimulator->GetMTAandMTC())   SetInput("AD_MTA_AND_MTC");
+  if (triggerSimulator->GetMTAorMTC())    SetInput("AD_MTA_OR_MTC");
+  if (triggerSimulator->GetBBA())         SetInput("0UBA");
+  if (triggerSimulator->GetBBC())         SetInput("0UBC");
+  if (triggerSimulator->GetBGAorBGC())    SetInput("AD_BGA_OR_BGC");
+  if (triggerSimulator->GetBeamGas())     SetInput("AD_BEAMGAS");
 }
-
-
-

--- a/AD/ADrec/AliADTrigger.h
+++ b/AD/ADrec/AliADTrigger.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 #ifndef ALIADTrigger_H
 #define ALIADTrigger_H
 // ---------------------
@@ -14,13 +15,13 @@
 
 class AliADTrigger : public AliTriggerDetector
 {
- public:
-                   AliADTrigger();   // constructor
-   virtual        ~AliADTrigger(){}  // destructor
-   virtual void    CreateInputs();
-   virtual void    Trigger();
+public:
+  AliADTrigger();
+  virtual        ~AliADTrigger() {}
+  virtual void    CreateInputs();
+  virtual void    Trigger();
 
-   ClassDef( AliADTrigger, 1 )  // AD Trigger Detector class
+  ClassDef( AliADTrigger, 1);  // AD Trigger Detector class
 };
 
 #endif // AliADTrigger_H

--- a/AD/ADsim/AliAD.cxx
+++ b/AD/ADsim/AliAD.cxx
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 /**************************************************************************
  * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  *                                                                        *
@@ -64,40 +65,28 @@
 #include "AliADCalibData.h"
 #include "AliADConst.h"
 
-ClassImp(AliAD)
- //__________________________________________________________________
+ClassImp(AliAD);
+//__________________________________________________________________
 AliAD::AliAD()
-   : AliDetector(),
-     fCalibData(NULL),
-     fSetADATwoInstalled(0),
-     fSetADCTwoInstalled(0)
+  : AliDetector()
+  , fCalibData(NULL)
+  , fSetADATwoInstalled(kFALSE)
+  , fSetADCTwoInstalled(kFALSE)
 {
-	/// Default Constructor
-    
-
 }
 
 //_____________________________________________________________________________
 AliAD::AliAD(const char *name, const char *title)
-   : AliDetector(name,title),
-     fCalibData(NULL),
-     fSetADATwoInstalled(kTRUE),
-     fSetADCTwoInstalled(kTRUE)
-
+  : AliDetector(name, title)
+  , fCalibData(NULL)
+  , fSetADATwoInstalled(kTRUE)
+  , fSetADCTwoInstalled(kTRUE)
 {
-  
-   // Standard constructor for AD Detector
-  
-
 }
 
 //_____________________________________________________________________________
 AliAD::~AliAD()
 {
-   //
-   // Default destructor for AD Detector
-   //
-  
 }
 
 //_____________________________________________________________________________
@@ -106,31 +95,31 @@ void AliAD::CreateMaterials()
   //
   // MATERIALS FOR ADC AND ADA
   //
-  
+
   // Parameters for simulation scope for ADA and ADC (stolen from AliVZEROv7::CreateMaterials )
-  Int_t    fieldType       = ((AliMagF*)TGeoGlobalMagField::Instance()->GetField())->Integ();     // Field type 
+  Int_t    fieldType       = ((AliMagF*)TGeoGlobalMagField::Instance()->GetField())->Integ();     // Field type
   Double_t maxField        = ((AliMagF*)TGeoGlobalMagField::Instance()->GetField())->Max();       // Field max.
   // Int_t   isxfld1 = ((AliMagF*)TGeoGlobalMagField::Instance()->GetField())->Integ();
   // Float_t sxmgmx  = ((AliMagF*)TGeoGlobalMagField::Instance()->GetField())->Max();
-  Int_t    isxfld2         = ((AliMagF*)TGeoGlobalMagField::Instance()->GetField())->PrecInteg();
+  // Int_t    isxfld2         = ((AliMagF*)TGeoGlobalMagField::Instance()->GetField())->PrecInteg(); not used
   Double_t maxBending      = 10;    // Max Angle
-  Double_t maxStepSize     = 0.01;  // Max step size 
+  Double_t maxStepSize     = 0.01;  // Max step size
   Double_t maxEnergyLoss   = 1;     // Max Delta E
   Double_t precision       = 0.003; // Precision
-  Double_t minStepSize     = 0.003; // Minimum step size 
+  Double_t minStepSize     = 0.003; // Minimum step size
   Float_t  density,  as[11], zs[11], ws[11];
   Double_t radLength, absLength, a_ad, z_ad;
   Int_t    id;
-  
+
   //
   // Air
   //
   Float_t aAir[4]={12.0107,14.0067,15.9994,39.948};
   Float_t zAir[4]={6.,7.,8.,18.};
   Float_t wAir[4]={0.000124,0.755267,0.231781,0.012827};
-  Float_t dAir = 1.20479E-3;
+  // Float_t dAir = 1.20479E-3; not used
   Float_t dAir1 = 1.20479E-10;
-  // Steel  
+  // Steel
   Float_t asteel[4] = { 55.847,51.9961, 58.6934, 28.0855 };
   Float_t zsteel[4] = {    26.,    24.,     28., 14.     };
   Float_t wsteel[4] = {   .715,    .18,      .1, .005    };
@@ -140,13 +129,13 @@ void AliAD::CreateMaterials()
   Float_t acasti[4] = {55.847,12.011,28.085,54.938};
   Float_t zcasti[4] = {26.,6.,14.,25.};
   Float_t wcasti[4] = {0.929,0.035,0.031,0.005};
-  // --- Define the various materials for GEANT --- 
-  //     Aluminum 
+  // --- Define the various materials for GEANT ---
+  //     Aluminum
   AliMaterial(9,  "ALU1      ", 26.98, 13., 2.7, 8.9, 37.2);
   AliMaterial(29, "ALU2      ", 26.98, 13., 2.7, 8.9, 37.2);
   AliMaterial(49, "ALU3      ", 26.98, 13., 2.7, 8.9, 37.2);
-  
-  //     Iron 
+
+  //     Iron
   AliMaterial(10, "IRON1     ", 55.85, 26., 7.87, 1.76, 17.1);
   AliMaterial(30, "IRON2     ", 55.85, 26., 7.87, 1.76, 17.1);
   AliMaterial(50, "IRON3     ", 55.85, 26., 7.87, 1.76, 17.1);
@@ -156,238 +145,237 @@ void AliAD::CreateMaterials()
   AliMaterial(11, "COPPER1   ", 63.55, 29., 8.96, 1.43, 15.1);
   AliMaterial(31, "COPPER2   ", 63.55, 29., 8.96, 1.43, 15.1);
   AliMaterial(51, "COPPER3   ", 63.55, 29., 8.96, 1.43, 15.1);
-  
-  //     Vacuum 
+
+  //     Vacuum
   AliMixture(16, "VACUUM1 ", aAir, zAir, dAir1, 4, wAir);
   AliMixture(36, "VACUUM2 ", aAir, zAir, dAir1, 4, wAir);
   AliMixture(56, "VACUUM3 ", aAir, zAir, dAir1, 4, wAir);
-  
-  //     Stainless Steel 
+
+  //     Stainless Steel
   AliMixture(19, "STAINLESS STEEL1", asteel, zsteel, 7.88, 4, wsteel);
   AliMixture(39, "STAINLESS STEEL2", asteel, zsteel, 7.88, 4, wsteel);
   AliMixture(59, "STAINLESS STEEL3", asteel, zsteel, 7.88, 4, wsteel);
-  
+
   //     Cast iron
   AliMixture(18, "CAST IRON1", acasti, zcasti, 7.2, 4, wcasti);
   AliMixture(38, "CAST IRON2", acasti, zcasti, 7.2, 4, wcasti);
   AliMixture(58, "CAST IRON3", acasti, zcasti, 7.2, 4, wcasti);
-  // **************** 
-  //     Defines tracking media parameters. 
-  //     Les valeurs sont commentees pour laisser le defaut 
-  //     a GEANT (version 3-21, page CONS200), f.m. 
+  // ****************
+  //     Defines tracking media parameters.
+  //     Les valeurs sont commentees pour laisser le defaut
+  //     a GEANT (version 3-21, page CONS200), f.m.
   Float_t epsil, stmin, tmaxfd, deemax, stemax;
-  epsil  = .001;  // Tracking precision, 
-  stemax = -1.;   // Maximum displacement for multiple scat 
-  tmaxfd = -20.;  // Maximum angle due to field deflection 
-  deemax = -.3;   // Maximum fractional energy loss, DLS 
+  epsil  = .001;  // Tracking precision,
+  stemax = -1.;   // Maximum displacement for multiple scat
+  tmaxfd = -20.;  // Maximum angle due to field deflection
+  deemax = -.3;   // Maximum fractional energy loss, DLS
   stmin  = -.8;
-  // *************** 
-  
-  //    Aluminum 
+  // ***************
+
+  //    Aluminum
   AliMedium(9,  "ALU_C0          ", 9, 0,  fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
   AliMedium(29, "ALU_C1          ", 29, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
   AliMedium(49, "ALU_C2          ", 49, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
-  
-  //    Iron 
+
+  //    Iron
   AliMedium(10, "FE_C0           ", 10, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
   AliMedium(30, "FE_C1           ", 30, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
   AliMedium(50, "FE_C2           ", 50, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
 
-  //    Copper 
+  //    Copper
   AliMedium(11, "Cu_C0           ", 11, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
   AliMedium(31, "Cu_C1           ", 31, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
   AliMedium(51, "Cu_C2           ", 51, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
-  
-  //    Vacuum 
+
+  //    Vacuum
   AliMedium(16, "VA_C0           ", 16, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
   AliMedium(36, "VA_C1           ", 36, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
   AliMedium(56, "VA_C2           ", 56, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
-  
-  //    Steel 
+
+  //    Steel
   AliMedium(19, "ST_C0           ", 19, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
   AliMedium(39, "ST_C1           ", 39, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
   AliMedium(59, "ST_C3           ", 59, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
 
-   //
-   // Parameters  for AD scintillator: NE-102 (BC400)
-   //
-   // NE-102, has the following properties : (from internet, need better reference)
-   //    Density : ca. 1.03 g/cm3
-   //    Electrons/cm3: 3.39 x 10^23
-   //    H atoms/cm3: 5.28 x 10^22
-   //    C atoms/cm3: 4.78 x 10^22
-   //    Ratio of H to C : 1.104 .
-   //    wavelength of emission : ~4.23 nm.
-   //    Decay time : ~2.4 ns.
-   //    Luminescent efficiency : typically 18% of NaI(Tl)
-   //    Photons/MeV: 2.5 x 10^4 
-   //
-   // H                // C 
-   // as[0] = 1.00794;    as[1] = 12.011;
-   // zs[0] = 1.;         zs[1] = 6.;
-   // ws[0] = 5.23;       ws[1] = 4.74;
-   // density = 1.032;
-   // id      = 1;
-   // AliMixture( id, "NE102", as, zs, density, -2, ws );
-   // AliMedium( id, "NE102", id, 1, fieldType, maxField, maxBending, maxStepSize,
-   //            maxEnergyLoss, precision, minStepSize );
+  //
+  // Parameters  for AD scintillator: NE-102 (BC400)
+  //
+  // NE-102, has the following properties : (from internet, need better reference)
+  //    Density : ca. 1.03 g/cm3
+  //    Electrons/cm3: 3.39 x 10^23
+  //    H atoms/cm3: 5.28 x 10^22
+  //    C atoms/cm3: 4.78 x 10^22
+  //    Ratio of H to C : 1.104 .
+  //    wavelength of emission : ~4.23 nm.
+  //    Decay time : ~2.4 ns.
+  //    Luminescent efficiency : typically 18% of NaI(Tl)
+  //    Photons/MeV: 2.5 x 10^4
+  //
+  // H                // C
+  // as[0] = 1.00794;    as[1] = 12.011;
+  // zs[0] = 1.;         zs[1] = 6.;
+  // ws[0] = 5.23;       ws[1] = 4.74;
+  // density = 1.032;
+  // id      = 1;
+  // AliMixture( id, "NE102", as, zs, density, -2, ws );
+  // AliMedium( id, "NE102", id, 1, fieldType, maxField, maxBending, maxStepSize,
+  //            maxEnergyLoss, precision, minStepSize );
 
-   // ecalvovi@cern.ch
-   // Parameters  for AD scintillator: BC404
-   //
-   // NE-102, has the following properties : (from internet, need better reference)
-   //    Density : ca. 1.032 g/cm3
-   //    Electrons/cm3: 3.37 x 10^23
-   //    H atoms/cm3: 5.21 x 10^22
-   //    C atoms/cm3: 4.74 x 10^22
-   //    Ratio of H to C : 1.100 
-   //    wavelength of emission : 408 nm.
-   //    Decay time : 1.8 ns.
-   //    Luminescent efficiency : typically 18% of NaI(Tl)
-   //    Photons/MeV: ??
-   //
-   // H                // C 
-   as[0] = 1.00794;    as[1] = 12.011;
-   zs[0] = 1.;         zs[1] = 6.;
-   ws[0] = 5.21;       ws[1] = 4.74;
-   density = 1.032;
-   id      = 1;
-   AliMixture( id, "BC404", as, zs, density, -2, ws );
-   AliMedium ( id, "BC404", id, 1, fieldType, maxField, maxBending, maxStepSize,
+  // ecalvovi@cern.ch
+  // Parameters  for AD scintillator: BC404
+  //
+  // NE-102, has the following properties : (from internet, need better reference)
+  //    Density : ca. 1.032 g/cm3
+  //    Electrons/cm3: 3.37 x 10^23
+  //    H atoms/cm3: 5.21 x 10^22
+  //    C atoms/cm3: 4.74 x 10^22
+  //    Ratio of H to C : 1.100
+  //    wavelength of emission : 408 nm.
+  //    Decay time : 1.8 ns.
+  //    Luminescent efficiency : typically 18% of NaI(Tl)
+  //    Photons/MeV: ??
+  //
+  // H                // C
+  as[0] = 1.00794;    as[1] = 12.011;
+  zs[0] = 1.;         zs[1] = 6.;
+  ws[0] = 5.21;       ws[1] = 4.74;
+  density = 1.032;
+  id      = 1;
+  AliMixture( id, "BC404", as, zs, density, -2, ws );
+  AliMedium ( id, "BC404", id, 1, fieldType, maxField, maxBending, maxStepSize,
               maxEnergyLoss, precision, minStepSize );
-   // parameters AliMedium: numed  name   nmat   isvol  ifield fieldm tmaxfd stemax deemax epsil  stmin  
-   // ... 
-   // isvol       sensitive volume if isvol!=0
-   // ifield      magnetic field flag (see below)
-   // fieldm      maximum magnetic field
-   // ...
-   // ifield =  0       no magnetic field
-   //        = -1       user decision in guswim
-   //        =  1       tracking performed with Runge Kutta
-   //        =  2       tracking performed with helix
-   //        =  3       constant magnetic field along z
+  // parameters AliMedium: numed  name   nmat   isvol  ifield fieldm tmaxfd stemax deemax epsil  stmin
+  // ...
+  // isvol       sensitive volume if isvol!=0
+  // ifield      magnetic field flag (see below)
+  // fieldm      maximum magnetic field
+  // ...
+  // ifield =  0       no magnetic field
+  //        = -1       user decision in guswim
+  //        =  1       tracking performed with Runge Kutta
+  //        =  2       tracking performed with helix
+  //        =  3       constant magnetic field along z
 
 
-   //
-   // Parameters for lightGuide:  
-   //     TODO check material 
-   // Should be Poly(methyl methacrylate) (PMMA) acrylic 
-   // (C5O2H8)n 
-   // Density  1.18 g/cm3
-   // Mixture PMMA    Aeff=12.3994 Zeff=6.23653 rho=1.18 radlen=34.0677 intlen=63.3073
-   // Element #0 : C  Z=  6.00 A= 12.01 w= 0.600 natoms=5
-   // Element #1 : H  Z=  1.00 A=  1.01 w= 0.081 natoms=8
-   // Element #2 : O  Z=  8.00 A= 16.00 w= 0.320 natoms=2
+  //
+  // Parameters for lightGuide:
+  //     TODO check material
+  // Should be Poly(methyl methacrylate) (PMMA) acrylic
+  // (C5O2H8)n
+  // Density  1.18 g/cm3
+  // Mixture PMMA    Aeff=12.3994 Zeff=6.23653 rho=1.18 radlen=34.0677 intlen=63.3073
+  // Element #0 : C  Z=  6.00 A= 12.01 w= 0.600 natoms=5
+  // Element #1 : H  Z=  1.00 A=  1.01 w= 0.081 natoms=8
+  // Element #2 : O  Z=  8.00 A= 16.00 w= 0.320 natoms=2
 
-   // Carbon          Hydrogen          Oxygen
-   as[0] = 12.0107;   as[1] = 1.00794;  as[2] = 15.9994;
-   zs[0] = 6.;        zs[1] = 1.;       zs[2] = 8.;
-   ws[0] = 0.60;      ws[1] = 0.081;    ws[2] = 0.32;
-   density = 1.18;
-   id      = 2;
-   AliMixture( id, "PMMA", as, zs, density, 3, ws );
-   AliMedium( id,"PMMA", id, 1, fieldType, maxField, maxBending, maxStepSize,
-              maxEnergyLoss, precision, minStepSize );
+  // Carbon          Hydrogen          Oxygen
+  as[0] = 12.0107;   as[1] = 1.00794;  as[2] = 15.9994;
+  zs[0] = 6.;        zs[1] = 1.;       zs[2] = 8.;
+  ws[0] = 0.60;      ws[1] = 0.081;    ws[2] = 0.32;
+  density = 1.18;
+  id      = 2;
+  AliMixture( id, "PMMA", as, zs, density, 3, ws );
+  AliMedium( id,"PMMA", id, 1, fieldType, maxField, maxBending, maxStepSize,
+             maxEnergyLoss, precision, minStepSize );
 
-   
-   // mu-metal
-   // Niquel          Iron              Molybdenum        Manganese
-   as[0] = 58.6934;   as[1] = 55.845;   as[2] = 95.94;    as[3] = 54.9380;  
-   zs[0] = 28.;       zs[1] = 26.;      zs[2] = 42.;      zs[3] = 25.;   
-   ws[0] = 0.802;     ws[1] = 0.14079;  ws[2] = 0.0485;   ws[3] = 0.005;
-   // Silicon         Chromium          Cobalt            Aluminium
-   as[4] = 28.0855;   as[5] = 51.9961;  as[6] = 58.9332;  as[7] = 26.981539;   
-   zs[4] = 14.;       zs[5] = 24.;      zs[6] = 27.;      zs[7] = 13.;   
-   ws[4] = 0.003;     ws[5] = 0.0002;   ws[6] = 0.0002;   ws[7] = 0.0001;
-   // Carbon          Phosphorus        Sulfur
-   as[8] = 12.0107;   as[9] = 30.97376; as[10] = 32.066;
-   zs[8] = 6.;        zs[9] = 15.;      zs[10] = 16.;
-   ws[8] = 0.00015;   ws[9] = 0.00005;  ws[10] = 0.00001;
-   density = 8.25;
-   id      = 3;
-   AliMixture( id, "MuMetal", as, zs, density, 11, ws );
-   AliMedium( id,"MuMetal", id, 1, fieldType, maxField, maxBending, maxStepSize,
-              maxEnergyLoss, precision, minStepSize );
 
-   // Parameters for ADCPMA: Aluminium
-   a_ad = 26.98; 
-   z_ad = 13.00;
-   density   = 2.7;
-   radLength = 8.9;
-   absLength = 37.2;
-   id = 4;
-   AliMaterial (id, "Alum",  a_ad, z_ad, density, radLength, absLength, 0, 0 );
-   AliMedium( id, "Alum", id, 1, fieldType, maxField, maxBending, maxStepSize,
-              maxEnergyLoss, precision, minStepSize );
+  // mu-metal
+  // Niquel          Iron              Molybdenum        Manganese
+  as[0] = 58.6934;   as[1] = 55.845;   as[2] = 95.94;    as[3] = 54.9380;
+  zs[0] = 28.;       zs[1] = 26.;      zs[2] = 42.;      zs[3] = 25.;
+  ws[0] = 0.802;     ws[1] = 0.14079;  ws[2] = 0.0485;   ws[3] = 0.005;
+  // Silicon         Chromium          Cobalt            Aluminium
+  as[4] = 28.0855;   as[5] = 51.9961;  as[6] = 58.9332;  as[7] = 26.981539;
+  zs[4] = 14.;       zs[5] = 24.;      zs[6] = 27.;      zs[7] = 13.;
+  ws[4] = 0.003;     ws[5] = 0.0002;   ws[6] = 0.0002;   ws[7] = 0.0001;
+  // Carbon          Phosphorus        Sulfur
+  as[8] = 12.0107;   as[9] = 30.97376; as[10] = 32.066;
+  zs[8] = 6.;        zs[9] = 15.;      zs[10] = 16.;
+  ws[8] = 0.00015;   ws[9] = 0.00005;  ws[10] = 0.00001;
+  density = 8.25;
+  id      = 3;
+  AliMixture( id, "MuMetal", as, zs, density, 11, ws );
+  AliMedium( id,"MuMetal", id, 1, fieldType, maxField, maxBending, maxStepSize,
+             maxEnergyLoss, precision, minStepSize );
 
-   // Parameters for ADCPMG: Glass for the simulation Aluminium 
-   // TODO fix material
-   a_ad = 26.98; 
-   z_ad = 13.00;
-   density   = 2.7;
-   radLength = 8.9;
-   absLength = 37.2;
-   id = 5;
-   AliMaterial( id, "Glass",  a_ad, z_ad, density, radLength, absLength, 0, 0 );
-   AliMedium( id, "Glass", id, 1, fieldType, maxField, maxBending, maxStepSize,
-              maxEnergyLoss, precision, minStepSize );
+  // Parameters for ADCPMA: Aluminium
+  a_ad = 26.98;
+  z_ad = 13.00;
+  density   = 2.7;
+  radLength = 8.9;
+  absLength = 37.2;
+  id = 4;
+  AliMaterial (id, "Alum",  a_ad, z_ad, density, radLength, absLength, 0, 0 );
+  AliMedium( id, "Alum", id, 1, fieldType, maxField, maxBending, maxStepSize,
+             maxEnergyLoss, precision, minStepSize );
+
+  // Parameters for ADCPMG: Glass for the simulation Aluminium
+  // TODO fix material
+  a_ad = 26.98;
+  z_ad = 13.00;
+  density   = 2.7;
+  radLength = 8.9;
+  absLength = 37.2;
+  id = 5;
+  AliMaterial( id, "Glass",  a_ad, z_ad, density, radLength, absLength, 0, 0 );
+  AliMedium( id, "Glass", id, 1, fieldType, maxField, maxBending, maxStepSize,
+             maxEnergyLoss, precision, minStepSize );
 
 
 }
 //_____________________________________________________________________________
 void AliAD::SetTreeAddress()
 {
-   //
-   // Sets tree address for hits.
-   //
+  //
+  // Sets tree address for hits.
+  //
 
-	TBranch *branch;
-  	char branchname[20];
-  	snprintf(branchname,19,"%s",GetName());
-  	// Branch address for hit tree
-  	TTree *treeH = fLoader->TreeH();
-  	if (treeH ) 
-	{
-    		branch = treeH->GetBranch(branchname);
-    		if (branch) branch->SetAddress(&fHits);
-  	}
+  TBranch *branch;
+  char branchname[20];
+  snprintf(branchname,19,"%s",GetName());
+  // Branch address for hit tree
+  TTree *treeH = fLoader->TreeH();
+  if (treeH )
+    {
+      branch = treeH->GetBranch(branchname);
+      if (branch) branch->SetAddress(&fHits);
+    }
 }
 
 
 //_____________________________________________________________________________
 void AliAD::MakeBranch(Option_t* opt)
 {
-	const char* oH = strstr(opt,"H");
-	if (fLoader->TreeH() && oH && (fHits==0x0))
-	{
-		fHits = new TClonesArray("AliADhit",1000);
-		fNhits = 0;
-	}
-	AliDetector::MakeBranch(opt);
+  const char* oH = strstr(opt,"H");
+  if (fLoader->TreeH() && oH && !fHits) {
+    fHits = new TClonesArray("AliADhit",1000);
+    fNhits = 0;
+  }
+  AliDetector::MakeBranch(opt);
 }
 //_____________________________________________________________________________
 AliLoader* AliAD::MakeLoader(const char* topfoldername)
-{ 
- 
-   AliDebug(1,Form("Creating AliADLoader, Top folder is %s ",topfoldername));
-   fLoader = new AliADLoader(GetName(),topfoldername);
-   return fLoader;
+{
+
+  AliDebugF(1, "Creating AliADLoader, Top folder is %s ",topfoldername);
+  fLoader = new AliADLoader(GetName(),topfoldername);
+  return fLoader;
 }
 
 //_____________________________________________________________________________
 AliDigitizer* AliAD::CreateDigitizer(AliDigitizationInput* digInput) const
 {
-   //
-   // Creates a digitizer for AD
-   //
-   return new AliADDigitizer(digInput);
+  //
+  // Creates a digitizer for AD
+  //
+  return new AliADDigitizer(digInput);
 }
 //_____________________________________________________________________________
 void AliAD::Hits2Digits(){
   //
   // Converts hits to digits
   //
-  // Creates the AD digitizer 
+  // Creates the AD digitizer
   AliADDigitizer* dig = new AliADDigitizer(this,AliADDigitizer::kHits2Digits);
 
   // Creates the digits
@@ -402,7 +390,7 @@ void AliAD::Hits2SDigits(){
   //
   // Converts hits to summable digits
   //
-  // Creates the AD digitizer 
+  // Creates the AD digitizer
   AliADDigitizer* dig = new AliADDigitizer(this,AliADDigitizer::kHits2SDigits);
 
   // Creates the sdigits
@@ -416,114 +404,112 @@ void AliAD::Hits2SDigits(){
 
 void AliAD::Digits2Raw()
 {
-   //
-   //  Converts digits of the current event to raw data
-   //
-   GetCalibData();
-   
-   AliAD *fAD = (AliAD*)gAlice->GetDetector("AD");
-   fLoader->LoadDigits();
-   TTree* digits = fLoader->TreeD();
-   if (!digits) {
-      Error("Digits2Raw", "no digits tree");
-      return;
-   }
-   TClonesArray * ADdigits = new TClonesArray("AliADdigit",1000);
-   fAD->SetTreeAddress();  		
-   digits->GetBranch("ADDigit")->SetAddress(&ADdigits); 
-  
-   const char *fileName    = AliDAQ::DdlFileName("AD",0);
-   AliADBuffer* buffer  = new AliADBuffer(fileName);
-   
-   // Get Trigger information first
-   // Read trigger inputs from trigger-detector object
-   AliDataLoader * dataLoader = fLoader->GetDigitsDataLoader();
-   if( !dataLoader->IsFileOpen() ) 
-        dataLoader->OpenFile("READ");
-   AliTriggerDetector* trgdet = (AliTriggerDetector*)dataLoader->GetDirectory()->Get("Trigger");
-   UInt_t triggerInfo = 0;
-   if(trgdet) {
-      triggerInfo = trgdet->GetMask() & 0xffff;
-   }
-   else {
-      AliError(Form("There is no trigger object for %s",fLoader->GetName()));
-   }
+  //
+  //  Converts digits of the current event to raw data
+  //
+  GetCalibData();
 
-   buffer->WriteTriggerInfo((UInt_t)triggerInfo); 
-   buffer->WriteTriggerScalers(); 
-   buffer->WriteBunchNumbers(); 
-  
-   // Now retrieve the channel information: charge smaples + time and 
-   // dump it into ADC and Time arrays
-   Int_t nEntries = Int_t(digits->GetEntries());
-   Short_t aADC[16][kADNClocks];
-   Short_t aTime[16];
-   Short_t aWidth[16];
-   Bool_t  aIntegrator[16];
-   Bool_t  aBBflag[16];
-   Bool_t  aBGflag[16];
-  
-   for (Int_t i = 0; i < nEntries; i++) {
-     fAD->ResetDigits();
-     digits->GetEvent(i);
-     Int_t ndig = ADdigits->GetEntriesFast(); 
-   
-     if(ndig == 0) continue;
-     for(Int_t k=0; k<ndig; k++){
-         AliADdigit* fADDigit = (AliADdigit*) ADdigits->At(k);
+  AliAD *fAD = (AliAD*)gAlice->GetDetector("AD");
+  fLoader->LoadDigits();
+  TTree* digits = fLoader->TreeD();
+  if (!digits) {
+    Error("Digits2Raw", "no digits tree");
+    return;
+  }
+  TClonesArray * ADdigits = new TClonesArray("AliADdigit",1000);
+  fAD->SetTreeAddress();
+  digits->GetBranch("ADDigit")->SetAddress(&ADdigits);
 
-	 Int_t iChannel       = kOnlineChannel[fADDigit->PMNumber()];
-	 
-	 for(Int_t iClock = 0; iClock < kADNClocks; ++iClock) aADC[iChannel][iClock] = fADDigit->ChargeADC(20-iClock);
-	 Int_t board = AliADCalibData::GetBoardNumber(iChannel);
-	 aTime[iChannel]      = TMath::Nint(fADDigit->Time() / fCalibData->GetTimeResolution(board));
-	 aWidth[iChannel]     = TMath::Nint(fADDigit->Width() / fCalibData->GetWidthResolution(board));
-	 aIntegrator[iChannel]= fADDigit->Integrator();
-	 aBBflag[iChannel]    = fADDigit->GetBBflag();
-	 aBGflag[iChannel]    = fADDigit->GetBGflag();
-	 
-         //AliDebug(1,Form("DDL: %s\tdigit number: %d\tPM number: %d\tADC: %d\tTime: %f",
-			 //fileName,k,fADDigit->PMNumber(),aADC[iChannel][AliADdigit::kADNClocks/2],aTime[iChannel])); 
-     }        
-   }
+  const char *fileName    = AliDAQ::DdlFileName("AD",0);
+  AliADBuffer* buffer  = new AliADBuffer(fileName);
 
-   // Now fill raw data	
-   Int_t iCIU=0;
-   for (Int_t  iV0CIU = 0; iV0CIU < 8; iV0CIU++) {
-   
-      if(iV0CIU != 2 && iV0CIU != 5) {
-       	buffer->WriteEmptyCIU();
-        continue;
-       }
-      // decoding of one Channel Interface Unit numbered iCIU - there are 8 channels per CIU (and 2 CIUs) : 
-      for(Int_t iChannel_Offset = iCIU*8; iChannel_Offset < (iCIU*8)+8; iChannel_Offset=iChannel_Offset+4) { 
-         for(Int_t iChannel = iChannel_Offset; iChannel < iChannel_Offset+4; iChannel++) {
-             buffer->WriteChannel(iChannel, aADC[iChannel], aIntegrator[iChannel]);       
-         }
-         buffer->WriteBeamFlags(&aBBflag[iChannel_Offset],&aBGflag[iChannel_Offset]); 
-         buffer->WriteMBInfo(); 
-         buffer->WriteMBFlags();   
-         buffer->WriteBeamScalers(); 
-      } 
+  // Get Trigger information first
+  // Read trigger inputs from trigger-detector object
+  AliDataLoader * dataLoader = fLoader->GetDigitsDataLoader();
+  if( !dataLoader->IsFileOpen() )
+    dataLoader->OpenFile("READ");
+  AliTriggerDetector* trgdet = (AliTriggerDetector*)dataLoader->GetDirectory()->Get("Trigger");
+  UInt_t triggerInfo = 0;
+  if(trgdet) {
+    triggerInfo = trgdet->GetMask() & 0xffff;
+  } else {
+    AliErrorF("There is no trigger object for %s",fLoader->GetName());
+  }
 
-      for(Int_t iChannel = iCIU*8 + 7; iChannel >= iCIU*8; iChannel--) {
-          buffer->WriteTiming(aTime[iChannel], aWidth[iChannel]); 
-      } // End of decoding of one CIU card
-      iCIU++;    
+  buffer->WriteTriggerInfo((UInt_t)triggerInfo);
+  buffer->WriteTriggerScalers();
+  buffer->WriteBunchNumbers();
+
+  // Now retrieve the channel information: charge smaples + time and
+  // dump it into ADC and Time arrays
+  Int_t nEntries = Int_t(digits->GetEntries());
+  Short_t aADC[16][kADNClocks];
+  Short_t aTime[16];
+  Short_t aWidth[16];
+  Bool_t  aIntegrator[16];
+  Bool_t  aBBflag[16];
+  Bool_t  aBGflag[16];
+
+  for (Int_t i = 0; i < nEntries; i++) {
+    fAD->ResetDigits();
+    digits->GetEvent(i);
+    Int_t ndig = ADdigits->GetEntriesFast();
+
+    if(ndig == 0) continue;
+    for(Int_t k=0; k<ndig; k++){
+      AliADdigit* fADDigit = (AliADdigit*) ADdigits->At(k);
+
+      Int_t iChannel       = kOnlineChannel[fADDigit->PMNumber()];
+
+      for(Int_t iClock = 0; iClock < kADNClocks; ++iClock) aADC[iChannel][iClock] = fADDigit->ChargeADC(20-iClock);
+      Int_t board = AliADCalibData::GetBoardNumber(iChannel);
+      aTime[iChannel]      = TMath::Nint(fADDigit->Time() / fCalibData->GetTimeResolution(board));
+      aWidth[iChannel]     = TMath::Nint(fADDigit->Width() / fCalibData->GetWidthResolution(board));
+      aIntegrator[iChannel]= fADDigit->Integrator();
+      aBBflag[iChannel]    = fADDigit->GetBBflag();
+      aBGflag[iChannel]    = fADDigit->GetBGflag();
+
+      //AliDebug(1,Form("DDL: %s\tdigit number: %d\tPM number: %d\tADC: %d\tTime: %f",
+      //fileName,k,fADDigit->PMNumber(),aADC[iChannel][AliADdigit::kADNClocks/2],aTime[iChannel]));
+    }
+  }
+
+  // Now fill raw data
+  Int_t iCIU=0;
+  for (Int_t  iV0CIU = 0; iV0CIU < 8; iV0CIU++) {
+    if(iV0CIU != 2 && iV0CIU != 5) {
+      buffer->WriteEmptyCIU();
+      continue;
+    }
+    // decoding of one Channel Interface Unit numbered iCIU - there are 8 channels per CIU (and 2 CIUs) :
+    for(Int_t iChannel_Offset = iCIU*8; iChannel_Offset < (iCIU*8)+8; iChannel_Offset=iChannel_Offset+4) {
+      for(Int_t iChannel = iChannel_Offset; iChannel < iChannel_Offset+4; iChannel++) {
+        buffer->WriteChannel(iChannel, aADC[iChannel], aIntegrator[iChannel]);
+      }
+      buffer->WriteBeamFlags(&aBBflag[iChannel_Offset],&aBGflag[iChannel_Offset]);
+      buffer->WriteMBInfo();
+      buffer->WriteMBFlags();
+      buffer->WriteBeamScalers();
+    }
+
+    for(Int_t iChannel = iCIU*8 + 7; iChannel >= iCIU*8; iChannel--) {
+      buffer->WriteTiming(aTime[iChannel], aWidth[iChannel]);
+    } // End of decoding of one CIU card
+    iCIU++;
   } // end of decoding the eight CIUs
 
-     
+
   delete buffer;
-  fLoader->UnloadDigits();  
+  fLoader->UnloadDigits();
 }
 
 //_____________________________________________________________________________
 
 Bool_t AliAD::Raw2SDigits(AliRawReader* rawReader)
 {
-	// reads raw data to produce sdigits
-	// for AD not implemented yet 
-	return kTRUE;
+  // reads raw data to produce sdigits
+  // for AD not implemented yet
+  return kTRUE;
 }
 
 //_____________________________________________________________________________
@@ -536,6 +522,6 @@ void AliAD::GetCalibData()
   AliCDBEntry *entry = AliCDBManager::Instance()->Get("AD/Calib/Data");
   if (entry) fCalibData = (AliADCalibData*) entry->GetObject();
   if (!fCalibData)  AliFatal("No calibration data from calibration database !");
-  
+
   return;
 }

--- a/AD/ADsim/AliAD.h
+++ b/AD/ADsim/AliAD.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 #ifndef ALIAD_H
 #define ALIAD_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
@@ -15,43 +16,40 @@
 
 class AliADCalibData;
 
-  
-class AliAD : public AliDetector {
- 
-public:
 
-                        AliAD();
-                        AliAD(const char *name, const char *title);
-  virtual              ~AliAD();
-  virtual	void	CreateMaterials();
-  virtual      Int_t     IsVersion() const { return -1;}
-  virtual      TString   Version() { return TString("");}
-  virtual      void     SetTreeAddress();  
-  virtual      void MakeBranch(Option_t* opt = "");
-  virtual      AliLoader*    MakeLoader(const char* topfoldername);
+class AliAD : public AliDetector {
+public:
+  AliAD();
+  AliAD(const char *name, const char *title);
+  virtual ~AliAD();
+
+  virtual      void       CreateMaterials();
+  virtual      Int_t      IsVersion() const { return -1;}
+  virtual      TString    Version() { return TString("");}
+  virtual      void       SetTreeAddress();
+  virtual      void       MakeBranch(Option_t* opt = "");
+  virtual      AliLoader* MakeLoader(const char* topfoldername);
   AliDigitizer*  CreateDigitizer(AliDigitizationInput* digInput) const;
   virtual AliTriggerDetector* CreateTriggerDetector() const { return new AliADTrigger();}
-  
+
   virtual    void       Hits2Digits();
   virtual    void       Hits2SDigits();
   virtual    void       Digits2Raw();
   virtual    Bool_t     Raw2SDigits(AliRawReader*);
-  virtual    void 	SetADATwoInstalled(Bool_t b){fSetADATwoInstalled = b;} // ecv
-  virtual    void  	SetADCTwoInstalled(Bool_t b){fSetADCTwoInstalled = b;} // ecv
-  virtual    Bool_t 	GetADATwoInstalled() const {return fSetADATwoInstalled;}  // ecv
-  virtual    Bool_t 	GetADCTwoInstalled() const {return fSetADCTwoInstalled;}  // ecv
+  virtual    void       SetADATwoInstalled(Bool_t b){fSetADATwoInstalled = b;} // ecv
+  virtual    void       SetADCTwoInstalled(Bool_t b){fSetADCTwoInstalled = b;} // ecv
+  virtual    Bool_t     GetADATwoInstalled() const {return fSetADATwoInstalled;}  // ecv
+  virtual    Bool_t     GetADCTwoInstalled() const {return fSetADCTwoInstalled;}  // ecv
   void                  GetCalibData();
 
-
 private:
-                       AliAD(const AliAD&); 
-                       AliAD& operator = (const AliAD&);
-  AliADCalibData *fCalibData;      //! Pointer to the calibration object 
-  Bool_t	fSetADATwoInstalled; 
-  Bool_t	fSetADCTwoInstalled; 
+  AliAD(const AliAD&);
+  AliAD& operator = (const AliAD&);
+  AliADCalibData *fCalibData;      //! Pointer to the calibration object
+  Bool_t          fSetADATwoInstalled;
+  Bool_t          fSetADCTwoInstalled;
 
-
-  ClassDef(AliAD,1)  // Base Class for the AD detector
+  ClassDef(AliAD,1);  // Base Class for the AD detector
 };
 
 #endif

--- a/AD/ADsim/AliADBuffer.cxx
+++ b/AD/ADsim/AliADBuffer.cxx
@@ -29,23 +29,21 @@
 #include "AliADConst.h"
 #include "AliFstream.h"
 
-ClassImp(AliADBuffer)
+ClassImp(AliADBuffer);
 
 //_____________________________________________________________________________
-AliADBuffer::AliADBuffer():TObject(),
-    fRemainingWord(0),
-    f()
+AliADBuffer::AliADBuffer()
+  : TObject()
+  , fRemainingWord(0)
+  , f()
 {
-  //
-  // default constructor
-  //
 }
 //_____________________________________________________________________________
-AliADBuffer::AliADBuffer(const char* fileName):TObject(),
-    fRemainingWord(0),
-    f()
+AliADBuffer::AliADBuffer(const char* fileName)
+  : TObject()
+  , fRemainingWord(0)
+  , f()
 {
-  // Constructor
   f = new AliFstream(fileName);
   AliRawDataHeaderSim header;
   f->WriteBuffer((char*)(&header), sizeof(header));
@@ -61,6 +59,7 @@ AliADBuffer::~AliADBuffer(){
   f->Seekp(0);
   f->WriteBuffer((char*)(&header), sizeof(header));
   delete f;
+  f = NULL;
 }
 
 //_____________________________________________________________________________
@@ -84,41 +83,41 @@ void AliADBuffer::WriteTriggerScalers() {
 
   // First the general trigger scalers (16 of them)
   for(Int_t i = 0; i < 16; i++) {
-      UInt_t data = 0;
-      f->WriteBuffer((char*)&data,sizeof(data));
+    UInt_t data = 0;
+    f->WriteBuffer((char*)&data,sizeof(data));
   }
 }
 
 //_____________________________________________________________________________
 void AliADBuffer::WriteBunchNumbers() {
-  // The method writes the Bunch Numbers corresponding 
+  // The method writes the Bunch Numbers corresponding
   // to the 10 Minimum Bias events
   // For the moment there is no way to simulate
   // this, so we fill the necessary 10 words with 0
 
   // First the bunch crossing numbers
   // for these 10 events
-  
+
   for(Int_t i = 0; i < 10; i++) {
-      UInt_t data = 0;
-      f->WriteBuffer((char*)&data,sizeof(data));
+    UInt_t data = 0;
+    f->WriteBuffer((char*)&data,sizeof(data));
   }
 
 }
 
 //_____________________________________________________________________________
 void AliADBuffer::WriteChannel(Int_t channel, Short_t *adc, Bool_t integrator){
-  // It writes AD charge information into a raw data file. 
+  // It writes AD charge information into a raw data file.
   // Being called by Digits2Raw
-  
+
   UInt_t data = 0;
   for(Int_t i = 0; i < kADNClocks; ++i) {
     if (adc[i] > 1023) {
-      AliWarning(Form("ADC (channel=%d) saturated: %d. Truncating to 1023",channel,adc[i]));
+      AliWarningF("ADC (channel=%d) saturated: %d. Truncating to 1023",channel,adc[i]);
       adc[i] = 1023;
     }
   }
-  
+
   if(channel%2 == 0) {
     for(Int_t i = 0; i < (kADNClocks/2); ++i) {
       data =   (adc[2*i] & 0x3ff);
@@ -148,14 +147,14 @@ void AliADBuffer::WriteChannel(Int_t channel, Short_t *adc, Bool_t integrator){
       f->WriteBuffer((char*)&data,sizeof(data));
     }
   }
-    
+
 }
 
 //_____________________________________________________________________________
 void AliADBuffer::WriteBeamFlags(Bool_t *bbFlag, Bool_t *bgFlag) {
   // The method writes information about
-  // the Beam-Beam and Beam-Gas flags i.e. 
-  // 6  words for the 4 channels 
+  // the Beam-Beam and Beam-Gas flags i.e.
+  // 6  words for the 4 channels
   // of half a CIU card
 
   // Beam-beam and beam-gas flags are available
@@ -175,7 +174,7 @@ void AliADBuffer::WriteBeamFlags(Bool_t *bbFlag, Bool_t *bgFlag) {
       if (bgFlag[iChannel]) data |= (1 << (2*iChannel + 17));
     }
     f->WriteBuffer((char*)&data,sizeof(data));
-  }  
+  }
   for(Int_t i = 0; i < 3; i++) {
     UInt_t data = 0;
     f->WriteBuffer((char*)&data,sizeof(data));
@@ -188,9 +187,8 @@ void AliADBuffer::WriteMBInfo() {
   // The method writes information about
   // the 10 previous minimum-bias events
   // i.e. channels charge for each of these
-  // 10 events (4*10 shorts for the 4 channels 
+  // 10 events (4*10 shorts for the 4 channels
   // of half a CIU card)
-    
   for(Int_t i = 0; i < 20; i++) {
     UInt_t data = 0;
     f->WriteBuffer((char*)&data,sizeof(data));
@@ -202,14 +200,12 @@ void AliADBuffer::WriteMBInfo() {
 void AliADBuffer::WriteMBFlags() {
   // The method writes information about
   // the Minimum Bias flags
-  // 5 16-bits words for the 4 channels 
+  // 5 16-bits words for the 4 channels
   // of half a CIU card + one empty 16-bit
-
-
   for(Int_t i = 0; i < 3; i++) {
     UInt_t data = 0;
-    f->WriteBuffer((char*)&data,sizeof(data));  
-    }
+    f->WriteBuffer((char*)&data,sizeof(data));
+  }
 }
 
 //_____________________________________________________________________________
@@ -221,7 +217,7 @@ void AliADBuffer::WriteBeamScalers() {
   // Beam-beam and beam-gas scalers for
   // 4 individual channel (4x4 words)
   // (64-bit + 64-bit)*4 = 32bit * 16
-  
+
   for(Int_t i = 0; i < 16; i++) {
     UInt_t data = 0;
     f->WriteBuffer((char*)&data,sizeof(data));
@@ -230,7 +226,7 @@ void AliADBuffer::WriteBeamScalers() {
 
 //_____________________________________________________________________________
 void AliADBuffer::WriteTiming(Short_t time, Short_t width) {
-  // It writes the timing information into a raw data file. 
+  // It writes the timing information into a raw data file.
   // Being called by Digits2Raw
 
   // Writes the timing information
@@ -241,10 +237,10 @@ void AliADBuffer::WriteTiming(Short_t time, Short_t width) {
 
 //_____________________________________________________________________________
 void AliADBuffer::WriteEmptyCIU() {
-  // The method writes holes in stream due to missing CIUs Ad has 2 vrt. to 8 VZERO 
+  // The method writes holes in stream due to missing CIUs Ad has 2 vrt. to 8 VZERO
   // There are 182 words per CIU
   for(Int_t i = 0; i < 182; i++) {
-      UInt_t data = 0;
-      f->WriteBuffer((char*)&data,sizeof(data));
+    UInt_t data = 0;
+    f->WriteBuffer((char*)&data,sizeof(data));
   }
 }

--- a/AD/ADsim/AliADBuffer.h
+++ b/AD/ADsim/AliADBuffer.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 #ifndef AliADBUFFER_H
 #define AliADBUFFER_H
 /* Copyright(c) 1998-2003, ALICE Experiment at CERN, All rights reserved. *
@@ -15,22 +16,22 @@ public:
   AliADBuffer();
   AliADBuffer(const char* fileName); //constructor
   virtual ~AliADBuffer(); //destructor
-  
+
   void    WriteTriggerInfo(UInt_t trigger);
   void    WriteTriggerScalers();
-  void    WriteBunchNumbers();  
+  void    WriteBunchNumbers();
 
   void    WriteChannel(Int_t channel, Short_t *adc, Bool_t integrator);
   void    WriteBeamFlags(Bool_t *bbFlag, Bool_t *bgFlag);
-  
+
   void    WriteMBInfo();
   void    WriteMBFlags();
-    
+
   void    WriteBeamScalers();
 
   void    WriteTiming(Short_t time, Short_t width);
-  
-  void	  WriteEmptyCIU();
+
+  void    WriteEmptyCIU();
 
 private:
   AliADBuffer(const AliADBuffer &source); // copy constructor
@@ -38,7 +39,7 @@ private:
 
   UInt_t      fRemainingWord; // Remaining data word between even and odd channel's data
   AliFstream* f;      //The IO file name
-  ClassDef(AliADBuffer,2)
+  ClassDef(AliADBuffer,2);
 };
 
 #endif

--- a/AD/ADsim/AliADDigitizer.cxx
+++ b/AD/ADsim/AliADDigitizer.cxx
@@ -394,7 +394,6 @@ void AliADDigitizer::DigitizeHits()
   // SDigits (fTime arrays)
   Int_t nTotPhot[16];
   Float_t PMTime[16];
-  Float_t PMTimeWeight[16];
   Int_t nPMHits[16];
 
   for(Int_t i=0; i<16; ++i) {
@@ -402,7 +401,6 @@ void AliADDigitizer::DigitizeHits()
     fLabels[i][0] = fLabels[i][1] = fLabels[i][2] = -1;
     nTotPhot[i] = 0;
     PMTime[i] = 10000;
-    PMTimeWeight[i] = 0;
     nPMHits[i] = 0;
   }
 
@@ -442,7 +440,6 @@ void AliADDigitizer::DigitizeHits()
       nTotPhot[pmt] += nPhot;
       nPMHits[pmt]++;
       //PMTime[pmt] += t*nPhot*nPhot;
-      //PMTimeWeight[pmt] += nPhot*nPhot;
       if (PMTime[pmt]>t) PMTime[pmt] = t;
 
     }//hit loop
@@ -454,7 +451,6 @@ void AliADDigitizer::DigitizeHits()
       PMTime[iPM] = 0.0;
       continue;
     }
-    //PMTime[iPM] = PMTime[iPM]/PMTimeWeight[iPM];
     PMTime[iPM] += fHptdcOffset[iPM];
 
     fChargeSignalShape->SetParameters(fCssOffset[iPM],fCssTau[iPM],fCssSigma[iPM]);

--- a/AD/ADsim/AliADDigitizer.cxx
+++ b/AD/ADsim/AliADDigitizer.cxx
@@ -517,7 +517,7 @@ void AliADDigitizer::DigitizeSDigits()
       if (clock >= 0 && clock < kADNClocks)
         fAdc[ipmt][clock] += fTime[ipmt][iBin]/kADChargePerADC;
     }
-    AliDebug(1,Form("Channel %d Offset %f Time %f",ipmt,fClockOffset[ipmt],fMCTime[ipmt]));
+    AliDebugF(1,"Channel %d Offset %f Time %f",ipmt,fClockOffset[ipmt],fMCTime[ipmt]);
     const Int_t board = AliADCalibData::GetBoardNumber(ipmt);
     if (ltFound && ttFound) {
       fTimeWidth[ipmt] = fCalibData->GetWidthResolution(board)*
@@ -539,7 +539,7 @@ void AliADDigitizer::DigitizeSDigits()
     Float_t adcClock = 0.0;
     for (Int_t iClock=0; iClock<kADNClocks; ++iClock) {
       Int_t integrator = (iClock + fEvenOrOdd) % 2;
-      AliDebug(1,Form("ADC %d %d %f",j,iClock,fAdc[j][iClock]));
+      AliDebugF(1, "ADC %d %d %f",j,iClock,fAdc[j][iClock]);
       fAdc[j][iClock]  += gRandom->Gaus(fAdcPedestal[j][integrator], fAdcSigma[j][integrator]);
     }
     for (Int_t iClock=0; iClock<kADNClocks; ++iClock) {
@@ -693,8 +693,8 @@ void AliADDigitizer::ReadSDigits()
         Int_t pmNumber = sDigit->PMNumber();
         Int_t nbins = sDigit->GetNBins();
         if (nbins != fNBins[pmNumber]) {
-          AliError(Form("Incompatible number of bins between digitizer (%d) and sdigit (%d) for PM %d! Skipping sdigit!",
-                        fNBins[pmNumber],nbins,pmNumber));
+          AliErrorF("Incompatible number of bins between digitizer (%d) and sdigit (%d) for PM %d! Skipping sdigit!",
+		    fNBins[pmNumber],nbins,pmNumber);
           continue;
         }
         // Sum the charges
@@ -914,7 +914,7 @@ void AliADDigitizer::ExtrapolateSplines()
     fTimeSlewingExtpol[i]->SetLineColor(kMagenta);
     Int_t fitStatus =  hTimeVsSignal->Fit(TimeSlewingFitName.Data(),"R"," ",-2.5,-1.5);
     if(fitStatus != 0) {
-      AliWarning(Form("Extrapolation of spline %d not succesfull",i));
+      AliWarningF("Extrapolation of spline %d not succesfull",i);
       fTimeSlewingExtpol[i] = 0x0;
     }
     delete c;
@@ -947,7 +947,7 @@ double AliADDigitizer::TimeSignalShape(double *x, double *par)
   if (xx <= par[3]) return a;
   Double_t b = 1./TMath::Power((xx-par[3])/par[4],1./par[5]);
   Double_t f = a*b/(a+b);
-  AliDebug(100,Form("x=%f func=%f",xx,f));
+  AliDebugF(100,"x=%f func=%f",xx,f);
   return f;
 }
 //____________________________________________________________________

--- a/AD/ADsim/AliADDigitizer.h
+++ b/AD/ADsim/AliADDigitizer.h
@@ -119,7 +119,7 @@ private:
   DigiTask_t fTask;                 //! The task (to be) executed by the digitizer
   AliAD     *fAD;                   //! Pointer to AliDetector object
 
-  ClassDef(AliADDigitizer,6)        // digitizer for AD
+  ClassDef(AliADDigitizer,6);       // digitizer for AD
 } ;
 
 #endif // AliADDigitizer_H

--- a/AD/ADsim/AliADQADataMakerSim.cxx
+++ b/AD/ADsim/AliADQADataMakerSim.cxx
@@ -17,15 +17,15 @@
 /* $Id: AliADQADataMakerSim.cxx 23123 2007-12-18 09:08:18Z hristov $ */
 
 //---
-//  Produces the data needed to calculate the quality assurance. 
+//  Produces the data needed to calculate the quality assurance.
 //  All data must be mergeable objects.
 //  Author : BC
 //---
 
 // --- ROOT system ---
 #include <TClonesArray.h>
-#include <TFile.h> 
-#include <TH1F.h> 
+#include <TFile.h>
+#include <TH1F.h>
 #include <TDirectory.h>
 // --- Standard library ---
 
@@ -33,39 +33,34 @@
 #include "AliESDEvent.h"
 #include "AliLog.h"
 #include "AliADdigit.h"
-#include "AliADSDigit.h" 
+#include "AliADSDigit.h"
 #include "AliADhit.h"
 #include "AliADQADataMakerSim.h"
 #include "AliQAChecker.h"
 
-ClassImp(AliADQADataMakerSim)
-           
-//____________________________________________________________________________ 
-  AliADQADataMakerSim::AliADQADataMakerSim() : 
-  AliQADataMakerSim(AliQAv1::GetDetName(AliQAv1::kAD), "AD Quality Assurance Data Maker")
+ClassImp(AliADQADataMakerSim);
 
+//____________________________________________________________________________
+AliADQADataMakerSim::AliADQADataMakerSim()
+  : AliQADataMakerSim(AliQAv1::GetDetName(AliQAv1::kAD), "AD Quality Assurance Data Maker")
 {
-  // constructor
-
-  
 }
 
-//____________________________________________________________________________ 
-AliADQADataMakerSim::AliADQADataMakerSim(const AliADQADataMakerSim& qadm) :
-  AliQADataMakerSim() 
+//____________________________________________________________________________
+AliADQADataMakerSim::AliADQADataMakerSim(const AliADQADataMakerSim& qadm)
+  : AliQADataMakerSim()
 {
-  //copy constructor 
-
-  SetName((const char*)qadm.GetName()) ; 
-  SetTitle((const char*)qadm.GetTitle()); 
+  SetName((const char*)qadm.GetName()) ;
+  SetTitle((const char*)qadm.GetTitle());
 }
 
 //__________________________________________________________________
 AliADQADataMakerSim& AliADQADataMakerSim::operator = (const AliADQADataMakerSim& qadm )
 {
-  // Assign operator.
-  this->~AliADQADataMakerSim();
-  new(this) AliADQADataMakerSim(qadm);
+  if (this != &qadm) {
+    this->~AliADQADataMakerSim();
+    new(this) AliADQADataMakerSim(qadm); // this is not exception safe!
+  }
   return *this;
 }
 //____________________________________________________________________________
@@ -74,111 +69,110 @@ void AliADQADataMakerSim::EndOfDetectorCycle(AliQAv1::TASKINDEX_t task, TObjArra
   //Detector specific actions at end of cycle
   // do the QA checking
   ResetEventTrigClasses();
- // AliQAChecker::Instance()->Run(AliQAv1::kAD, task, list) ;
+  // AliQAChecker::Instance()->Run(AliQAv1::kAD, task, list) ;
 }
 
- 
-//____________________________________________________________________________ 
+
+//____________________________________________________________________________
 void AliADQADataMakerSim::InitHits()
 {
- 
   // create Hits histograms in Hits subdir
-  const Bool_t expert   = kTRUE ; 
-  const Bool_t image    = kTRUE ; 
-  
-  TH1I * h0 = new TH1I("hHitMultiplicity", "Hit multiplicity distribution in AD;# of Hits;Entries", 300, 0, 299) ; 
+  const Bool_t expert   = kTRUE ;
+  const Bool_t image    = kTRUE ;
+
+  TH1I * h0 = new TH1I("hHitMultiplicity", "Hit multiplicity distribution in AD;# of Hits;Entries", 300, 0, 299) ;
   h0->Sumw2() ;
-  Add2HitsList(h0, 0, !expert, image) ;  
-  
-  TH1I * h1 = new TH1I("hHitCellNumber", "Hit cell distribution in AD;Cell;# of Hits", 16, 0, 16) ; 
+  Add2HitsList(h0, 0, !expert, image) ;
+
+  TH1I * h1 = new TH1I("hHitCellNumber", "Hit cell distribution in AD;Cell;# of Hits", 16, 0, 16) ;
   h1->Sumw2() ;
-  Add2HitsList(h1, 1, !expert, image) ; 
-  
-  TH1I * h2 = new TH1I("hHitNPhotons", "Number of photons per hit in AD;# of Photons;Entries", 100000, 0, 100000) ; 
+  Add2HitsList(h1, 1, !expert, image) ;
+
+  TH1I * h2 = new TH1I("hHitNPhotons", "Number of photons per hit in AD;# of Photons;Entries", 100000, 0, 100000) ;
   h2->Sumw2() ;
   Add2HitsList(h2, 2, !expert, image) ;
-  
-  TH2I * h3 = new TH2I("hCellNPhotons", "Number of photons per cell in AD;Cell;# of Photons", 16, 0, 16, 100000, 0, 100000) ; 
+
+  TH2I * h3 = new TH2I("hCellNPhotons", "Number of photons per cell in AD;Cell;# of Photons", 16, 0, 16, 100000, 0, 100000) ;
   h2->Sumw2() ;
   Add2HitsList(h3, 3, !expert, image) ;
-  
-  TH2D * h4 = new TH2D("hCellTof", "Time of flight per cell in AD;Cell;Time of Flight [ns]", 16, 0, 16, 6000,40,100) ; 
+
+  TH2D * h4 = new TH2D("hCellTof", "Time of flight per cell in AD;Cell;Time of Flight [ns]", 16, 0, 16, 6000,40,100) ;
   h2->Sumw2() ;
-  Add2HitsList(h4, 4, !expert, image) ; 
-   
+  Add2HitsList(h4, 4, !expert, image) ;
+
   //
-  ClonePerTrigClass(AliQAv1::kHITS); // this should be the last line    
+  ClonePerTrigClass(AliQAv1::kHITS); // this should be the last line
 }
 
 
-//____________________________________________________________________________ 
+//____________________________________________________________________________
 void AliADQADataMakerSim::InitSDigits()
 {
   // create Digits histograms in Digits subdir
-  const Bool_t expert   = kTRUE ; 
-  const Bool_t image    = kTRUE ; 
-  
-  TH1I *fhSDigCharge[16]; 
+  const Bool_t expert   = kTRUE ;
+  const Bool_t image    = kTRUE ;
+
+  // TH1I *fhSDigCharge[16];  not used
 
   // create SDigits histograms in SDigits subdir
-  TH1I * h0 = new TH1I("hSDigitMultiplicity", "SDigits multiplicity distribution in AD;# of Digits;Entries", 17,-0.5,16.5) ; 
+  TH1I * h0 = new TH1I("hSDigitMultiplicity", "SDigits multiplicity distribution in AD;# of Digits;Entries", 17,-0.5,16.5) ;
   h0->Sumw2() ;
   Add2SDigitsList(h0, 0, !expert, image) ;
-  
-  TH2D * h1 = new TH2D("hSDigitChargePerPM", "SDigits total amplified charge per PM in AD;PM number;Charge [C]", 16, 0, 16, 1000,1e-13, 1e-9); 
+
+  TH2D * h1 = new TH2D("hSDigitChargePerPM", "SDigits total amplified charge per PM in AD;PM number;Charge [C]", 16, 0, 16, 1000,1e-13, 1e-9);
   h1->Sumw2() ;
   Add2SDigitsList(h1, 1, !expert, image) ;
-  
+
   //
   ClonePerTrigClass(AliQAv1::kSDIGITS); // this should be the last line
 }
 
 
 
-//____________________________________________________________________________ 
+//____________________________________________________________________________
 void AliADQADataMakerSim::InitDigits()
 {
   // create Digits histograms in Digits subdir
-  const Bool_t expert   = kTRUE ; 
-  const Bool_t image    = kTRUE ; 
+  const Bool_t expert   = kTRUE ;
+  const Bool_t image    = kTRUE ;
 
   // create Digits histograms in Digits subdir
-  TH1I * h0 = new TH1I("hDigitMultiplicity", "Digits multiplicity distribution in AD;# of Digits;Entries", 17,-0.5,16.5) ; 
+  TH1I * h0 = new TH1I("hDigitMultiplicity", "Digits multiplicity distribution in AD;# of Digits;Entries", 17,-0.5,16.5) ;
   h0->Sumw2() ;
   Add2DigitsList(h0, 0, !expert, image) ;
-     
-  TH2D * h1 = new TH2D("hDigitLeadingTimePerPM", "Leading time distribution per PM in AD;PM number;Leading Time [ns]",16,0,16, 3062, 0.976562, 300); 
+
+  TH2D * h1 = new TH2D("hDigitLeadingTimePerPM", "Leading time distribution per PM in AD;PM number;Leading Time [ns]",16,0,16, 3062, 0.976562, 300);
   h1->Sumw2() ;
-  Add2DigitsList(h1, 1, !expert, image) ; 
-  
-  TH2D * h2 = new TH2D("hDigitTimeWidthPerPM", "Time width distribution per PM in AD;PM number;Time width [ns]",16,0,16, 153, 2.343750, 121.875000); 
+  Add2DigitsList(h1, 1, !expert, image) ;
+
+  TH2D * h2 = new TH2D("hDigitTimeWidthPerPM", "Time width distribution per PM in AD;PM number;Time width [ns]",16,0,16, 153, 2.343750, 121.875000);
   h2->Sumw2() ;
   Add2DigitsList(h2, 2, !expert, image) ;
-  
+
   TH2I * h3 = new TH2I("hDigitChargePerClockPerPM", "Charge array per PM in AD;PM number; Clock",16,0,16,21, -10.5, 10.5);
   h3->Sumw2();
   Add2DigitsList(h3, 3, !expert, image) ;
-  
+
   TH1I * h4 = new TH1I("hDigitBBflagsAD","Number of BB flags in AD; # of BB flags; Entries",17,-0.5,16.5);
   h4->Sumw2();
   Add2DigitsList(h4, 4, !expert, image) ;
-  
+
   TH1I * h5 = new TH1I("hDigitBBflagsADA","Number of BB flags in ADA; # of BB flags; Entries",9,-0.5,8.5);
   h5->Sumw2();
   Add2DigitsList(h5, 5, !expert, image) ;
-  
+
   TH1I * h6 = new TH1I("hDigitBBflagsADC","Number of BB flags in ADC; # of BB flags; Entries",9,-0.5,8.5);
   h6->Sumw2();
   Add2DigitsList(h6, 6, !expert, image) ;
-  
+
   TH2D * h7 = new TH2D("hDigitTotalChargePerPM", "Total Charge per PM in AD;PM number; Charge [ADC counts]",16,0,16,10000,0,10000);
   h7->Sumw2();
   Add2DigitsList(h7, 7, !expert, image) ;
-  
+
   TH2I * h8 = new TH2I("hDigitMaxChargeClockPerPM", "Clock with maximum charge per PM in AD;PM number; Clock ",16,0,16,21, -10.5, 10.5);
   h8->Sumw2();
   Add2DigitsList(h8, 8, !expert, image) ;
-   
+
   //
   ClonePerTrigClass(AliQAv1::kDIGITS); // this should be the last line
 }
@@ -187,22 +181,21 @@ void AliADQADataMakerSim::InitDigits()
 //____________________________________________________________________________
 void AliADQADataMakerSim::MakeHits()
 {
-	//make QA data from Hits
+  //make QA data from Hits
 
   Int_t nhits = fHitsArray->GetEntriesFast();
   FillHitsData(0,nhits) ;    // fills Hit multiplicity
-  for (Int_t ihit=0;ihit<nhits;ihit++) 
-    {
-	   AliADhit  * ADHit   = (AliADhit*) fHitsArray->UncheckedAt(ihit);
-	   if (!ADHit) {
- 	      AliError("The unchecked hit doesn't exist");
-	      break;
-	   }
-	   FillHitsData(1,ADHit->GetCell());
-	   FillHitsData(2,ADHit->GetNphot());
-	   FillHitsData(3,ADHit->GetCell(),ADHit->GetNphot());
-	   FillHitsData(4,ADHit->GetCell(),ADHit->GetTof());
-	}
+  for (Int_t ihit=0;ihit<nhits;ihit++) {
+    AliADhit  * ADHit   = (AliADhit*) fHitsArray->UncheckedAt(ihit);
+    if (!ADHit) {
+      AliError("The unchecked hit doesn't exist");
+      break;
+    }
+    FillHitsData(1,ADHit->GetCell());
+    FillHitsData(2,ADHit->GetNphot());
+    FillHitsData(3,ADHit->GetCell(),ADHit->GetNphot());
+    FillHitsData(4,ADHit->GetCell(),ADHit->GetTof());
+  }
 }
 
 
@@ -211,46 +204,44 @@ void AliADQADataMakerSim::MakeHits()
 void AliADQADataMakerSim::MakeHits(TTree *hitTree)
 {
   //fills QA histos for Hits
- if (fHitsArray)
-   fHitsArray->Clear() ; 
-  else 
+  if (fHitsArray)
+    fHitsArray->Clear() ;
+  else
     fHitsArray = new TClonesArray("AliADhit", 1000);
-  
+
   TBranch * branch = hitTree->GetBranch("AD") ;
   if ( ! branch ) {
     AliWarning("AD branch in Hit Tree not found") ;
   } else {
-
-   if (branch) {
+    if (branch) {
       branch->SetAddress(&fHitsArray);
     }else{
       AliError("Branch AD hit not found");
       exit(111);
-    } 
+    }
     // Check id histograms already created for this Event Specie
     if ( ! GetHitsData(0) )
       InitHits() ;
-    
+
     Int_t ntracks    = (Int_t) hitTree->GetEntries();
-    
+
     if (ntracks<=0) return;
     // Start loop on tracks in the hits containers
     for (Int_t track=0; track<ntracks;track++) {
       branch->GetEntry(track);
       Int_t nhits = fHitsArray->GetEntriesFast();
       FillHitsData(0,nhits) ;    // fills Hit multiplicity
-      for (Int_t ihit=0;ihit<nhits;ihit++) 
-	{
-	  AliADhit  * ADHit   = (AliADhit*) fHitsArray->UncheckedAt(ihit);
-	  if (!ADHit) {
- 	    AliError("The unchecked hit doesn't exist");
-	    break;
-	  }
-	  FillHitsData(1,ADHit->GetCell());
-	  FillHitsData(2,ADHit->GetNphot());
-	  FillHitsData(3,ADHit->GetCell(),ADHit->GetNphot());
-	  FillHitsData(4,ADHit->GetCell(),ADHit->GetTof());	 
+      for (Int_t ihit=0;ihit<nhits;ihit++) {
+	AliADhit  * ADHit   = (AliADhit*) fHitsArray->UncheckedAt(ihit);
+	if (!ADHit) {
+	  AliError("The unchecked hit doesn't exist");
+	  break;
 	}
+	FillHitsData(1,ADHit->GetCell());
+	FillHitsData(2,ADHit->GetNphot());
+	FillHitsData(3,ADHit->GetCell(),ADHit->GetNphot());
+	FillHitsData(4,ADHit->GetCell(),ADHit->GetTof());
+      }
     }
   }
   //
@@ -264,25 +255,25 @@ void AliADQADataMakerSim::MakeHits(TTree *hitTree)
 //____________________________________________________________________________
 void AliADQADataMakerSim::MakeSDigits(TTree *sdigitTree)
 {
-    // makes data from Digit Tree
-	
-  if (fSDigitsArray)
-    fSDigitsArray->Clear() ; 
-  else 
-    fSDigitsArray = new TClonesArray("AliADSDigit", 1000) ; 
+  // makes data from Digit Tree
 
-    TBranch * branch = sdigitTree->GetBranch("ADSDigit") ;
-    if ( ! branch ) {
-         AliWarning("AD branch in SDigit Tree not found") ; 
-    } else {
-         branch->SetAddress(&fSDigitsArray) ;
-         branch->GetEntry(0) ; 
-         MakeSDigits() ; 
-    }  
-    //
-    IncEvCountCycleDigits();
-    IncEvCountTotalDigits();
-    //    
+  if (fSDigitsArray)
+    fSDigitsArray->Clear() ;
+  else
+    fSDigitsArray = new TClonesArray("AliADSDigit", 1000) ;
+
+  TBranch * branch = sdigitTree->GetBranch("ADSDigit") ;
+  if ( ! branch ) {
+    AliWarning("AD branch in SDigit Tree not found") ;
+  } else {
+    branch->SetAddress(&fSDigitsArray) ;
+    branch->GetEntry(0) ;
+    MakeSDigits() ;
+  }
+  //
+  IncEvCountCycleDigits();
+  IncEvCountTotalDigits();
+  //
 }
 
 //____________________________________________________________________________
@@ -290,17 +281,17 @@ void AliADQADataMakerSim::MakeSDigits()
 {
   // makes data from SDigits
 
-  FillSDigitsData(0,fSDigitsArray->GetEntriesFast()) ; 
-  TIter next(fSDigitsArray) ; 
-    AliADSDigit *ADSDigit ; 
-    while ( (ADSDigit = dynamic_cast<AliADSDigit *>(next())) ) {
-         Int_t   PMNumber  = ADSDigit->PMNumber();
-	 Int_t   Nbins = ADSDigit->GetNBins();
-	 Double_t totCharge = 0;
-	
-	 for(Int_t i = 0; i<Nbins; i++)totCharge += ADSDigit->GetCharges()[i];       
-         FillSDigitsData(1, PMNumber, totCharge) ;
-    }  
+  FillSDigitsData(0,fSDigitsArray->GetEntriesFast()) ;
+  TIter next(fSDigitsArray) ;
+  AliADSDigit *ADSDigit ;
+  while ( (ADSDigit = dynamic_cast<AliADSDigit *>(next())) ) {
+    Int_t   PMNumber  = ADSDigit->PMNumber();
+    Int_t   Nbins = ADSDigit->GetNBins();
+    Double_t totCharge = 0;
+
+    for(Int_t i = 0; i<Nbins; i++)totCharge += ADSDigit->GetCharges()[i];
+    FillSDigitsData(1, PMNumber, totCharge) ;
+  }
 }
 
 //____________________________________________________________________________
@@ -308,59 +299,58 @@ void AliADQADataMakerSim::MakeDigits()
 {
   // makes data from Digits
 
-  FillDigitsData(0,fDigitsArray->GetEntriesFast()) ; 
-  TIter next(fDigitsArray) ; 
-    AliADdigit *ADDigit ; 
-    Int_t nBBflagsADA = 0;
-    Int_t nBBflagsADC = 0;
-    
-    while ( (ADDigit = dynamic_cast<AliADdigit *>(next())) ) {
-         Int_t totCharge = 0;
-         Int_t   PMNumber  = ADDigit->PMNumber();
+  FillDigitsData(0,fDigitsArray->GetEntriesFast()) ;
+  TIter next(fDigitsArray) ;
+  AliADdigit *ADDigit ;
+  Int_t nBBflagsADA = 0;
+  Int_t nBBflagsADC = 0;
 
-	 if(PMNumber<8 && ADDigit->GetBBflag()) nBBflagsADC++;
-	 if(PMNumber>7 && ADDigit->GetBBflag()) nBBflagsADA++;
-	 
-	 Short_t adc[21];
-	 for(Int_t iClock=0; iClock<21; iClock++) { 
-	 adc[iClock]= ADDigit->ChargeADC(iClock);
-	 FillDigitsData(3, PMNumber,(float)iClock-10,(float)adc[iClock]);
-	 totCharge += adc[iClock];
-	 }
-	    
-         FillDigitsData(1,PMNumber,ADDigit->Time()); 
-	 FillDigitsData(2,PMNumber,ADDigit->Width());
-	 FillDigitsData(7,PMNumber,totCharge);
-	 FillDigitsData(8,PMNumber,TMath::LocMax(21,adc)-10); 
-	 
+  while ( (ADDigit = dynamic_cast<AliADdigit *>(next())) ) {
+    Int_t totCharge = 0;
+    Int_t   PMNumber  = ADDigit->PMNumber();
+
+    if(PMNumber<8 && ADDigit->GetBBflag()) nBBflagsADC++;
+    if(PMNumber>7 && ADDigit->GetBBflag()) nBBflagsADA++;
+
+    Short_t adc[21];
+    for(Int_t iClock=0; iClock<21; iClock++) {
+      adc[iClock]= ADDigit->ChargeADC(iClock);
+      FillDigitsData(3, PMNumber,(float)iClock-10,(float)adc[iClock]);
+      totCharge += adc[iClock];
     }
-    FillDigitsData(4,nBBflagsADA+nBBflagsADC);
-    FillDigitsData(5,nBBflagsADA);
-    FillDigitsData(6,nBBflagsADC);  
+
+    FillDigitsData(1,PMNumber,ADDigit->Time());
+    FillDigitsData(2,PMNumber,ADDigit->Width());
+    FillDigitsData(7,PMNumber,totCharge);
+    FillDigitsData(8,PMNumber,TMath::LocMax(21,adc)-10);
+  }
+  FillDigitsData(4,nBBflagsADA+nBBflagsADC);
+  FillDigitsData(5,nBBflagsADA);
+  FillDigitsData(6,nBBflagsADC);
 }
 
 //____________________________________________________________________________
 void AliADQADataMakerSim::MakeDigits(TTree *digitTree)
 {
-    // makes data from Digit Tree
-	
-  if (fDigitsArray)
-    fDigitsArray->Clear() ; 
-  else 
-    fDigitsArray = new TClonesArray("AliADdigit", 1000) ; 
+  // makes data from Digit Tree
 
-    TBranch * branch = digitTree->GetBranch("ADDigit") ;
-    if ( ! branch ) {
-         AliWarning("AD branch in Digit Tree not found") ; 
-    } else {
-         branch->SetAddress(&fDigitsArray) ;
-         branch->GetEntry(0) ; 
-         MakeDigits() ; 
-    }  
-    //
-    IncEvCountCycleDigits();
-    IncEvCountTotalDigits();
-    //    
+  if (fDigitsArray)
+    fDigitsArray->Clear() ;
+  else
+    fDigitsArray = new TClonesArray("AliADdigit", 1000) ;
+
+  TBranch * branch = digitTree->GetBranch("ADDigit") ;
+  if ( ! branch ) {
+    AliWarning("AD branch in Digit Tree not found") ;
+  } else {
+    branch->SetAddress(&fDigitsArray) ;
+    branch->GetEntry(0) ;
+    MakeDigits() ;
+  }
+  //
+  IncEvCountCycleDigits();
+  IncEvCountTotalDigits();
+  //
 }
 
 

--- a/AD/ADsim/AliADQADataMakerSim.h
+++ b/AD/ADsim/AliADQADataMakerSim.h
@@ -1,16 +1,17 @@
+// -*- C++ -*-
 #ifndef ALIADQADATAMAKERSIM_H
 #define ALIADQADATAMAKERSIM_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights
- * reserved. 
+ * reserved.
  *
- * See cxx source for full Copyright notice                               
+ * See cxx source for full Copyright notice
  */
 
 #include "AliQADataMakerSim.h"
 
-class TH1F ; 
-class TH1I ; 
-class TList ; 
+class TH1F ;
+class TH1I ;
+class TList ;
 
 //_____________________________________________________________________
 //
@@ -19,36 +20,28 @@ class TList ;
 // Author : BC
 //_____________________________________________________________________
 
-
-
 class AliADQADataMakerSim: public AliQADataMakerSim {
-
- public:
+public:
   AliADQADataMakerSim() ;          // ctor
-  AliADQADataMakerSim(const AliADQADataMakerSim& qadm) ; 
-  AliADQADataMakerSim& operator = (const AliADQADataMakerSim& qadm) ;  
+  AliADQADataMakerSim(const AliADQADataMakerSim& qadm) ;
+  AliADQADataMakerSim& operator = (const AliADQADataMakerSim& qadm) ;
   virtual ~AliADQADataMakerSim() {} // dtor
-  
- private:
+
+private:
   virtual void   EndOfDetectorCycle(AliQAv1::TASKINDEX_t, TObjArray ** list);
   virtual void   InitHits();
-  virtual void   InitSDigits(); 
-  virtual void   InitDigits();  
+  virtual void   InitSDigits();
+  virtual void   InitDigits();
   virtual void   MakeHits() ;
   virtual void   MakeHits(TTree* hitTree) ;
-  virtual void   MakeSDigits() ; 
-  virtual void   MakeSDigits(TTree* digitTree) ; 
-  virtual void   MakeDigits() ; 
-  virtual void   MakeDigits(TTree* sdigitTree) ; 
-  virtual void   StartOfDetectorCycle() ; 
-  
-  ClassDef(AliADQADataMakerSim,0)  // description 
-    };
+  virtual void   MakeSDigits() ;
+  virtual void   MakeSDigits(TTree* digitTree) ;
+  virtual void   MakeDigits() ;
+  virtual void   MakeDigits(TTree* sdigitTree) ;
+  virtual void   StartOfDetectorCycle() ;
+
+  ClassDef(AliADQADataMakerSim,0);
+};
 
 #endif // AliADQADataMakerSim_H
 //____________________________________________________________________
-//
-// Local Variables: 
-//  mode: c++
-// End:
-//

--- a/AD/ADsim/AliADTriggerSimulator.cxx
+++ b/AD/ADsim/AliADTriggerSimulator.cxx
@@ -12,7 +12,7 @@
  * about the suitability of this software for any purpose. It is          *
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
-// 
+//
 // Class AliADTriggerSimulator
 // ------------------------------
 //  Simulate the AD Trigger response
@@ -36,140 +36,145 @@
 #include "AliADConst.h"
 #include "AliCTPTimeParams.h"
 
-ClassImp(AliADTriggerSimulator)
+ClassImp(AliADTriggerSimulator);
 
 //_____________________________________________________________________________
-AliADTriggerSimulator::AliADTriggerSimulator(TTree * digitsTree, TClonesArray* digits) : 
-TObject(),fCalibData(NULL),fDigitsTree(digitsTree),fDigits(digits),fTriggerWord(0)
+AliADTriggerSimulator::AliADTriggerSimulator(TTree * digitsTree, TClonesArray* digits)
+  : TObject()
+  , fCalibData(NULL)
+  , fDigitsTree(digitsTree)
+  , fDigits(digits)
+  , fTriggerWord(0)
 {
-	// constructor
-	fCalibData = LoadCalibData();
-	LoadClockOffset();
-	
-	for(int i=0;i<16;i++) {
-		fBBFlags[i] = fBGFlags[i] = kFALSE;
-		fCharges[i] = 0;
-		fTime[i] = 0;
-	}
-	GenerateBCMask();
-	GenerateBBWindows();
-	GenerateBGWindows();
-			
+  // constructor
+  fCalibData = LoadCalibData();
+  LoadClockOffset();
+
+  for(int i=0;i<16;i++) {
+    fBBFlags[i] = fBGFlags[i] = kFALSE;
+    fCharges[i] = 0;
+    fTime[i] = 0;
+  }
+  GenerateBCMask();
+  GenerateBBWindows();
+  GenerateBGWindows();
 }
 //_____________________________________________________________________________
-AliADTriggerSimulator::AliADTriggerSimulator() : 
-TObject(),fCalibData(NULL),fDigitsTree(NULL),fDigits(NULL),fTriggerWord(0)
+AliADTriggerSimulator::AliADTriggerSimulator()
+  : TObject()
+  , fCalibData(NULL)
+  , fDigitsTree(NULL)
+  , fDigits(NULL),
+    fTriggerWord(0)
 {
-	// Default constructor
-	fCalibData = LoadCalibData();
-	LoadClockOffset();
+  // Default constructor
+  fCalibData = LoadCalibData();
+  LoadClockOffset();
 
-	for(int i=0;i<16;i++) {
-		fBBFlags[i] = fBGFlags[i] = kFALSE;
-		fCharges[i] = 0;
-		fTime[i] = 0;
-	}
-	GenerateBCMask();
-	GenerateBBWindows();
-	GenerateBGWindows();	
+  for(int i=0;i<16;i++) {
+    fBBFlags[i] = fBGFlags[i] = kFALSE;
+    fCharges[i] = 0;
+    fTime[i] = 0;
+  }
+  GenerateBCMask();
+  GenerateBBWindows();
+  GenerateBGWindows();
 }
 
 //_____________________________________________________________________________
 AliADTriggerSimulator::~AliADTriggerSimulator(){
-// Destructor
+  // Destructor
   for (Int_t i=0; i<kNCIUBoards; i++) {
-    delete fBBGate[i];
-    delete fBGGate[i];
-    delete fBCMask[i];
+    if (fBBGate[i]) delete fBBGate[i]; fBBGate[i] = NULL;
+    if (fBGGate[i]) delete fBGGate[i]; fBGGate[i] = NULL;
+    if (fBCMask[i]) delete fBCMask[i]; fBCMask[i] = NULL;
   }
 }
 
 //_____________________________________________________________________________
-void AliADTriggerSimulator::GenerateBCMask() 
+void AliADTriggerSimulator::GenerateBCMask()
 {
   // Generates the BC mask
   // Gate at central clock 25ns wide
   for (Int_t i=0; i<kNCIUBoards; i++) {
-  	  fBCMask[i] = new AliADLogicalSignal();
-  	  fBCMask[i]->SetStartTime(fWindowOffset[i]);
-  	  fBCMask[i]->SetStopTime(fWindowOffset[i]+25.0);
-  }    
-
+    fBCMask[i] = new AliADLogicalSignal();
+    fBCMask[i]->SetStartTime(fWindowOffset[i]);
+    fBCMask[i]->SetStopTime(fWindowOffset[i]+25.0);
+  }
 }
 
-
 //_____________________________________________________________________________
-void AliADTriggerSimulator::GenerateBBWindows() 
+void AliADTriggerSimulator::GenerateBBWindows()
 {
   // Generates the BB observation window
   // In case gates are open the windows are equal to 25ns
   if (AreGatesOpen()) {
-	for (Int_t i=0; i<kNCIUBoards; i++) {
-	        fBBGate[i] = new AliADLogicalSignal();
-		fBBGate[i]->SetStartTime(fWindowOffset[i]);
-		fBBGate[i]->SetStopTime(fWindowOffset[i]+25.0);
-	}    
+    for (Int_t i=0; i<kNCIUBoards; i++) {
+      fBBGate[i] = new AliADLogicalSignal();
+      fBBGate[i]->SetStartTime(fWindowOffset[i]);
+      fBBGate[i]->SetStopTime(fWindowOffset[i]+25.0);
+    }
   }
   else {
-	for (Int_t i=0; i<kNCIUBoards; i++) {
-		AliADLogicalSignal clk1BB(fCalibData->GetClk1Win1(i),fCalibData->GetDelayClk1Win1(i),fCalibData->GetLatchWin1(i),fCalibData->GetResetWin1(i));
-		AliADLogicalSignal clk2BB(fCalibData->GetClk2Win1(i),fCalibData->GetDelayClk2Win1(i),fCalibData->GetLatchWin1(i),fCalibData->GetResetWin1(i));
-		fBBGate[i] = new AliADLogicalSignal(clk1BB & clk2BB);
-		fBBGate[i]->SetStartTime(fBBGate[i]->GetStartTime()+fWindowOffset[i]);
-		fBBGate[i]->SetStopTime(fBBGate[i]->GetStopTime()+fWindowOffset[i]);
-					
-	}
+    for (Int_t i=0; i<kNCIUBoards; i++) {
+      AliADLogicalSignal clk1BB(fCalibData->GetClk1Win1(i),fCalibData->GetDelayClk1Win1(i),fCalibData->GetLatchWin1(i),fCalibData->GetResetWin1(i));
+      AliADLogicalSignal clk2BB(fCalibData->GetClk2Win1(i),fCalibData->GetDelayClk2Win1(i),fCalibData->GetLatchWin1(i),fCalibData->GetResetWin1(i));
+      fBBGate[i] = new AliADLogicalSignal(clk1BB & clk2BB);
+      fBBGate[i]->SetStartTime(fBBGate[i]->GetStartTime()+fWindowOffset[i]);
+      fBBGate[i]->SetStopTime(fBBGate[i]->GetStopTime()+fWindowOffset[i]);
+
+    }
   }
 }
 //_____________________________________________________________________________
-void AliADTriggerSimulator::GenerateBGWindows() 
+void AliADTriggerSimulator::GenerateBGWindows()
 {
   // Generates the BG observation window
   // In case gates are open the windows are equal to 25ns
   if (AreGatesOpen()) {
-	for (Int_t i=0; i<kNCIUBoards; i++) {
-	        fBGGate[i] = new AliADLogicalSignal();
-		fBGGate[i]->SetStartTime(fWindowOffset[i]);
-		fBGGate[i]->SetStopTime(fWindowOffset[i]+25.0);
-	}    
+    for (Int_t i=0; i<kNCIUBoards; i++) {
+      fBGGate[i] = new AliADLogicalSignal();
+      fBGGate[i]->SetStartTime(fWindowOffset[i]);
+      fBGGate[i]->SetStopTime(fWindowOffset[i]+25.0);
+    }
   }
   else {
-	for (Int_t i=0; i<kNCIUBoards; i++) {
-		AliADLogicalSignal clk1BG(fCalibData->GetClk1Win2(i),fCalibData->GetDelayClk1Win2(i),fCalibData->GetLatchWin2(i),fCalibData->GetResetWin2(i));
-		clk1BG.SetStartTime(clk1BG.GetStartTime()+2);
-		clk1BG.SetStopTime(clk1BG.GetStopTime()+2);
-		AliADLogicalSignal clk2BG(fCalibData->GetClk2Win2(i),fCalibData->GetDelayClk2Win2(i),fCalibData->GetLatchWin2(i),fCalibData->GetResetWin2(i));
-		clk2BG.SetStartTime(clk2BG.GetStartTime()-2);
-		clk2BG.SetStopTime(clk2BG.GetStopTime()-2);
-		fBGGate[i] = new AliADLogicalSignal(clk1BG & clk2BG);
-		fBGGate[i]->SetStartTime(fBGGate[i]->GetStartTime()+fWindowOffset[i]);
-		fBGGate[i]->SetStopTime(fBGGate[i]->GetStopTime()+fWindowOffset[i]);	
-	}
+    for (Int_t i=0; i<kNCIUBoards; i++) {
+      AliADLogicalSignal clk1BG(fCalibData->GetClk1Win2(i),fCalibData->GetDelayClk1Win2(i),fCalibData->GetLatchWin2(i),fCalibData->GetResetWin2(i));
+      clk1BG.SetStartTime(clk1BG.GetStartTime()+2);
+      clk1BG.SetStopTime(clk1BG.GetStopTime()+2);
+      AliADLogicalSignal clk2BG(fCalibData->GetClk2Win2(i),fCalibData->GetDelayClk2Win2(i),fCalibData->GetLatchWin2(i),fCalibData->GetResetWin2(i));
+      clk2BG.SetStartTime(clk2BG.GetStartTime()-2);
+      clk2BG.SetStopTime(clk2BG.GetStopTime()-2);
+      fBGGate[i] = new AliADLogicalSignal(clk1BG & clk2BG);
+      fBGGate[i]->SetStartTime(fBGGate[i]->GetStartTime()+fWindowOffset[i]);
+      fBGGate[i]->SetStopTime(fBGGate[i]->GetStopTime()+fWindowOffset[i]);
+    }
   }
 }
 
 //_____________________________________________________________________________
-AliADCalibData * AliADTriggerSimulator::LoadCalibData() const 
+AliADCalibData * AliADTriggerSimulator::LoadCalibData() const
 {
-	// Gets Trigger object for AD set
-        AliDebug(1,"Loading Trigger parameters");
-	AliCDBManager *man = AliCDBManager::Instance();
-	
-	
-	AliCDBEntry *entry=0;
-	
-	entry = man->Get("AD/Calib/Data");
-	if(!entry){
-		AliFatal("Load of calibration data from default storage failed!");
-		return NULL;
-	}
-	
-	AliADCalibData *calibData = NULL;
-	
-	if (entry) calibData = (AliADCalibData*) entry->GetObject();
-	if (!calibData)  AliError("No Trigger data from database !");
-	
-	return calibData;
+  // Gets Trigger object for AD set
+  AliDebug(1,"Loading Trigger parameters");
+  AliCDBManager *man = AliCDBManager::Instance();
+
+
+  AliCDBEntry *entry=0;
+
+  entry = man->Get("AD/Calib/Data");
+  if(!entry){
+    AliFatal("Load of calibration data from default storage failed!");
+    return NULL;
+  }
+
+  AliADCalibData *calibData = NULL;
+
+  if (entry) calibData = (AliADCalibData*) entry->GetObject();
+  if (!calibData)  AliError("No Trigger data from database !");
+
+  return calibData;
 }
 
 
@@ -205,148 +210,147 @@ void AliADTriggerSimulator::LoadClockOffset()
   //Start of the central clock in HPTDC time
   for(Int_t board = 0; board < kNCIUBoards; ++board) {
     fWindowOffset[board] = (((Float_t)calibdata->GetRollOver(board)-
-			    (Float_t)calibdata->GetTriggerCountOffset(board))*25.0
-		             -l1Delay
-		             -kADOffset);
-    AliDebug(1,Form("Board %d Offset %f",board,fWindowOffset[board]));
+                             (Float_t)calibdata->GetTriggerCountOffset(board))*25.0
+                            -l1Delay
+                            -kADOffset);
+    AliDebugF(1,"Board %d Offset %f",board,fWindowOffset[board]);
   }
 }
 //_____________________________________________________________________________
 void AliADTriggerSimulator::FillFlags(Bool_t *bbFlag, Bool_t *bgFlag, Float_t time[16]){
 
   for(Int_t i = 0; i<16; i++){
-  	Int_t board   = AliADCalibData::GetBoardNumber(i);
-	
-	Bool_t inBCmask = fBCMask[board]->IsInCoincidence(time[i]);
-	Bool_t inBBwindow = fBBGate[board]->IsInCoincidence(time[i]);
-	Bool_t inBGwindow = fBGGate[board]->IsInCoincidence(time[i]);
-	
-	/*/
-	Bool_t inBBwindow = kFALSE;
-	Bool_t inBGwindow = kFALSE;
-	
-	AliADLogicalSignal fBBGateShifted;
-	AliADLogicalSignal fBGGateShifted;
-	for(Int_t j=-10; j<=10; j++){
-		fBBGateShifted.SetStartTime(fBBGate[board]->GetStartTime() + 25*j);
-		fBBGateShifted.SetStopTime(fBBGate[board]->GetStopTime() + 25*j);
-		fBGGateShifted.SetStartTime(fBGGate[board]->GetStartTime() + 25*j);
-		fBGGateShifted.SetStopTime(fBGGate[board]->GetStopTime() + 25*j);
-		
-		if(fBBGateShifted.IsInCoincidence(time[i])) inBBwindow = kTRUE;
-		if(fBGGateShifted.IsInCoincidence(time[i])) inBGwindow = kTRUE;
-		}
-	/*/
-	bbFlag[i] = inBBwindow;
-	bgFlag[i] = inBGwindow;
-	
-	//AliInfo(Form("Ch %d Time=%.1f BCM=%d BB=%d BG=%d",i,time[i],inBCmask,bbFlag[i],bgFlag[i] ));
-  	}
+    Int_t board   = AliADCalibData::GetBoardNumber(i);
+
+    // Bool_t inBCmask = fBCMask[board]->IsInCoincidence(time[i]); not used
+    Bool_t inBBwindow = fBBGate[board]->IsInCoincidence(time[i]);
+    Bool_t inBGwindow = fBGGate[board]->IsInCoincidence(time[i]);
+
+    /*/
+      Bool_t inBBwindow = kFALSE;
+      Bool_t inBGwindow = kFALSE;
+
+      AliADLogicalSignal fBBGateShifted;
+      AliADLogicalSignal fBGGateShifted;
+      for(Int_t j=-10; j<=10; j++){
+      fBBGateShifted.SetStartTime(fBBGate[board]->GetStartTime() + 25*j);
+      fBBGateShifted.SetStopTime(fBBGate[board]->GetStopTime() + 25*j);
+      fBGGateShifted.SetStartTime(fBGGate[board]->GetStartTime() + 25*j);
+      fBGGateShifted.SetStopTime(fBGGate[board]->GetStopTime() + 25*j);
+
+      if(fBBGateShifted.IsInCoincidence(time[i])) inBBwindow = kTRUE;
+      if(fBGGateShifted.IsInCoincidence(time[i])) inBGwindow = kTRUE;
+      }
+      /*/
+    bbFlag[i] = inBBwindow;
+    bgFlag[i] = inBGwindow;
+    //AliInfo(Form("Ch %d Time=%.1f BCM=%d BB=%d BG=%d",i,time[i],inBCmask,bbFlag[i],bgFlag[i] ));
+  }
 }
 //_____________________________________________________________________________
 void AliADTriggerSimulator::Run() {
-//	AliInfo("Generating AD Triggers");
-//	Print("");
-	
-	// Loop over AD entries
-	Int_t nEntries = (Int_t)fDigitsTree->GetEntries();
-	for (Int_t ievt=0; ievt<nEntries; ievt++) {
-		fDigitsTree->GetEvent(ievt);
-		
-		Int_t nDigits = fDigits->GetEntriesFast();
-		for (Int_t iDigit=0; iDigit<nDigits; iDigit++) {
-			AliADdigit* digit = (AliADdigit*)fDigits->At(iDigit);
-			
-			Int_t integrator = digit->Integrator();
-			Int_t pmNumber   = digit->PMNumber();
-			Int_t board   = AliADCalibData::GetBoardNumber(pmNumber);
-			if (board < 0) continue;
-			
-			if(fCalibData->GetEnableCharge(pmNumber)) {
-				fCharges[pmNumber] = digit->ChargeADC(kADNClocks/2);
-				if(fCalibData->GetPedestalSubtraction(board)) {
-					if(fCharges[pmNumber]>=(Float_t) fCalibData->GetOnlinePedestalCut(integrator,pmNumber)){ 
-						fCharges[pmNumber] -= (Float_t) fCalibData->GetOnlinePedestal(integrator,pmNumber);
-					} else {
-						fCharges[pmNumber] = 0.;
-					}
-				}
-			} else {
-				fCharges[pmNumber] = 0.;
-			}
-			
-			fTime[pmNumber] = digit->Time();
-			
-		} // end of loop over digits
-	} // end of loop over events in digits tree
-	FillFlags(fBBFlags,fBGFlags,fTime);
-	
-	Int_t nBBflagsADA = 0;
-	Int_t nBBflagsADC = 0;
-	Int_t nBGflagsADA = 0;
-	Int_t nBGflagsADC = 0;
-	Float_t chargeADA   = 0.;
-	Float_t chargeADC   = 0.;
+  //    AliInfo("Generating AD Triggers");
+  //    Print("");
 
-	for(int i=0;i<16;i++) {
-		if(i<8) chargeADC += fCharges[i];
-		else chargeADA += fCharges[i];	
-	}
-	
-	for(Int_t iChannel=0; iChannel<4; iChannel++) {//Loop over pairs of pads
-    	    //Enable time is used to turn off the coincidence 
-      	    if((!fCalibData->GetEnableTiming(iChannel) || fBBFlags[iChannel]) && (!fCalibData->GetEnableTiming(iChannel+4) || fBBFlags[iChannel+4])) nBBflagsADC++;
-      	    if((!fCalibData->GetEnableTiming(iChannel) || fBGFlags[iChannel]) && (!fCalibData->GetEnableTiming(iChannel+4) || fBGFlags[iChannel+4])) nBGflagsADC++;
+  // Loop over AD entries
+  Int_t nEntries = (Int_t)fDigitsTree->GetEntries();
+  for (Int_t ievt=0; ievt<nEntries; ievt++) {
+    fDigitsTree->GetEvent(ievt);
 
-      	    if((!fCalibData->GetEnableTiming(iChannel+8) || fBBFlags[iChannel+8]) && (!fCalibData->GetEnableTiming(iChannel+12) || fBBFlags[iChannel+12])) nBBflagsADA++;
-      	    if((!fCalibData->GetEnableTiming(iChannel+8) || fBGFlags[iChannel+8]) && (!fCalibData->GetEnableTiming(iChannel+12) || fBGFlags[iChannel+12])) nBGflagsADA++;
-	}
+    Int_t nDigits = fDigits->GetEntriesFast();
+    for (Int_t iDigit=0; iDigit<nDigits; iDigit++) {
+      AliADdigit* digit = (AliADdigit*)fDigits->At(iDigit);
 
-	// BBA
-	if(nBBflagsADA>=fCalibData->GetBBAThreshold())  SetBBA();
-	
-	// BBC
-	if(nBBflagsADC>=fCalibData->GetBBCThreshold())  SetBBC();
+      Int_t integrator = digit->Integrator();
+      Int_t pmNumber   = digit->PMNumber();
+      Int_t board   = AliADCalibData::GetBoardNumber(pmNumber);
+      if (board < 0) continue;
 
-	// BBA_AND_BBC
-	if(GetBBA() && GetBBC())  SetBBAandBBC();
-	
-	// BBA_OR_BBC
-	if(GetBBA() || GetBBC()) SetBBAorBBC();
+      if(fCalibData->GetEnableCharge(pmNumber)) {
+        fCharges[pmNumber] = digit->ChargeADC(kADNClocks/2);
+        if(fCalibData->GetPedestalSubtraction(board)) {
+          if(fCharges[pmNumber]>=(Float_t) fCalibData->GetOnlinePedestalCut(integrator,pmNumber)){
+            fCharges[pmNumber] -= (Float_t) fCalibData->GetOnlinePedestal(integrator,pmNumber);
+          } else {
+            fCharges[pmNumber] = 0.;
+          }
+        }
+      } else {
+        fCharges[pmNumber] = 0.;
+      }
 
-	// BGA
-	if(nBGflagsADA>=fCalibData->GetBGAThreshold()) SetBGA();
+      fTime[pmNumber] = digit->Time();
 
-	// BGC
-	if(nBGflagsADC>=fCalibData->GetBGCThreshold()) SetBGC();
-	
-	// BGA_AND_BBC (Beam Gas from RB24 side)
-	if(nBBflagsADC>=fCalibData->GetBBCForBGThreshold() && GetBGA()) SetBGAandBBC();
-	
-	// BGC_AND_BBA (Beam Gas from RB26 side)
-	if(nBBflagsADA>=fCalibData->GetBBAForBGThreshold() && GetBGC()) SetBGCandBBA();
+    } // end of loop over digits
+  } // end of loop over events in digits tree
+  FillFlags(fBBFlags,fBGFlags,fTime);
 
-	
-	// MTA_AND_MTC (Multiplicity Trigger)
-	if((nBBflagsADA<=fCalibData->GetMultADAThrHigh() && nBBflagsADA>=fCalibData->GetMultADAThrLow())
-	   && (nBBflagsADC<=fCalibData->GetMultADCThrHigh() && nBBflagsADC>=fCalibData->GetMultADCThrLow()) ) 
-		SetMTAandMTC();
-	
-	// MTA_OR_MTC (Multiplicity Trigger)
-	if((nBBflagsADA<=fCalibData->GetMultADAThrHigh() && nBBflagsADA>=fCalibData->GetMultADAThrLow())
-	   || (nBBflagsADC<=fCalibData->GetMultADCThrHigh() && nBBflagsADC>=fCalibData->GetMultADCThrLow()) ) 
-		SetMTAorMTC();
-	
-	// BGA_OR_BGC
-	if(GetBGA() || GetBGC()) SetBGAorBGC();
-	
-	// (BGA and BBC) or (BGC and BBA) (Beam Gas from one of the two sides)
-	if(GetBGAandBBC() || GetBGCandBBA()) SetBeamGas();
+  Int_t nBBflagsADA = 0;
+  Int_t nBBflagsADC = 0;
+  Int_t nBGflagsADA = 0;
+  Int_t nBGflagsADC = 0;
+  Float_t chargeADA   = 0.;
+  Float_t chargeADC   = 0.;
 
-	//AliInfo(Form("BB Flags : ADA = %d  ADC = %d ",nBBflagsADA, nBBflagsADC )); 
-	//AliInfo(Form("BG Flags : ADA = %d  ADC = %d ",nBGflagsADA, nBGflagsADC )); 
-	//AliInfo(Form("Charges  : ADA = %d  ADC = %d ",chargeADA, chargeADC )); 
-	
+  for(int i=0;i<16;i++) {
+    if(i<8) chargeADC += fCharges[i];
+    else chargeADA += fCharges[i];
+  }
+
+  for(Int_t iChannel=0; iChannel<4; iChannel++) {//Loop over pairs of pads
+    //Enable time is used to turn off the coincidence
+    if((!fCalibData->GetEnableTiming(iChannel) || fBBFlags[iChannel]) && (!fCalibData->GetEnableTiming(iChannel+4) || fBBFlags[iChannel+4])) nBBflagsADC++;
+    if((!fCalibData->GetEnableTiming(iChannel) || fBGFlags[iChannel]) && (!fCalibData->GetEnableTiming(iChannel+4) || fBGFlags[iChannel+4])) nBGflagsADC++;
+
+    if((!fCalibData->GetEnableTiming(iChannel+8) || fBBFlags[iChannel+8]) && (!fCalibData->GetEnableTiming(iChannel+12) || fBBFlags[iChannel+12])) nBBflagsADA++;
+    if((!fCalibData->GetEnableTiming(iChannel+8) || fBGFlags[iChannel+8]) && (!fCalibData->GetEnableTiming(iChannel+12) || fBGFlags[iChannel+12])) nBGflagsADA++;
+  }
+
+  // BBA
+  if(nBBflagsADA>=fCalibData->GetBBAThreshold())  SetBBA();
+
+  // BBC
+  if(nBBflagsADC>=fCalibData->GetBBCThreshold())  SetBBC();
+
+  // BBA_AND_BBC
+  if(GetBBA() && GetBBC())  SetBBAandBBC();
+
+  // BBA_OR_BBC
+  if(GetBBA() || GetBBC()) SetBBAorBBC();
+
+  // BGA
+  if(nBGflagsADA>=fCalibData->GetBGAThreshold()) SetBGA();
+
+  // BGC
+  if(nBGflagsADC>=fCalibData->GetBGCThreshold()) SetBGC();
+
+  // BGA_AND_BBC (Beam Gas from RB24 side)
+  if(nBBflagsADC>=fCalibData->GetBBCForBGThreshold() && GetBGA()) SetBGAandBBC();
+
+  // BGC_AND_BBA (Beam Gas from RB26 side)
+  if(nBBflagsADA>=fCalibData->GetBBAForBGThreshold() && GetBGC()) SetBGCandBBA();
+
+
+  // MTA_AND_MTC (Multiplicity Trigger)
+  if((nBBflagsADA<=fCalibData->GetMultADAThrHigh() && nBBflagsADA>=fCalibData->GetMultADAThrLow())
+     && (nBBflagsADC<=fCalibData->GetMultADCThrHigh() && nBBflagsADC>=fCalibData->GetMultADCThrLow()) )
+    SetMTAandMTC();
+
+  // MTA_OR_MTC (Multiplicity Trigger)
+  if((nBBflagsADA<=fCalibData->GetMultADAThrHigh() && nBBflagsADA>=fCalibData->GetMultADAThrLow())
+     || (nBBflagsADC<=fCalibData->GetMultADCThrHigh() && nBBflagsADC>=fCalibData->GetMultADCThrLow()) )
+    SetMTAorMTC();
+
+  // BGA_OR_BGC
+  if(GetBGA() || GetBGC()) SetBGAorBGC();
+
+  // (BGA and BBC) or (BGC and BBA) (Beam Gas from one of the two sides)
+  if(GetBGAandBBC() || GetBGCandBBA()) SetBeamGas();
+
+  //AliInfo(Form("BB Flags : ADA = %d  ADC = %d ",nBBflagsADA, nBBflagsADC ));
+  //AliInfo(Form("BG Flags : ADA = %d  ADC = %d ",nBGflagsADA, nBGflagsADC ));
+  //AliInfo(Form("Charges  : ADA = %d  ADC = %d ",chargeADA, chargeADC ));
+
 }
 
 //_____________________________________________________________________________
@@ -360,9 +364,9 @@ Bool_t AliADTriggerSimulator::AreGatesOpen() const {
 
   for (int i=0; i<kNCIUBoards; i++) {
     if (fCalibData->GetDelayClk1Win1(i)!=0 ||
-	fCalibData->GetDelayClk2Win1(i)!=0 ||
-	fCalibData->GetDelayClk1Win2(i)!=0 ||
-	fCalibData->GetDelayClk2Win2(i)!=0)
+        fCalibData->GetDelayClk2Win1(i)!=0 ||
+        fCalibData->GetDelayClk1Win2(i)!=0 ||
+        fCalibData->GetDelayClk2Win2(i)!=0)
       return kFALSE;
   }
   return kTRUE;

--- a/AD/ADsim/AliADTriggerSimulator.h
+++ b/AD/ADsim/AliADTriggerSimulator.h
@@ -1,11 +1,12 @@
+// -*- C++ -*-
 #ifndef ALIADTRIGGERSIMULATOR_H
 #define ALIADTRIGGERSIMULATOR_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights
- * reserved. 
+ * reserved.
  *
- * See cxx source for full Copyright notice                               
+ * See cxx source for full Copyright notice
  */
-// 
+//
 // Class AliADTriggerSimulator
 // ------------------------------
 //  Simulate the AD Trigger response
@@ -23,84 +24,81 @@ class TClonesArray;
 
 class AliADTriggerSimulator : public TObject {
 public:
-	AliADTriggerSimulator();
-	AliADTriggerSimulator(TTree * digitsTree, TClonesArray* digits);
-	~AliADTriggerSimulator();
-	
-	AliADCalibData * GetCalibData() const {return fCalibData;};
-	
-	Bool_t GetBBAandBBC() const		{return (fTriggerWord & 0x1);};
-	Bool_t GetBBAorBBC() const		{return (fTriggerWord>>1 & 0x1);};
-	Bool_t GetBGAandBBC() const		{return (fTriggerWord>>2 & 0x1);};
-	Bool_t GetBGA() const			{return (fTriggerWord>>3 & 0x1);};
-	Bool_t GetBGCandBBA() const		{return (fTriggerWord>>4 & 0x1);};
-	Bool_t GetBGC() const			{return (fTriggerWord>>5 & 0x1);};
-	Bool_t GetCTA1andCTC1() const	{return (fTriggerWord>>6 & 0x1);};
-	Bool_t GetCTA1orCTC1() const	{return (fTriggerWord>>7 & 0x1);};
-	Bool_t GetCTA2andCTC2() const	{return (fTriggerWord>>8 & 0x1);};
-	Bool_t GetCTA2orCTC2() const	{return (fTriggerWord>>9 & 0x1);};
-	Bool_t GetMTAandMTC() const		{return (fTriggerWord>>10 & 0x1);};
-	Bool_t GetMTAorMTC() const		{return (fTriggerWord>>11 & 0x1);};
-	Bool_t GetBBA() const			{return (fTriggerWord>>12 & 0x1);};
-	Bool_t GetBBC() const			{return (fTriggerWord>>13 & 0x1);};
-	Bool_t GetBGAorBGC() const		{return (fTriggerWord>>14 & 0x1);};
-	Bool_t GetBeamGas() const		{return (fTriggerWord>>15 & 0x1);};
-	
-	void SetBBAandBBC()		{ (fTriggerWord += 0x1);};
-	void SetBBAorBBC()		{ (fTriggerWord += 0x1<<1);};
-	void SetBGAandBBC()		{ (fTriggerWord += 0x1<<2);};
-	void SetBGA()			{ (fTriggerWord += 0x1<<3);};
-	void SetBGCandBBA()		{ (fTriggerWord += 0x1<<4);};
-	void SetBGC()			{ (fTriggerWord += 0x1<<5);};
-	void SetCTA1andCTC1()	{ (fTriggerWord += 0x1<<6);};
-	void SetCTA1orCTC1()	{ (fTriggerWord += 0x1<<7);};
-	void SetCTA2andCTC2()	{ (fTriggerWord += 0x1<<8);};
-	void SetCTA2orCTC2()	{ (fTriggerWord += 0x1<<9);};
-	void SetMTAandMTC()		{ (fTriggerWord += 0x1<<10);};
-	void SetMTAorMTC()		{ (fTriggerWord += 0x1<<11);};	
-	void SetBBA()			{ (fTriggerWord += 0x1<<12);};
-	void SetBBC()			{ (fTriggerWord += 0x1<<13);};
-	void SetBGAorBGC()		{ (fTriggerWord += 0x1<<14);};
-	void SetBeamGas()		{ (fTriggerWord += 0x1<<15);};
-	
-	void Run();
-	void FillFlags(Bool_t *bbFlag, Bool_t *bgFlag, Float_t time[16]);
-	virtual void Print(Option_t* /* opt */) const;
-	
+  AliADTriggerSimulator();
+  AliADTriggerSimulator(TTree * digitsTree, TClonesArray* digits);
+  virtual ~AliADTriggerSimulator();
+
+  AliADCalibData * GetCalibData() const {return fCalibData;};
+
+  Bool_t GetBBAandBBC() const		{return (fTriggerWord & 0x1);};
+  Bool_t GetBBAorBBC() const		{return (fTriggerWord>>1 & 0x1);};
+  Bool_t GetBGAandBBC() const		{return (fTriggerWord>>2 & 0x1);};
+  Bool_t GetBGA() const			{return (fTriggerWord>>3 & 0x1);};
+  Bool_t GetBGCandBBA() const		{return (fTriggerWord>>4 & 0x1);};
+  Bool_t GetBGC() const			{return (fTriggerWord>>5 & 0x1);};
+  Bool_t GetCTA1andCTC1() const         {return (fTriggerWord>>6 & 0x1);};
+  Bool_t GetCTA1orCTC1() const          {return (fTriggerWord>>7 & 0x1);};
+  Bool_t GetCTA2andCTC2() const         {return (fTriggerWord>>8 & 0x1);};
+  Bool_t GetCTA2orCTC2() const          {return (fTriggerWord>>9 & 0x1);};
+  Bool_t GetMTAandMTC() const           {return (fTriggerWord>>10 & 0x1);};
+  Bool_t GetMTAorMTC() const            {return (fTriggerWord>>11 & 0x1);};
+  Bool_t GetBBA() const                 {return (fTriggerWord>>12 & 0x1);};
+  Bool_t GetBBC() const                 {return (fTriggerWord>>13 & 0x1);};
+  Bool_t GetBGAorBGC() const            {return (fTriggerWord>>14 & 0x1);};
+  Bool_t GetBeamGas() const             {return (fTriggerWord>>15 & 0x1);};
+
+  void SetBBAandBBC()           { (fTriggerWord += 0x1);};
+  void SetBBAorBBC()            { (fTriggerWord += 0x1<<1);};
+  void SetBGAandBBC()           { (fTriggerWord += 0x1<<2);};
+  void SetBGA()                 { (fTriggerWord += 0x1<<3);};
+  void SetBGCandBBA()           { (fTriggerWord += 0x1<<4);};
+  void SetBGC()                 { (fTriggerWord += 0x1<<5);};
+  void SetCTA1andCTC1()         { (fTriggerWord += 0x1<<6);};
+  void SetCTA1orCTC1()          { (fTriggerWord += 0x1<<7);};
+  void SetCTA2andCTC2()         { (fTriggerWord += 0x1<<8);};
+  void SetCTA2orCTC2()          { (fTriggerWord += 0x1<<9);};
+  void SetMTAandMTC()           { (fTriggerWord += 0x1<<10);};
+  void SetMTAorMTC()            { (fTriggerWord += 0x1<<11);};
+  void SetBBA()                 { (fTriggerWord += 0x1<<12);};
+  void SetBBC()                 { (fTriggerWord += 0x1<<13);};
+  void SetBGAorBGC()            { (fTriggerWord += 0x1<<14);};
+  void SetBeamGas()             { (fTriggerWord += 0x1<<15);};
+
+  void Run();
+  void FillFlags(Bool_t *bbFlag, Bool_t *bgFlag, Float_t time[16]);
+  virtual void Print(Option_t* /* opt */) const;
+
 private:
-	// Private methods
-	AliADTriggerSimulator(const AliADTriggerSimulator &/*triggerSim*/);
-	AliADTriggerSimulator& operator= (const AliADTriggerSimulator & /*triggerSim*/);
-	AliADCalibData * LoadCalibData() const ;
-	void                  LoadClockOffset();
-	void GenerateBBWindows();
-	void GenerateBGWindows();
-	void GenerateBCMask();
-	Bool_t AreGatesOpen() const;
-	
-	// Members
-	AliADLogicalSignal * fBBGate[kNCIUBoards];  // BB Observation window
-	AliADLogicalSignal * fBGGate[kNCIUBoards];  // BG Observation window
-	AliADLogicalSignal * fBCMask[kNCIUBoards];  // BC Mask
+  // Private methods
+  AliADTriggerSimulator(const AliADTriggerSimulator &/*triggerSim*/);
+  AliADTriggerSimulator& operator= (const AliADTriggerSimulator & /*triggerSim*/);
+  AliADCalibData * LoadCalibData() const ;
+  void             LoadClockOffset();
+  void GenerateBBWindows();
+  void GenerateBGWindows();
+  void GenerateBCMask();
+  Bool_t AreGatesOpen() const;
 
-	AliADCalibData *fCalibData; // Object holding the trigger configuration parameters
-	Float_t fWindowOffset[kNCIUBoards]; // TDC clock offset including roll-over, trig count and L0->L1 delay
-	
-	TTree* fDigitsTree; //Pointer to AD digit tree
-	TClonesArray* fDigits; //Pointer to AD digit array
-	
-	Float_t fTime[16];
-	Bool_t fBBFlags[16]; // Individual BB Flags
-	Bool_t fBGFlags[16]; // Individual BG Flags
-	Float_t  fCharges[16]; // Individual Charge
-	
-	UShort_t fTriggerWord; // Word holding the 16 triggers return by the FEE
-		
-	ClassDef( AliADTriggerSimulator, 4 )  
+  // Members
+  AliADLogicalSignal *fBBGate[kNCIUBoards];  // BB Observation window
+  AliADLogicalSignal *fBGGate[kNCIUBoards];  // BG Observation window
+  AliADLogicalSignal *fBCMask[kNCIUBoards];  // BC Mask
 
+  AliADCalibData *fCalibData; // Object holding the trigger configuration parameters
+  Float_t fWindowOffset[kNCIUBoards]; // TDC clock offset including roll-over, trig count and L0->L1 delay
+
+  TTree* fDigitsTree; //Pointer to AD digit tree
+  TClonesArray* fDigits; //Pointer to AD digit array
+
+  Float_t fTime[16];
+  Bool_t fBBFlags[16]; // Individual BB Flags
+  Bool_t fBGFlags[16]; // Individual BG Flags
+  Float_t  fCharges[16]; // Individual Charge
+
+  UShort_t fTriggerWord; // Word holding the 16 triggers return by the FEE
+
+  ClassDef( AliADTriggerSimulator, 4);
 };
 
 
 #endif // ALIADTRIGGERSIMULATOR_H
-
-

--- a/AD/ADsim/AliADhit.cxx
+++ b/AD/ADsim/AliADhit.cxx
@@ -17,58 +17,56 @@
 
 //_________________________________________________________________________
 //
-//      Hit class for AD detector   
-//  
+//      Hit class for AD detector
+//
 //_________________________________________________________________________
-
 
 #include "AliADhit.h"
 
-ClassImp(AliADhit)
+ClassImp(AliADhit);
 
 //_____________________________________________________________________________
 AliADhit::AliADhit()
-  : AliHit(), 
-  fModule(0),
-  fEk(0.),
-  fPt(0.),
-  fPx(0.),
-  fPy(0.),
-  fPz(0.),
-  fTof(0.),
-  fTleng(0.),
-  fEloss(0.),
-  fNphot(0),
-  fCell(0),
-  fPrimary(0),
-  fPDG(0),
-  fPDGMother(0)
+  : AliHit()
+  , fModule(0)
+  , fEk(0.)
+  , fPt(0.)
+  , fPx(0.)
+  , fPy(0.)
+  , fPz(0.)
+  , fTof(0.)
+  , fTleng(0.)
+  , fEloss(0.)
+  , fNphot(0)
+  , fCell(0)
+  , fPrimary(0)
+  , fPDG(0)
+  , fPDGMother(0)
 {
-   // Default constructor
+  // Default constructor
 }
 
 //_____________________________________________________________________________
 AliADhit::AliADhit(Int_t shunt, Int_t track, Int_t* vol, Float_t* hits)
-  : AliHit(shunt, track),
-  fModule(vol[4]),
-  fEk(hits[3]),
-  fPt(hits[4]),
-  fPx(hits[5]),
-  fPy(hits[6]),
-  fPz(hits[7]),
-  fTof(hits[8]),
-  fTleng(hits[9]),
-  fEloss(hits[10]),
-  fNphot(vol[3]),
-  fCell(vol[4]),         
-  fPrimary(vol[0]),
-  fPDG(vol[1]),
-  fPDGMother(vol[2])
+  : AliHit(shunt, track)
+  , fModule(vol[4])
+  , fEk(hits[3])
+  , fPt(hits[4])
+  , fPx(hits[5])
+  , fPy(hits[6])
+  , fPz(hits[7])
+  , fTof(hits[8])
+  , fTleng(hits[9])
+  , fEloss(hits[10])
+  , fNphot(vol[3])
+  , fCell(vol[4])
+  , fPrimary(vol[0])
+  , fPDG(vol[1])
+  , fPDGMother(vol[2])
 {
-   // Constructor
-   fX           = hits[0];      // X position of hit
-   fY           = hits[1];      // Y position of hit
-   fZ           = hits[2];      // Z position of hit   
+  fX = hits[0];      // X position of hit
+  fY = hits[1];      // Y position of hit
+  fZ = hits[2];      // Z position of hit
 }
 //_____________________________________________________________________________
 AliADhit::~AliADhit()
@@ -77,5 +75,3 @@ AliADhit::~AliADhit()
   // Default destructor.
   //
 }
-
-

--- a/AD/ADsim/AliADhit.h
+++ b/AD/ADsim/AliADhit.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 #ifndef ALIADHIT_H
 #define ALIADHIT_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
@@ -10,52 +11,51 @@
 //  Manager and hits classes for set : AD     //
 //                                            //
 ////////////////////////////////////////////////
- 
+
 #include "AliHit.h"
 #include "TObjArray.h"
 
- 
-class AliADhit : public AliHit {
- 
-public:
-                    AliADhit();
-                    AliADhit(Int_t shunt, Int_t track, Int_t *vol, Float_t *hits);
-  virtual          ~AliADhit();
-  	  Int_t     GetModule()	   const { return fModule; }
-          Float_t   GetEnergy()    const { return fEk; }
-          Float_t   GetPt()        const { return fPt; }
-          Float_t   GetPx()        const { return fPx; }
-          Float_t   GetPy()        const { return fPy; }
-          Float_t   GetPz()        const { return fPz; }
-          Float_t   GetTof()       const { return fTof; };
-          Float_t   GetTrackleng() const { return fTleng; }
-          Float_t   GetEloss()     const { return fEloss; }
-            Int_t   GetNphot()     const { return fNphot; }
-            Int_t   GetCell()      const { return fCell; }
-            Int_t   GetTrackStatus()    const { return fPrimary; }
-            Int_t   GetTrackPDG()       const { return fPDG; }
-            Int_t   GetTrackPDGMother() const { return fPDGMother; }
- 
-protected:
-	  Int_t fModule;	  
-          Float_t   fEk;            // kinetic energy of the entering particle
-          Float_t   fPt;            // Local transverse momentum of the particle
-          Float_t   fPx;            // Local Px momentum of the particle
-          Float_t   fPy;            // Local Py momentum of the particle
-          Float_t   fPz;            // Local Pz momentum of the particle
-          Float_t   fTof;           // Particle time of flight wrt vertex
-          Float_t   fTleng;         // Track length in ADA or ADD detector
-          Float_t   fEloss;         // Energy loss in AD detector
-            Int_t   fNphot;         // Number of photons created by current hit 
-            Int_t   fCell;          // Scintillator cell (Sector Number) (ADA1 = 10-14, ADA2 = 20-24, ADC1 = 30-34, ADC2 = 40-44)
 
-   // The following are for fast analysis, but nor really needed, can be retrive from AliStack with track ID on fTrack
-            Int_t   fPrimary;       // flag (track primary or secondary)
-            Int_t   fPDG;           // PDG code
-            Int_t   fPDGMother;     // PDG code of the mother
-            
+class AliADhit : public AliHit {
+public:
+  AliADhit();
+  AliADhit(Int_t shunt, Int_t track, Int_t *vol, Float_t *hits);
+  virtual          ~AliADhit();
+  Int_t     GetModule()	   const { return fModule; }
+  Float_t   GetEnergy()    const { return fEk; }
+  Float_t   GetPt()        const { return fPt; }
+  Float_t   GetPx()        const { return fPx; }
+  Float_t   GetPy()        const { return fPy; }
+  Float_t   GetPz()        const { return fPz; }
+  Float_t   GetTof()       const { return fTof; };
+  Float_t   GetTrackleng() const { return fTleng; }
+  Float_t   GetEloss()     const { return fEloss; }
+  Int_t     GetNphot()     const { return fNphot; }
+  Int_t     GetCell()      const { return fCell; }
+  Int_t     GetTrackStatus()    const { return fPrimary; }
+  Int_t     GetTrackPDG()       const { return fPDG; }
+  Int_t     GetTrackPDGMother() const { return fPDGMother; }
+
+protected:
+  Int_t fModule;
+  Float_t   fEk;            // kinetic energy of the entering particle
+  Float_t   fPt;            // Local transverse momentum of the particle
+  Float_t   fPx;            // Local Px momentum of the particle
+  Float_t   fPy;            // Local Py momentum of the particle
+  Float_t   fPz;            // Local Pz momentum of the particle
+  Float_t   fTof;           // Particle time of flight wrt vertex
+  Float_t   fTleng;         // Track length in ADA or ADD detector
+  Float_t   fEloss;         // Energy loss in AD detector
+  Int_t     fNphot;         // Number of photons created by current hit
+  Int_t     fCell;          // Scintillator cell (Sector Number) (ADA1 = 10-14, ADA2 = 20-24, ADC1 = 30-34, ADC2 = 40-44)
+
+  // The following are for fast analysis, but nor really needed, can be retrive from AliStack with track ID on fTrack
+  Int_t   fPrimary;       // flag (track primary or secondary)
+  Int_t   fPDG;           // PDG code
+  Int_t   fPDGMother;     // PDG code of the mother
+
 private:
-  ClassDef(AliADhit,1) //  Hits for detector AD
+  ClassDef(AliADhit,1); //  Hits for detector AD
 };
 
 #endif

--- a/AD/ADsim/AliADv1.cxx
+++ b/AD/ADsim/AliADv1.cxx
@@ -57,7 +57,6 @@
 
 // --- AliRoot header files ---
 
-
 #include "AliADhit.h"
 #include "AliADdigit.h"
 #include "AliADv1.h"
@@ -68,49 +67,45 @@
 #include "AliMC.h"
 #include "AliTrackReference.h"
 
+ClassImp(AliADv1);
 
-ClassImp(AliADv1)
 //__________________________________________________________________
-AliADv1::AliADv1() : 
-  AliAD(),
-  fADCstruct(kTRUE),
-  fADCPosition(kADCInTunnel),
-  fADCLightYield(93.75),
-  fADCPhotoCathodeEfficiency(0.18),
-  fADALightYield(93.75),
-  fADAPhotoCathodeEfficiency(0.18),
-  fKeepHistory(kFALSE)
+AliADv1::AliADv1()
+  : AliAD()
+  , fADCstruct(kTRUE)
+  , fADCPosition(kADCInTunnel)
+  , fADCLightYield(93.75)
+  , fADCPhotoCathodeEfficiency(0.18)
+  , fADALightYield(93.75)
+  , fADAPhotoCathodeEfficiency(0.18)
+  , fKeepHistory(kFALSE)
 {
-   // Default Constructor
-    fHits = 0;
+  fHits = NULL;
 }
 
 //_____________________________________________________________________________
-AliADv1::AliADv1(const char *name, const char *title) : 
-  AliAD(name,title),  
-  fADCstruct(kTRUE),
-  fADCPosition(kADCInTunnel),
-  fADCLightYield(93.75),
-  fADCPhotoCathodeEfficiency(0.18),
-  fADALightYield(93.75),
-  fADAPhotoCathodeEfficiency(0.18),
-  fKeepHistory(kFALSE)
+AliADv1::AliADv1(const char *name, const char *title)
+  : AliAD(name, title)
+  , fADCstruct(kTRUE)
+  , fADCPosition(kADCInTunnel)
+  , fADCLightYield(93.75)
+  , fADCPhotoCathodeEfficiency(0.18)
+  , fADALightYield(93.75)
+  , fADAPhotoCathodeEfficiency(0.18)
+  , fKeepHistory(kFALSE)
 {
-   // Standard constructor for AD Detector
-  
-   AliModule* pipe = gAlice->GetModule("PIPE");
-   if( (!pipe) ) {
-      Error("Constructor","AD needs PIPE!!!\n");
-      exit(1);
-   } 
-   fHits = new TClonesArray("AliADhit",400);
-   gAlice->GetMCApp()->AddHitList(fHits);
+  AliModule* pipe = gAlice->GetModule("PIPE");
+  if( (!pipe) ) {
+    Error("Constructor","AD needs PIPE!!!\n");
+    exit(1);
+  }
+  fHits = new TClonesArray("AliADhit",400);
+  gAlice->GetMCApp()->AddHitList(fHits);
 }
 
 //_____________________________________________________________________________
 AliADv1::~AliADv1()
 {
-	// default destructor
 }
 //_____________________________________________________________________________
 void AliADv1::Init()
@@ -131,11 +126,7 @@ void AliADv1::Init()
 //_____________________________________________________________________________
 void AliADv1::CreateGeometry()
 {
-  //
-  // Create the geometry for the AD arrays
-  //
   CreateAD();
-  
 }
 //_____________________________________________________________________________
 void AliADv1::ReadADCFromEnv() {
@@ -198,19 +189,19 @@ void AliADv1::CreateAD()
   Rx90m = new TGeoRotation("Rx90m",   0., -90.,   0.) ;
   Rx90  = new TGeoRotation("Rx90" ,   0.,  90.,   0.) ;
   Rx180 = new TGeoRotation("Rx180",   0., 180.,   0.) ;  //   4    |   1
-  Rz180 = new TGeoRotation("Rz180", 180.,   0.,   0.) ;  // --------------->  x  
+  Rz180 = new TGeoRotation("Rz180", 180.,   0.,   0.) ;  // --------------->  x
   Ry180 = new TGeoRotation("Ry180", 180., 180.,   0.) ;  //   3    |   2
   Ry90m = new TGeoRotation("Ry90m",  90., -90., -90.) ;
   // Get Mediums needed.
-  TGeoMedium * kMedAlu       = gGeoManager->GetMedium("AD_Alum");   // Aluminium 
-  TGeoMedium * kMedSteelSh   = gGeoManager->GetMedium("AD_ST_C0");  // Stainless Steel 
-  TGeoMedium * kMedVacuum    = gGeoManager->GetMedium("AD_VA_C0");  // Stainless Steel 
+  TGeoMedium * kMedAlu       = gGeoManager->GetMedium("AD_Alum");   // Aluminium
+  TGeoMedium * kMedSteelSh   = gGeoManager->GetMedium("AD_ST_C0");  // Stainless Steel
+  TGeoMedium * kMedVacuum    = gGeoManager->GetMedium("AD_VA_C0");  // Stainless Steel
   //
   // Private comunication by Arturo Tauro (2014, Apr 23)
-  // According to last survey measurement done this morning, 
+  // According to last survey measurement done this morning,
   // the C-side wall is at Z = - 18959mm.
   //
-  const Double_t kZwall        = 1895.9 ;  // Aluminium plate z position 
+  const Double_t kZwall        = 1895.9 ;  // Aluminium plate z position
   const Double_t kZendAbs      = 1880.75;  // End of CC block absorber
   const Double_t kZbegVMAOI    = 1919.2 ;  // Begining of Warm Module
   const Double_t kZbegValve    = 1910.7 ;  // Begining of Valve
@@ -234,7 +225,7 @@ void AliADv1::CreateAD()
   new TGeoCompositeShape("shIonPumpVBi", "shIonPumpVB1i+shIonPumpVB2i:ctPumpVB2");
   TGeoShape * sh3 = new TGeoCompositeShape("shIonPumpVB",  "shIonPumpVBo-shIonPumpVBi");
   TGeoVolume * voIonPumpVB = new TGeoVolume("voIonPumpVB", sh3, kMedAlu);
-  // Variables 
+  // Variables
   Double_t alpha, beta, tga2, tga, sa, ca, ctgb, d, Ro, Ri, phi1, dphi, H, L, z;
   // Drawing: LHCVSR__0054
   // Vacuum Screen - RF
@@ -257,17 +248,17 @@ void AliADv1::CreateAD()
   Ri = 6.3/2.; Ro = Ri + h;
   z = (9.71/2. - Ri) / tga;
   shVSRflange->DefineSection(3,            z,   Ri, Ro);
-  // 
+  //
   Double_t   Dtga = 6.6*tga - 0.5*(9.71-6.3)    ;
   Double_t x = (h - 0.11 - Dtga) / (ctgb - tga) ;
   Double_t y = x * ctgb;
   z  = 6.6 - x;
   Ro = Ri + 0.11 + y;
   shVSRflange->DefineSection(4,            z,   Ri, Ro);
-  z  = 6.6; 
+  z  = 6.6;
   Ro = Ri + 0.11;
   shVSRflange->DefineSection(5,            z,   Ri, Ro);
-  z  = 7.1; 
+  z  = 7.1;
   shVSRflange->DefineSection(6,            z,   Ri, Ro);
   TGeoVolume * voVSRflange = new TGeoVolume("voVSRflange", shVSRflange, kMedAlu);
   //
@@ -295,7 +286,7 @@ void AliADv1::CreateAD()
   Ro  = Ri + d/ca;
   shVSR0->DefineSection(5,        14.0 ,      Ri, Ro);
   // printf("  Ro: %8.2f\n", Ro);
-  // Make holes 
+  // Make holes
   new TGeoBBox("shHoleBody"    , 0.15, 0.60, 0.3);
   new TGeoTube("shHoleEnd", 0.  , 0.15, 0.3);
   (new TGeoTranslation("trHoleBody", 0., -0.6, 0.))->RegisterYourself();
@@ -312,21 +303,21 @@ void AliADv1::CreateAD()
   (new TGeoCombiTrans("ctHole4", 0., Ro , z, Rx90m))->RegisterYourself();
   // Now make a sector of RF transition tube
   new TGeoCompositeShape("shVSRsec",
-   "shVSR0 - (shHole:ctHole1 + shHole:ctHole2 + shHole:ctHole3 + shHole:ctHole4)");
+                         "shVSR0 - (shHole:ctHole1 + shHole:ctHole2 + shHole:ctHole3 + shHole:ctHole4)");
   // Now define rotations for each sector
   TString strSh = "shVSRsec ";
   for (Int_t i=1; i<=11; i++) {
-   (new TGeoRotation(Form("rSec%d",i), 30. * i, 0. , 0.))->RegisterYourself();
-   strSh+=Form("+ shVSRsec:rSec%d",i);
+    (new TGeoRotation(Form("rSec%d",i), 30. * i, 0. , 0.))->RegisterYourself();
+    strSh+=Form("+ shVSRsec:rSec%d",i);
   }
   // printf("%s\n", strSh.Data());
   TGeoCompositeShape * shVSR = new TGeoCompositeShape("shVSR", strSh.Data());
   // Now assembly the sector to form VSR RF transition tube !
   TGeoVolume * voVSR = new TGeoVolume("voVSR", shVSR, kMedAlu);
-  // 
+  //
   // Drawing: LHCVSR__0057
   // RF CONTACT
-  // 
+  //
   Ro = 0.5 * 6.3;
   d  = 0.03;
   Ri = Ro - d;
@@ -344,7 +335,7 @@ void AliADv1::CreateAD()
   Double_t R0 =  1.75;
   Double_t R1 = 10.48;
   Double_t R2 =  0.81 + 0.28;
-  phi1 = 0.; dphi = 360.; 
+  phi1 = 0.; dphi = 360.;
 
   TGeoPcon * shVSRcontact = new TGeoPcon("shVSRcont", phi1, dphi, 6);
   z = 0.;
@@ -447,9 +438,9 @@ void AliADv1::CreateAD()
   Double_t az [nsec] = {0.9, 0.915, 0.915, 11.885, 11.885, 11.9};
   Double_t aRi[nsec] = {5.0, 5.0  , 5.685,  5.685,  5.0  ,  5.0};
   for (Int_t i=0; i<nsec; i++) {
-   z=az[i]; Ri = aRi[i]; Ro = 5.7;
-   //printf("  i: %2d  z: %8.2f  Ri: %8.2f  Ro: %8.2f\n", i, z, Ri, Ro );
-   shVBUcent ->DefineSection( i, z, Ri, Ro);
+    z=az[i]; Ri = aRi[i]; Ro = 5.7;
+    //printf("  i: %2d  z: %8.2f  Ri: %8.2f  Ro: %8.2f\n", i, z, Ri, Ro );
+    shVBUcent ->DefineSection( i, z, Ri, Ro);
   }
 
   ( new TGeoCombiTrans("ctEnd9mm", 0., 0., 0.9, Ry180)) -> RegisterYourself();
@@ -462,27 +453,27 @@ void AliADv1::CreateAD()
   Double_t aRi2[nsec2] = {5.15, 5.15, 5.03, 5.03, 5.455, 5.455, 5.03, 5.03, 5.59, 5.59} ;
   TGeoPcon * shVBUrotFlg  = new TGeoPcon("shVBUrotFlg" , 0., 360., nsec2);
   for (Int_t i=0; i<nsec2; i++) {
-   z=az2[i]; Ri = aRi2[i]; Ro = 6.02;
-   //printf("  i: %2d  z: %8.2f  Ri: %8.2f  Ro: %8.2f\n", i, z, Ri, Ro );
-   shVBUrotFlg ->DefineSection( i, z, Ri, Ro);
+    z=az2[i]; Ri = aRi2[i]; Ro = 6.02;
+    //printf("  i: %2d  z: %8.2f  Ri: %8.2f  Ro: %8.2f\n", i, z, Ri, Ro );
+    shVBUrotFlg ->DefineSection( i, z, Ri, Ro);
   }
   TGeoVolume * voVBUrotFlg = new TGeoVolume("voVBUrotFlg", shVBUrotFlg, kMedAlu);
 
-  // Flange 
+  // Flange
   TGeoPcon * shVBUflg  = new TGeoPcon("shVBUflg" , 0., 360., 4);
-  z  = 0; 
-  Ri = 6.02; Ro = 7.6; 
+  z  = 0;
+  Ri = 6.02; Ro = 7.6;
   shVBUflg->DefineSection(0, z, Ri, Ro);
-  z  = 1.31; 
+  z  = 1.31;
   shVBUflg->DefineSection(1, z, Ri, Ro);
-  z  = 1.31; 
-  Ri = 5.15; 
+  z  = 1.31;
+  Ri = 5.15;
   shVBUflg->DefineSection(2, z, Ri, Ro);
   z  = 2.0;
   shVBUflg->DefineSection(3, z, Ri, Ro);
   TGeoVolume * voVBUflg = new TGeoVolume("voVBUflg", shVBUflg, kMedAlu);
 
-   
+
   // Add the metal plate at the end of Absorber
   // Plate:  80 cm x 80 cm x 1.95 cm (Thickness is aproximatted) (ernesto.calvo@pucp.edu.pe)
   // The End of the concrete abosorber is at kZendAbs = 1880.75
@@ -490,8 +481,8 @@ void AliADv1::CreateAD()
   new TGeoBBox("shBasePlate", 80./2., 80./2.,  1.95/2.);
   new TGeoTube("shHolePlate",  0.   , 12.3  ,  1.95   );
   TGeoVolume* voSaa3EndPlate  =  new TGeoVolume("voYSaa3EndPlate",
-      new TGeoCompositeShape("shYSaa3EndPlate","shBasePlate-shHolePlate"),
-      kMedSteelSh);
+                                                new TGeoCompositeShape("shYSaa3EndPlate","shBasePlate-shHolePlate"),
+                                                kMedSteelSh);
   //
   // Add Rods
   //
@@ -507,58 +498,58 @@ void AliADv1::CreateAD()
   ( new TGeoTranslation("trRod2", 0., 0., -dzRodL/2. + dzRodA + dzRodB/2.) )->RegisterYourself();
   ( new TGeoTranslation("trRod3", 0., 0.,  dzRodL/2. - dzRodB/2.)          )->RegisterYourself();
   TGeoVolume * voSaa3Rod = new TGeoVolume("YSAA3Rod",
-      new TGeoCompositeShape("shLargeRod+shRodA:trRod1 + shRodB:trRod2 + shRodB:trRod3"),
-      kMedSteelSh);
+                                          new TGeoCompositeShape("shLargeRod+shRodA:trRod1 + shRodB:trRod2 + shRodB:trRod3"),
+                                          kMedSteelSh);
   //
-  // Define Valve support (VS)  (ernesto.calvo@pucp.edu.pe) 
+  // Define Valve support (VS)  (ernesto.calvo@pucp.edu.pe)
   //
-  const Double_t dyVS =  5.5; 
-  const Double_t dxVS = 30.0; 
+  const Double_t dyVS =  5.5;
+  const Double_t dxVS = 30.0;
   const Double_t dzVS =  1.0;
   TGeoVolume * voVS = new TGeoVolume("voVS",
-      new TGeoBBox("shVS", dxVS/2., dyVS/2., dzVS/2.),
-      kMedSteelSh);
+                                     new TGeoBBox("shVS", dxVS/2., dyVS/2., dzVS/2.),
+                                     kMedSteelSh);
 
-  // Add Valve (Valve is divided in parts VA,VB,VC and VD)  (ernesto.calvo@pucp.edu.pe) 
+  // Add Valve (Valve is divided in parts VA,VB,VC and VD)  (ernesto.calvo@pucp.edu.pe)
   TGeoVolumeAssembly * voValve = new TGeoVolumeAssembly("voValve");
   //
-  // Define volume VA  (ernesto.calvo@pucp.edu.pe) 
-  const Double_t dxVA  = 20.3; 
-  const Double_t dyVA  = 48.0; 
-  const Double_t dzVA  =  6.0; // Width 
+  // Define volume VA  (ernesto.calvo@pucp.edu.pe)
+  const Double_t dxVA  = 20.3;
+  const Double_t dyVA  = 48.0;
+  const Double_t dzVA  =  6.0; // Width
   const Double_t dz2VA =  8.5; // Full width including protuding boxes
-  // Valve position  (ernesto.calvo@pucp.edu.pe) 
+  // Valve position  (ernesto.calvo@pucp.edu.pe)
   const Double_t zPosValve =  kZbegValve + dz2VA/2.;
   //
   new TGeoBBox("shVAbox",       dxVA/2., dyVA/2.,     dzVA/2.);
   new TGeoBBox("shVAHbox",  -1.+dxVA/2.,   3./2.,    dz2VA/2.);
   new TGeoTube("shVAC",              0.,     7.9,    dz2VA/2.);
   new TGeoTube("shVACh",             0.,     5.3,    dz2VA   );
-  // translation for shVAHbox (ernesto.calvo@pucp.edu.pe) 
+  // translation for shVAHbox (ernesto.calvo@pucp.edu.pe)
   ( new TGeoTranslation("trVAH1", 0.,  12.75, 0.) )->RegisterYourself();
   ( new TGeoTranslation("trVAH2", 0., -12.75, 0.) )->RegisterYourself();
 
   TGeoVolume * voValveVA = new TGeoVolume("voValveVA",
-      new TGeoCompositeShape("(shVAbox + shVAHbox:trVAH1 + shVAHbox:trVAH2 + shVAC)-shVACh"),
-      kMedSteelSh);
+                                          new TGeoCompositeShape("(shVAbox + shVAHbox:trVAH1 + shVAHbox:trVAH2 + shVAC)-shVACh"),
+                                          kMedSteelSh);
   voValve->AddNode(voValveVA, 1, 0);
   // Define Vacuum Hole of Valve
   TGeoTube   * shVACvach   = new TGeoTube("shVACvach", 0., 5.3, dz2VA/2.);
   TGeoVolume * voValveVAvh = new TGeoVolume("voValveVAvacuum", shVACvach, kMedVacuum);
   voValve->AddNode(voValveVAvh,1,0);
-  // Also add valve Support (ernesto.calvo@pucp.edu.pe) 
+  // Also add valve Support (ernesto.calvo@pucp.edu.pe)
   voValve->AddNode(voVS, 1, new TGeoTranslation(0.,  12.75, -dz2VA/2.-dzVS/2.));
   voValve->AddNode(voVS, 2, new TGeoTranslation(0., -12.75, -dz2VA/2.-dzVS/2.));
 
-  // Define Volume VB (ernesto.calvo@pucp.edu.pe) 
-  const Double_t dxVB = 23.5; 
-  const Double_t dyVB =  5.0; 
-  const Double_t dzVB =  9.4; 
-  TGeoVolume * voValveVB = new TGeoVolume("voValveVB", 
-      new TGeoBBox("shVBbox", dxVB/2., dyVB/2., dzVB/2.),
-      kMedSteelSh);
+  // Define Volume VB (ernesto.calvo@pucp.edu.pe)
+  const Double_t dxVB = 23.5;
+  const Double_t dyVB =  5.0;
+  const Double_t dzVB =  9.4;
+  TGeoVolume * voValveVB = new TGeoVolume("voValveVB",
+                                          new TGeoBBox("shVBbox", dxVB/2., dyVB/2., dzVB/2.),
+                                          kMedSteelSh);
   voValve->AddNode(voValveVB, 1, new TGeoTranslation(  0., dyVA/2. +dyVB/2. , 0));
-  // Define Volume VC (ernesto.calvo@pucp.edu.pe) 
+  // Define Volume VC (ernesto.calvo@pucp.edu.pe)
   const Double_t R1VC  =  4.5 /2.;
   const Double_t R2VC  =  8.1 /2.;
   const Double_t dy1VC  = 10.0;
@@ -568,42 +559,42 @@ void AliADv1::CreateAD()
   ( new TGeoTranslation("trVC21", 0., 0.,  dy1VC/2. - dy2VC/2.) )->RegisterYourself();
   ( new TGeoTranslation("trVC22", 0., 0., -dy1VC/2. + dy2VC/2.) )->RegisterYourself();
   TGeoVolume * voValveVC = new TGeoVolume("voValveVC",
-      new TGeoCompositeShape("shVC1  + shVC2:trVC21 + shVC2:trVC22"),
-      kMedSteelSh);
-  voValve->AddNode(voValveVC, 1, new TGeoCombiTrans( 
-        0., dyVA/2. + dyVB + dy1VC/2. , 0, Rx90) );
-  // Define volume VD (ernesto.calvo@pucp.edu.pe) 
+                                          new TGeoCompositeShape("shVC1  + shVC2:trVC21 + shVC2:trVC22"),
+                                          kMedSteelSh);
+  voValve->AddNode(voValveVC, 1, new TGeoCombiTrans(
+                                                    0., dyVA/2. + dyVB + dy1VC/2. , 0, Rx90) );
+  // Define volume VD (ernesto.calvo@pucp.edu.pe)
   const Double_t dxVD = 15.9;
   const Double_t dyVD = 23.0;
   const Double_t dzVD = 14.0;
   TGeoVolume * voValveVD = new TGeoVolume("voValveVD",
-      new TGeoBBox("shVD", dxVD/2., dyVD/2., dzVD/2.),
-      kMedSteelSh);
-  voValve->AddNode(voValveVD, 1, 
-      new TGeoTranslation( 1.25, dyVA/2. + dyVB + dy1VC + dyVD/2. , 0) );
+                                          new TGeoBBox("shVD", dxVD/2., dyVD/2., dzVD/2.),
+                                          kMedSteelSh);
+  voValve->AddNode(voValveVD, 1,
+                   new TGeoTranslation( 1.25, dyVA/2. + dyVB + dy1VC + dyVD/2. , 0) );
 
   //
-  // Define volume Front Bar (ernesto.calvo@pucp.edu.pe) 
+  // Define volume Front Bar (ernesto.calvo@pucp.edu.pe)
   //
-  const Double_t dxF  = 67.4; 
-  const Double_t dyF  =  4.0; 
-  const Double_t dzF  =  2.0; 
+  const Double_t dxF  = 67.4;
+  const Double_t dyF  =  4.0;
+  const Double_t dzF  =  2.0;
   const Double_t R1FC =  8.1;
   const Double_t R2FC = 11.5;
-  const Double_t dxFA  = (dxF-R1FC)/2.; 
- 
+  const Double_t dxFA  = (dxF-R1FC)/2.;
+
   new TGeoBBox("shFA", dxFA/2., dyF/2., dzF/2.);
   new TGeoTube("shFC",      0.,   R2FC, dzF/2.);
   new TGeoTube("shFCH",     0.,   R1FC, 2.*dzF);
   ( new TGeoTranslation("trFA1",  R1FC +dxFA/2., 0., 0.) )->RegisterYourself();
   ( new TGeoTranslation("trFA2", -R1FC -dxFA/2., 0., 0.) )->RegisterYourself();
   TGeoVolume * voFrontBar = new TGeoVolume("voFrontBar",
-      new TGeoCompositeShape("shFA:trFA1 + shFA:trFA2 + (shFC - shFCH)"),
-      kMedSteelSh);
+                                           new TGeoCompositeShape("shFA:trFA1 + shFA:trFA2 + (shFC - shFCH)"),
+                                           kMedSteelSh);
   // Make Lateral Bars
   const Double_t kdzLatBar = 22.9;
-  TGeoVolume * voLatBar = new TGeoVolume("voLatBar", 
-    new TGeoTube("shLatBar",0., dyF/2., kdzLatBar/2.), kMedSteelSh);
+  TGeoVolume * voLatBar = new TGeoVolume("voLatBar",
+                                         new TGeoTube("shLatBar",0., dyF/2., kdzLatBar/2.), kMedSteelSh);
   //
   // Define Compensator Magnet coils
   //
@@ -627,14 +618,14 @@ void AliADv1::CreateAD()
   TGeoCompositeShape * shCoil = new TGeoCompositeShape("shCoil0", strSh);
   TGeoVolume * voCoil = new TGeoVolume("voCoil", shCoil, kMedSteelSh);
 
-  // 
-  // ALUMINIUM PLATES 
+  //
+  // ALUMINIUM PLATES
   //
 
   // Shape for aluminium Plate separating cavern and LHC tunnel
   const Double_t dAlWallThick = 0.5; // thickness of aluminium plates (cm)
   //
-  // RB24/26 Tunnel Floor 
+  // RB24/26 Tunnel Floor
   R   = 220.;
   // h   = 140.;
   // phi = TMath::ACos(h / r);
@@ -650,18 +641,18 @@ void AliADv1::CreateAD()
   (new TGeoTranslation("trHUWAT3",         -70., -110. - 140. +40., 0.)) -> RegisterYourself();
 
   //
-  //  Wall Big Aluminium Plate with Squared Hole 
+  //  Wall Big Aluminium Plate with Squared Hole
   //
   const Double_t dSqrHoleSide = 33.0; // Side
   new TGeoBBox("shWallSqrHole", dSqrHoleSide*0.5, dSqrHoleSide*0.5, dAlWallThick);
-  strSh  = ""; 
+  strSh  = "";
   strSh += "shWallBase:trAntiBeamAxis - ";
   strSh += " ( shWallCutBot:trHUWAT3" ;
   strSh += " + shWallSqrHole )";
-  TGeoVolume* voWallBigPlate = new TGeoVolume("voWallBigPlate", 
-    new TGeoCompositeShape("shWallBigPlate", strSh), kMedAlu );
+  TGeoVolume* voWallBigPlate = new TGeoVolume("voWallBigPlate",
+                                              new TGeoCompositeShape("shWallBigPlate", strSh), kMedAlu );
   //
-  // Wall Squared Aluminium Plate 
+  // Wall Squared Aluminium Plate
   //
   const Double_t dCircHoleRad = 9.5; // Radius
   new TGeoTube("shCircHole", 0., dCircHoleRad, dAlWallThick);
@@ -673,13 +664,13 @@ void AliADv1::CreateAD()
   ( new TGeoTranslation("trWallRod4", -12.5,  12.75, 0.)) -> RegisterYourself();
   new TGeoBBox("shWallSqrPlateBase", dSqrHoleSide*0.5 + 5.0, dSqrHoleSide*0.5 + 5.0, dAlWallThick/2.);
   strSh  = " ((((";
-  strSh += " ( shWallSqrPlateBase - shCircHole )"; 
+  strSh += " ( shWallSqrPlateBase - shCircHole )";
   strSh += " - shRodHole:trWallRod1)"  ;
   strSh += " - shRodHole:trWallRod2)"  ;
   strSh += " - shRodHole:trWallRod3)"  ;
   strSh += " - shRodHole:trWallRod4)"  ;
-  TGeoVolume* voWallSqrPlate = new TGeoVolume("HUWAT_AlWall02", 
-    new TGeoCompositeShape("shWallSqrPlate", strSh ), kMedAlu);
+  TGeoVolume* voWallSqrPlate = new TGeoVolume("HUWAT_AlWall02",
+                                              new TGeoCompositeShape("shWallSqrPlate", strSh ), kMedAlu);
   // ==========================================================================
   //
   // Define Mother Vacuum volume of VMAOI  (need shIonPumpVBo)
@@ -695,10 +686,10 @@ void AliADv1::CreateAD()
   (new TGeoTranslation("trMoFlange2", 0., 0., 28.0 - 0.5*kdzMoFlange     )) -> RegisterYourself();
   (new TGeoTranslation("trMoBellow" , 0., 0., 28.0 - 0.5*kdzMoBellow     )) -> RegisterYourself();
   (new TGeoTranslation("trMoTTube"  , 0., 0., kziTTube +  0.5*kdzTTube   )) -> RegisterYourself();
-  
-  TGeoCompositeShape * shMoVMAOI =  
-      new TGeoCompositeShape("shMoVMAOI", 
-      "shMoFlange:trMoFlange1 + shMoBellow:trMoBellow + shMoFlange:trMoFlange2 + shIonPumpVBo:trMoTTube");
+
+  TGeoCompositeShape * shMoVMAOI =
+    new TGeoCompositeShape("shMoVMAOI",
+                           "shMoFlange:trMoFlange1 + shMoBellow:trMoBellow + shMoFlange:trMoFlange2 + shIonPumpVBo:trMoTTube");
   TGeoVolume * voMoVMAOI = new TGeoVolume("voMoVMAOI", shMoVMAOI, kMedVacuum);
   voMoVMAOI->AddNode(voVSR      ,1, new TGeoTranslation(0., 0., 7.1 - 0.45));
   voMoVMAOI->AddNode(voIonPumpVB,1, new TGeoTranslation(0., 0., 1 + 11.5/2.));
@@ -707,19 +698,19 @@ void AliADv1::CreateAD()
   voMoVMAOI->AddNode(voVSRcontF ,1, new TGeoTranslation(0.,0.,28.));
   z = 1.0 + 11.5;
   voMoVMAOI->AddNode( new TGeoVolume("voVBU9mm", shVBU9mm, kMedAlu),
-               1, new TGeoTranslation(0.,0., z) );
+                      1, new TGeoTranslation(0.,0., z) );
   voMoVMAOI->AddNode( new TGeoVolume("voVBU26mm", shVBU26mm, kMedAlu),
-               1, new TGeoTranslation(0.,0., z + 11.9) );
+                      1, new TGeoTranslation(0.,0., z + 11.9) );
   voMoVMAOI->AddNode( new TGeoVolume("voVBUcent", shVBUcent, kMedAlu),
-               1, new TGeoTranslation(0.,0., z) );
-  voMoVMAOI->AddNode( voVBUrotFlg, 1, 
-               new TGeoCombiTrans(0.,0.,1.31, Ry180) );
-  voMoVMAOI->AddNode( voVBUrotFlg, 2, 
-               new TGeoTranslation(0.,0.,28. - 1.31) );
-  voMoVMAOI->AddNode( voVBUflg, 1, 
-               new TGeoTranslation(0.,0.,0.) );
-  voMoVMAOI->AddNode( voVBUflg, 2, 
-               new TGeoCombiTrans(0.,0.,28., Ry180) );
+                      1, new TGeoTranslation(0.,0., z) );
+  voMoVMAOI->AddNode( voVBUrotFlg, 1,
+                      new TGeoCombiTrans(0.,0.,1.31, Ry180) );
+  voMoVMAOI->AddNode( voVBUrotFlg, 2,
+                      new TGeoTranslation(0.,0.,28. - 1.31) );
+  voMoVMAOI->AddNode( voVBUflg, 1,
+                      new TGeoTranslation(0.,0.,0.) );
+  voMoVMAOI->AddNode( voVBUflg, 2,
+                      new TGeoCombiTrans(0.,0.,28., Ry180) );
   // ==========================================================================
   //
   // AD Support structure by Pieter Ijzerman
@@ -729,8 +720,8 @@ void AliADv1::CreateAD()
   // Cover plate_______________________________________________________________
   TGeoXtru * shADcoverplate = new TGeoXtru(2);
   shADcoverplate->SetNameTitle("shADcoverplate","shADcoverplate");
-  Double_t y1[] = {  0.0, 18.50, 18.50, 22.50, 22.50, 18.50, 18.50, 22.50, 22.50, 18.50, 18.50,   .00 ,  .00, 15.25, 15.25,  .00 }; 
-  Double_t x1[] = {  0.0,   .00,  5.15,  5.15, 17.15, 17.15, 24.25, 24.25, 36.25, 36.25, 41.40, 41.40 ,35.70, 35.70,  5.70, 5.70 }; 
+  Double_t y1[] = {  0.0, 18.50, 18.50, 22.50, 22.50, 18.50, 18.50, 22.50, 22.50, 18.50, 18.50,   .00 ,  .00, 15.25, 15.25,  .00 };
+  Double_t x1[] = {  0.0,   .00,  5.15,  5.15, 17.15, 17.15, 24.25, 24.25, 36.25, 36.25, 41.40, 41.40 ,35.70, 35.70,  5.70, 5.70 };
   nvertices = sizeof(x1)/sizeof(Double_t);
   shADcoverplate->DefinePolygon(nvertices,x1,y1);
   shADcoverplate->DefineSection(0, -0.1, -20.7, 0.0, 1.0); // Z position, offset and scale for first section
@@ -750,12 +741,12 @@ void AliADv1::CreateAD()
   TGeoVolume * voADsidebox = new TGeoVolume("voADsidebox", shADsidebox, kMedAlu);
 
 
-// Define a TNode where this example resides in the TGeometry
-// Draw the TGeometry
+  // Define a TNode where this example resides in the TGeometry
+  // Draw the TGeometry
   TGeoVolume * voADhorizontalside = new TGeoVolume("voADhorizontalside", shADhorizontalside, kMedAlu);
   TGeoVolume * voADcoverplate = new TGeoVolume("voADcoverplate", shADcoverplate, kMedAlu);
   //
-  TGeoVolume *voADsupport = new TGeoVolumeAssembly("voADsupport"); 
+  TGeoVolume *voADsupport = new TGeoVolumeAssembly("voADsupport");
   voADsupport->AddNode(voADcoverplate,  1, new TGeoTranslation( 0., 0., -5.66/2.-0.23));
   voADsupport->AddNode(voADcoverplate,  2, new TGeoTranslation( 0., 0., +5.66/2.+0.23));
   voADsupport->AddNode(voADhorizontalside,  1, new TGeoCombiTrans( -6.0 - 7.1/2., 22.5-0.4, -5.66/2., Rx90));
@@ -770,23 +761,23 @@ void AliADv1::CreateAD()
   // ==========================================================================
 
   TGeoVolume *ad = new TGeoVolumeAssembly("AD");
-  
+
   // Get medium for ADA
   TGeoMedium * medADASci        = gGeoManager->GetMedium("AD_BC404"); // AD Scin.
   // TGeoMedium * medADALG      = gGeoManager->GetMedium("AD_PMMA");  // lightGuide
   // TGeoMedium * medADAPMGlass = gGeoManager->GetMedium("AD_Glass"); // Glass for Aluminium simulation
   // TGeoMedium * medADAPMAlum  = gGeoManager->GetMedium("AD_Alum");
-  
-  // Get Medium for ADC 
+
+  // Get Medium for ADC
   TGeoMedium * medADCSci     = gGeoManager->GetMedium("AD_BC404");
   // TGeoMedium * medADCLG      = gGeoManager->GetMedium("AD_PMMA");
   // TGeoMedium * medADCPMGlass = gGeoManager->GetMedium("AD_Glass");
   // TGeoMedium * medADCPMAlum  = gGeoManager->GetMedium("AD_Alum");
-  
-  // ADA Scintillator Pad 
+
+  // ADA Scintillator Pad
   const Double_t kADACellSideY = 21.6;
   const Double_t kADACellSideX = 18.1;
-  // ADC Scintillator Pad 
+  // ADC Scintillator Pad
   const Double_t kADCCellSideY = 21.6;
   const Double_t kADCCellSideX = 18.1;
   // WLS bar          :  0.40 cm ( 4.0 mm )
@@ -809,58 +800,58 @@ void AliADv1::CreateAD()
   Double_t WLS_dz =  2.5;
   Double_t WLS_SideA_Long_dy  = 24.20; // 24.2;
   Double_t WLS_SideC_Long_dy  = 24.20; // 24.2;
-  Double_t WLS_SideA_Short_dy = 18.20; // 18.41; 
-  Double_t WLS_SideC_Short_dy = 20.70; // 20.91; 
+  Double_t WLS_SideA_Short_dy = 18.20; // 18.41;
+  Double_t WLS_SideC_Short_dy = 20.70; // 20.91;
   // Creating ADA WLS bars_____________________________________________________
-  TGeoVolume * vADA_WLS_s = new TGeoVolume( "ADAWLSshort", 
-      new TGeoBBox( "shADAWLSbarShort" , WLS_dx/2.0, WLS_SideA_Short_dy/2.0, WLS_dz/2.0),
-      medADASci);      
-  TGeoVolume * vADA_WLS_l = new TGeoVolume( "ADAWLSlong" , 
-      new TGeoBBox( "shADAWLSbarLong"  , WLS_dx/2.0, WLS_SideA_Long_dy /2.0, WLS_dz/2.0),
-      medADASci);      
+  TGeoVolume * vADA_WLS_s = new TGeoVolume( "ADAWLSshort",
+                                            new TGeoBBox( "shADAWLSbarShort" , WLS_dx/2.0, WLS_SideA_Short_dy/2.0, WLS_dz/2.0),
+                                            medADASci);
+  TGeoVolume * vADA_WLS_l = new TGeoVolume( "ADAWLSlong" ,
+                                            new TGeoBBox( "shADAWLSbarLong"  , WLS_dx/2.0, WLS_SideA_Long_dy /2.0, WLS_dz/2.0),
+                                            medADASci);
   vADA_WLS_l->SetLineColor( kRed );
   vADA_WLS_s->SetLineColor( kRed );
   // Creating ADC WLS bars_____________________________________________________
-  TGeoVolume * vADC_WLS_s = new TGeoVolume( "ADCWLSshort", 
-      new TGeoBBox( "shADCWLSbarShort" , WLS_dx/2.0, WLS_SideC_Short_dy/2.0, WLS_dz/2.0),
-      medADCSci);      
-  TGeoVolume * vADC_WLS_l = new TGeoVolume( "ADCWLSlong" , 
-      new TGeoBBox( "shADCWLSbarLong"  , WLS_dx/2.0, WLS_SideC_Long_dy /2.0, WLS_dz/2.0),
-      medADCSci);      
+  TGeoVolume * vADC_WLS_s = new TGeoVolume( "ADCWLSshort",
+                                            new TGeoBBox( "shADCWLSbarShort" , WLS_dx/2.0, WLS_SideC_Short_dy/2.0, WLS_dz/2.0),
+                                            medADCSci);
+  TGeoVolume * vADC_WLS_l = new TGeoVolume( "ADCWLSlong" ,
+                                            new TGeoBBox( "shADCWLSbarLong"  , WLS_dx/2.0, WLS_SideC_Long_dy /2.0, WLS_dz/2.0),
+                                            medADCSci);
   vADC_WLS_l->SetLineColor(kRed);
   vADC_WLS_s->SetLineColor(kRed);
   // Make ADA scintillator pad_________________________________________________
   new TGeoBBox( "shADAbox" , kADACellSideX/2.0, kADACellSideY/2.0, kADACelldz/2.0 );
   new TGeoTube( "shADAHole",               0. , kADABeamPipeR    , kADACelldz     );
   ( new TGeoTranslation("trADAbox", X, Y, 0.)) -> RegisterYourself();
-  // 
-  TGeoVolume * vADA1 = new TGeoVolume( "ADApad", 
-    new TGeoCompositeShape("shADApad", "shADAbox:trADAbox-shADAHole"), medADASci );      
+  //
+  TGeoVolume * vADA1 = new TGeoVolume( "ADApad",
+                                       new TGeoCompositeShape("shADApad", "shADAbox:trADAbox-shADAHole"), medADASci );
   vADA1->SetLineColor( kColorADA );
-  
-  TGeoVolume *secADA  = new TGeoVolumeAssembly( "ADAsec" ); 
+
+  TGeoVolume *secADA  = new TGeoVolumeAssembly( "ADAsec" );
   // Add PAD
-  secADA->AddNode( vADA1, 1, 0); 
-  secADA->AddNode( vADA_WLS_s, 1, 
-      new TGeoTranslation(0.1 + WLS_dx/2.0, kADABeamPipeR + WLS_SideA_Short_dy/2.0, 0.0) ); 
-  secADA->AddNode( vADA_WLS_l, 1, 
-      new TGeoTranslation(kShiftX + WLS_dx/2.0 + kADACellSideX + 0.04, kShiftY + WLS_SideA_Long_dy/2.0, 0.0) ); 
+  secADA->AddNode( vADA1, 1, 0);
+  secADA->AddNode( vADA_WLS_s, 1,
+                   new TGeoTranslation(0.1 + WLS_dx/2.0, kADABeamPipeR + WLS_SideA_Short_dy/2.0, 0.0) );
+  secADA->AddNode( vADA_WLS_l, 1,
+                   new TGeoTranslation(kShiftX + WLS_dx/2.0 + kADACellSideX + 0.04, kShiftY + WLS_SideA_Long_dy/2.0, 0.0) );
 
   /// Assembling ADA adding 4 sectors                                       //  Sectors
   TGeoVolume *vADAarray = new TGeoVolumeAssembly( "ADA" );                  //        ^ y
-  vADAarray->AddNode( secADA, 1 );                                          //        |   
+  vADAarray->AddNode( secADA, 1 );                                          //        |
   vADAarray->AddNode( secADA, 2, Ry180 );                                   //   2    |   1
-  vADAarray->AddNode( secADA, 3, Rz180 );                                   // --------------->  x     
+  vADAarray->AddNode( secADA, 3, Rz180 );                                   // --------------->  x
   vADAarray->AddNode( secADA, 4, Rx180 );                                   //   3    |   4
   //                                                                        //        |
   // Add ADA layer 2 and 3 to AD volume
   // const Float_t kPosAD2 = 1695.0;
   // const Float_t kPosAD3 = 1700.0;
-  // ad->AddNode(vADAarray,1, new TGeoTranslation(0., 0., kPosAD2)); 
+  // ad->AddNode(vADAarray,1, new TGeoTranslation(0., 0., kPosAD2));
   // ad->AddNode(vADAarray,2, new TGeoTranslation(0., 0., kPosAD3));
   // const Float_t kPosADA = 1699.7;  // z-center of assembly (cm) Old
   const Float_t kPosADA = 1696.67;  // z-center of assembly (cm) New, according to Survey by F. Klumb and E.Calvo 2015 Sept 4th.
-  ad->AddNode(vADAarray,    1, new TGeoTranslation(0., 0., kPosADA - kADACelldz/2. -0.23)); 
+  ad->AddNode(vADAarray,    1, new TGeoTranslation(0., 0., kPosADA - kADACelldz/2. -0.23));
   ad->AddNode(vADAarray,    2, new TGeoTranslation(0., 0., kPosADA + kADACelldz/2. +0.23));
   ad->AddNode(voADsupport,  1, new TGeoTranslation(0., 0., kPosADA));
   ad->AddNode(voADsupport,  2, new TGeoCombiTrans (0., 0., kPosADA, Rz180));
@@ -879,39 +870,39 @@ void AliADv1::CreateAD()
   X = kShiftX + kADCCellSideX * 0.5;
   Y = kShiftY + kADCCellSideY * 0.5;
   ( new TGeoTranslation("trADCbox", X, Y, 0.) ) -> RegisterYourself();
-  // 
-  TGeoVolume * vADCpad = new TGeoVolume( "ADCpad", 
-    new TGeoCompositeShape("shADCpad", "shADCbox:trADCbox-shADCHole"), medADCSci );      
+  //
+  TGeoVolume * vADCpad = new TGeoVolume( "ADCpad",
+                                         new TGeoCompositeShape("shADCpad", "shADCbox:trADCbox-shADCHole"), medADCSci );
   vADCpad->SetLineColor( kColorADC );
-  
+
   /// Creating Sector for Tunnel (Asembly:  Scintillator Pad + Light guide + PM )
   TGeoVolume *voADC  = new TGeoVolumeAssembly("ADCsec");
   // Add PAD
   voADC->AddNode( vADCpad, 1, 0);
   // Add ADC WLS Short bar
-  voADC->AddNode( vADC_WLS_s, 1, 
-      new TGeoTranslation( 0.1 + WLS_dx/2.0, kADCBeamPipeR + WLS_SideC_Short_dy/2.0, 0.0) ); 
+  voADC->AddNode( vADC_WLS_s, 1,
+                  new TGeoTranslation( 0.1 + WLS_dx/2.0, kADCBeamPipeR + WLS_SideC_Short_dy/2.0, 0.0) );
   // Add ADC WLS Long  bar
-  voADC->AddNode( vADC_WLS_l, 1, 
-      new TGeoTranslation( 0.04 + WLS_dx/2.0 + kADCCellSideX + kShiftX, kShiftY + WLS_SideC_Long_dy/2.0, 0.0) ); 
-  
+  voADC->AddNode( vADC_WLS_l, 1,
+                  new TGeoTranslation( 0.04 + WLS_dx/2.0 + kADCCellSideX + kShiftX, kShiftY + WLS_SideC_Long_dy/2.0, 0.0) );
+
   /// Assembling ADC adding the 4 sectors                 //  Sectors
   TGeoVolume *vADCarray = new TGeoVolumeAssembly("ADC");  //        ^ y
-  vADCarray->AddNode( voADC, 1 );                         //        |   
+  vADCarray->AddNode( voADC, 1 );                         //        |
   vADCarray->AddNode( voADC, 2, Ry180 );                  //   2    |   1
-  vADCarray->AddNode( voADC, 3, Rz180 );                  // --------------->  x  
+  vADCarray->AddNode( voADC, 3, Rz180 );                  // --------------->  x
   vADCarray->AddNode( voADC, 4, Rx180 );                  //   3    |   4
                                                           //        |
-                                                                             
+
 
   // ==========================================================================
   //
   // Add ADC to AD volume
   //
-  // Note to future maintainers: 
-  // In previous AliRoot versions the position z = -1900.75 corresponded 
-  // to the end of the YSAA3_CC_BLOCK (concrete block shielding just before 
-  // the C-Side LHC wall). Now this has been fixed to agree with reality. 
+  // Note to future maintainers:
+  // In previous AliRoot versions the position z = -1900.75 corresponded
+  // to the end of the YSAA3_CC_BLOCK (concrete block shielding just before
+  // the C-Side LHC wall). Now this has been fixed to agree with reality.
   // The YSAA3_CC_BLOCK starts at 1800.75 and ends at 1880.75 cm.
   //
   // Ernesto Calvo and Alberto Gago.
@@ -919,52 +910,52 @@ void AliADv1::CreateAD()
   // - agago@pucp.edu.pe
   //
   // ==========================================================================
-  
+
   // *  ad -> AddNode(vADCarray , 1, new TGeoTranslation(0., 0., kZendADC2 + kADCCelldz/2.)); // Tunnel
   // *  ad -> AddNode(vADCarray , 2, new TGeoTranslation(0., 0., kZbegADC1 - kADCCelldz/2.)); // Tunnel
   // *  const Float_t kZbegADC1 = -kZbegFrontBar-2.
-  // *  const Float_t kZendADC2 = -1959.0;            // (ecalvovi@cern.ch) 
-  
+  // *  const Float_t kZendADC2 = -1959.0;            // (ecalvovi@cern.ch)
+
   switch (fADCPosition ) {
-    case kADCInTunnel:
-      {
-        // const Float_t kZbegADC1 = -kZbegFrontBar-2.;  // (ecalvovi@cern.ch) 
-        // const Float_t kZendADC2 = -1959.0;            // (ecalvovi@cern.ch) 
-        // ad -> AddNode(vADCarray , 1, new TGeoTranslation(0., 0., kZendADC2 + kADCCelldz/2.)); // Tunnel
-        // ad -> AddNode(vADCarray , 2, new TGeoTranslation(0., 0., kZbegADC1 - kADCCelldz/2.)); // Tunnel
-        const Float_t kPosADC = -kZbegFrontBar-2.-3.0-0.3;  // 3.0 = (5.6 + 0.2 + 0.2)/2. // (ecalvovi@cern.ch) 
-        printf("CreateAD: kPosADC=%8.2f\n", kPosADC);
-        ad -> AddNode(vADCarray,   1, new TGeoTranslation(0., 0., kPosADC - kADCCelldz/2. - 0.23)); // Tunnel // ADC1
-        ad -> AddNode(vADCarray,   2, new TGeoTranslation(0., 0., kPosADC + kADCCelldz/2. + 0.23)); // Tunnel // ADC2
-        ad -> AddNode(voADsupport, 3, new TGeoTranslation(0., 0., kPosADC));
-        ad -> AddNode(voADsupport, 4, new TGeoCombiTrans (0., 0., kPosADC, Rz180));
-        break;
-      }
-    case kADCInCavern:
-      {
-        printf("FATAL: vADCInCavern is now obsolete!");
-        exit(1);
-        // const Float_t kZbegADC1 = -1890.0;  // (ecalvovi@cern.ch) 
-        // const Float_t kZbegADC2 = -1885.0;  // (ecalvovi@cern.ch) 
-        // ad -> AddNode(vADCarrayH, 1, new TGeoTranslation(0., 0., kZbegADC1 - kADCCelldz/2.)); // Cavern
-        // ad -> AddNode(vADCarrayH, 2, new TGeoTranslation(0., 0., kZbegADC2 - kADCCelldz/2.)); // Cavern
-        break;
-      }
-    case kADCInBoth:
-      {
-        printf("FATAL: vADCInBoth   is now obsolete!");
-        exit(1);
-        // const Float_t kZbegADC1 = -kZbegFrontBar-2.;  // (ecalvovi@cern.ch) 
-        // const Float_t kZbegADC2 = -1885.0;            // (ecalvovi@cern.ch) 
-        // ad -> AddNode(vADCarray , 1, new TGeoTranslation(0., 0., kZbegADC1 - kADCCelldz/2.)); // Tunnel
-        // ad -> AddNode(vADCarrayH, 2, new TGeoTranslation(0., 0., kZbegADC2 - kADCCelldz/2.)); // Cavern 
-        break;
-      }
+  case kADCInTunnel:
+    {
+      // const Float_t kZbegADC1 = -kZbegFrontBar-2.;  // (ecalvovi@cern.ch)
+      // const Float_t kZendADC2 = -1959.0;            // (ecalvovi@cern.ch)
+      // ad -> AddNode(vADCarray , 1, new TGeoTranslation(0., 0., kZendADC2 + kADCCelldz/2.)); // Tunnel
+      // ad -> AddNode(vADCarray , 2, new TGeoTranslation(0., 0., kZbegADC1 - kADCCelldz/2.)); // Tunnel
+      const Float_t kPosADC = -kZbegFrontBar-2.-3.0-0.3;  // 3.0 = (5.6 + 0.2 + 0.2)/2. // (ecalvovi@cern.ch)
+      printf("CreateAD: kPosADC=%8.2f\n", kPosADC);
+      ad -> AddNode(vADCarray,   1, new TGeoTranslation(0., 0., kPosADC - kADCCelldz/2. - 0.23)); // Tunnel // ADC1
+      ad -> AddNode(vADCarray,   2, new TGeoTranslation(0., 0., kPosADC + kADCCelldz/2. + 0.23)); // Tunnel // ADC2
+      ad -> AddNode(voADsupport, 3, new TGeoTranslation(0., 0., kPosADC));
+      ad -> AddNode(voADsupport, 4, new TGeoCombiTrans (0., 0., kPosADC, Rz180));
+      break;
+    }
+  case kADCInCavern:
+    {
+      printf("FATAL: vADCInCavern is now obsolete!");
+      exit(1);
+      // const Float_t kZbegADC1 = -1890.0;  // (ecalvovi@cern.ch)
+      // const Float_t kZbegADC2 = -1885.0;  // (ecalvovi@cern.ch)
+      // ad -> AddNode(vADCarrayH, 1, new TGeoTranslation(0., 0., kZbegADC1 - kADCCelldz/2.)); // Cavern
+      // ad -> AddNode(vADCarrayH, 2, new TGeoTranslation(0., 0., kZbegADC2 - kADCCelldz/2.)); // Cavern
+      break;
+    }
+  case kADCInBoth:
+    {
+      printf("FATAL: vADCInBoth   is now obsolete!");
+      exit(1);
+      // const Float_t kZbegADC1 = -kZbegFrontBar-2.;  // (ecalvovi@cern.ch)
+      // const Float_t kZbegADC2 = -1885.0;            // (ecalvovi@cern.ch)
+      // ad -> AddNode(vADCarray , 1, new TGeoTranslation(0., 0., kZbegADC1 - kADCCelldz/2.)); // Tunnel
+      // ad -> AddNode(vADCarrayH, 2, new TGeoTranslation(0., 0., kZbegADC2 - kADCCelldz/2.)); // Cavern
+      break;
+    }
   }
 
 
   // ==========================================================================
-  // 
+  //
   // Add structure volumes to top volume
   //
   // ==========================================================================
@@ -974,7 +965,7 @@ void AliADv1::CreateAD()
   z = kZwall;
   top->AddNode(voWallBigPlate, 1, new TGeoTranslation(0., 0., z - 0.5 * dAlWallThick ));
   top->AddNode(voWallSqrPlate, 1, new TGeoTranslation(0., 0., z + 0.5 * dAlWallThick ));
-  z = kZendAbs + 1.95 + dzRodL/2.; 
+  z = kZendAbs + 1.95 + dzRodL/2.;
   top->AddNode(voSaa3Rod,  1, new TGeoTranslation(  12.5, -12.75, z));
   top->AddNode(voSaa3Rod,  2, new TGeoTranslation(  12.5,  12.75, z));
   top->AddNode(voSaa3Rod,  3, new TGeoTranslation( -12.5, -12.75, z));
@@ -1004,7 +995,7 @@ void AliADv1::CreateAD()
   //
   TGeoVolume *alice = gGeoManager->GetVolume("ALIC");
   alice->AddNode(ad, 1);
-  
+
 
   // gGeoManager->DefaultColors();
   // gGeoManager->CloseGeometry();
@@ -1012,52 +1003,51 @@ void AliADv1::CreateAD()
   // gGeoManager->SetVisOption(0);
   // alice->Draw("ogl");
 
-  return; 
+  return;
   printf("<=== AliADv1::CreateAD(): ver=[Feb 3st, 2015]; contact=[ecalvovi@cern.ch]\n");
 }
 
 //_____________________________________________________________________________
 void AliADv1::AddAlignableVolumes() const
 {
-   //
-   // Create entries for alignable volumes associating the symbolic volume
-   // name with the corresponding volume path. Needs to be syncronized with
-   // eventual changes in the geometry.
-   //
-   // ADA and ADC 
-   TString volpath1, volpath2, volpath3, volpath4;
-   TString symname1, symname2, symname3, symname4;
+  //
+  // Create entries for alignable volumes associating the symbolic volume
+  // name with the corresponding volume path. Needs to be syncronized with
+  // eventual changes in the geometry.
+  //
+  // ADA and ADC
+  TString volpath1, volpath2, volpath3, volpath4;
+  TString symname1, symname2, symname3, symname4;
 
-   symname1 = "AD/ADC1";
-   symname2 = "AD/ADC2"; 
-   symname3 = "AD/ADA1";
-   symname4 = "AD/ADA2"; 
-   switch (fADCPosition) {
-     case kADCInTunnel:
-       volpath1 = "/ALIC_1/AD_1/ADC_1";
-       volpath2 = "/ALIC_1/AD_1/ADC_2";
-       break;
-     case kADCInCavern:
-       volpath1 = "/ALIC_1/AD_1/ADCh_1";
-       volpath2 = "/ALIC_1/AD_1/ADCh_2";
-       break;
-     case kADCInBoth:
-       volpath1 = "/ALIC_1/AD_1/ADC_1";
-       volpath2 = "/ALIC_1/AD_1/ADCh_2";
-       break;
-   }
-   volpath3 = "/ALIC_1/AD_1/ADA_1";
-   volpath4 = "/ALIC_1/AD_1/ADA_2";
+  symname1 = "AD/ADC1";
+  symname2 = "AD/ADC2";
+  symname3 = "AD/ADA1";
+  symname4 = "AD/ADA2";
+  switch (fADCPosition) {
+  case kADCInTunnel:
+    volpath1 = "/ALIC_1/AD_1/ADC_1";
+    volpath2 = "/ALIC_1/AD_1/ADC_2";
+    break;
+  case kADCInCavern:
+    volpath1 = "/ALIC_1/AD_1/ADCh_1";
+    volpath2 = "/ALIC_1/AD_1/ADCh_2";
+    break;
+  case kADCInBoth:
+    volpath1 = "/ALIC_1/AD_1/ADC_1";
+    volpath2 = "/ALIC_1/AD_1/ADCh_2";
+    break;
+  }
+  volpath3 = "/ALIC_1/AD_1/ADA_1";
+  volpath4 = "/ALIC_1/AD_1/ADA_2";
 
-   if ( !gGeoManager->SetAlignableEntry(symname1.Data(), volpath1.Data()) )
-      AliFatal(Form( "Alignable entry %s not created. Volume path %s not valid", symname1.Data(), volpath1.Data()) );
-   if ( GetADCTwoInstalled() && !gGeoManager->SetAlignableEntry(symname2.Data(), volpath2.Data()) )
-      AliFatal(Form( "Alignable entry %s not created. Volume path %s not valid", symname2.Data(), volpath2.Data()) );
-   if ( !gGeoManager->SetAlignableEntry(symname3.Data(), volpath3.Data()) )
-      AliFatal(Form( "Alignable entry %s not created. Volume path %s not valid", symname3.Data(), volpath3.Data()) );
-   if ( GetADATwoInstalled() && !gGeoManager->SetAlignableEntry(symname4.Data(), volpath4.Data()) )
-      AliFatal(Form("Alignable entry %s not created. Volume path %s not valid", symname4.Data(), volpath4.Data()) );
-   
+  if ( !gGeoManager->SetAlignableEntry(symname1.Data(), volpath1.Data()) )
+    AliFatalF("Alignable entry %s not created. Volume path %s not valid", symname1.Data(), volpath1.Data());
+  if ( GetADCTwoInstalled() && !gGeoManager->SetAlignableEntry(symname2.Data(), volpath2.Data()) )
+    AliFatalF("Alignable entry %s not created. Volume path %s not valid", symname2.Data(), volpath2.Data());
+  if ( !gGeoManager->SetAlignableEntry(symname3.Data(), volpath3.Data()) )
+    AliFatalF("Alignable entry %s not created. Volume path %s not valid", symname3.Data(), volpath3.Data());
+  if ( GetADATwoInstalled() && !gGeoManager->SetAlignableEntry(symname4.Data(), volpath4.Data()) )
+    AliFatalF("Alignable entry %s not created. Volume path %s not valid", symname4.Data(), volpath4.Data());
 }
 
 
@@ -1065,187 +1055,184 @@ void AliADv1::AddAlignableVolumes() const
 void AliADv1::StepManager()
 {
 
-   //
-   // Routine called at every step in the AD
-   //
+  //
+  // Routine called at every step in the AD
+  //
 
-   // ADA and ADC static Variables         //
-   // static  Int_t   numStep_ad = 0;      //
-   // static  Int_t   vol_ad[2];           //
-  
-   /////////////////////////////////////////////////////////////////////////
-   //                            ADA and ADC                              //
-   /////////////////////////////////////////////////////////////////////////
-      
-      
-   // Get sensitive volumes id (scintillator pads)
-   static Int_t idADA  = fMC->VolId( "ADApad" );
-   static Int_t idADC  = fMC->VolId( "ADCpad" );
-   // static Int_t idADCh = fMC->VolId( "ADCpadH" );
-   
-   static Bool_t fOnlyOnce = kTRUE;
-   if (fOnlyOnce) {
-     //printf("  fMC->VolId(\"ADApad\" ) = %3d\n", idADA);
-     //printf("  fMC->VolId(\"ADCpad\" ) = %3d\n", idADC);
-     // printf("  fMC->VolId(\"ADCpadH\") = %3d\n", idADCh);
-     fOnlyOnce = kFALSE;
-   }
+  // ADA and ADC static Variables         //
+  // static  Int_t   numStep_ad = 0;      //
+  // static  Int_t   vol_ad[2];           //
 
-   // We keep only charged tracks : 
-   // if ( !fMC->TrackCharge() || !fMC->IsTrackAlive() ) return;
-   // We keep charged and non-charged tracks : 
-   if ( !fMC->IsTrackAlive() ) return;
-   
-   Int_t copy;
-   Int_t current_volid = fMC->CurrentVolID( copy );
+  /////////////////////////////////////////////////////////////////////////
+  //                            ADA and ADC                              //
+  /////////////////////////////////////////////////////////////////////////
 
-   // check is the track is in a sensitive volume
-   // if( current_volid != idADA && current_volid != idADC && current_volid != idADCh ) {
-   if( current_volid != idADA && current_volid != idADC ) {
-      return; // not in the sensitive volume 
-   }
-   
-   // First read the position, otherwise weird results! //ecv
-   Double_t s[3];
-   Float_t  x[3];
-   fMC->TrackPosition( s[0], s[1], s[2] );
-   for ( Int_t j=0; j<3; j++ ) x[j] = s[j];
-   
-   // Get sector copy (1,2,3,4) ( 1 level up from pad )
-   Int_t sect;
-   fMC->CurrentVolOffID( 1, sect );
-   
-   // Get Detector copy (1,2) ( 2 levels up from pad )
-   Int_t detc;
-   fMC->CurrentVolOffID( 2, detc );
 
-   // Set detector type: ADA or ADC
-   Int_t ADlayer = (current_volid == idADC ) ? 0 : 2;
+  // Get sensitive volumes id (scintillator pads)
+  static Int_t idADA  = fMC->VolId( "ADApad" );
+  static Int_t idADC  = fMC->VolId( "ADCpad" );
+  // static Int_t idADCh = fMC->VolId( "ADCpadH" );
 
-   //printf("CurVolID: %d | sect: %2d | detc: %2d\n", current_volid, sect, detc); 
+  static Bool_t fOnlyOnce = kTRUE;
+  if (fOnlyOnce) {
+    //printf("  fMC->VolId(\"ADApad\" ) = %3d\n", idADA);
+    //printf("  fMC->VolId(\"ADCpad\" ) = %3d\n", idADC);
+    // printf("  fMC->VolId(\"ADCpadH\") = %3d\n", idADCh);
+    fOnlyOnce = kFALSE;
+  }
 
-   sect--;          //     sector within layer [0-3]
-   detc--;          //     detector copy       [0-1]
-   ADlayer += detc; //     global layer number [0-3]
+  // We keep only charged tracks :
+  // if ( !fMC->TrackCharge() || !fMC->IsTrackAlive() ) return;
+  // We keep charged and non-charged tracks :
+  if ( !fMC->IsTrackAlive() ) return;
 
-   Int_t ADsector = ADlayer*4 + sect; // Global AD sector number [0-15]
-   // Layer    Sector Number 
-   // ADC 0  =   0- 3
-   // ADC 1  =   4- 7
-   // ADA 2  =   8-11
-   // ADA 3  =  12-15
-   //printf("\n ADsector: %2d | ADlayer: %2d | sect: %2d | x: %8.2f | y: %8.2f | z: %8.2f\n", ADsector, ADlayer, sect, x[0], x[1], x[2]); // Debug ECV
-   
-   Double_t lightYield_ad;
-   Double_t photoCathodeEfficiency;
-  
-   if( ADlayer <2 )  {
-      lightYield_ad          = fADCLightYield;
-      photoCathodeEfficiency = fADCPhotoCathodeEfficiency;
-   } else  {
-      lightYield_ad          = fADALightYield;
-      photoCathodeEfficiency = fADAPhotoCathodeEfficiency;
-   }
-      
-   Float_t destep_ad = fMC->Edep();
-   Float_t step_ad   = fMC->TrackStep();
-   Int_t  nPhotonsInStep_ad = Int_t( destep_ad / (lightYield_ad * 1e-9) ); 
-   nPhotonsInStep_ad = gRandom->Poisson( nPhotonsInStep_ad );
-   
-   static  Float_t eloss_ad    = 0.;
-   static  Float_t tlength_ad  = 0.;   
-   static  Int_t   nPhotons_ad = 0;      
-   static  Float_t hits_ad[11];            
-   static  Int_t   vol_ad[5];
+  Int_t copy;
+  Int_t current_volid = fMC->CurrentVolID( copy );
 
-   eloss_ad   += destep_ad;
-   tlength_ad += step_ad;  
- 
-   if ( fMC->IsTrackEntering() ) {
-      nPhotons_ad = nPhotonsInStep_ad;
-      Double_t p[4];
-      fMC->TrackMomentum( p[0], p[1], p[2], p[3] );
-      Float_t pt  = TMath::Sqrt( p[0]*p[0] + p[1]*p[1] + p[2]*p[2] ); 
-      TParticle *par = gAlice->GetMCApp()->Particle(gAlice->GetMCApp()->GetCurrentTrackNumber());
-      Int_t imo = par->GetFirstMother();
-      Int_t pdgMo = 0;
-      if ( imo > 0 ) {
-         TParticle * pmot = gAlice->GetMCApp()->Particle(imo);
-         pdgMo = pmot->GetPdgCode();
-      }
+  // check is the track is in a sensitive volume
+  // if( current_volid != idADA && current_volid != idADC && current_volid != idADCh ) {
+  if( current_volid != idADA && current_volid != idADC ) {
+    return; // not in the sensitive volume
+  }
 
-      // Set integer values
-      vol_ad[0]  = par->GetStatusCode();    // secondary flag //ecv
-      vol_ad[1]  = par->GetPdgCode();       // PDG code
-      vol_ad[2]  = pdgMo;                   // PDG of the mother
-      // Set float values
-      hits_ad[0]  = x[0];     // X
-      hits_ad[1]  = x[1];     // Y 
-      hits_ad[2]  = x[2];     // Z       
-      hits_ad[3]  = p[3];     // kinetic energy of the entering particle
-      hits_ad[4]  = pt;       // Pt
-      hits_ad[5]  = p[0];     // Px
-      hits_ad[6]  = p[1];     // Py
-      hits_ad[7]  = p[2];     // Pz
-      hits_ad[8]  = 1.0e09*fMC->TrackTime(); // in ns!
-  
-      tlength_ad = 0.0;
-      eloss_ad   = 0.0; 
-      
-      return; // without return, we count 2 times nPhotonsInStep_ad !!!???
-   }
-   
-   nPhotons_ad += nPhotonsInStep_ad;
+  // First read the position, otherwise weird results! //ecv
+  Double_t s[3];
+  Float_t  x[3];
+  fMC->TrackPosition( s[0], s[1], s[2] );
+  for ( Int_t j=0; j<3; j++ ) x[j] = s[j];
 
-   if( fMC->IsTrackExiting() || fMC->IsTrackStop() || fMC->IsTrackDisappeared() ) {
+  // Get sector copy (1,2,3,4) ( 1 level up from pad )
+  Int_t sect;
+  fMC->CurrentVolOffID( 1, sect );
 
-      // Set integer values
-      vol_ad[3]  = nPhotons_ad;
-      vol_ad[4]  = ADsector;  // sector number (scintillator ID)
-      // Set float values
-      hits_ad[9]  = tlength_ad;    // track lenght inside ADC or ADA
-      hits_ad[10] = eloss_ad;      // energy loss
-      Int_t track; 
-      if(fKeepHistory) track = gAlice->GetMCApp()->GetCurrentTrackNumber();
-      else track = gAlice->GetMCApp()->GetPrimary( gAlice->GetMCApp()->GetCurrentTrackNumber() );
-      AddHit( track, vol_ad, hits_ad ); // <-- this is in AliAD.cxx
-      tlength_ad        = 0.0;
-      eloss_ad          = 0.0; 
-      nPhotons_ad       = 0;
-   }
-       
-    //Track reference   
-    if( fMC->IsTrackEntering() || fMC->IsTrackExiting() ) AddTrackReference(gAlice->GetMCApp()->GetCurrentTrackNumber(), AliTrackReference::kAD);
+  // Get Detector copy (1,2) ( 2 levels up from pad )
+  Int_t detc;
+  fMC->CurrentVolOffID( 2, detc );
+
+  // Set detector type: ADA or ADC
+  Int_t ADlayer = (current_volid == idADC ) ? 0 : 2;
+
+  //printf("CurVolID: %d | sect: %2d | detc: %2d\n", current_volid, sect, detc);
+
+  sect--;          //     sector within layer [0-3]
+  detc--;          //     detector copy       [0-1]
+  ADlayer += detc; //     global layer number [0-3]
+
+  Int_t ADsector = ADlayer*4 + sect; // Global AD sector number [0-15]
+  // Layer    Sector Number
+  // ADC 0  =   0- 3
+  // ADC 1  =   4- 7
+  // ADA 2  =   8-11
+  // ADA 3  =  12-15
+  //printf("\n ADsector: %2d | ADlayer: %2d | sect: %2d | x: %8.2f | y: %8.2f | z: %8.2f\n", ADsector, ADlayer, sect, x[0], x[1], x[2]); // Debug ECV
+
+  Double_t lightYield_ad;
+  Double_t photoCathodeEfficiency;
+
+  if( ADlayer <2 )  {
+    lightYield_ad          = fADCLightYield;
+    photoCathodeEfficiency = fADCPhotoCathodeEfficiency;
+  } else  {
+    lightYield_ad          = fADALightYield;
+    photoCathodeEfficiency = fADAPhotoCathodeEfficiency;
+  }
+
+  Float_t destep_ad = fMC->Edep();
+  Float_t step_ad   = fMC->TrackStep();
+  Int_t  nPhotonsInStep_ad = Int_t( destep_ad / (lightYield_ad * 1e-9) );
+  nPhotonsInStep_ad = gRandom->Poisson( nPhotonsInStep_ad );
+
+  static  Float_t eloss_ad    = 0.;
+  static  Float_t tlength_ad  = 0.;
+  static  Int_t   nPhotons_ad = 0;
+  static  Float_t hits_ad[11];
+  static  Int_t   vol_ad[5];
+
+  eloss_ad   += destep_ad;
+  tlength_ad += step_ad;
+
+  if ( fMC->IsTrackEntering() ) {
+    nPhotons_ad = nPhotonsInStep_ad;
+    Double_t p[4];
+    fMC->TrackMomentum( p[0], p[1], p[2], p[3] );
+    Float_t pt  = TMath::Sqrt( p[0]*p[0] + p[1]*p[1] + p[2]*p[2] );
+    TParticle *par = gAlice->GetMCApp()->Particle(gAlice->GetMCApp()->GetCurrentTrackNumber());
+    Int_t imo = par->GetFirstMother();
+    Int_t pdgMo = 0;
+    if ( imo > 0 ) {
+      TParticle * pmot = gAlice->GetMCApp()->Particle(imo);
+      pdgMo = pmot->GetPdgCode();
+    }
+
+    // Set integer values
+    vol_ad[0]  = par->GetStatusCode();    // secondary flag //ecv
+    vol_ad[1]  = par->GetPdgCode();       // PDG code
+    vol_ad[2]  = pdgMo;                   // PDG of the mother
+    // Set float values
+    hits_ad[0]  = x[0];     // X
+    hits_ad[1]  = x[1];     // Y
+    hits_ad[2]  = x[2];     // Z
+    hits_ad[3]  = p[3];     // kinetic energy of the entering particle
+    hits_ad[4]  = pt;       // Pt
+    hits_ad[5]  = p[0];     // Px
+    hits_ad[6]  = p[1];     // Py
+    hits_ad[7]  = p[2];     // Pz
+    hits_ad[8]  = 1.0e09*fMC->TrackTime(); // in ns!
+
+    tlength_ad = 0.0;
+    eloss_ad   = 0.0;
+
+    return; // without return, we count 2 times nPhotonsInStep_ad !!!???
+  }
+
+  nPhotons_ad += nPhotonsInStep_ad;
+
+  if( fMC->IsTrackExiting() || fMC->IsTrackStop() || fMC->IsTrackDisappeared() ) {
+
+    // Set integer values
+    vol_ad[3]  = nPhotons_ad;
+    vol_ad[4]  = ADsector;  // sector number (scintillator ID)
+    // Set float values
+    hits_ad[9]  = tlength_ad;    // track lenght inside ADC or ADA
+    hits_ad[10] = eloss_ad;      // energy loss
+    Int_t track;
+    if(fKeepHistory) track = gAlice->GetMCApp()->GetCurrentTrackNumber();
+    else track = gAlice->GetMCApp()->GetPrimary( gAlice->GetMCApp()->GetCurrentTrackNumber() );
+    AddHit( track, vol_ad, hits_ad ); // <-- this is in AliAD.cxx
+    tlength_ad        = 0.0;
+    eloss_ad          = 0.0;
+    nPhotons_ad       = 0;
+  }
+
+  //Track reference
+  if( fMC->IsTrackEntering() || fMC->IsTrackExiting() ) AddTrackReference(gAlice->GetMCApp()->GetCurrentTrackNumber(), AliTrackReference::kAD);
 }
 //_________________________________________________________
 void AliADv1::AddHit(Int_t track, Int_t *vol, Float_t *hits)
 {
-	TClonesArray &lhits = *fHits;
-	new(lhits[fNhits++]) AliADhit(fIshunt,track,vol,hits);
+  TClonesArray &lhits = *fHits;
+  new(lhits[fNhits++]) AliADhit(fIshunt,track,vol,hits);
 }
 //_________________________________________________________
 // void AliADv1::AddDigits(Int_t* track, Int_t module, Float_t time)
 // {
-// 	TClonesArray &ldigits = *fDigits;
-// 	new(ldigits[fNdigits++]) AliADdigit(track,module,time);
+//      TClonesArray &ldigits = *fDigits;
+//      new(ldigits[fNdigits++]) AliADdigit(track,module,time);
 // }
 //_________________________________________________________
 void AliADv1::MakeBranch(Option_t *option)
 {
-
-	// Create branches in the current tree
-	TString branchname(Form("%s",GetName()));
-	AliDebug(2,Form("fBufferSize = %d",fBufferSize));
-	const char *cH = strstr(option,"H");
-	if (fHits && fLoader->TreeH() && cH)
-	{
-		fLoader->TreeH()->Branch(branchname.Data(),&fHits,fBufferSize);
-		AliDebug(2,Form("Making Branch %s for hits",branchname.Data()));
-	}
-	const char *cD = strstr(option,"D");
-  	if (fDigits   && fLoader->TreeD() && cD) 
-	{
-    		fLoader->TreeD()->Branch(branchname.Data(),&fDigits, fBufferSize);
-    		AliDebug(2,Form("Making Branch %s for digits",branchname.Data()));
-  	}  
+  // Create branches in the current tree
+  TString branchname(Form("%s",GetName()));
+  AliDebugF(2, "fBufferSize = %d",fBufferSize);
+  const char *cH = strstr(option,"H");
+  if (fHits && fLoader->TreeH() && cH) {
+    fLoader->TreeH()->Branch(branchname.Data(),&fHits,fBufferSize);
+    AliDebugF(2, "Making Branch %s for hits",branchname.Data());
+  }
+  const char *cD = strstr(option,"D");
+  if (fDigits && fLoader->TreeD() && cD) {
+    fLoader->TreeD()->Branch(branchname.Data(),&fDigits, fBufferSize);
+    AliDebugF(2, "Making Branch %s for digits",branchname.Data());
+  }
 }

--- a/AD/ADsim/AliADv1.cxx
+++ b/AD/ADsim/AliADv1.cxx
@@ -1126,16 +1126,9 @@ void AliADv1::StepManager()
   // ADA 3  =  12-15
   //printf("\n ADsector: %2d | ADlayer: %2d | sect: %2d | x: %8.2f | y: %8.2f | z: %8.2f\n", ADsector, ADlayer, sect, x[0], x[1], x[2]); // Debug ECV
 
-  Double_t lightYield_ad;
-  Double_t photoCathodeEfficiency;
-
-  if( ADlayer <2 )  {
-    lightYield_ad          = fADCLightYield;
-    photoCathodeEfficiency = fADCPhotoCathodeEfficiency;
-  } else  {
-    lightYield_ad          = fADALightYield;
-    photoCathodeEfficiency = fADAPhotoCathodeEfficiency;
-  }
+  Double_t lightYield_ad = (ADlayer < 2
+			    ? fADCLightYield
+			    : fADALightYield);
 
   Float_t destep_ad = fMC->Edep();
   Float_t step_ad   = fMC->TrackStep();

--- a/AD/ADsim/AliADv1.h
+++ b/AD/ADsim/AliADv1.h
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 #ifndef ALIADV1_H
 #define ALIADV1_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
@@ -21,15 +22,15 @@
 
 #include "AliAD.h"
 #include "TGeoCompositeShape.h"
+
 class AliADv1 : public AliAD {
 public:
-   
-                        AliADv1();
-                        AliADv1(const char *name, const char *title);
-  virtual void   AddAlignableVolumes() const;
-  virtual              ~AliADv1();
+  AliADv1();
+  AliADv1(const char *name, const char *title);
+  virtual ~AliADv1();
 
-   
+  virtual void   AddAlignableVolumes() const;
+
   virtual TString  Version() { return TString("v1"); }
   virtual   Int_t  IsVersion() const { return 1; }
   virtual    void  AddHit(Int_t track, Int_t *vol, Float_t *hits);
@@ -44,34 +45,31 @@ public:
   enum ADCPosition_t { kADCInTunnel, kADCInCavern, kADCInBoth};
 
 protected:
-
   // functions for ADA and ADC
   void ReadADCFromEnv(void);
   TGeoCompositeShape * MakeShapeADCpadH(const Double_t W, const Double_t H, const Double_t dz);
   virtual    void  CreateAD();
+
 private:
   // Position of ADC: In the Tunnel, In the Cavern, or in Both
-  Bool_t      fADCstruct;
+  Bool_t        fADCstruct;
   ADCPosition_t fADCPosition;
   //! ADC Geometrical & Optical parameters :
-  
+
   Double_t    fADCLightYield;       //! Lightyield in NE102
   Double_t    fADCPhotoCathodeEfficiency;
 
   //! ADA Geometrical & Optical parameters :
- 
+
   Double_t    fADALightYield;       //! Lightyield in NE102
-  Double_t    fADAPhotoCathodeEfficiency; 
-  
-  Bool_t      fKeepHistory; 
+  Double_t    fADAPhotoCathodeEfficiency;
 
+  Bool_t      fKeepHistory;
 
-  AliADv1(const AliAD&); 
-  AliADv1& operator = (const AliADv1&); 
-  
-  ClassDef(AliADv1, 1)  //!Class for the AD detector
-   
+  AliADv1(const AliAD&);
+  AliADv1& operator = (const AliADv1&);
+
+  ClassDef(AliADv1, 1);  //Class for the AD detector
 };
-
 
 #endif

--- a/AD/CMakeLists.txt
+++ b/AD/CMakeLists.txt
@@ -13,6 +13,8 @@
 # * provided "as is" without express or implied warranty.                  *
 # **************************************************************************
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+
 add_subdirectory(ADbase)
 add_subdirectory(ADrec)
 add_subdirectory(ADsim)

--- a/STARLIGHT/AliStarLight/AliGenStarLight.cxx
+++ b/STARLIGHT/AliStarLight/AliGenStarLight.cxx
@@ -20,7 +20,7 @@
 #include "starlight.h"
 #include "upcevent.h"
 #include "AliRunLoader.h"
-#include "AliGenEventHeader.h"
+#include "AliSLEventHeader.h"
 #include "AliGenStarLight.h"
 
 #include "TLorentzVector.h"
@@ -173,11 +173,12 @@ void AliGenStarLight::Generate() {
   if (fHeader)
     delete fHeader;
 
-  fHeader = new AliGenEventHeader("SL");
+  fHeader = new AliSLEventHeader();
   const TArrayF vertexPosition(3, vpos);
   fHeader->SetPrimaryVertex(vertexPosition);
   fHeader->SetInteractionTime(vpos[3]);
   fHeader->SetNProduced(nt);
+  fSLgenerator->ImportEventInfo(fHeader->GetEventInfo());
   AddHeader(fHeader);
   SetHighWaterMark(nt);
   AliRunLoader::Instance()->CdGAFile();

--- a/STARLIGHT/AliStarLight/AliGenStarLight.h
+++ b/STARLIGHT/AliStarLight/AliGenStarLight.h
@@ -16,7 +16,7 @@
 //- AliRoot Includes
 #include "AliGenMC.h"
 
-class AliGenEventHeader;
+class AliSLEventHeader;
 
 class AliGenStarLight : public AliGenMC {
 public:
@@ -57,11 +57,11 @@ public:
   Double_t    fRapidityMotherMax;
   Double_t    fEtaChildMin;       // Max < Min: no cut
   Double_t    fEtaChildMax;
-  TStarLight *fSLgenerator;     //! Pointer to StarLight Generator.
+  TStarLight *fSLgenerator;       //! Pointer to StarLight Generator.
 
-  AliGenEventHeader *fHeader; //!
+  AliSLEventHeader *fHeader;      //!
 
-  ClassDef(AliGenStarLight,4); // STARlight parameterisation generator
+  ClassDef(AliGenStarLight,5);
 } ;
 
 #endif

--- a/STARLIGHT/AliStarLight/AliSLEventHeader.cxx
+++ b/STARLIGHT/AliStarLight/AliSLEventHeader.cxx
@@ -1,0 +1,23 @@
+// -*- C++ -*-
+
+#include "AliSLEventHeader.h"
+
+ClassImp(AliSLEventHeader);
+
+Double_t AliSLEventHeader::GetEventInfo(const char* name) const
+{
+  const TParameter<double>* p = dynamic_cast<const TParameter<double>* >(fEventInfo->FindObject(name));
+  if (p)
+    return p->GetVal();
+
+  AliErrorF("key '%s' does not exist", name);
+  return 0.0;
+}
+
+void AliSLEventHeader::Print(Option_t* opt) const
+{
+  AliGenEventHeader::Print(opt);
+  Printf("STARLIGHT Event info: ");
+  if (fEventInfo)
+    fEventInfo->Print();
+}

--- a/STARLIGHT/AliStarLight/AliSLEventHeader.h
+++ b/STARLIGHT/AliStarLight/AliSLEventHeader.h
@@ -1,0 +1,36 @@
+// -*- C++ -*-
+#ifndef ALI_SL_EVENT_HEADER_H
+#define ALI_SL_EVENT_HEADER_H
+
+#include <THashList.h>
+#include <TParameter.h>
+
+#include "AliLog.h"
+#include "AliGenEventHeader.h"
+
+class AliSLEventHeader : public AliGenEventHeader {
+public:
+  AliSLEventHeader(const char* name="STARLIGHT Event Header")
+    : AliGenEventHeader(name)
+    , fEventInfo(new THashList) {
+    fEventInfo->SetOwner(kTRUE);
+  }
+  virtual ~AliSLEventHeader() { delete fEventInfo; fEventInfo = NULL; }
+
+  Double_t GetEventInfo(const char* name) const;
+  TList* GetEventInfo() { return fEventInfo; }
+  void ClearEventInfo() { if (fEventInfo) fEventInfo->Clear(); }
+
+  virtual void Print(Option_t* ) const;
+
+protected:
+private:
+  AliSLEventHeader(const AliSLEventHeader& );
+  AliSLEventHeader& operator=(const AliSLEventHeader& );
+
+  THashList *fEventInfo;
+
+  ClassDef(AliSLEventHeader, 1);
+} ;
+
+#endif // ALI_SL_EVENT_HEADER_H

--- a/STARLIGHT/AliStarLight/AliStarLightLinkDef.h
+++ b/STARLIGHT/AliStarLight/AliStarLightLinkDef.h
@@ -14,4 +14,5 @@
 #pragma link C++ class AliGenStarLight+;
 #pragma link C++ class AliDecayerSLEvtGen+;
 #pragma link C++ class AliGenSLEvtGen+;
+#pragma link C++ class AliSLEventHeader+;
 #endif

--- a/STARLIGHT/AliStarLight/CMakeLists.txt
+++ b/STARLIGHT/AliStarLight/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SRCS
     AliGenStarLight.cxx
     AliDecayerSLEvtGen.cxx
     AliGenSLEvtGen.cxx
+    AliSLEventHeader.cxx
    )
 
 # Headers from sources

--- a/STARLIGHT/starlight/TStarLight/TStarLight.cxx
+++ b/STARLIGHT/starlight/TStarLight/TStarLight.cxx
@@ -24,6 +24,8 @@
 #include <TObjArray.h>
 #include <TClonesArray.h>
 #include <TParticle.h>
+#include <TList.h>
+#include <TParameter.h>
 
 #include "inputParameters.h"
 #include "starlight.h"
@@ -43,8 +45,8 @@ TStarLight::TStarLight()
 
 //----------------------------------------------------------------------
 TStarLight::TStarLight(const char* name,         // The name of this object in the root name tables
-		       const char* title,        // A title for this object
-		       const char* slConfigFile) // file used to configure STARlight.
+                       const char* title,        // A title for this object
+                       const char* slConfigFile) // file used to configure STARlight.
   : TGenerator(name, title)       // Default initlization of base class
   , fErrorStatus(0)               // Error status flag 0=OK
   , fConfigFileName(slConfigFile) // Confiuration file name
@@ -53,7 +55,7 @@ TStarLight::TStarLight(const char* name,         // The name of this object in t
   , fEvent()                      // object holding STARlight simulated event.
 {
   // if (NULL == fInputParameters) {
-  //   fErrorStatus = -5; // Init failed. Creating inputParamtere class    
+  //   fErrorStatus = -5; // Init failed. Creating inputParamtere class
   //   Error("TStarLight", "creating inputParameters class failed");
   //   return;
   // } // end if
@@ -81,8 +83,7 @@ TStarLight::~TStarLight()
 
 //----------------------------------------------------------------------
 void TStarLight::GenerateEvent() {
-
-  if (NULL == fStarLight) {
+  if (!fStarLight) {
     fErrorStatus = -1; // generate failed. No generator.
     Fatal("GenerateEvent", "TStarLight class/object not properly constructed");
     return;
@@ -107,8 +108,7 @@ Int_t TStarLight::ImportParticles(TClonesArray *part, // Pointer to array of par
 				  Option_t *opt) {    // A character array of options.
   // Return:
   //   The number of particles added to the TClonesArray *part.
-
-  if (NULL == part)
+  if (!part)
     return 0;
 
   TClonesArray &clonesParticles = *part;
@@ -117,7 +117,7 @@ Int_t TStarLight::ImportParticles(TClonesArray *part, // Pointer to array of par
   Int_t nVtx(0);
   Double_t vtx(0), vty(0), vtz(0), vtt(0);
   const std::vector<vector3>* slVtx = fEvent.getVertices();
-  if (NULL == slVtx) { // not vertex assume 0,0,0,0;
+  if (!slVtx) { // not vertex assume 0,0,0,0;
     vtx = vty = vtz = vtt = 0.0;
   } else { // a vertex exits
     slVtx = fEvent.getVertices();
@@ -291,4 +291,9 @@ Double_t TStarLight::GetParameter(const char* name) const {
   }
   Fatal("GetParameter", "parameter '%s' not found", name);
   return 0.0;
+}
+
+void TStarLight::ImportEventInfo(TList *l) const {
+  l->AddLast(new TParameter<double>("Bslope", fEvent.getBslope()));
+  l->AddLast(new TParameter<double>("t2",     fEvent.gett2()));
 }

--- a/STARLIGHT/starlight/TStarLight/TStarLight.h
+++ b/STARLIGHT/starlight/TStarLight/TStarLight.h
@@ -39,9 +39,10 @@ struct pthread_mutex_t;
 #include "randomgenerator.h"
 
 using std::ostream;
-// 
+//
 class TObjArray;
 class TClonesArray;
+class TList;
 
 class TStarLight : public TGenerator {
  public:
@@ -59,6 +60,8 @@ class TStarLight : public TGenerator {
   virtual TObjArray* ImportParticles(Option_t *opt="");
   virtual void       SetParameter(const char* key, Double_t val);
   virtual Double_t   GetParameter(const char* name) const;
+
+  void ImportEventInfo(TList *) const;
 
   // read configuration from a file
   void ImportConfigurationFromFile(const char* filename){
@@ -136,4 +139,3 @@ class TStarLight : public TGenerator {
 } ;
 
 #endif
-

--- a/STARLIGHT/starlight/include/gammaavm.h
+++ b/STARLIGHT/starlight/include/gammaavm.h
@@ -57,7 +57,7 @@ class Gammaavectormeson : public eventChannel
    upcEvent produceEvent();
 
   void pickwy(double &W, double &Y);
-  void momenta(double W,double Y,double &E,double &px,double &py,double &pz,int &tcheck);
+  void momenta(double W,double Y,double &E,double &px,double &py,double &pz,int &tcheck, double &bSlope, double& t2);
   double pTgamma(double E); 
   void vmpt(double W,double Y,double &E,double &px,double &py, double &pz,int &tcheck);
   void twoBodyDecay(starlightConstants::particleTypeEnum &ipid,double W,double px0,double py0,double pz0,double &px1,double &py1,double&pz1,double &px2,double &py2,double &pz2,int &iFbadevent);

--- a/STARLIGHT/starlight/include/upcevent.h
+++ b/STARLIGHT/starlight/include/upcevent.h
@@ -52,10 +52,14 @@ class upcEvent
       void addParticle(starlightParticle &part) { _particles.push_back(part); }
       void addVertex(vector3 &vertex) { _vertices.push_back(vertex); }
       void addGamma(float egamma) { _gammaEnergies.push_back(egamma); }
+      void setBslopeAndt2(double bSlope, double t2) { _bSlope = bSlope; _t2 = t2; }
 
       const std::vector<starlightParticle> * getParticles() const { return &_particles; }
       const std::vector<vector3> * getVertices() const { return &_vertices; }
       const std::vector<float> * getGammaEnergies() const { return &_gammaEnergies; }
+
+      double getBslope() const { return _bSlope; }
+      double gett2() const { return _t2; }
 
       upcEvent & operator=(const upcEvent&);
       upcEvent & operator+(const upcEvent&);
@@ -66,6 +70,8 @@ class upcEvent
       std::vector<starlightParticle> _particles;
       std::vector<vector3> _vertices;
       std::vector<float> _gammaEnergies;
+      double _bSlope;  // gammaavm b-slope
+      double _t2;      // gammaavm t^2
 };
 
 

--- a/STARLIGHT/starlight/src/upcevent.cpp
+++ b/STARLIGHT/starlight/src/upcevent.cpp
@@ -37,11 +37,15 @@
 upcEvent::upcEvent() :
         _particles(0)
         ,_vertices(0)
+	,_bSlope(0)
+	,_t2(0)
 { }
 
 upcEvent::upcEvent(starlightConstants::event &ev) :
         _particles(0)
         ,_vertices(0)
+	,_bSlope(0)
+	,_t2(0)
 {
   for(int i = 0; i < ev._numberOfTracks; i++)
     {
@@ -70,6 +74,8 @@ upcEvent& upcEvent::operator=(const upcEvent& rhs)
     this->_particles = rhs._particles;
     this->_vertices = rhs._vertices;
     this->_gammaEnergies = rhs._gammaEnergies;
+    _bSlope = rhs._bSlope;
+    _t2 = rhs._t2;
   }
   return *this;
 }
@@ -88,6 +94,7 @@ upcEvent& upcEvent::operator+(const upcEvent& ev)
   {
     this->_gammaEnergies.push_back(ev._gammaEnergies.at(n));
   }
+  // what to do with _bSlope, _t2?
   return *this;
 }
 


### PR DESCRIPTION
- for rec and sim: TClonesArray::Clear -> TClonesArray::Delete (TF1::Clear is not implemented)
- calling TF1::Optimize() only for ROOT5
- numerous fixes for wrong code formatting
- AliDebug,Info,Fatal,Log(Form(...)) -> AliDebug,Info,Fatal,LogF(...)
- enforcing warning=error for all AD code (tested on OSX/clang, to be verified for gcc4.9)