### PR TITLE
ATO-405, ATO-410 - change: related to NDim. fits

### DIFF
--- a/STAT/AliTMinuitToolkit.cxx
+++ b/STAT/AliTMinuitToolkit.cxx
@@ -39,6 +39,7 @@
 #include "TGraph.h"
 #include <vector>
 #include "TPRegexp.h"
+#include "TStatToolkit.h"
 
 std::map<std::string, AliTMinuitToolkit*> AliTMinuitToolkit::fPredefinedFitters;  
 
@@ -276,7 +277,7 @@ void AliTMinuitToolkit::FitterFCN(int &/*npar*/, double */*info*/, double &fchis
     if (logLike){
       Double_t normDelta = delta*weight;
       toAdd=logLike->EvalPar(&delta,likeParam);
-      continue;
+      //      continue;
     }else{
       if (fitter->IsHuberCost() == true) {       //hubert norm
 	delta = delta*weight;                   // normalization
@@ -395,7 +396,12 @@ void AliTMinuitToolkit::Fit(Option_t *option) {
   
   // initialize parameters (step size???)
   for (Int_t iparam=0; iparam<nParam; iparam++){
-    minuit->SetParameter(iparam, Form("p[%d]",iparam), (*fInitialParam)(iparam,0), (*fInitialParam)(iparam,1), (*fInitialParam)(iparam, 2), (*fInitialParam)(iparam, 3));
+    if (sOption.Contains("rndmInit")){
+      Double_t initValue=(*fInitialParam)(iparam, 0)+gRandom->Gaus()*(*fInitialParam)(iparam,1);
+      minuit->SetParameter(iparam, Form("p[%d]",iparam), initValue, (*fInitialParam)(iparam,1), (*fInitialParam)(iparam, 2), (*fInitialParam)(iparam, 3));
+    }else{
+      minuit->SetParameter(iparam, Form("p[%d]",iparam), (*fInitialParam)(iparam,0), (*fInitialParam)(iparam,1), (*fInitialParam)(iparam, 2), (*fInitialParam)(iparam, 3));
+    }
     /*
       if (doReset){
       minuit->SetParameter(iparam, Form("p[%d]",iparam), (*fInitialParam)(iparam,0), (*fInitialParam)(iparam,1), (*fInitialParam)(iparam, 2), (*fInitialParam)(iparam, 3));
@@ -440,11 +446,10 @@ void AliTMinuitToolkit::Fit(Option_t *option) {
 }
 
 
-Int_t AliTMinuitToolkit::FillFitter(TTree * inputTree, TString values, TString variables, TString selection, Int_t firstEntry, Int_t nentries ){
+Int_t AliTMinuitToolkit::FillFitter(TTree * inputTree, TString values, TString variables, TString selection, Int_t firstEntry, Int_t nentries, Bool_t doReset ){
   //
   // Make unbinned fit
   //
-  ClearData();
   TString query=values;
   query+=":";
   query+=variables;
@@ -456,6 +461,13 @@ Int_t AliTMinuitToolkit::FillFitter(TTree * inputTree, TString values, TString v
   fVarNames=variables.Tokenize(":");
   Int_t nVals= fValueNames->GetEntries();
   Int_t nVars= fVarNames->GetEntries();
+  if (doReset==kFALSE  && fPoints!=NULL){
+    if (fPoints->GetNrows()!=nVars){
+      ::Error("AliTMinuitToolkit::UnbinnedFit","Not comatible number of variables: %d instead of %d: variables:  %s",nVars, fPoints->GetNrows(), query.Data());
+      return -1;
+    }
+  }
+
   Int_t entries = inputTree->Draw(query.Data(),selection.Data(),"goffpara",nentries,firstEntry);
   if (entries<=0) {
     ::Error("AliTMinuitToolkit::UnbinnedFit","badly formatted values or variables: %s",query.Data());
@@ -463,14 +475,22 @@ Int_t AliTMinuitToolkit::FillFitter(TTree * inputTree, TString values, TString v
     ::Error("AliTMinuitToolkit::UnbinnedFit","variables: %s",variables.Data());
     return -1;
   }  
-  fPoints=new TMatrixD(entries,nVars);
-  fValues=new TMatrixD(entries,nVals);
+  Int_t index0=0;
+  if (doReset || fPoints==NULL) {
+    ClearData();
+    fPoints=new TMatrixD(entries,nVars);
+    fValues=new TMatrixD(entries,nVals);
+  }else{
+    index0= fPoints->GetNrows();
+    fPoints->ResizeTo(index0+entries,nVars);
+    fValues->ResizeTo(index0+entries,nVals);
+  }
   for (Int_t iPoint=0; iPoint<entries; iPoint++){
     for (Int_t iVar=0; iVar<nVars; iVar++){
-      (*fPoints)(iPoint,iVar)=inputTree->GetVal(iVar+nVals)[iPoint];
+      (*fPoints)(index0+iPoint,iVar)=inputTree->GetVal(iVar+nVals)[iPoint];
     }
     for (Int_t iVal=0; iVal<nVals; iVal++){
-      (*fValues)(iPoint,iVal)=inputTree->GetVal(iVal)[iPoint];
+      (*fValues)(index0+iPoint,iVal)=inputTree->GetVal(iVal)[iPoint];
     }
   }
 }
@@ -509,6 +529,8 @@ Double_t  AliTMinuitToolkit::GaussCachyLogLike(Double_t *x, Double_t *p){
   Double_t vCauchy=p[1]/(TMath::Pi()*(p[1]*p[1]+(*x)*(*x)));
   Double_t vGaus=(TMath::Abs(*x)<20) ? TMath::Gaus(*x,0,1.,kTRUE):0.;
   return TMath::Abs(TMath::Log(p[0]*vGaus+(1-p[0])*vCauchy)-1);
+  static Double_t norm= 1/TMath::Gaus(0,0,1.,kTRUE);
+  return TMath::Abs(TMath::Log((p[0]*vGaus+(1-p[0])*vCauchy)*norm));
 }
 
 void AliTMinuitToolkit::Bootstrap(Int_t nIter, const char * reportName, Option_t *option){
@@ -517,8 +539,8 @@ void AliTMinuitToolkit::Bootstrap(Int_t nIter, const char * reportName, Option_t
   // fitting parameters done on several times on modified data (random samples with replacement)  (to be done togerher with M-stimator)
   //    to emulate different data population
   //    reduce problem with local minima in the M-estimator estimated parameters - robust mean/median
-  //    obtined RMS can be used to estimate error of the estemator
-  //    
+  //    obtained RMS can be used to estimate error of the estemator
+  //   
   static Int_t counter=0;
   Int_t nPoints= fPoints->GetNrows();
   fPointIndex.Set(nPoints);
@@ -558,8 +580,10 @@ void AliTMinuitToolkit::Bootstrap(Int_t nIter, const char * reportName, Option_t
   TVectorD &par=*fParam;
   TVectorD &rms=*fRMSEstimator;
   for (Int_t iPar=0; iPar<nPar;iPar++) {
+    Double_t rmsf,meanf;
+    TStatToolkit::EvaluateUni(nIter,vecPar[iPar].data(),meanf,rmsf,TMath::Max(nIter*0.75,1.));
     par[iPar]=TMath::Median(nIter,vecPar[iPar].data());
-    rms[iPar]=TMath::RMS(nIter,vecPar[iPar].data());
+    rms[iPar]=rmsf;
   }
   fPointIndex.Set(0);
   return ;

--- a/STAT/AliTMinuitToolkit.h
+++ b/STAT/AliTMinuitToolkit.h
@@ -43,7 +43,7 @@ public:
   void  FitHistogram(TH1 *const his,  Option_t* option = "");
   void  FitGraph(TGraph *const gr, Option_t* option = "");
   //  Int_t UnbinnedFit(TTree * inputTree, TString values, TString variables, TString selection, Int_t firstEntry, Int_t nentries);
-  Int_t FillFitter(TTree * inputTree, TString values, TString variables, TString selection, Int_t firstEntry, Int_t nentries);
+  Int_t FillFitter(TTree * inputTree, TString values, TString variables, TString selection, Int_t firstEntry, Int_t nentries, Bool_t doReset=kTRUE);
   TString GetFitFunctionAsAlias();
   void Bootstrap(Int_t nIter, const char* reportName, Option_t  *option=0);
   void TwoFoldCrossValidation(Int_t nIter, const char*reportName, Option_t *option=0);

--- a/TPC/TPCcalib/AliTPCDistortionFit.h
+++ b/TPC/TPCcalib/AliTPCDistortionFit.h
@@ -10,10 +10,12 @@ public:
   // static interface to distortion map - AliTPCChebCorr - used for TTree and TFormula evaluation  
   static Int_t RegisterFitters();
   static Double_t LineFieldLocal(const Double_t *x, const Double_t *param);  
+  static Double_t NLinesFieldLocal(const Double_t *x, const Double_t *param);  
   static Int_t LoadDistortionMaps(Int_t run, const char *storage=NULL);
-  static void  LoadDistortionTree(const char *chinput);
+  static TString   LoadDistortionTree(const char *chinput);
   static void  SetMetadata(TTree * tree, TString friendName,Int_t run);
   static void  PrintMap(TPRegexp *filter=NULL);
+  static void MakeFitExample1(Int_t run, const char * chinput);
   //
   static void   RegisterMap(TString mapName,  AliTPCChebCorr *map);
   static Int_t  GetNameHash(string name){  return fgkMapNameHash[name];}
@@ -26,6 +28,8 @@ public:
   static Double_t EvalRho(Int_t hashIndex, Int_t hashref, int sector, int row, float y2x, float z, Int_t dir, Double_t wt, Double_t dz,  Double_t dr, Double_t drphi,  Double_t Ez);
   // static eval with interpolation
   static Double_t EvalSector(Int_t hashIndex, Double_t fsector, int row, float z2x, int dimOut, int interpol, Double_t mndiv);  
+  static Double_t EvalSector(Int_t hashIndex, Int_t hashRef,  Double_t fsector, int row, float z2x, int dimOut);  
+  static Double_t EvalSectorBckg(Int_t hashIndex, Int_t hashRef, Double_t fsector, int row, float z2x, int dimOut, Double_t dRow, Double_t dSec);  
   static Double_t EvalEfieldSector(Int_t hashIndex, Int_t hashref, Float_t fsector, int row, float z2x, int dimOut, Int_t polarity, Double_t wt, Double_t dz, Double_t Ez, Int_t interpolationType, Double_t mBinSize);
   static Double_t EvalRhoSector(Int_t hashIndex, Int_t hashref, Float_t fsector, int row, float z2x, Int_t polarity, Double_t wt, Double_t dz,  Double_t dr, Double_t drphi,  Double_t Ez, Int_t interpolationType, Double_t mBinSize);
 protected:


### PR DESCRIPTION
 ATO-405,ATO-336 - Physics model fit TB -https://indico.cern.ch/event/605126/
  
* Extended intefrace for fitter filling using TTree (doReset)  
* One line fit working version
  * used in TB presentation     
  * https://indico.cern.ch/event/605126/contributions/2538484/attachments/1441002/2218550/DistortionAnalitycalModelsForTB_06042017_v2.pdf
* Multi line fit implemented but not (yet)  converging ...
  * to be finished
* bug fix from previous commit
  * forgotten continue 
