### PR TITLE
PWGPP-292- Check pointers before deleting

### DIFF
--- a/AD/ADrec/AliADReconstructor.cxx
+++ b/AD/ADrec/AliADReconstructor.cxx
@@ -508,9 +508,9 @@ void AliADReconstructor::FillESD(TTree* digitsTree, TTree* /*clustersTree*/,AliE
       fESDADfriend->SetTime (pmNumber, digit->Time());
       fESDADfriend->SetWidth(pmNumber, digit->Width());
 
-      if (fCorrectForSaturation) {
-	f_Int0->Delete(); // TF1 does not implement TObject::Clear()
-	f_Int1->Delete();
+      if (fCorrectForSaturation ) {
+	if (f_Int0) f_Int0->Delete(); // TF1 does not implement TObject::Clear()
+	if (f_Int1) f_Int1->Delete();
       }
     } // end of loop over digits
   } // end of loop over events in digits tree


### PR DESCRIPTION
Adding check of the existence of pointer

###  Description:

We are running ITS/TPC/TRD reconstruction benchmark for the LHC15l period with current master  (one day old) (git describe v5-07-20-2281-g023c8b0)
* Out of 370 jobs, 290 jobs failed (see benchmark stacktrace histogram and csv/tree file attached).
* Out of them 220 jobs failed in the AliADReconstructor.
* Not sure if the problem is because of missing check or some memory overweite - but to be sure I added pointer checks 

```
    if (fCorrectForSaturation ) {
    f_Int0->Delete(); // TF1 does not implement TObject::Clear()
    f_Int1->Delete();
      }
```