### PR TITLE
Merge Patches to TPC tracker and to HLT HWCF emulator for next study of HLT clusterizer performance

### DIFF
--- a/HLT/TPCLib/AliHLTTPCHWCFData.h
+++ b/HLT/TPCLib/AliHLTTPCHWCFData.h
@@ -42,7 +42,7 @@ class TArrayC;
  *   word 0: header (big endian 32bit unsigned)
  *           bit 31-30: 0x11 indicates cluster
  *           bit 29-24: row number in partition
- *           bit 23: is set when the cluster is an edge cluster
+ *           bit 23: is set when the cluster is a border (edge cluster or at branch borders or interleaved row) cluster
  *           bit 22-0: Qmax, fixed point number with 6 bits after the point
  *   word 1: bit 31: is set when cluster is deconvoluted in pad direction
  *           bit 30: is set when cluster is deconvoluted in time direction

--- a/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFDataTypes.h
+++ b/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFDataTypes.h
@@ -81,6 +81,7 @@ struct AliHLTTPCHWCFClusterFragment
   AliHLTUInt64_t fLastQ; // for merged fragments, charge of the last (highest pad value)
                          //    fragment bein merged, needed for deconvolution
   AliHLTUInt64_t fLargestQ; //for merging: charge of the cluster fragment with the largest Q
+  AliHLTUInt64_t fLargestQ2; //for merging: charge of the cluster fragment with the second largest Q
   AliHLTUInt32_t fLargestQPad; //for merging: pad that had the cluster fragment with the largest Q
   AliHLTUInt32_t fNPads; // how many pads are in the cluster 
   bool fSlope;           // for merged fragments, ==1 if fLastQ decreases
@@ -101,7 +102,7 @@ AliHLTTPCHWCFCluster(): fFlag(0), fRowQ(0), fQ(0), fT(0), fP(0), fT2(0), fP2(0),
   AliHLTUInt32_t fFlag; // 0 - Off, 1 - data, 2 - RCU trailer, 3 - end of data
   AliHLTUInt32_t fRowQ; // bits 30-31 = 0x3
                         // bits 24-29 = row number
-                        // bit  23    = flag: edge cluster 
+                        // bit  23    = flag: border cluster (edge or branch border or interleaved row)
                         // bits 0 -22 = max adc value as fixed point integer,
                         //              with 12 bits after the point
   AliHLTUInt32_t fQ;    // 0-29 total charge as fixed point integer, 12 bits after the point

--- a/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFDivisionUnit.cxx
+++ b/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFDivisionUnit.cxx
@@ -174,8 +174,8 @@ const AliHLTTPCHWCFCluster *AliHLTTPCHWCFDivisionUnit::OutputStream()
     if (fkInput->fEdge)
     {
       AliHLTFloat32_t& cog = *((AliHLTFloat32_t*)&fOutput.fP);
-      AliHLTFloat32_t peak = (float)fkInput->fLargestQPad;
-      if (cog < 30 ? (cog > peak) : (cog < peak))
+      AliHLTFloat32_t peak = (float) fkInput->fLargestQPad;
+      if ((cog < 30 ? (cog > peak) : (cog < peak)) && fkInput->fLargestQPad != 0xFFFFFFFF && fkInput->fLargestQ * 2 >= fkInput->fLargestQ2 * 3)
       {
         AliHLTFloat32_t& sigmay = *((AliHLTFloat32_t*)&fOutput.fP2);
         //printf("Difference %f SHIFTING %f --> %f\n", fabs(peak - cog), cog, peak);

--- a/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFDivisionUnit.cxx
+++ b/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFDivisionUnit.cxx
@@ -161,9 +161,8 @@ const AliHLTTPCHWCFCluster *AliHLTTPCHWCFDivisionUnit::OutputStream()
   
   if (fTagEdgeClusters)
   {
-    if (fkInput->fBorder) fOutput.fRowQ |= (0x1 << 23);
+    if (fkInput->fBorder) fOutput.fRowQ |= (0x1 << 23); //We actually tag with the border flag, because also the clusters at branch borders and interleaved rows have edge effects.
   }
-  
 
   *((AliHLTFloat32_t*)&fOutput.fP) = (float)fkInput->fP/q;
   *((AliHLTFloat32_t*)&fOutput.fT) = (float)fkInput->fT/q;
@@ -178,7 +177,10 @@ const AliHLTTPCHWCFCluster *AliHLTTPCHWCFDivisionUnit::OutputStream()
       AliHLTFloat32_t peak = (float)fkInput->fLargestQPad;
       if (cog < 30 ? (cog > peak) : (cog < peak))
       {
-        cog = peak;  
+        AliHLTFloat32_t& sigmay = *((AliHLTFloat32_t*)&fOutput.fP2);
+        //printf("Difference %f SHIFTING %f --> %f\n", fabs(peak - cog), cog, peak);
+        sigmay += peak * peak - cog * cog;
+        cog = peak;
       }
     }
   }

--- a/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFMergerUnit.cxx
+++ b/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFMergerUnit.cxx
@@ -145,8 +145,8 @@ const AliHLTTPCHWCFClusterFragment *AliHLTTPCHWCFMergerUnit::OutputStream()
       // flush the search range
   
       if( fSearchStart[ib]<fSearchEnd[ib] ){
-      fSearchStart[ib]++;
-      return &(fSearchRange[ib][fSearchStart[ib]-1]);
+        fSearchStart[ib]++;
+        return &(fSearchRange[ib][fSearchStart[ib]-1]);
       }    
     
       fInsertRow[ib] = -1;
@@ -204,7 +204,7 @@ const AliHLTTPCHWCFClusterFragment *AliHLTTPCHWCFMergerUnit::OutputStream()
   
   AliHLTTPCHWCFClusterFragment *ret = 0;
   
-  if( fSearchStart[ib]<fSearchEnd[ib]  && fSearchRange[ib][fSearchStart[ib]].fTMean+fMatchDistance>fInput.fTMean ){
+  if( fSearchStart[ib]<fSearchEnd[ib] && fSearchRange[ib][fSearchStart[ib]].fTMean+fMatchDistance>fInput.fTMean ){
     AliHLTTPCHWCFClusterFragment &s = fSearchRange[ib][fSearchStart[ib]++];
     if( fDeconvolute && s.fSlope && s.fLastQ<fInput.fLastQ ){
       //cout<<"push from search range at "<<fSearchStart[ib]-1<<" of "<<fSearchEnd[ib]<<endl;
@@ -229,12 +229,12 @@ const AliHLTTPCHWCFClusterFragment *AliHLTTPCHWCFMergerUnit::OutputStream()
       fInput.fP2 += s.fP2;
       fInput.fBorder |= s.fBorder;
       fInput.fIsDeconvolutedPad |= s.fIsDeconvolutedPad;
-	  fInput.fEdge |= s.fEdge;
+      fInput.fEdge |= s.fEdge;
       fInput.fMC.insert(fInput.fMC.end(), s.fMC.begin(), s.fMC.end());
       if (s.fLargestQ > fInput.fLargestQ)
       {
-	fInput.fLargestQ = s.fLargestQ;
-	fInput.fLargestQPad = s.fLargestQPad;      
+        fInput.fLargestQ = s.fLargestQ;
+        fInput.fLargestQPad = s.fLargestQPad;      
       }
       if( !fMatchTimeFollow ) fInput.fTMean = s.fTMean;    
       ret = 0;

--- a/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFMergerUnit.cxx
+++ b/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFMergerUnit.cxx
@@ -228,6 +228,7 @@ const AliHLTTPCHWCFClusterFragment *AliHLTTPCHWCFMergerUnit::OutputStream()
       fInput.fP += s.fP;
       fInput.fP2 += s.fP2;
       fInput.fBorder |= s.fBorder;
+      fInput.fIsDeconvolutedPad |= s.fIsDeconvolutedPad;
 	  fInput.fEdge |= s.fEdge;
       fInput.fMC.insert(fInput.fMC.end(), s.fMC.begin(), s.fMC.end());
       if (s.fLargestQ > fInput.fLargestQ)

--- a/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFMergerUnit.cxx
+++ b/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFMergerUnit.cxx
@@ -233,8 +233,13 @@ const AliHLTTPCHWCFClusterFragment *AliHLTTPCHWCFMergerUnit::OutputStream()
       fInput.fMC.insert(fInput.fMC.end(), s.fMC.begin(), s.fMC.end());
       if (s.fLargestQ > fInput.fLargestQ)
       {
+        fInput.fLargestQ2 = fInput.fLargestQ;
         fInput.fLargestQ = s.fLargestQ;
         fInput.fLargestQPad = s.fLargestQPad;      
+      }
+      else if (s.fLargestQ > fInput.fLargestQ2)
+      {
+        fInput.fLargestQ2 = s.fLargestQ;
       }
       if( !fMatchTimeFollow ) fInput.fTMean = s.fTMean;    
       ret = 0;

--- a/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFPeakFinderUnit.cxx
+++ b/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFPeakFinderUnit.cxx
@@ -191,7 +191,7 @@ const AliHLTTPCHWCFBunch *AliHLTTPCHWCFPeakFinderUnit::OutputStream()
   if( n>0 ){
     if( !slope )
     {
-      if( fNoiseSuppressionNeighbor >= 3 && n>3 && qLast4 > qLast4 && qLast4 > qLast2 && qLast4 > qLast) {fOutput.fData[n-4].fPeak = 1;fOutput.fData[n-1].fPeak = 2;}
+      if( fNoiseSuppressionNeighbor >= 3 && n>3 && qLast4 > qLast3 && qLast4 > qLast2 && qLast4 > qLast) {fOutput.fData[n-4].fPeak = 1;fOutput.fData[n-1].fPeak = 2;}
       else if( fNoiseSuppressionNeighbor >= 2 && n>2 && qLast3 > qLast2 && qLast3 > qLast) {fOutput.fData[n-3].fPeak = 1;fOutput.fData[n-1].fPeak = 2;}
       else if( fNoiseSuppressionNeighbor && n>1 && qLast2 > qLast) {fOutput.fData[n-2].fPeak = 1;fOutput.fData[n-1].fPeak = 2;}
       else fOutput.fData[n-1].fPeak = 1;

--- a/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFProcessorUnit.cxx
+++ b/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFProcessorUnit.cxx
@@ -120,7 +120,7 @@ const AliHLTTPCHWCFClusterFragment *AliHLTTPCHWCFProcessorUnit::OutputStream()
   fOutput.fPad = fkBunch->fPad;
   fOutput.fBranch = fkBunch->fBranch;
   fOutput.fBorder = fkBunch->fBorder;
-  fOutput.fEdge = fkBunch->fEdge;
+  fOutput.fEdge = 0; //Set below with some more constraints
   fOutput.fQmax = 0;
   fOutput.fQ = 0;
   fOutput.fT = 0;
@@ -262,6 +262,7 @@ const AliHLTTPCHWCFClusterFragment *AliHLTTPCHWCFProcessorUnit::OutputStream()
     fOutput.fP2+= q*fkBunch->fPad*fkBunch->fPad;
     fOutput.fMC.push_back(d.fMC);
   }
+  fOutput.fEdge = fkBunch->fEdge && iEnd > iStart + 2 && qPeak > 5;
   fOutput.fLargestQ = fOutput.fQ;
   fOutput.fLargestQPad = fOutput.fPad;
   

--- a/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFProcessorUnit.cxx
+++ b/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFProcessorUnit.cxx
@@ -133,6 +133,7 @@ const AliHLTTPCHWCFClusterFragment *AliHLTTPCHWCFProcessorUnit::OutputStream()
   fOutput.fIsDeconvolutedPad = 0;
   fOutput.fConsecutiveTimeDeconvolution = 0;
   fOutput.fLargestQ = 0;
+  fOutput.fLargestQ2 = 0;
   fOutput.fLargestQPad = 0;
   fOutput.fMC.clear();
   
@@ -264,7 +265,7 @@ const AliHLTTPCHWCFClusterFragment *AliHLTTPCHWCFProcessorUnit::OutputStream()
   }
   fOutput.fEdge = fkBunch->fEdge && iEnd > iStart + 2 && qPeak > 5;
   fOutput.fLargestQ = fOutput.fQ;
-  fOutput.fLargestQPad = fOutput.fPad;
+  fOutput.fLargestQPad = fkBunch->fEdge ? fkBunch->fPad : 0xFFFFFFFF; //We only correct if the largest charge is at the edge cluster. Mark other pads as -1
   
   if( fkBunch->fData.size()==1 && fOutput.fQ < fSingleSeqLimit ) return 0;  
   

--- a/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFProcessorUnit.cxx
+++ b/HLT/TPCLib/HWCFemulator/AliHLTTPCHWCFProcessorUnit.cxx
@@ -132,6 +132,8 @@ const AliHLTTPCHWCFClusterFragment *AliHLTTPCHWCFProcessorUnit::OutputStream()
   fOutput.fNDeconvolutedTime = 0;
   fOutput.fIsDeconvolutedPad = 0;
   fOutput.fConsecutiveTimeDeconvolution = 0;
+  fOutput.fLargestQ = 0;
+  fOutput.fLargestQPad = 0;
   fOutput.fMC.clear();
   
   if( fkBunch->fFlag==2 && fkBunch->fData.size()==1 ){ // rcu trailer word, forward it 

--- a/SHUTTLE/AliShuttleConfig.h
+++ b/SHUTTLE/AliShuttleConfig.h
@@ -111,7 +111,9 @@ public:
 
 	virtual void Print(Option_t* option = NULL) const;
 
+#if !defined(G__ROOT) && !defined(__CINT__) && !defined(G__DICTIONARY)
 private:
+#endif
 
 	class AliShuttleDCSConfigHolder: public TObject {
 	public:
@@ -185,7 +187,7 @@ private:
 		ClassDef(AliShuttleDetConfigHolder, 0);
 	};
 
-
+private:
 	AliShuttleConfig(const AliShuttleConfig& other);
 	AliShuttleConfig& operator= (const AliShuttleConfig& other);
 	UInt_t SetGlobalConfig(TList* globalList);

--- a/TPC/TPCrec/AliTPCtracker.cxx
+++ b/TPC/TPCrec/AliTPCtracker.cxx
@@ -4285,6 +4285,9 @@ void AliTPCtracker::MakeSeeds3(TObjArray * arr, Int_t sec, Int_t i1, Int_t i2,  
 	//
         Double_t sy1=kr1[is]->GetSigmaY2()*2., sz1=kr1[is]->GetSigmaZ2()*2.;
         Double_t sy2=kcl->GetSigmaY2()*2.,     sz2=kcl->GetSigmaZ2()*2.;
+        if (kr1[is]->GetType()<0) {sy1 += 0.25;sz1 += 0.25;} // edge cluster
+        if (kcl->GetType()<0) {sy2 += 0.25;sz2 += 0.25;} // edge cluster
+
 	//Double_t sy3=400*3./12., sy=0.1, sz=0.1;
 	Double_t sy3=25000*x[4]*x[4]+0.1, sy=0.1, sz=0.1;
 	//Double_t sy3=25000*x[4]*x[4]*60+0.5, sy=0.1, sz=0.1;
@@ -4612,6 +4615,8 @@ void AliTPCtracker::MakeSeeds3Dist(TObjArray * arr, Int_t sec, Int_t i1, Int_t i
 	//
         Double_t sy1=kr1[is]->GetSigmaY2()*2., sz1=kr1[is]->GetSigmaZ2()*2.;
         Double_t sy2=kcl->GetSigmaY2()*2.,     sz2=kcl->GetSigmaZ2()*2.;
+        if (kr1[is]->GetType()<0) {sy1 += 0.25;sz1 += 0.25;} // edge cluster
+        if (kcl->GetType()<0) {sy2 += 0.25;sz2 += 0.25;} // edge cluster
 	//Double_t sy3=400*3./12., sy=0.1, sz=0.1;
 	Double_t sy3=25000*x[4]*x[4]+0.1, sy=0.1, sz=0.1;
 	//Double_t sy3=25000*x[4]*x[4]*60+0.5, sy=0.1, sz=0.1;

--- a/TPC/TPCrec/AliTPCtracker.cxx
+++ b/TPC/TPCrec/AliTPCtracker.cxx
@@ -4287,6 +4287,7 @@ void AliTPCtracker::MakeSeeds3(TObjArray * arr, Int_t sec, Int_t i1, Int_t i2,  
         Double_t sy2=kcl->GetSigmaY2()*2.,     sz2=kcl->GetSigmaZ2()*2.;
         if (kr1[is]->GetType()<0) {sy1 += 0.25;sz1 += 0.25;} // edge cluster
         if (kcl->GetType()<0) {sy2 += 0.25;sz2 += 0.25;} // edge cluster
+        if (sy1 < 0.2) sy1 = 0.2;if (sy2 < 0.2) sy2 = 0.2;if (sz1 < 0.1) sz1 = 0.1;if (sz2 < 0.1) sz2 = 0.1; //Minimum error for small edge clusters / single pad clusters
 
 	//Double_t sy3=400*3./12., sy=0.1, sz=0.1;
 	Double_t sy3=25000*x[4]*x[4]+0.1, sy=0.1, sz=0.1;
@@ -4617,6 +4618,7 @@ void AliTPCtracker::MakeSeeds3Dist(TObjArray * arr, Int_t sec, Int_t i1, Int_t i
         Double_t sy2=kcl->GetSigmaY2()*2.,     sz2=kcl->GetSigmaZ2()*2.;
         if (kr1[is]->GetType()<0) {sy1 += 0.25;sz1 += 0.25;} // edge cluster
         if (kcl->GetType()<0) {sy2 += 0.25;sz2 += 0.25;} // edge cluster
+        if (sy1 < 0.2) sy1 = 0.2;if (sy2 < 0.2) sy2 = 0.2;if (sz1 < 0.1) sz1 = 0.1;if (sz2 < 0.1) sz2 = 0.1; //Minimum error for small edge clusters / single pad clusters
 	//Double_t sy3=400*3./12., sy=0.1, sz=0.1;
 	Double_t sy3=25000*x[4]*x[4]+0.1, sy=0.1, sz=0.1;
 	//Double_t sy3=25000*x[4]*x[4]*60+0.5, sy=0.1, sz=0.1;


### PR DESCRIPTION
Modifications:
- Fix in TPC tracker to use non-zero covariance estimate for tracks whose seed starts with single-pad cluster.
- Implement improved edge correction in HLT HWCF for studying clusterizer performace.
- Minor patches from Heiko to HLT HWCF emulator.
- Fix in privacy of nested shuttle classes to enable compilation with GCC 5 and newer and CINT.
- Fix some code indentation and comments