### PR TITLE
Add: Use field polarity in the space charge fit

### DIFF
--- a/STAT/STATLinkDef.h
+++ b/STAT/STATLinkDef.h
@@ -49,6 +49,7 @@
 #pragma link C++ class std::map<std::string,TVectorF*>+;
 #pragma link C++ class std::map<std::string,TVectorD*>+;
 #pragma link C++ class std::map<UInt_t,THn*>+;
+#pragma link C++ class std::map<Int_t,TClonesArray*>+;
 
 /*
 // RS At the moment is not recognized by the CINT...


### PR DESCRIPTION
### ATO-405,ATO-336 - Physics model fit
* Use field polarity in the fit
* modification for drawings (to enable  macro compilation)
### ADD: class std::map<Int_t,TClonesArray*> ￼…
* Used for caching of the MC track references and AliHelix in $AliPhysics_SRC/PWGPP/AliMCTreeTools.cxx