### PR TITLE
added missing dependency XMLIO

### DIFF
--- a/EVGEN/CMakeLists.txt
+++ b/EVGEN/CMakeLists.txt
@@ -115,7 +115,7 @@ generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS STEERBase STEER ESD TEvtGen FASTSIM THepMCParser)
+set(LIBDEPS STEERBase STEER ESD TEvtGen FASTSIM THepMCParser XMLIO)
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Add a library to the project using the specified source files


### PR DESCRIPTION
for some reason this was not necessary 
- on OSX: ROOT 5.34/30 (heads/v5-34-00-patches@v5-34-28-57-gec27989, Mar 23
2017, 14:28:00 on macosx64), and
- on lxplus7: ROOT v5-34-30-alice7-2
and only showed up when @ekryshen tested AliGenReaderLHE on CentOS7