### PR TITLE
Remove the online flag from data size plot + code cleanup

### DIFF
--- a/ITS/ITSbase/AliITSQASDDDataMakerRec.cxx
+++ b/ITS/ITSbase/AliITSQASDDDataMakerRec.cxx
@@ -82,8 +82,6 @@ AliITSQASDDDataMakerRec::AliITSQASDDDataMakerRec(AliITSQADataMakerRec *aliITSQAD
   fSDDhRawsTask(0),
   fSDDhDigitsTask(0),
   fSDDhRecPointsTask(0),
-  fOnlineOffsetRaws(0),
-  fOnlineOffsetRecPoints(0),
   fGenRawsOffset(0),
   fGenDigitsOffset(0),
   fGenRecPointsOffset(0),
@@ -115,8 +113,6 @@ AliITSQASDDDataMakerRec::AliITSQASDDDataMakerRec(const AliITSQASDDDataMakerRec& 
   fSDDhRawsTask(qadm.fSDDhRawsTask),
   fSDDhDigitsTask(qadm.fSDDhDigitsTask),
   fSDDhRecPointsTask(qadm.fSDDhRecPointsTask),
-  fOnlineOffsetRaws(qadm.fOnlineOffsetRaws),
-  fOnlineOffsetRecPoints(qadm.fOnlineOffsetRecPoints),
   fGenRawsOffset(qadm.fGenRawsOffset),
   fGenDigitsOffset(qadm.fGenDigitsOffset),
   fGenRecPointsOffset(qadm.fGenRecPointsOffset),
@@ -457,6 +453,17 @@ Int_t AliITSQASDDDataMakerRec::InitRaws()
   rv = fAliITSQADataMakerRec->Add2RawsList(hcalibl4,kActiveModLay4+offsRW, !expert, image, !saveCorr); 
   fSDDhRawsTask++;
 
+  //Event Size
+  TH1F *hsize = new TH1F("SDDEventSize","SDD Event Size ",500,-0.5,199.5);
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,4,0)
+  hsize->SetBit(TH1::kCanRebin);
+#endif
+  hsize->GetXaxis()->SetTitle("Event Size [kB]");
+  hsize->GetYaxis()->SetTitle("Entries");
+  rv = fAliITSQADataMakerRec->Add2RawsList(hsize,kSDDDataSize+offsRW, !expert, image, !saveCorr);
+  fSDDhRawsTask++;
+
+    
   TH1F *hsummarydata = new TH1F("SDDRawDataCheck","SDDRawDataCheck",46,-0.5,45.5);//10 summary of raw data checks Non expert and image
   hsummarydata->GetXaxis()->SetLabelSize(0.02);
   hsummarydata->GetXaxis()->SetTickLength(0.01);
@@ -528,8 +535,7 @@ Int_t AliITSQASDDDataMakerRec::InitRaws()
   hsummarydata->GetXaxis()->LabelsOption("v");
 
   rv = fAliITSQADataMakerRec->Add2RawsList(hsummarydata,kSDDRawDataCheck+offsRW, !expert, !image, !saveCorr);
-  fSDDhRawsTask++; 
-  fOnlineOffsetRaws = fSDDhRawsTask;
+  fSDDhRawsTask++;
 
   //online part
   if(fkOnline){
@@ -538,16 +544,6 @@ Int_t AliITSQASDDDataMakerRec::InitRaws()
     hddl->GetXaxis()->SetTitle("Channel");
     hddl->GetYaxis()->SetTitle("DDL Number");
     rv = fAliITSQADataMakerRec->Add2RawsList(hddl,kSDDOnlineDDLPattern+offsRW, expert, !image, !saveCorr);
-    fSDDhRawsTask++;
-
-    //Event Size 
-    TH1F *hsize = new TH1F("SDDEventSize","SDD Event Size ",500,-0.5,199.5);
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,4,0)
-    hsize->SetBit(TH1::kCanRebin);
-#endif
-    hsize->GetXaxis()->SetTitle("Event Size [kB]");
-    hsize->GetYaxis()->SetTitle("Entries");
-    rv = fAliITSQADataMakerRec->Add2RawsList(hsize,kSDDDataSize+offsRW, expert, image, !saveCorr);
     fSDDhRawsTask++;
 
     Int_t nTimeBins= 256/fTimeBinSize;
@@ -638,12 +634,10 @@ Int_t AliITSQASDDDataMakerRec::MakeRaws(AliRawReader* rawReader)
       continue;
     } 
     if(stream->IsCompletedDDL()) {
-      if(fkOnline){
-	if ((rawReader->GetDDLID() != prevDDLID)&&(ddldata[iddl])==kFALSE){
-	  size += rawReader->GetDataSize();//in bytes
-	  prevDDLID = rawReader->GetDDLID();
-	  ddldata[iddl]=kTRUE;
-	}
+      if ((rawReader->GetDDLID() != prevDDLID)&&(ddldata[iddl])==kFALSE){
+	size += rawReader->GetDataSize();//in bytes
+	prevDDLID = rawReader->GetDDLID();
+	ddldata[iddl]=kTRUE;
       }
       AliDebug(AliQAv1::GetQADebugLevel(),Form("IsCompletedDDL == KTRUE\n"));
       continue;
@@ -690,9 +684,7 @@ Int_t AliITSQASDDDataMakerRec::MakeRaws(AliRawReader* rawReader)
   for(Int_t jmod=0; jmod<fgknSDDmodules; jmod++){
     fAliITSQADataMakerRec->FillRawsData(kSDDNofDigitsVsMod+offsRW,jmod+fgkmodoffset,cntMod[jmod]);
   }
-  if(fkOnline){
-    fAliITSQADataMakerRec->FillRawsData(kSDDDataSize+offsRW,size/1024.);//KB
-  }
+  fAliITSQADataMakerRec->FillRawsData(kSDDDataSize+offsRW,size/1024.);//KB
 	
   AliDebug(AliQAv1::GetQADebugLevel(),Form("Event completed, %d raw digits read",cnt)); 
   delete stream;
@@ -1079,7 +1071,6 @@ Int_t AliITSQASDDDataMakerRec::InitRecPoints()
   rv = fAliITSQADataMakerRec->Add2RecPointsList(hsummarydatarp,kSDDRecpDataCheck+offsRP, !expert, image);
   fSDDhRecPointsTask++;
 
-  fOnlineOffsetRecPoints = fSDDhRecPointsTask;
   if(fkOnline){
     TH2F *hxy1ev = new TH2F("SDDGlobalCoordDistribYXFSE","YX Global Coord Distrib FSE",112,-28,28,112,-28,28);
     hxy1ev->GetYaxis()->SetTitle("Y (cm)");

--- a/ITS/ITSbase/AliITSQASDDDataMakerRec.h
+++ b/ITS/ITSbase/AliITSQASDDDataMakerRec.h
@@ -54,7 +54,7 @@ public:
 		  kSDDRawLadModLay3Norm,kSDDRawLadModLay4Norm,
 		  kSDDNofDigits,kSDDNofDigitsVsMod,
 		  kActiveModLay3,kActiveModLay4,kSDDRawDataCheck,
-		  kSDDOnlineDDLPattern,kSDDDataSize,kChargeMapFirstMod};
+		  kSDDDataSize,kSDDOnlineDDLPattern,kChargeMapFirstMod};
 
   enum DIGITHISTOS {kSDDDigModPattern,kSDDDigAnode,
 		    kSDDDigTimeBin,kSDDDigADC, kNumOfSDDDigitHistos};
@@ -96,8 +96,6 @@ private:
   Int_t   fSDDhRawsTask;                       // number of histo booked for each the Raws Task SDD
   Int_t   fSDDhDigitsTask;                     // number of histo booked for each the RecPoints Task SDD
   Int_t   fSDDhRecPointsTask;                  // number of histo booked for each the RecPoints Task SDD
-  Int_t   fOnlineOffsetRaws;					// index for starting online histograms for Raws
-  Int_t   fOnlineOffsetRecPoints;					// index for starting online histograms for RecPoints
   Int_t   *fGenRawsOffset;                     // QAchecking Raws offset       
   Int_t   *fGenDigitsOffset;                   // QAchecking RecPoints offset       
   Int_t   *fGenRecPointsOffset;                // QAchecking RecPoints offset       
@@ -106,7 +104,7 @@ private:
   TObjArray *fCalibration;                     //Array of Calibration Object
   TObjArray *fHistoCalibration;                //Array of the Calibration histograms for the normalization
   Int_t fPulserRun;                            // pulser run number (to identify calibration)
-  ClassDef(AliITSQASDDDataMakerRec,14)         // description 
+  ClassDef(AliITSQASDDDataMakerRec,15)         // description 
 
 };
 


### PR DESCRIPTION
This modification is needed to have in the DQM report the plot of the SDD data size.
Two obsolete data members were removed