### PR TITLE
Log information on N transported and N kept tracks

### DIFF
--- a/STEER/STEERBase/AliStack.cxx
+++ b/STEER/STEERBase/AliStack.cxx
@@ -579,6 +579,7 @@ void AliStack::FinishEvent()
        if(!allFilled) allFilled = kTRUE;
     }
   }
+  AliInfoF("Ntrack=%d kept from %d transported\n",fNtrack,fNtransported);
 } 
 //_____________________________________________________________________________
 


### PR DESCRIPTION
To keep track of the number of particles transported by geant