### PR TITLE
Include common methods to AliAODMCParticle and AliMCParticle in AliVParticle for common access of ESD/AOD MC information

### DIFF
--- a/STEER/AOD/AliAODMCParticle.h
+++ b/STEER/AOD/AliAODMCParticle.h
@@ -39,7 +39,9 @@ class AliAODMCParticle: public AliVParticle {
     virtual Double_t Pt()        const;
     virtual Double_t P()         const;
     virtual Bool_t   PxPyPz(Double_t p[3]) const;
-    
+  
+    virtual void     Momentum(TLorentzVector & lv)  { lv.SetPxPyPzE(Px(),Py(),Pz(),E()) ; }
+  
     virtual Double_t OneOverPt() const;
     virtual Double_t Phi()       const;
     virtual Double_t Theta()     const;
@@ -48,7 +50,8 @@ class AliAODMCParticle: public AliVParticle {
     virtual Double_t Yv() const;
     virtual Double_t Zv() const;
     virtual Bool_t   XvYvZv(Double_t x[3]) const;  
-    virtual Double_t T() const;
+    virtual Double_t T()  const;
+    virtual Double_t Tv() const;
 
     virtual Double_t E()          const;
     virtual Double_t M()          const;
@@ -66,10 +69,11 @@ class AliAODMCParticle: public AliVParticle {
 
     // 
     virtual Double_t GetCalcMass() const;
-    virtual void SetDaughter(Int_t i,Int_t id){if(i<2)fDaughter[i] = id;}
+    virtual void  SetDaughter(Int_t i,Int_t id){if(i<2)fDaughter[i] = id;}
     virtual Int_t GetDaughter(Int_t i) const {if(i<2)return fDaughter[i];else return -1;}
+    virtual Int_t GetDaughterLabel(Int_t i) const { return GetDaughter(i); }
     virtual Int_t GetNDaughters  () const { return fDaughter[1]>0 ? fDaughter[1]-fDaughter[0]+1 : (fDaughter[0]>0 ? 1:0 ) ;}
-    virtual void SetMother(Int_t im){fMother = im;}
+    virtual void  SetMother(Int_t im){fMother = im;}
     virtual Int_t GetMother() const {return fMother;}
 
     virtual Int_t   GetFirstDaughter()   const {return fDaughter[0];}
@@ -95,6 +99,9 @@ class AliAODMCParticle: public AliVParticle {
       // bit shift by 16
       return fFlag>>16;
     }
+
+    void        SetMCStatusCode(Int_t status) { SetStatus(status)  ; }
+    virtual UInt_t MCStatusCode()       const { return GetStatus() ; }
 
     // Bitwise operations
     void SetPrimary(Bool_t b = kTRUE){
@@ -175,7 +182,7 @@ class AliAODMCParticle: public AliVParticle {
     };
   */
 
-  ClassDef(AliAODMCParticle,8)  // AliVParticle realisation for AODMCParticles
+  ClassDef(AliAODMCParticle,9)  // AliVParticle realisation for AODMCParticles
 
 };
 
@@ -193,6 +200,7 @@ inline Double_t AliAODMCParticle::Yv()        const {return fVy;}
 inline Double_t AliAODMCParticle::Zv()        const {return fVz;}
 inline Bool_t   AliAODMCParticle::XvYvZv(Double_t x[3]) const { x[0] = fVx; x[1] = fVy; x[2] = fVz; return kTRUE; }
 inline Double_t AliAODMCParticle::T()         const {return fVt;}
+inline Double_t AliAODMCParticle::Tv()        const {return fVt;}
 inline Double_t AliAODMCParticle::E()         const {return fE;}
 inline Double_t AliAODMCParticle::Eta()       const {  
   Double_t pmom = P();

--- a/STEER/STEERBase/AliMCEvent.cxx
+++ b/STEER/STEERBase/AliMCEvent.cxx
@@ -585,7 +585,8 @@ AliVParticle* AliMCEvent::GetTrack(Int_t i) const
 	Int_t imo  = part->GetFirstMother();
 	Int_t id1  = part->GetFirstDaughter();
 	Int_t id2  = part->GetLastDaughter();
-	mcParticle->SetLabel(i); // RS mcParticle should refer to its position in its parent stack
+       mcParticle->SetLabel(i); // RS mcParticle should refer to its position in its parent stack
+       mcParticle->SetStack(fStack);
 	if (fPrimaryOffset > 0 || fSecondaryOffset > 0) {
 	  // Remapping of the mother and daughter indices
 	  if (imo>=0) {

--- a/STEER/STEERBase/AliMCParticle.cxx
+++ b/STEER/STEERBase/AliMCParticle.cxx
@@ -38,7 +38,8 @@ AliMCParticle::AliMCParticle():
     fMother(-1),
     fFirstDaughter(-1),
     fLastDaughter(-1),
-    fGeneratorIndex(-1)
+    fGeneratorIndex(-1),
+    fStack(0)
 {
     // Constructor
 }
@@ -53,7 +54,8 @@ AliMCParticle::AliMCParticle(TParticle* part, TObjArray* rarray, Int_t index):
     fMother(-1),
     fFirstDaughter(-1),
     fLastDaughter(-1),
-    fGeneratorIndex(-1)
+    fGeneratorIndex(-1),
+    fStack(0)
 {
     // Constructor
     if (rarray != 0) {
@@ -71,7 +73,8 @@ AliMCParticle::AliMCParticle(const AliMCParticle& mcPart) :
     fMother(-1),
     fFirstDaughter(-1),
     fLastDaughter(-1),
-    fGeneratorIndex(-1)
+    fGeneratorIndex(-1),
+    fStack(0)
 {
 // Copy constructor
 }

--- a/STEER/STEERBase/AliMCParticle.h
+++ b/STEER/STEERBase/AliMCParticle.h
@@ -17,6 +17,7 @@
 
 #include "AliTrackReference.h"
 #include "AliVParticle.h"
+#include "AliStack.h"
 
 class AliMCParticle: public AliVParticle {
 public:
@@ -34,6 +35,8 @@ public:
     virtual Double_t P()         const;
     virtual Bool_t   PxPyPz(Double_t p[3]) const;
    
+    virtual void     Momentum(TLorentzVector & lv)  { fParticle->Momentum(lv) ; }
+  
     virtual Double_t OneOverPt() const;
     virtual Double_t Phi()       const;
     virtual Double_t Theta()     const;
@@ -43,7 +46,8 @@ public:
     virtual Double_t Zv()        const;
     virtual Bool_t   XvYvZv(Double_t x[3]) const;  
     virtual Double_t T()         const;
-
+    virtual Double_t Tv()        const;
+  
     virtual Double_t E()          const;
     virtual Double_t M()          const;
     
@@ -52,10 +56,11 @@ public:
     
     virtual Short_t Charge()      const;
 
-    virtual Int_t    Label()         const;
-    virtual Int_t    GetLabel()      const {return Label();}
-    virtual Int_t    PdgCode()       const {return fParticle->GetPdgCode();}
-    virtual TParticle* Particle() const {return fParticle;}
+    virtual Int_t    Label()       const;
+    virtual Int_t    GetLabel()    const  {return Label();}
+    virtual Int_t    PdgCode()     const  {return fParticle->GetPdgCode();}
+    virtual UInt_t   MCStatusCode() const {return fParticle->GetStatusCode();}
+    virtual TParticle* Particle()  const  {return fParticle;}
     
     // PID
     virtual const Double_t *PID() const {return 0;} // return PID object (to be defined, still)
@@ -68,16 +73,25 @@ public:
     // "Trackable" criteria
     Float_t  GetTPCTrackLength(Float_t bz, Float_t ptmin, Int_t &counter, Float_t deadWidth, Float_t zMax=230. );
     // Navigation
-    virtual Int_t GetMother()        const {return fMother;}
-    Int_t GetFirstDaughter() const {return fFirstDaughter;}
-    Int_t GetLastDaughter()  const {return fLastDaughter;}
+    virtual Int_t GetMother()       const {return fMother;}
+    Int_t GetFirstDaughter()        const {return fFirstDaughter;}
+    Int_t GetLastDaughter()         const {return fLastDaughter;}
+    Int_t GetDaughterLabel(Int_t i) const {return fParticle->GetDaughter(i) ;}
+    Int_t GetNDaughters()           const {return fParticle->GetNDaughters();}
+    
     void  SetMother(Int_t idx)        {fMother        = idx;}
     void  SetFirstDaughter(Int_t idx) {fFirstDaughter = idx;}
     void  SetLastDaughter(Int_t idx)  {fLastDaughter  = idx;}
     void  SetLabel(Int_t label)       {fLabel         = label;}
     virtual void    SetGeneratorIndex(Short_t i) {fGeneratorIndex = i;}
     virtual Short_t GetGeneratorIndex() const {return fGeneratorIndex;}
-    
+
+    const AliStack*  GetStack()           const {return fStack;}
+    void             SetStack(AliStack* st)     {fStack = st  ;}
+    Bool_t     IsPhysicalPrimary()        const {return fStack->IsPhysicalPrimary(fLabel);} 
+    Bool_t     IsSecondaryFromWeakDecay() const {return fStack->IsSecondaryFromWeakDecay(fLabel);}
+    Bool_t     IsSecondaryFromMaterial()  const {return fStack->IsSecondaryFromMaterial(fLabel);}
+
  private:
     TParticle *fParticle;             // The wrapped TParticle
     TObjArray *fTrackReferences;      // Array to track references
@@ -87,7 +101,9 @@ public:
     Int_t      fFirstDaughter;        // First daughter
     Int_t      fLastDaughter;         // LastDaughter
     Short_t    fGeneratorIndex;       // !Generator index in cocktail  
-  ClassDef(AliMCParticle,0)  // AliVParticle realisation for MCParticles
+    AliStack*  fStack;                //! stack the particle belongs to
+
+  ClassDef(AliMCParticle,1)  // AliVParticle realisation for MCParticles
 };
 
 inline Double_t AliMCParticle::Px()        const {return fParticle->Px();}
@@ -103,7 +119,8 @@ inline Double_t AliMCParticle::Xv()        const {return fParticle->Vx();}
 inline Double_t AliMCParticle::Yv()        const {return fParticle->Vy();}
 inline Double_t AliMCParticle::Zv()        const {return fParticle->Vz();}
 inline Bool_t   AliMCParticle::XvYvZv(Double_t x[3]) const { x[0] = Xv(); x[1] = Yv(); x[2] = Zv(); return kTRUE; }
-inline Double_t AliMCParticle::T()        const {return fParticle->T();}
+inline Double_t AliMCParticle::T()         const {return fParticle->T();}
+inline Double_t AliMCParticle::Tv()        const {return fParticle->T();}
 inline Double_t AliMCParticle::E()         const {return fParticle->Energy();}
 inline Double_t AliMCParticle::Eta()       const {return fParticle->Eta();}
 

--- a/STEER/STEERBase/AliVParticle.h
+++ b/STEER/STEERBase/AliVParticle.h
@@ -14,6 +14,9 @@
 #include <TObject.h>
 #include "AliVMisc.h"
 
+class TLorentzVector;
+class TParticle;
+
 #include <float.h>
 
 const Double_t kAlmost1=1. - Double_t(FLT_EPSILON);
@@ -41,10 +44,14 @@ public:
   virtual Double_t P()  const = 0;
   virtual Bool_t   PxPyPz(Double_t p[3]) const = 0;
 
+  virtual void     Momentum(TLorentzVector &)  { ; }
+  
   virtual Double_t Xv() const = 0;
   virtual Double_t Yv() const = 0;
   virtual Double_t Zv() const = 0;
   virtual Bool_t   XvYvZv(Double_t x[3]) const = 0;  
+//virtual Double_t T()          const { return -1; } // Conflicts with AliAODTrack.h
+  virtual Double_t Tv()         const { return 0 ; } 
 
   virtual Double_t OneOverPt()  const = 0;
   virtual Double_t Phi()        const = 0;
@@ -58,13 +65,19 @@ public:
   virtual Double_t Y()          const = 0;
   
   virtual Short_t Charge()      const = 0;
+  
+  virtual Int_t   Label()       const { return -1; } 
   virtual Int_t   GetLabel()    const = 0;
   // PID
   virtual Int_t   PdgCode()     const = 0;       
   virtual const Double_t *PID() const = 0; // return PID object (to be defined, still)
 
-
+  // Not possible GetStatus(), Long in AliVTrack, Int in AliMCParticle  
+//virtual UInt_t  GetStatus()    const { return 0  ; }
+  virtual UInt_t  MCStatusCode() const { return 0  ; }
   
+  virtual TParticle *Particle()  const { return NULL ; }
+
   /** Compare this class with an other instance of this class
    *  used in a TCollection::Sort()/TClonesArray::Sort()
    *  @param   obj  ptr to other instance
@@ -78,7 +91,7 @@ public:
    *  @return     always kTRUE;
    */
   Bool_t IsSortable() const  { return kTRUE; }
-  virtual Bool_t IsPrimary()  const  { return kFALSE; }
+
   virtual void    SetFlag(UInt_t) {;}
   virtual UInt_t  GetFlag() const {return 0;}  
 
@@ -92,9 +105,27 @@ public:
   virtual Int_t   GetMother()   const {return -1;}
   virtual Int_t   GetFirstDaughter()   const {return -1;}
   virtual Int_t   GetLastDaughter()    const {return -1;}
+  // Cannot use GetDaughter because of AliAODRecoDecay
+//virtual Int_t   GetDaughter(Int_t)      const {return -1;}
+  virtual Int_t   GetDaughterLabel(Int_t) const {return -1;}
+  virtual Int_t   GetNDaughters  ()       const {return 0 ;}
+  
   virtual void    SetGeneratorIndex(Short_t) {;}
   virtual Short_t GetGeneratorIndex() const {return -1;}
-  ClassDef(AliVParticle, 3)  // base class for particles
+  
+  virtual void    SetPrimary(Bool_t)   { ; }
+  virtual Bool_t  IsPrimary()          const { return 0  ; }
+  
+  virtual void    SetPhysicalPrimary(Bool_t ) { ; }
+  virtual Bool_t  IsPhysicalPrimary()  const { return 0  ; }
+  
+  virtual void    SetSecondaryFromWeakDecay(Bool_t ) { ; }
+  virtual Bool_t  IsSecondaryFromWeakDecay() const { return 0  ; }
+  
+  virtual void    SetSecondaryFromMaterial(Bool_t ) { ; }
+  virtual Bool_t  IsSecondaryFromMaterial() const { return 0  ; }
+  
+  ClassDef(AliVParticle, 4)  // base class for particles
 };
 
 #endif


### PR DESCRIPTION
I have added to AliVParticle the common methods defined in AliMCParticle and AliAODMCParticle, plus a few more. In doing so would be able to get access the MC information from an analysis task in the same way for ESDs and AODs just doing

AliVParticle* particle = MCEvent()->GetTrack(label)
and replacing AliMCParticle and AliAODMCParticle in the analysis tasks.

Few minor remarks:

* GetStatus() -> There is a different definition in AliVTrack and Ali*Particle, in one it is an Int and in other a long. I have added MCStatusCode() for the MC information

* GetDaughter() -> There is already a method called like that in AliAODRecoDecay returning non int objects, so I renamed if for the recovery of the MC labels as GetDaughterLabel

* T() -> In AliAODTrack there is a template of something with this name so I introduced Tv() like it is done for the coordinates (Xv(), Yv(), Zv()) which returns exactly the same thing as T()

* Momentum(): I use this method from TParticle 

* Particle(): It is only usable for AliMCParticle, but I think it is an easy way to distinguish in analysis code between Stack and AOD information if the pointer is null
