### PR TITLE
PWGPP-312 - Bug fix: Memory leak

### DIFF
--- a/STEER/ESD/AliESDv0.cxx
+++ b/STEER/ESD/AliESDv0.cxx
@@ -903,13 +903,13 @@ Double_t AliESDv0::GetKFInfo(UInt_t p1, UInt_t p2, Int_t type) const{
   }
   AliKFParticle kfp1(  *(paramP), spdg[p1] *TMath::Sign(1,p1) );
   AliKFParticle kfp2( *(paramN), spdg[p2] *TMath::Sign(1,p2) );
-  AliKFParticle *v0KF = new AliKFParticle;
-  *(v0KF)+=kfp1;
-  *(v0KF)+=kfp2;
-  if (type==0) return v0KF->GetMass();
-  if (type==1) return v0KF->GetErrMass();
-  if (type==2) return v0KF->GetChi2();
-  if (type==3) return v0KF->GetPt(); 
+  AliKFParticle v0KF;
+  v0KF+=kfp1;
+  v0KF+=kfp2;
+  if (type==0) return v0KF.GetMass();
+  if (type==1) return v0KF.GetErrMass();
+  if (type==2) return v0KF.GetChi2();
+  if (type==3) return v0KF.GetPt(); 
 
   return 0;
 }


### PR DESCRIPTION
###  PWGPP-312, ATO-373 - Add: Memory diagnostic in AliTreePlayer::MakeHistograms

* Use AliSysInfo (syswatch.log) to indicate memory usage
  * stamp after each histogram creation
  * stamp after each chunk processing
* Print Memory usage in stdout
  * after each histogram creation and total size