### PR TITLE
STARLIGHT b-slope parameterization is made configurable

### DIFF
--- a/STARLIGHT/AliGenFlat2Trk/AliGenFlat2Trk.cxx
+++ b/STARLIGHT/AliGenFlat2Trk/AliGenFlat2Trk.cxx
@@ -80,12 +80,8 @@ AliGenFlat2Trk::AliGenFlat2Trk(Int_t    pid,
 
 AliGenFlat2Trk::~AliGenFlat2Trk()
 {
-  if (fTheta)
-    delete fTheta;
-  fTheta = NULL;
-  if (fHeader)
-    delete fHeader;
-  fHeader = NULL;
+  SafeDelete(fTheta);
+  SafeDelete(fHeader);
 }
 
 Double_t AliGenFlat2Trk::SetMinvMin(Double_t m) {
@@ -219,8 +215,7 @@ void AliGenFlat2Trk::Generate()
     const TArrayF eventVertex(3, origin);
 
     // Header
-    if (fHeader)
-      delete fHeader;
+    SafeDelete(fHeader);
     fHeader = new AliGenEventHeader("AliGenFlat2Trk");
 
     // Event Vertex

--- a/STARLIGHT/AliStarLight/AliGenStarLight.cxx
+++ b/STARLIGHT/AliStarLight/AliGenStarLight.cxx
@@ -53,11 +53,8 @@ AliGenStarLight::AliGenStarLight(Int_t npart)
 }
 //----------------------------------------------------------------------
 AliGenStarLight::~AliGenStarLight() {
-  if (NULL != fSLgenerator) delete fSLgenerator;
-  fSLgenerator = NULL;
-  if (fHeader)
-    delete fHeader;
-  fHeader = NULL;
+  SafeDelete(fSLgenerator);
+  SafeDelete(fHeader);
 }
 void AliGenStarLight::ImportConfigurationFromFile(const char* filename) {
   if (NULL == fSLgenerator) {
@@ -170,8 +167,7 @@ void AliGenStarLight::Generate() {
   if (kFALSE == genOK)
     AliFatal("Maximum number of trials reached");
 
-  if (fHeader)
-    delete fHeader;
+  SafeDelete(fHeader);
 
   fHeader = new AliSLEventHeader();
   const TArrayF vertexPosition(3, vpos);

--- a/STARLIGHT/starlight/TStarLight/TStarLight.cxx
+++ b/STARLIGHT/starlight/TStarLight/TStarLight.cxx
@@ -78,9 +78,7 @@ TStarLight::TStarLight(const char* name,         // The name of this object in t
 //----------------------------------------------------------------------
 TStarLight::~TStarLight()
 {
-  if (fStarLight)
-    delete fStarLight;
-  fStarLight = NULL;
+  SafeDelete(fStarLight);
 }
 
 //----------------------------------------------------------------------

--- a/STARLIGHT/starlight/TStarLight/TStarLight.h
+++ b/STARLIGHT/starlight/TStarLight/TStarLight.h
@@ -135,7 +135,7 @@ class TStarLight : public TGenerator {
   inputParameters  fInputParameters;  //   simulation input information.
   upcEvent         fEvent;            //!  object holding STARlight simulated event.
 
-  ClassDef(TStarLight,1); // STARlight interface to ROOT's Virtual Monte Carlo
+  ClassDef(TStarLight,2); // STARlight interface to ROOT's Virtual Monte Carlo
 } ;
 
 #endif

--- a/STARLIGHT/starlight/include/gammaavm.h
+++ b/STARLIGHT/starlight/include/gammaavm.h
@@ -96,6 +96,9 @@ class Gammaavectormeson : public eventChannel
   int    _bslopeDef;
   double _bslopeVal;
   double _pEnergy;
+  // used when _bslopeDef==3
+  double _bslope0;
+  double _bslope_alphaprime;
   nBodyPhaseSpaceGen* _phaseSpaceGen;
   
 };

--- a/STARLIGHT/starlight/include/inputParameters.h
+++ b/STARLIGHT/starlight/include/inputParameters.h
@@ -198,6 +198,8 @@ public:
         double       axionMass             () const { return _axionMass.value();              }  ///< returns axion mass //AXION HACK
 	int          bslopeDefinition      () const { return _bslopeDefinition.value();       }  ///< returns the definition of b-slope
 	double       bslopeValue           () const { return _bslopeValue.value();            }  ///< returns the value of b-slope
+        double       bslope0               () const { return _bslope0.value();                }  ///<
+        double       bslope_alphaprime     () const { return _bslope_alphaprime.value();      }  ///<
 	starlightConstants::particleTypeEnum    prodParticleType     () const { return _particleType;    }  ///< returns type of produced particle
 	starlightConstants::decayTypeEnum       prodParticleDecayType() const { return _decayType;       }  ///< returns decay type of produced particle
 	starlightConstants::interactionTypeEnum interactionType      () const { return _interactionType; }  ///< returns interaction type
@@ -241,6 +243,8 @@ public:
 	void setAxionMass        (double v)  {  _axionMass = v;                   }  ///< sets axion mass    //AXION HACK
 	void setbslopeDefinition      (int v)  {  _bslopeDefinition = v;          }  ///< sets the definition of b slope
         void setbslopeValue           (double v)  {  _bslopeValue = v;            }  ///< sets the value of b slope
+        void setbslope0               (double v)  {  _bslope0 = v;                }  ///< sets the value of the b-slope parameterization
+        void setbslope_alphaprime     (double v)  {  _bslope_alphaprime = v;      }  ///< sets the value of the b-slope parameterization
 
 	int  printVM                  () const { return _printVM.value();         }  ///< returns the printVM value
 	void setprintVM               (int v)  {  _printVM = v;                   }  ///< sets the value of _printVM
@@ -318,6 +322,8 @@ private:
         parameter<double, VALIDITY_CHECK>          _axionMass;               ///Axion mass//AXION HACK
         parameter<unsigned int, VALIDITY_CHECK>    _bslopeDefinition;        ///< Optional parameter to set different values of slope parameter
         parameter<double, VALIDITY_CHECK>          _bslopeValue;             ///< Value of slope parameter when _bslopeDefinition is set to 1
+        parameter<double, VALIDITY_CHECK>          _bslope0;                 ///< Parameterization of slope parameter when _bslopeDefinition is set to 3
+        parameter<double, VALIDITY_CHECK>          _bslope_alphaprime;       ///< Parameterization of slope parameter when _bslopeDefinition is set to 3
 	parameter<unsigned int, VALIDITY_CHECK>    _printVM;                 ///< Optional parameter to set printing options for VM cross section
 
 	starlightConstants::particleTypeEnum       _particleType;

--- a/STARLIGHT/starlight/src/gammaavm.cpp
+++ b/STARLIGHT/starlight/src/gammaavm.cpp
@@ -65,7 +65,8 @@ Gammaavectormeson::Gammaavectormeson(const inputParameters& inputParametersInsta
 	_VMptmax=inputParametersInstance.maxPtInterference();
 	_VMdpt=inputParametersInstance.ptBinWidthInterference();
         _ProductionMode=inputParametersInstance.productionMode();
-
+        _bslope0=inputParametersInstance.bslope0();
+        _bslope_alphaprime=inputParametersInstance.bslope_alphaprime();
         N0 = 0; N1 = 0; N2 = 0; 
 	  if (_VMpidtest == starlightConstants::FOURPRONG){
 		// create n-body phase-spage generator
@@ -468,9 +469,15 @@ void Gammaavectormeson::momenta(double W,double Y,double &E,double &px,double &p
                     break; 
 		  case 2:
                     //This is Wgammap dependence of b from H1 (Eur. Phys. J. C 46 (2006) 585)
-		    Wgammap = sqrt(4.*Egam*_pEnergy); 
+		    Wgammap = sqrt(4.*Egam*_pEnergy);
 		    bslope_tdist = 4.63 + 4.*0.164*log(Wgammap/90.0);
-		    if( N0 <= 1 )cout<<" ATTENTION: Using energy dependent value of bslope!"<<endl; 
+		    if( N0 <= 1 )cout<<" ATTENTION: Using energy dependent value of bslope! (H1 parameterization)"<<endl; 
+                    break;
+                  case 3:
+                    // Wgammap dependence of b with user settable parameters (b0, alpha')
+		    Wgammap = sqrt(4.*Egam*_pEnergy);
+		    bslope_tdist = _bslope0 + 4.*_bslope_alphaprime*log(Wgammap/90.0);
+		    if( N0 <= 1 )cout<<" ATTENTION: Using energy dependent value of bslope! (b0="<<_bslope0<<" alphaprime="<<_bslope_alphaprime<<")"<<endl; 
 		    break;
 		  default:
 		    cout<<" Undefined setting for BSLOPE_DEFINITION "<<endl;

--- a/STARLIGHT/starlight/src/inputParameters.cpp
+++ b/STARLIGHT/starlight/src/inputParameters.cpp
@@ -87,6 +87,8 @@ inputParameters::inputParameters()
           _axionMass             (this, "AXION_MASS",50, NOT_REQUIRED),  // AXION HACK
 	  _bslopeDefinition      (this, "BSLOPE_DEFINITION",0, NOT_REQUIRED),
 	  _bslopeValue           (this, "BSLOPE_VALUE",4.0,NOT_REQUIRED),
+	  _bslope0               (this, "BSLOPE0",4.63,NOT_REQUIRED),
+	  _bslope_alphaprime     (this, "BSLOPE_ALPHAPRIME",0.164,NOT_REQUIRED),
 	  _printVM               (this, "PRINT_VM",0,NOT_REQUIRED)
 {
   // All parameters must be initialised in initialisation list!


### PR DESCRIPTION
- b-slope parameterization is made configurable:
```
BSLOPE_DEFINITION = 0 -> default
BSLOPE_DEFINITION = 1 -> user defined: using BSLOPE_VALUE 
BSLOPE_DEFINITION = 2 -> use the H1 parameterization
BSLOPE_DEFINITION = 3 -> NEW: the H1 parameterization parameters are configurable, e.g.,                                                                                                         
  BSLOPE0           = 4.36                                                                                   
  BSLOPE_ALPHAPRIME = 0.164
```

- using SafeDelete(X) (code becomes shorter)
