### PR TITLE
Adapting preprocessor to the changes in the amanda server

### DIFF
--- a/EMCAL/EMCALbase/AliEMCALPreprocessor.cxx
+++ b/EMCAL/EMCALbase/AliEMCALPreprocessor.cxx
@@ -493,14 +493,23 @@ UInt_t AliEMCALPreprocessor::MapTriggerConfig(TMap* dcsAliasMap)
       stuConfig->SetFw(dcsVal->GetInt());
     }
     
+    if((dcsVal = ReadDCSValue(dcsAliasMap, Form("%s_STU_PATCHSIZE", *idet)))){
+    	AliInfo(Form("saving value: %d\n", dcsVal->GetInt()));
+    	stuConfig->SetPatchSize(dcsVal->GetInt());
+    }
+    if((dcsVal = ReadDCSValue(dcsAliasMap, Form("%s_STU_MEDIAN", *idet)))){
+    	AliInfo(Form("saving value: %d\n", dcsVal->GetInt()));
+    	stuConfig->SetMedianMode(dcsVal->GetInt());
+    }
+
     AliDCSValue *errorcount(NULL);
-    for(Int_t itru = 0; itru < 32; itru++)
+    for(Int_t itru = 0; itru < 68; itru++)
     {
       // TODO: Cross check - we might receive multiple data points
       // Currently a test procedure
-      if(itru > 14 && !isEMCAL) continue;
+      if(itru > 55 && !isEMCAL) continue;
       
-      snprintf(buf, bufsize, "%s_STU_ERROR_COUNT_TRU%d", *idet, itru);
+      snprintf(buf, bufsize, "%s_STU_ERROR_COUNT_TRU%0d", *idet, itru);
       AliInfo(Form("Reading %s", buf));
       
       TObjArray *dcsvals = (TObjArray *)dcsAliasMap->GetValue(buf);
@@ -718,7 +727,7 @@ AliDCSValue *AliEMCALPreprocessor::ReadDCSValue(const TMap *values, const char *
   TObjArray * dcsvalarray = (TObjArray*)values->GetValue(valname);
   if (!dcsvalarray)
   {
-    AliWarning(Form("%s alias not found!", valname));
+    AliWarning(Form("%s alias value not found!", valname));
     return NULL;
   }
   else

--- a/EMCAL/EMCALbase/AliEMCALTriggerDCSConfig.cxx
+++ b/EMCAL/EMCALbase/AliEMCALTriggerDCSConfig.cxx
@@ -40,6 +40,7 @@ AliEMCALTriggerDCSConfig::AliEMCALTriggerDCSConfig() : TObject()
 //_____________________________________________________________________________
 AliEMCALTriggerDCSConfig::~AliEMCALTriggerDCSConfig()
 {	
-  delete fTRUArr; fTRUArr = 0x0;
-  delete fSTUObj; fSTUObj = 0x0;
+  delete fTRUArr;
+  delete fSTUObj;
+  delete fSTUDCAL;
 }

--- a/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.cxx
@@ -36,7 +36,9 @@ ClassImp(AliEMCALTriggerSTUDCSConfig::AliEMCALTriggerSTUTRUErrorCount) ;
 AliEMCALTriggerSTUDCSConfig::AliEMCALTriggerSTUDCSConfig() : TObject(),
 fGetRawData(1),
 fRegion(0xFFFFFFFF),
-fFw(0x2A012)
+fFw(0x2A012),
+fPatchSize(0),
+fMedian(0)
 {
   for (int i = 0; i < 3; i++) 
   {
@@ -48,7 +50,7 @@ fFw(0x2A012)
   }
   
   memset(fPHOSScale, 0, sizeof(Int_t) * 4);
-  memset(fTRUErrorCounts, 0, sizeof(TClonesArray *) * 32);
+  memset(fTRUErrorCounts, 0, sizeof(TClonesArray *) * 68);
 }
 
 ///
@@ -56,7 +58,7 @@ fFw(0x2A012)
 //_____________________________________________________________________________
 AliEMCALTriggerSTUDCSConfig::~AliEMCALTriggerSTUDCSConfig()
 {
-  for(int itru = 0; itru < 32; itru++)
+  for(int itru = 0; itru < 68; itru++)
   {
     if(fTRUErrorCounts[itru]) delete fTRUErrorCounts[itru];
   }
@@ -80,7 +82,7 @@ void AliEMCALTriggerSTUDCSConfig::GetSegmentation(TVector2& v1, TVector2& v2, TV
 //_____________________________________________________________________________
 void  AliEMCALTriggerSTUDCSConfig::SetTRUErrorCounts(Int_t itru, Int_t itime, ULong64_t errorcounts)
 {
-  if(itru >= 32) return;
+  if(itru > 67) return;
   
   if(!fTRUErrorCounts[itru])
     fTRUErrorCounts[itru] = new TClonesArray("AliEMCALTriggerSTUDCSConfig::AliEMCALTriggerSTUTRUErrorCount");
@@ -103,7 +105,7 @@ void  AliEMCALTriggerSTUDCSConfig::SetTRUErrorCounts(Int_t itru, Int_t itime, UL
 //_____________________________________________________________________________
 TClonesArray *AliEMCALTriggerSTUDCSConfig::GetErrorCountsForTRU(Int_t itru) const
 {
-  if(itru >= 32) return NULL;
+  if(itru > 67) return NULL;
   
   return fTRUErrorCounts[itru];
 }

--- a/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.h
+++ b/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.h
@@ -71,6 +71,8 @@ public:
   void    SetFw(Int_t fv)                  { fFw         = fv; }
   void    SetPHOSScale(int iscale, int val) { fPHOSScale[iscale] = val; }
   void    SetTRUErrorCounts(Int_t itru, Int_t itime, ULong64_t errorcounts);
+  void    SetPatchSize(Int_t size)         { fPatchSize =size; }
+  void    SetMedianMode(Int_t mode)        { fMedian =mode;    }
   
   Int_t   GetG(int i, int j) const { return fG[i][j];    }
   Int_t   GetJ(int i, int j) const { return fJ[i][j];    }
@@ -78,6 +80,8 @@ public:
   Int_t   GetRegion()        const { return fRegion;     }
   Int_t   GetFw()            const { return fFw;         }
   Int_t   GetPHOSScale(Int_t iscale) const { return fPHOSScale[iscale]; }
+  Int_t   GetPatchSize()     const { return fPatchSize;  }
+  Int_t   GetMedianMode()    const { return fMedian;     }
   
   void    GetSegmentation(TVector2& v1, TVector2& v2, TVector2& v3, TVector2& v4) const;
   
@@ -96,10 +100,12 @@ private:
   Int_t                   fRegion;                    ///< Region
   Int_t                   fFw;                        ///< Firmware version
   Int_t                   fPHOSScale[4];              ///< PHOS scale factors
-  TClonesArray            *fTRUErrorCounts[32];       ///< TRU error counts
+  Int_t                   fPatchSize;                 ///< Jet patch size: 0 for 8x8 and 2 for 16x16
+  Int_t                   fMedian;                    ///< 1 in case of using EMCAL/DCAL for estimating the median
+  TClonesArray            *fTRUErrorCounts[68];       ///< TRU error counts
   
   /// \cond CLASSIMP
-  ClassDef(AliEMCALTriggerSTUDCSConfig,4) ;
+  ClassDef(AliEMCALTriggerSTUDCSConfig,5) ;
   /// \endcond
   
 };


### PR DESCRIPTION
1. EMC pre-processor must look also for {E/D}MC_STU_PATCHSIZE and {E/D}MC_STU_MEDIAN aliases
   and then these must be written in AliEMCALTriggerSTUDCSConfig.
2. The array length for STU ERROR counts must be 67 for EMCAL and 55 for DCAL.
3. The format of these aliases must be {E/D}MC_STU_ERROR_COUNT_TRU01,
   {E/D}MC_STU_ERROR_COUNT_TRU02,… instead of currently used {E/D}MC_STU_ERROR_COUNT_TRU1,
   {E/D}MC_STU_ERROR_COUNT_TRU2,…
4. Increase ClassDef of class AliEMCALTriggerSTUConfig as data members were added.
(Martin)