### PR TITLE
PWGPP-312- Add: marker size and line width as part of style

### DIFF
--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -20,18 +20,18 @@
 ///      * TStyle
 ///      * MarkerStyle[]  AliDrawStyle::GetMarkerStyle(const char *style, Int_t index);
 ///      * MarkerColors[] AliDrawStyle::GetMarkerColor(const char *style, Int_t index);
-///      * FillColors[]   AliDrawStyle::GetFillColor(const char *style, Int_t index); 
+///      * FillColors[]   AliDrawStyle::GetFillColor(const char *style, Int_t index);
 ///  * Default styles are created  AliDrawStyle::SetDefaults()
 ///    * default style is based on the fig template -  https://twiki.cern.ch/twiki/pub/ALICE/ALICERecommendationsResultPresentationText/figTemplate.C
 ///    * users should be able to regiester their oun styles (e.g in macros)
 ///  * Usage (work in progress)
-///    * performance reports -  with styles as a parameter 
+///    * performance reports -  with styles as a parameter
 ///    * QA reports
-///    * AliTreePlayer, and TStatToolkit  
+///    * AliTreePlayer, and TStatToolkit
 /// \author marian  Ivanov marian.ivanov@cen.ch
 ///
 ///  ## Example usage
-///  
+///
 ///  \code
 ///  AliDrawStyle::SetDefaults()
 ///  // Style example
@@ -48,9 +48,9 @@
 ///  // Standard ALICE marker/colors arrays
 ///  AliDrawStyle::GetMarkerStyle("figTemplate",0)
 ///  AliDrawStyle::GetMarkerColor("figTemplate",0)
-///  \endcode  
+///  \endcode
 
-  
+
 
 #include "AliDrawStyle.h"
 #include "TStyle.h"
@@ -84,38 +84,38 @@ TString AliDrawStyle::GetLatexAlice(const char * symbol){
   return  fLatexAlice[symbol];
 }
 
-/// \param  style - name of style used 
+/// \param  style - name of style used
 /// \param index  - marker index
 /// \return marker style for given stylename, index
 Int_t AliDrawStyle::GetMarkerStyle(const char *style, Int_t index){
-  
+
   return  AliDrawStyle::fMarkerStyles[style][index];
 }
 
-/// \param  style - name of style used 
+/// \param  style - name of style used
 /// \param index  - marker index
 /// \return marker color for given stylename, index
 Int_t AliDrawStyle::GetMarkerColor(const char *style, Int_t index){
   return  AliDrawStyle::fMarkerColors[style][index];
 }
-/// \param  style - name of style used 
+/// \param  style - name of style used
 /// \param index  - marker index
 /// \return marker color for given stylename, index
 Float_t AliDrawStyle::GetMarkerSize(const char *style, Int_t index){
   return  AliDrawStyle::fMarkerSize[style][index];
 }
 
-/// \param  style - name of style used 
+/// \param  style - name of style used
 /// \param index  - marker index
 /// \return fill color for given stylename, index
 Int_t AliDrawStyle::GetFillColor(const char *style, Int_t index){
-  return  AliDrawStyle::fFillColors[style][index];  
+  return  AliDrawStyle::fFillColors[style][index];
 }
-/// \param  style - name of style used 
+/// \param  style - name of style used
 /// \param index  - marker index
 /// \return fill color for given stylename, index
 Float_t AliDrawStyle::GetLineWidth(const char *style, Int_t index){
-  return  AliDrawStyle::fLineWidth[style][index];  
+  return  AliDrawStyle::fLineWidth[style][index];
 }
 
 
@@ -162,7 +162,7 @@ void  AliDrawStyle::AddLatexSymbol(const char * symbolName, const char * symbolT
 }
 void  AliDrawStyle::RegisterDefaultLatexSymbols(){
   //
-  // Set default AliRoot/Latex/root shortcuts 
+  // Set default AliRoot/Latex/root shortcuts
   //
   fLatexAlice["qpt"]="#it{q}/#it{p}_{T} (GeV/#it{c})^{-1}";
   fLatexAlice["qpt0"]="#it{q}/#it{p}_{T}";
@@ -185,7 +185,7 @@ void   AliDrawStyle::RegisterDefaultStyle(){
 
 void  AliDrawStyle::RegisterDefaultMarkers(){
   //
-  // Style source: 
+  // Style source:
   // https://twiki.cern.ch/twiki/pub/ALICE/ALICERecommendationsResultPresentationText/figTemplate.C
   const Int_t fillColors[] = {kGray+1,  kRed-10, kBlue-9, kGreen-8, kMagenta-9, kOrange-9,kCyan-8,kYellow-7, kBlack, kRed+1 }; // for syst bands
   const Int_t colors[]     = {kBlack, kRed+1 , kBlue+1, kGreen+3, kMagenta+1, kOrange-1,kCyan+2,kYellow+2,kGray+1,  kRed-10 };
@@ -200,11 +200,11 @@ void  AliDrawStyle::RegisterDefaultMarkers(){
     (fMarkerStyles["figTemplate"])[i]=markers[i];
     (fMarkerColors["figTemplate"])[i]=colors[i];
     (fMarkerSize["figTemplate"])[i]=1;
-    (fFillColors["figTemplate"])[i]=fillColors[i];   
+    (fFillColors["figTemplate"])[i]=fillColors[i];
     (fLineWidth["figTemplate"])[i]=0.5;
   }
   // style inspired by TRD performance paper
-  Int_t colorsTRD[12]={0};  
+  Int_t colorsTRD[12]={0};
   const Int_t markersTRD[]    = {kOpenCircle,kFullCircle, kOpenSquare,kFullSquare, kOpenStar,kFullStar, kOpenDiamond,kFullDiamond, kOpenCross,kFullCross };
   const Float_t markerTRDSize[]    = {1,1, 0.9,0.9, 1.4,1.4, 1.1,1.1, 1.2,1.2 };
   colorsTRD[0]=TColor::GetColor("#0000DD");
@@ -232,22 +232,22 @@ void  AliDrawStyle::RegisterDefaultMarkers(){
 
   for (Int_t i=0; i<10; i++){
     (fMarkerStyles["figTemplateTRD"])[i]=markersTRD[i];
-    (fMarkerColors["figTemplateTRD"])[i]=TColor::GetColorDark(colorsTRD[i]); 
+    (fMarkerColors["figTemplateTRD"])[i]=TColor::GetColorDark(colorsTRD[i]);
     (fMarkerSize["figTemplateTRD"])[i]=markerTRDSize[i];
-    (fFillColors["figTemplateTRD"])[i]=fillColors[i];   
+    (fFillColors["figTemplateTRD"])[i]=fillColors[i];
     (fLineWidth["figTemplateTRD"])[i]=0.5;
     //
     (fMarkerStyles["figTemplateTRDPair"])[i]=markersTRD[i];
-    (fMarkerColors["figTemplateTRDPair"])[i]=TColor::GetColorDark(colorsTRD[i/2]); 
+    (fMarkerColors["figTemplateTRDPair"])[i]=TColor::GetColorDark(colorsTRD[i/2]);
     (fMarkerSize["figTemplateTRDPair"])[i]=markerTRDSize[i];
-    (fFillColors["figTemplateTRDPair"])[i]=fillColors[i/2];   
+    (fFillColors["figTemplateTRDPair"])[i]=fillColors[i/2];
     (fLineWidth["figTemplateTRDPair"])[i]=0.5;
   }
 
 }
 
 TStyle*  RegisterDefaultStyleFigTemplate(Bool_t graypalette) {
-  // Style source: 
+  // Style source:
   // https://twiki.cern.ch/twiki/pub/ALICE/ALICERecommendationsResultPresentationText/figTemplate.C
   //
   TStyle * figStyle = new TStyle;

--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -20,18 +20,18 @@
 ///      * TStyle
 ///      * MarkerStyle[]  AliDrawStyle::GetMarkerStyle(const char *style, Int_t index);
 ///      * MarkerColors[] AliDrawStyle::GetMarkerColor(const char *style, Int_t index);
-///      * FillColors[]   AliDrawStyle::GetFillColor(const char *style, Int_t index);
+///      * FillColors[]   AliDrawStyle::GetFillColor(const char *style, Int_t index); 
 ///  * Default styles are created  AliDrawStyle::SetDefaults()
 ///    * default style is based on the fig template -  https://twiki.cern.ch/twiki/pub/ALICE/ALICERecommendationsResultPresentationText/figTemplate.C
 ///    * users should be able to regiester their oun styles (e.g in macros)
 ///  * Usage (work in progress)
-///    * performance reports -  with styles as a parameter
+///    * performance reports -  with styles as a parameter 
 ///    * QA reports
-///    * AliTreePlayer, and TStatToolkit
+///    * AliTreePlayer, and TStatToolkit  
 /// \author marian  Ivanov marian.ivanov@cen.ch
 ///
 ///  ## Example usage
-///
+///  
 ///  \code
 ///  AliDrawStyle::SetDefaults()
 ///  // Style example
@@ -41,16 +41,16 @@
 ///  //
 ///  // Standard ALICE latex symbols
 ///  AliDrawStyle::PrintLatexSymbols(0,TPRegexp("."))
-///  AliDrawStyle::GetLatexAlice("qPt")
+///  AliDrawStyle::GetLatexAlice("qpt")
 ///  AliDrawStyle::AddLatexSymbol("dphi", "#Delta#it#phi (unit)")
 ///  AliDrawStyle::GetLatexAlice("dphi")
 ///  //
 ///  // Standard ALICE marker/colors arrays
 ///  AliDrawStyle::GetMarkerStyle("figTemplate",0)
 ///  AliDrawStyle::GetMarkerColor("figTemplate",0)
-///  \endcode
+///  \endcode  
 
-
+  
 
 #include "AliDrawStyle.h"
 #include "TStyle.h"
@@ -61,9 +61,11 @@
 //
 std::map<TString, TString>  AliDrawStyle::fLatexAlice;
 std::map<TString, TStyle*>  AliDrawStyle::fStyleAlice;
-std::map<TString, std::vector<int> > AliDrawStyle::fMarkerStyles;
-std::map<TString, std::vector<int> > AliDrawStyle::fMarkerColors;
-std::map<TString, std::vector<int> > AliDrawStyle::fFillColors;
+std::map<TString, std::vector<int>> AliDrawStyle::fMarkerStyles;
+std::map<TString, std::vector<int>> AliDrawStyle::fMarkerColors;
+std::map<TString, std::vector<float>> AliDrawStyle::fMarkerSize;
+std::map<TString, std::vector<int>> AliDrawStyle::fFillColors;
+std::map<TString, std::vector<float>> AliDrawStyle::fLineWidth;
 
 void AliDrawStyle::SetDefaults(){
   AliDrawStyle::RegisterDefaultLatexSymbols();
@@ -82,25 +84,38 @@ TString AliDrawStyle::GetLatexAlice(const char * symbol){
   return  fLatexAlice[symbol];
 }
 
-/// \param  style - name of style used
+/// \param  style - name of style used 
 /// \param index  - marker index
 /// \return marker style for given stylename, index
 Int_t AliDrawStyle::GetMarkerStyle(const char *style, Int_t index){
+  
   return  AliDrawStyle::fMarkerStyles[style][index];
 }
 
-/// \param  style - name of style used
+/// \param  style - name of style used 
 /// \param index  - marker index
 /// \return marker color for given stylename, index
 Int_t AliDrawStyle::GetMarkerColor(const char *style, Int_t index){
   return  AliDrawStyle::fMarkerColors[style][index];
 }
+/// \param  style - name of style used 
+/// \param index  - marker index
+/// \return marker color for given stylename, index
+Float_t AliDrawStyle::GetMarkerSize(const char *style, Int_t index){
+  return  AliDrawStyle::fMarkerSize[style][index];
+}
 
-/// \param  style - name of style used
+/// \param  style - name of style used 
 /// \param index  - marker index
 /// \return fill color for given stylename, index
 Int_t AliDrawStyle::GetFillColor(const char *style, Int_t index){
-  return  AliDrawStyle::fFillColors[style][index];
+  return  AliDrawStyle::fFillColors[style][index];  
+}
+/// \param  style - name of style used 
+/// \param index  - marker index
+/// \return fill color for given stylename, index
+Float_t AliDrawStyle::GetLineWidth(const char *style, Int_t index){
+  return  AliDrawStyle::fLineWidth[style][index];  
 }
 
 
@@ -147,12 +162,15 @@ void  AliDrawStyle::AddLatexSymbol(const char * symbolName, const char * symbolT
 }
 void  AliDrawStyle::RegisterDefaultLatexSymbols(){
   //
-  // Set default AliRoot/Latex/root shortcuts
+  // Set default AliRoot/Latex/root shortcuts 
   //
-  fLatexAlice["qPt"]="#it{p}_{T} (GeV/#it{c})";
-  fLatexAlice["Pt"]="#it{p}_{T}";
-  fLatexAlice["sqPtMev"]="#sigma_{#it{q}/#it{p}_{T}}/#it{p}_{T}^{2} (MeV/#it{c})^{-1}";
-  fLatexAlice["PbPb502"]="Pb#font[122]{-}Pb #sqrt{#it{s}_{NN}} =5.02 TeV";
+  fLatexAlice["qpt"]="#it{q}/#it{p}_{T} (GeV/#it{c})^{-1}";
+  fLatexAlice["qpt0"]="#it{q}/#it{p}_{T}";
+  fLatexAlice["pt"]="#it{p}_{T}  (GeV/#it{c}) ";
+  fLatexAlice["pt0"]="#it{p}_{T} ";
+  //  fLatexAlice["sqptmev"]="#sigma_{#it{q}/#it{p}_{T}}/#it{p}_{T}^{2} (MeV/#it{c})^{-1}";
+  fLatexAlice["sqptmev"]="#sigma_{#it{q}/#it{p}_{T}} (MeV/#it{c})^{-1}";
+  fLatexAlice["pbpb502"]="Pb#font[122]{-}Pb #sqrt{#it{s}_{NN}} =5.02 TeV";
   fLatexAlice["pp13"]="pp #sqrt{#it{s}} = 13 TeV ";
   fLatexAlice["drphi"]="#Delta_{#it{r#phi}} (cm)";
   fLatexAlice["srphi"]="#sigma_{#it{r#phi}} (cm)";
@@ -167,7 +185,7 @@ void   AliDrawStyle::RegisterDefaultStyle(){
 
 void  AliDrawStyle::RegisterDefaultMarkers(){
   //
-  // Style source:
+  // Style source: 
   // https://twiki.cern.ch/twiki/pub/ALICE/ALICERecommendationsResultPresentationText/figTemplate.C
   const Int_t fillColors[] = {kGray+1,  kRed-10, kBlue-9, kGreen-8, kMagenta-9, kOrange-9,kCyan-8,kYellow-7, kBlack, kRed+1 }; // for syst bands
   const Int_t colors[]     = {kBlack, kRed+1 , kBlue+1, kGreen+3, kMagenta+1, kOrange-1,kCyan+2,kYellow+2,kGray+1,  kRed-10 };
@@ -175,28 +193,61 @@ void  AliDrawStyle::RegisterDefaultMarkers(){
   //
   (fMarkerStyles["figTemplate"])=std::vector<int>(10);
   (fMarkerColors["figTemplate"])=std::vector<int>(10);
+  (fMarkerSize["figTemplate"])=std::vector<float>(10);
   (fFillColors["figTemplate"])=std::vector<int>(10);
-  (fMarkerStyles["figTemplatePair"])=std::vector<int>(10);
-  (fMarkerColors["figTemplatePair"])=std::vector<int>(10);
-  (fFillColors["figTemplatePair"])=std::vector<int>(10);
+  (fLineWidth["figTemplate"])=std::vector<float>(10);
   for (Int_t i=0;i<10; i++){
     (fMarkerStyles["figTemplate"])[i]=markers[i];
     (fMarkerColors["figTemplate"])[i]=colors[i];
-    (fFillColors["figTemplate"])[i]=fillColors[i];
-    (fMarkerStyles["figTemplatePair"])[i]=markers[i];
-    (fMarkerColors["figTemplatePair"])[i]=colors[i/2];
-    (fFillColors["figTemplatePair"])[i]=fillColors[i/2];
-    //
-    (fMarkerStyles["figTemplateDark"])[i]=TColor::GetColorDark(markers[i]);
-    (fMarkerColors["figTemplateDark"])[i]=TColor::GetColorDark(colors[i]);
-    (fFillColors["figTemplateDark"])[i]=TColor::GetColorDark(fillColors[i/2]);
+    (fMarkerSize["figTemplate"])[i]=1;
+    (fFillColors["figTemplate"])[i]=fillColors[i];   
+    (fLineWidth["figTemplate"])[i]=0.5;
   }
+  // style inspired by TRD performance paper
+  Int_t colorsTRD[12]={0};  
+  const Int_t markersTRD[]    = {kOpenCircle,kFullCircle, kOpenSquare,kFullSquare, kOpenStar,kFullStar, kOpenDiamond,kFullDiamond, kOpenCross,kFullCross };
+  const Float_t markerTRDSize[]    = {1,1, 0.9,0.9, 1.4,1.4, 1.1,1.1, 1.2,1.2 };
+  colorsTRD[0]=TColor::GetColor("#0000DD");
+  colorsTRD[1]=TColor::GetColor("#00EE00");
+  colorsTRD[2]=TColor::GetColor("#FF0000");
+  colorsTRD[3]=TColor::GetColor("#00EEDD");
+  colorsTRD[4]=TColor::GetColor("#FFEE00");
+  colorsTRD[5]=TColor::GetColor("#FF00DD");
+  colorsTRD[6]=TColor::GetColor("#9999DD");
+  colorsTRD[7]=TColor::GetColor("#99EE99");
+  colorsTRD[8]=TColor::GetColor("#FF9999");
+  colorsTRD[9]=TColor::GetColor("#66AADD");
+  colorsTRD[10]=TColor::GetColor("#AAEE66");
+  colorsTRD[11]=TColor::GetColor("#FF66AA");
+  (fMarkerStyles["figTemplateTRD"])=std::vector<int>(10);
+  (fMarkerColors["figTemplateTRD"])=std::vector<int>(10);
+  (fMarkerSize["figTemplateTRD"])=std::vector<float>(10);
+  (fFillColors["figTemplateTRD"])=std::vector<int>(10);
+  (fLineWidth["figTemplateTRD"])=std::vector<float>(10);
+  (fMarkerStyles["figTemplateTRDPair"])=std::vector<int>(10);
+  (fMarkerColors["figTemplateTRDPair"])=std::vector<int>(10);
+  (fMarkerSize["figTemplateTRDPair"])=std::vector<float>(10);
+  (fFillColors["figTemplateTRDPair"])=std::vector<int>(10);
+  (fLineWidth["figTemplateTRDPair"])=std::vector<float>(10);
 
+  for (Int_t i=0; i<10; i++){
+    (fMarkerStyles["figTemplateTRD"])[i]=markersTRD[i];
+    (fMarkerColors["figTemplateTRD"])[i]=TColor::GetColorDark(colorsTRD[i]); 
+    (fMarkerSize["figTemplateTRD"])[i]=markerTRDSize[i];
+    (fFillColors["figTemplateTRD"])[i]=fillColors[i];   
+    (fLineWidth["figTemplateTRD"])[i]=0.5;
+    //
+    (fMarkerStyles["figTemplateTRDPair"])[i]=markersTRD[i];
+    (fMarkerColors["figTemplateTRDPair"])[i]=TColor::GetColorDark(colorsTRD[i/2]); 
+    (fMarkerSize["figTemplateTRDPair"])[i]=markerTRDSize[i];
+    (fFillColors["figTemplateTRDPair"])[i]=fillColors[i/2];   
+    (fLineWidth["figTemplateTRDPair"])[i]=0.5;
+  }
 
 }
 
 TStyle*  RegisterDefaultStyleFigTemplate(Bool_t graypalette) {
-  // Style source:
+  // Style source: 
   // https://twiki.cern.ch/twiki/pub/ALICE/ALICERecommendationsResultPresentationText/figTemplate.C
   //
   TStyle * figStyle = new TStyle;

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -10,14 +10,14 @@
 ///      * TStyle
 ///      * MarkerStyle[]  AliDrawStyle::GetMarkerStyle(const char *style, Int_t index);
 ///      * MarkerColors[] AliDrawStyle::GetMarkerColor(const char *style, Int_t index);
-///      * FillColors[]   AliDrawStyle::GetFillColor(const char *style, Int_t index);
+///      * FillColors[]   AliDrawStyle::GetFillColor(const char *style, Int_t index); 
 ///  * Default styles are created  AliDrawStyle::SetDefaults()
 ///    * default style is based on the fig template -  https://twiki.cern.ch/twiki/pub/ALICE/ALICERecommendationsResultPresentationText/figTemplate.C
 ///    * users should be able to regiester their oun styles (e.g in macros)
 ///  * Usage (work in progress)
-///    * performance reports -  with styles as a parameter
+///    * performance reports -  with styles as a parameter 
 ///    * QA reports
-///    * AliTreePlayer, and TStatToolkit
+///    * AliTreePlayer, and TStatToolkit  
 /// \author marian  Ivanov marian.ivanov@cen.ch
 
 
@@ -26,7 +26,7 @@
 #include <vector>
 #include <string>
 #include "TString.h"
-class TPRegexp;
+class TPRegexp; 
 class TStyle;
 
 class AliDrawStyle : public TObject{
@@ -35,17 +35,21 @@ public:
   static void SetDefaults();
   static TString GetLatexAlice(const char * symbol);
   static void AddLatexSymbol(const char * symbolName, const char * symbolTitle);
-  static Int_t GetMarkerStyle(const char *style, Int_t index);
-  static Int_t GetMarkerColor(const char *style, Int_t index);
-  static Int_t GetFillColor(const char *style, Int_t index);
+  static Int_t   GetMarkerStyle(const char *style, Int_t index);
+  static Float_t GetMarkerSize(const char *style, Int_t index);
+  static Int_t   GetMarkerColor(const char *style, Int_t index);
+  static Int_t   GetFillColor(const char *style, Int_t index); 
+  static Float_t GetLineWidth(const char *style, Int_t index); 
   static void PrintLatexSymbols(Option_t *option,TPRegexp& regExp);
   static void PrintStyles(Option_t *option, TPRegexp& regExp);
 protected:
   static std::map<TString, TString> fLatexAlice;              // map of prefdefiend latex symbols - fomatted according ALICE rules
-  static std::map<TString, TStyle*>  fStyleAlice;             // map of Alice predefined styles (+user defined)
-  static std::map<TString, std::vector<int> > fMarkerStyles;  // map of predefiend marker styles arrays
-  static std::map<TString, std::vector<int> > fMarkerColors;  // map of predefiend colors  arrays
-  static std::map<TString, std::vector<int> > fFillColors;    // map of predefiend fill colors arrays
+  static std::map<TString, TStyle*>  fStyleAlice;             // map of Alice predefined styles (+user defined) 
+  static std::map<TString, std::vector<int>> fMarkerStyles;   // map of predefined marker styles arrays
+  static std::map<TString, std::vector<int>> fMarkerColors;   // map of predefined colors  arrays
+  static std::map<TString, std::vector<float>> fMarkerSize;     // map of predefined marker sizes ()
+  static std::map<TString, std::vector<int>> fFillColors;     // map of predefined fill colors arrays 
+  static std::map<TString, std::vector<float>> fLineWidth;      // map of predefined line width 
   //
   static void  RegisterDefaultLatexSymbols();                 // initialize default LatexSymbols
   static void  RegisterDefaultStyle();                        // initialize default TStyles

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -10,14 +10,14 @@
 ///      * TStyle
 ///      * MarkerStyle[]  AliDrawStyle::GetMarkerStyle(const char *style, Int_t index);
 ///      * MarkerColors[] AliDrawStyle::GetMarkerColor(const char *style, Int_t index);
-///      * FillColors[]   AliDrawStyle::GetFillColor(const char *style, Int_t index); 
+///      * FillColors[]   AliDrawStyle::GetFillColor(const char *style, Int_t index);
 ///  * Default styles are created  AliDrawStyle::SetDefaults()
 ///    * default style is based on the fig template -  https://twiki.cern.ch/twiki/pub/ALICE/ALICERecommendationsResultPresentationText/figTemplate.C
 ///    * users should be able to regiester their oun styles (e.g in macros)
 ///  * Usage (work in progress)
-///    * performance reports -  with styles as a parameter 
+///    * performance reports -  with styles as a parameter
 ///    * QA reports
-///    * AliTreePlayer, and TStatToolkit  
+///    * AliTreePlayer, and TStatToolkit
 /// \author marian  Ivanov marian.ivanov@cen.ch
 
 
@@ -26,7 +26,7 @@
 #include <vector>
 #include <string>
 #include "TString.h"
-class TPRegexp; 
+class TPRegexp;
 class TStyle;
 
 class AliDrawStyle : public TObject{
@@ -38,18 +38,18 @@ public:
   static Int_t   GetMarkerStyle(const char *style, Int_t index);
   static Float_t GetMarkerSize(const char *style, Int_t index);
   static Int_t   GetMarkerColor(const char *style, Int_t index);
-  static Int_t   GetFillColor(const char *style, Int_t index); 
-  static Float_t GetLineWidth(const char *style, Int_t index); 
+  static Int_t   GetFillColor(const char *style, Int_t index);
+  static Float_t GetLineWidth(const char *style, Int_t index);
   static void PrintLatexSymbols(Option_t *option,TPRegexp& regExp);
   static void PrintStyles(Option_t *option, TPRegexp& regExp);
 protected:
   static std::map<TString, TString> fLatexAlice;              // map of prefdefiend latex symbols - fomatted according ALICE rules
-  static std::map<TString, TStyle*>  fStyleAlice;             // map of Alice predefined styles (+user defined) 
+  static std::map<TString, TStyle*>  fStyleAlice;             // map of Alice predefined styles (+user defined)
   static std::map<TString, std::vector<int>> fMarkerStyles;   // map of predefined marker styles arrays
   static std::map<TString, std::vector<int>> fMarkerColors;   // map of predefined colors  arrays
   static std::map<TString, std::vector<float>> fMarkerSize;     // map of predefined marker sizes ()
-  static std::map<TString, std::vector<int>> fFillColors;     // map of predefined fill colors arrays 
-  static std::map<TString, std::vector<float>> fLineWidth;      // map of predefined line width 
+  static std::map<TString, std::vector<int>> fFillColors;     // map of predefined fill colors arrays
+  static std::map<TString, std::vector<float>> fLineWidth;      // map of predefined line width
   //
   static void  RegisterDefaultLatexSymbols();                 // initialize default LatexSymbols
   static void  RegisterDefaultStyle();                        // initialize default TStyles


### PR DESCRIPTION
### Style extensions
* small changes in latex labels
* array of marker size adjustable
  * part of the style (different markers can have different default size) parameter in style
* Add: TRD inspired figure style figTemplateTRD and figTemplateTRDPair

### Merged my version and #195 ￼…
* I misunderstood original message from Dario to do not approve pull request
* In meantime I implemented extension of AliDrawStyle class
  * adding line width and marker size array as part of style
* Merged version - removing all white spaces at the end of lines