### PR TITLE
ATO-418 - Add: adopt format for the multi-pad canvas

### DIFF
--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -38,6 +38,7 @@
 ///  //
 ///  AliDrawStyle::PrintStyles(0,TPRegexp("."));
 ///  AliDrawStyle::ApplyStyle("figTemplate");
+///  gPad->UseCurrentStyle();  // force current style for current data    
 ///  //
 ///  // Standard ALICE latex symbols
 ///  AliDrawStyle::PrintLatexSymbols(0,TPRegexp("."))

--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -58,6 +58,7 @@
 #include "TError.h"
 #include "TPRegexp.h"
 #include "TColor.h"
+#include "TMath.h"
 #include <iostream>
 //
 std::map<TString, TString>  AliDrawStyle::fLatexAlice;
@@ -181,6 +182,26 @@ void   AliDrawStyle::RegisterDefaultStyle(){
   //
   fStyleAlice["figTemplate"]=RegisterDefaultStyleFigTemplate(kFALSE);
   fStyleAlice["figTemplateGrey"]=RegisterDefaultStyleFigTemplate(kFALSE);
+  //
+  TStyle *style=RegisterDefaultStyleFigTemplate(kFALSE);
+  style->SetName("figTemplate2"); 
+  style->SetTitleXSize(TMath::Power(2,0.5)*style->GetTitleXSize());
+  style->SetTitleYSize(TMath::Power(2,0.5)*style->GetTitleYSize());
+  style->SetLabelSize(TMath::Power(2,0.5)*style->GetLabelSize("X"),"X");
+  style->SetLabelSize(TMath::Power(2,0.5)*style->GetLabelSize("Y"),"Y");
+  style->SetLabelSize(TMath::Power(2,0.5)*style->GetLabelSize("Z"),"Z");  
+  fStyleAlice["figTemplate2"]=style;
+  //
+  style=RegisterDefaultStyleFigTemplate(kFALSE);
+  style->SetName("figTemplate3"); 
+  style->SetTitleXSize(TMath::Power(3,0.5)*style->GetTitleXSize());
+  style->SetTitleYSize(TMath::Power(3,0.5)*style->GetTitleYSize());
+  style->SetLabelSize(TMath::Power(3,0.5)*style->GetLabelSize("X"),"X");
+  style->SetLabelSize(TMath::Power(3,0.5)*style->GetLabelSize("Y"),"Y");
+  style->SetLabelSize(TMath::Power(3,0.5)*style->GetLabelSize("Z"),"Z");  
+  fStyleAlice["figTemplate3"]=style;
+
+
 
 }
 

--- a/STAT/AliTreePlayer.cxx
+++ b/STAT/AliTreePlayer.cxx
@@ -1081,7 +1081,9 @@ TPad *  AliTreePlayer::DrawHistograms(TPad  * pad, TObjArray * hisArray, TString
   // structure pad
   TString padDescription=drawList->At(0)->GetName();
   if (pad==NULL){
-    pad = new TCanvas(drawExpression, drawExpression,1000,800);
+    static Int_t counter=0;
+    pad = new TCanvas(TString::Format("canvasCounter%d",counter).Data(), drawExpression,1000,800);
+    counter++;
   }
   // divide pads
   Int_t nPads=0, nRows=0;
@@ -1091,7 +1093,7 @@ TPad *  AliTreePlayer::DrawHistograms(TPad  * pad, TObjArray * hisArray, TString
     Int_t nCols=TString(padRows->At(iRow)->GetName()).Atoi();
     for (Int_t iCol=0; iCol<nCols; iCol++){
       pad->cd();      
-      TPad * newPad=new TPad("pad","pad",iCol/Double_t(nCols),(nRows-iRow-1)/Double_t(nRows),(iCol+1)/Double_t(nCols),(nRows-iRow)/Double_t(nRows));
+      TPad * newPad=new TPad(Form("pad%d",nPads),Form("pad%d",nPads),iCol/Double_t(nCols),(nRows-iRow-1)/Double_t(nRows),(iCol+1)/Double_t(nCols),(nRows-iRow)/Double_t(nRows));
       newPad->Draw();
       nPads++;
       newPad->SetNumber(nPads);
@@ -1103,10 +1105,11 @@ TPad *  AliTreePlayer::DrawHistograms(TPad  * pad, TObjArray * hisArray, TString
   TPRegexp isPadOption("^%O");
   Bool_t isLogY=kFALSE;
   for (Int_t iPad=0; iPad<nPads; iPad++){
+    Int_t nGraphs=0, nHistos=0;
     if (drawList->At(iPad+1)==NULL) break;
     //TVirtualPad  *cPad = 
-    pad->cd(iPad+1);
-    TLegend * legend = new TLegend(0.11,0.85, 0.89,0.99, TString::Format("Pad%d",iPad));
+    TVirtualPad *cPad = pad->cd(iPad+1);    
+    TLegend * legend = new TLegend(cPad->GetLeftMargin()+0.02,0.7,1-cPad->GetRightMargin()-0.02 ,1-cPad->GetTopMargin()-0.02, TString::Format("Pad%d",iPad));
     legend->SetNColumns(2);
     legend->SetBorderSize(0);
     TString padSetup=drawList->At(iPad+1)->GetName();
@@ -1175,7 +1178,11 @@ TPad *  AliTreePlayer::DrawHistograms(TPad  * pad, TObjArray * hisArray, TString
       TH1 * hProj =0;
       TGraphErrors*gr=0;
       //
-      if (nDims==1) hProj=his->Projection(projString.Atoi());
+      if (nDims==1) {
+	hProj=his->Projection(projString.Atoi());
+	//hProj->SetName(Form("Pad%d_His%d",iPad,nHistos));  // 
+	nHistos++;
+      }
       if (nDims==2) {
 	Int_t dim0 = projString.Atoi();
 	Int_t dim1 = TString(&(projString[2])).Atoi();
@@ -1183,7 +1190,9 @@ TPad *  AliTreePlayer::DrawHistograms(TPad  * pad, TObjArray * hisArray, TString
 	for (Int_t iProj=0; iProj<8; iProj++){
 	  if (drawOption.Contains(projType[iProj])){
 	    gr=TStatToolkit::MakeStat1D(his2D,0,1.0,iProj,21+ihis,ihis+1);
-	    gr->SetName(padDrawList->At(ihis)->GetName());
+	    //gr->SetName(Form("gr_Pad%d_Graph%d",iPad,nGraphs));  // 
+	    nGraphs++;
+	    // gr->SetTitle(Form("gr_Pad%d_Graph%d",iPad,nGraphs));  // 
 	    gr->SetTitle(padDrawList->At(ihis)->GetName());
 	    gr->GetXaxis()->SetTitle(his2D->GetXaxis()->GetTitle());
 	    gr->GetYaxis()->SetTitle(his2D->GetYaxis()->GetTitle());


### PR DESCRIPTION
### ATO-418 - Add: adopt format for the multi-pad canvas
* title size and labels font size (non linear font size scaling)
  * 2x2 pads  - "figTemplate2"
  * 3x3 pads- "figTemplate3"

### ATO-418 Modification: to enable C macro printing ￼…
*  use only valin C++ names (letters and numbers)