### PR TITLE
ATO-46 - Add cache of the MC and raw data production trees 

### DIFF
--- a/STAT/AliExternalInfo.h
+++ b/STAT/AliExternalInfo.h
@@ -95,7 +95,7 @@ public:
   TTree*  GetTreeAliVersRD();
   TTree*  GetTreeAliVersMC();
   TTree*  GetTreeMCPassGuess();
-//  TString GetMCPassGuess();
+  TString GetMCPassGuess(TString MCprodname);
   
   TChain* GetChain(TString type, TString period, TString pass);
   TChain* GetChainMC()                                                  {return GetChain("MonALISA.MC", "", "");}

--- a/STAT/AliExternalInfo.h
+++ b/STAT/AliExternalInfo.h
@@ -90,8 +90,13 @@ public:
   TTree* GetTreeProdCycle()                                             {return GetTree("MonALISA.ProductionCycle", "", "");}
   TTree* GetTreeCPass()                                                 {return GetTree("MonALISA.ProductionCPass", "", "");}
   TTree* GetTreeProdCycleByID(TString ID)                               {return GetTree("MonALISA.ProductionCycleID", ID, "");}
-  TTree*  GetCPassTree(const char * period, const  char *pass); 
-
+  TTree* GetCPassTree(const char * period, const  char *pass); 
+  
+  TTree*  GetTreeAliVersRD();
+  TTree*  GetTreeAliVersMC();
+  TTree*  GetTreeMCPassGuess();
+//  TString GetMCPassGuess();
+  
   TChain* GetChain(TString type, TString period, TString pass);
   TChain* GetChainMC()                                                  {return GetChain("MonALISA.MC", "", "");}
   TChain* GetChainRCT(TString period, TString pass)                     {return GetChain("MonALISA.RCT", period, pass);}


### PR DESCRIPTION
### Implemented new functions - caching information form MonAlias production tables
* loop over master production table  ( cvs version of https://alimonitor.cern.ch/production/raw.jsp )
  * querying caching information for each productions ()
  * new trees:
```
+  TTree*  GetTreeAliVersRD();
+  TTree*  GetTreeAliVersMC();
+  TTree*  GetTreeMCPassGuess();
+  TString GetMCPassGuess(TString MCprodname);
```
  * Example usage in https://alice.its.cern.ch/jira/secure/EditComment!default.jspa?id=28255&commentId=196511
    * some extension expected -  - indication of faulures of "anchor guess"
    * export ot eh Mc table, resp. to Elastc

### Tree structure  example(GetTreeMCPassGuess)
```
TTree * tree = info.GetTreeMCPassGuess()
tree.GetListOfBranches().ls()
OBJ: TObjArray  TObjArray       An array of objects : 0
 OBJ: TBranch   aliroot root/C : 0 at: 0x3211560
 OBJ: TBranch   aliphysics      phys/C : 0 at: 0x320dca0
 OBJ: TBranch   prodName        out/C : 0 at: 0x320f6a0
 OBJ: TBranch   anchorProdTag   anchprod/C : 0 at: 0x3210710
 OBJ: TBranch   anchorPassName_guess    anchpass/C : 0 at: 0x3210e40
 OBJ: TBranch   anchoraliroot_guess     anchroot/C : 0 at: 0x320e840
 OBJ: TBranch   anchoraliphys_guess     anchphys/C : 0 at: 0x3211d40
```
