### PR TITLE
Add missing using namespace std

### DIFF
--- a/STAT/AliExternalInfo.cxx
+++ b/STAT/AliExternalInfo.cxx
@@ -25,6 +25,8 @@
 #include "TPRegexp.h" 
 ClassImp(AliExternalInfo)
 
+using namespace std;
+
 const TString AliExternalInfo::fgkDefaultConfig="$ALICE_ROOT/STAT/Macros/AliExternalInfo.cfg";
 
 AliExternalInfo::AliExternalInfo(TString localStorageDirectory, TString configLocation, Int_t verbose/*, Bool_t copyToLocalStorage*/) :

--- a/STAT/AliTreePlayer.cxx
+++ b/STAT/AliTreePlayer.cxx
@@ -52,6 +52,8 @@
 #include "TLegend.h"
 #include "AliSysInfo.h"
 
+using namespace std;
+
 ClassImp(AliTreePlayer)
 
 //_____________________________________________________________________________


### PR DESCRIPTION
Needed for compilation under ROOT6.