### PR TITLE
ALIROOT-7286 Avoid 0 as default run number to access mapping from OCDB.

### DIFF
--- a/MUON/MUONcalib/AliMUONBusPatchEvolution.cxx
+++ b/MUON/MUONcalib/AliMUONBusPatchEvolution.cxx
@@ -117,7 +117,7 @@ void AliMUONBusPatchEvolution::ComputeNumberOfPads()
     }
   }
 
-  cdbm->SetRun(0);
+  cdbm->SetRun(9999999);
 
   AliMpCDB::LoadAll();
 


### PR DESCRIPTION
Run 0 triggers reading from (most probably non-existing) local OCDB.
Use a large number instead to get the latest run available for the
period at hand (in cvmfs case) or any period (in raw:// case).