### PR TITLE
Hiing econv

### DIFF
--- a/HIJING/hijing1_36/hijhrd.F
+++ b/HIJING/hijing1_36/hijhrd.F
@@ -14,7 +14,9 @@ C     or not(0). Information of jets are in  COMMON/ATTJET and     *
 C     /MINJET. ABS(NFP(JP,6)) is the total number jets produced by *
 C    JP. If NFP(JP,6)<0 JP can not produce jet anymore.	           *
 C*******************************************************************
-	DIMENSION IP(100,2),IPQ(50),IPB(50),IT(100,2),ITQ(50),ITB(50)
+	DIMENSION IP(100,2),IPQ(50),IPB(50),IT(100,2),ITQ(50),ITB(50) 
+	INTEGER maxmiss
+c	PARAMETER (maxmiss = 50)
 #define BLANKET_SAVE
 #include "hijcrdn.inc"
 #include "hiparnt.inc"
@@ -41,6 +43,11 @@ C		SIZE OF COMMON BLOCK FOR # OF SINGLE STRINGS
 	MXSJ=100
 C		SIZE OF COMMON BLOCK FOR # OF PARTON PER SINGLE
 C		STRING
+	maxmiss=50
+	IF (IHPR2(30).GT.0) THEN
+	   maxmiss=IHPR2(30)
+        ENDIF
+C
 	JFLG=0
 	IHNT2(11)=JP
 	IHNT2(12)=JT
@@ -66,8 +73,12 @@ C
 C		********for the first hard scattering of (JP,JT)
 C			have collision only when Ycm(JP)>Ycm(JT)
 
-	ECUT1=HIPR1(1)+HIPR1(8)+PP(JP,14)+PP(JP,15)
-	ECUT2=HIPR1(1)+HIPR1(8)+PT(JT,14)+PT(JT,15)
+        ECUT1=-1.0
+        ECUT2=-1.0
+	IF (IHPR2(31).EQ.1) THEN
+	   ECUT1=HIPR1(1)+HIPR1(8)+PP(JP,14)+PP(JP,15)
+	   ECUT2=HIPR1(1)+HIPR1(8)+PT(JT,14)+PT(JT,15)
+	ENDIF
 	IF(PP(JP,4).LE.ECUT1) THEN
 		NFP(JP,6)=-ABS(NFP(JP,6))
 		RETURN
@@ -138,13 +149,13 @@ C		********q-qbar jets must has minimum mass HIPR1(1)
 
 	IF(PEP.LE.ECUT1) THEN
 		MISP=MISP+1
-		IF(MISP.LT.50) GO TO 155
+		IF(MISP.LT.maxmiss) GO TO 155
 		NFP(JP,6)=-ABS(NFP(JP,6))
 		RETURN
 	ENDIF
 	IF(PET.LE.ECUT2) THEN
 		MIST=MIST+1
-		IF(MIST.LT.50) GO TO 155
+		IF(MIST.LT.maxmiss) GO TO 155
 		NFT(JT,6)=-ABS(NFT(JT,6))
 		RETURN
 	ENDIF
@@ -155,7 +166,7 @@ C			 can not produce jet anymore
 	WM=PEP-PZP+PET-PZT
 	IF(WP.LT.0.0 .OR. WM.LT.0.0) THEN
 		MISS=MISS+1
-		IF(MISS.LT.50) GO TO 155
+		IF(MISS.LT.maxmiss) GO TO 155
 		RETURN
 	ENDIF
 C		********the total W+, W- must be positive
@@ -165,7 +176,7 @@ C		********the total W+, W- must be positive
 	SXX=(AMPX+AMTX)**2
 	IF(SW.LT.SXX.OR.VINT(43).LT.HIPR1(1)) THEN
 		MISS=MISS+1
-		IF(MISS.LT.50) GO TO 155
+		IF(MISS.LT.maxmiss) GO TO 155
 		RETURN
 	ENDIF  
 C		********the proj and targ remnants must have at least
@@ -319,7 +330,7 @@ c
 c
 	IF(LPQ.NE.LPB .OR. LTQ.NE.LTB) THEN
 		MISS=MISS+1
-		IF(MISS.LE.50) GO TO 155
+		IF(MISS.LE.maxmiss) GO TO 155
 		WRITE(6,*) ' Q -QBAR NOT MATCHED IN HIJHRD'
 		JFLG=0
 		RETURN
@@ -484,7 +495,7 @@ C************************correction made on Oct. 14,1994*****
 200	CONTINUE
 	IF(LPQ.NE.LPB) THEN
 	   MISS=MISS+1
-	   IF(MISS.LE.50) GO TO 155
+	   IF(MISS.LE.maxmiss) GO TO 155
 	   WRITE(6,*) LPQ,LPB, 'Q-QBAR NOT CONSERVED OR NOT MATCHED'
 	   JFLG=0
 	   RETURN

--- a/HIJING/hijing1_36/hijing.F
+++ b/HIJING/hijing1_36/hijing.F
@@ -377,9 +377,9 @@ C			********perform elastic collisions
 	   RNIP(JP,JT)=RANTOT
 	   SJIP(JP,JT)=HINT1(18)
 	   NCOLT=NCOLT+1
-           if (R2.GT.2.D0) THEN
-              write (8,*) R2
-           ENDIF
+c           if (R2.GT.2.D0) THEN
+c              write (8,*) R2
+c           ENDIF
 	   IPCOL(NCOLT)=JP
 	   ITCOL(NCOLT)=JT
 70	CONTINUE

--- a/HIJING/hijing1_36/vegas.F
+++ b/HIJING/hijing1_36/vegas.F
@@ -85,8 +85,8 @@ C
       NDO=ND
 C
 8     CONTINUE
-      IF(NPRN.NE.0) WRITE(16,200) NDIM,CALLS,IT,ITMX,ACC,MDS,ND
-     1                           ,(XL(J),XU(J),J=1,NDIM)
+c      IF(NPRN.NE.0) WRITE(16,200) NDIM,CALLS,IT,ITMX,ACC,MDS,ND
+c     1                           ,(XL(J),XU(J),J=1,NDIM)
 C
       ENTRY VEGAS3(FXN,AVGI,SD,CHI2A)
 C         - MAIN INTEGRATION LOOP
@@ -160,10 +160,10 @@ C
 C****this is the line 150
       IF(NPRN.EQ.0) GO TO 21
       TSI=DSQRT(TSI)
-      WRITE(16,201) IT,TI,TSI,AVGI,SD,CHI2A
+c      WRITE(16,201) IT,TI,TSI,AVGI,SD,CHI2A
       IF(NPRN.GE.0) GO TO 21
-      DO 20 J=1,NDIM
-20    WRITE(16,202) J,(XI(I,J),DI(I,J),D(I,J),I=1,ND)
+c      DO 20 J=1,NDIM
+c20    WRITE(16,202) J,(XI(I,J),DI(I,J),D(I,J),I=1,ND)
 C
 C   REFINE GRID
 C

--- a/THijing/AliGenHijing.cxx
+++ b/THijing/AliGenHijing.cxx
@@ -85,7 +85,9 @@ AliGenHijing::AliGenHijing()
      fFreeTargSpecn(0),
      fFreeTargSpecp(0),
      fFragmNeutrons(0x0),
-     fFragmProtons(0x0)
+     fFragmProtons(0x0),
+     fEConv(1),
+     fMissing(50)
 {
   // Constructor
   fEnergyCMS = 5500.;
@@ -138,8 +140,9 @@ AliGenHijing::AliGenHijing(Int_t npart)
      fFreeTargSpecn(0),
      fFreeTargSpecp(0),
      fFragmNeutrons(0x0),
-     fFragmProtons(0x0)
-
+     fFragmProtons(0x0),
+     fEConv(1),
+     fMissing(50)
 {
 // Default PbPb collisions at 5. 5 TeV
 //
@@ -236,6 +239,11 @@ void AliGenHijing::Init()
       fFragmNeutrons = dynamic_cast<TF1*> (file->Get("funcorrn"));
       fFragmProtons = dynamic_cast<TF1*> (file->Get("funcorrp"));
     }
+
+    // deal with energy/momentun conservation and counting of errors in hijhrd
+    fHijing->SetIHPR2(31,fEConv);
+    if (fMissing>0)
+      fHijing->SetIHPR2(30,fMissing);
     
     AliGenMC::Init();
     

--- a/THijing/AliGenHijing.h
+++ b/THijing/AliGenHijing.h
@@ -33,11 +33,9 @@ class AliGenHijing : public AliGenMC
     virtual void    SetSeed(UInt_t seed);
     // set centre of mass energy
     virtual void    SetEnergyCMS(Float_t energy=5500) {fEnergyCMS=energy;}
-    virtual void    SetReferenceFrame(TString frame="CMS")
-	{fFrame=frame;}
-
-    virtual void    SetImpactParameterRange(Float_t bmin = 0, Float_t bmax = 15.)
-	{fMinImpactParam=bmin; fMaxImpactParam=bmax;}
+    virtual void    SetReferenceFrame(TString frame="CMS") {fFrame=frame;}
+    virtual void    SetEconv(Bool_t ec, Int_t nmiss=50) {fEConv=ec; fMissing=nmiss;}
+    virtual void    SetImpactParameterRange(Float_t bmin = 0, Float_t bmax = 15.) {fMinImpactParam=bmin; fMaxImpactParam=bmax;}
     virtual void    KeepFullEvent();
     virtual void    SetJetQuenching(Int_t flag=1)     {fQuench     = flag;}
     virtual void    SetShadowing(Int_t flag=1)        {fShadowing  = flag;}
@@ -148,6 +146,8 @@ class AliGenHijing : public AliGenMC
     Int_t 	fFreeTargSpecp;    // Num. of spectator protons from target nucleus
     TF1		*fFragmNeutrons;   // data driven correction for nuclear fragment formation
     TF1		*fFragmProtons;   // data driven correction for nuclear fragment formation
+    Bool_t      fEConv;           // if 1 switch on econv in hijhrd (def=1)
+    Int_t       fMissing;         // if >0 then set number of misses in hijhrd (def = 50)
 
  private:
     AliGenHijing(const AliGenHijing &Hijing);
@@ -163,6 +163,6 @@ class AliGenHijing : public AliGenMC
     Int_t FreeSpectatorsn(Float_t b, Int_t nSpecn);
     Int_t FreeSpectatorsp(Float_t b, Int_t nSpecp);
     
-    ClassDef(AliGenHijing, 10) // AliGenerator interface to Hijing
+    ClassDef(AliGenHijing, 11) // AliGenerator interface to Hijing
 };
 #endif


### PR DESCRIPTION
Patch makes possible to disable adhoc energy conservation
and allows the number of misses to be set in hijhrd.f
The settings are propagated via IHPR2(31) and (30) using
the function AliGenHijing::SetEconv(Bool_t ec, Int_t nmiss=50).

The patch also removes annoying print outs to fort.16 and fort.8
