### PR TITLE
TRD: AliTRDcalibDB reset TRAP config in Invalidate()

### DIFF
--- a/TRD/TRDbase/AliTRDcalibDB.cxx
+++ b/TRD/TRDbase/AliTRDcalibDB.cxx
@@ -438,7 +438,10 @@ void AliTRDcalibDB::Invalidate()
   }
 
   fOnlineGainTableID = 0;
-
+  // Invalidate cached TRAP config
+  fTrapConfigName="";
+  fTrapConfigVersion="";
+  fTrapConfig=0;
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
Dear @qgp ,

This PR resets the cached TRAP config in the AliTRDcalibDB upon a call to Invalidate(). Without this fix, a typical `db->SetRun(); db->GetTRAPConfig();` looks like this


```bash
I-TAlienFile::Open: Accessing image 2 of alien:///alice/data/OCDBFoldervsRunRange.xml?filetype=raw&cachesz=4000000&readaheadsz=2000000&rmpolicy=1 in SE <ALICE::Kosice::SE>
[TFile::Cp] Total 0.00 MB	|====================| 100.00 % [0.1 MB/s]
I-AliCDBHandler::OnStartDocument: Reading XML file for LHCPeriod <-> Run Range correspondence
I-AliCDBManager::GetLHCPeriodAgainstAlienFile:  LHC folder = alien://folder=/alice/data/2016/OCDB
I-AliCDBManager::GetLHCPeriodAgainstAlienFile:  LHC period start run = 247171
I-AliCDBManager::GetLHCPeriodAgainstAlienFile:  LHC period end run = 267257
------------ Run 249533 ------------
I-AliCDBGrid::QueryCDB: Querying files valid for run 249533 and path "*" into CDB storage  "alien:///alice/data/2016/OCDB/"
I-AliCDBGrid::QueryValidFiles: Only latest version will be returned
I-AliCDBGrid::QueryCDB: 301 valid files found!
I-TAlienFile::Open: Accessing image 1 of alien:///alice/data/2016/OCDB/TRD/Calib/DCS/Run249533_999999999_v2_s0.root in SE <ALICE::CERN::OCDB>
I-AliTRDcalibDB::LoadTrapConfig: looking for TRAPconfig "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b0-fs1e24-ht200-qs0e24s24e23-pidlinear_ptrg.r5570"
I-TAlienFile::Open: Accessing image 1 of alien:///alice/data/2016/OCDB/TRD/Calib/TrapConfig/Run0_999999999_v3_s0.root in SE <ALICE::CERN::OCDB>
I-AliTRDcalibDB::GetTrapConfig: using TRAPconfig "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b0-fs1e24-ht200-qs0e24s24e23-pidlinear_ptrg.r5570"
I-AliTRDcalibDB::GetOnlineGainTableID: looking for gaintable: Krypton_2015-02 (id 10)
I-TAlienFile::Open: Accessing image 1 of alien:///alice/data/2016/OCDB/TRD/Calib/Krypton_2015-02/Run0_999999999_v1_s0.root in SE <ALICE::CERN::OCDB>
I-AliTRDcalibDB::CacheCDBEntry: loaded gain table: TRD/Calib/Krypton_2015-02
------------ Run 249536 ------------
I-AliCDBGrid::QueryCDB: Querying files valid for run 249536 and path "*" into CDB storage  "alien:///alice/data/2016/OCDB/"
I-AliCDBGrid::QueryValidFiles: Only latest version will be returned
I-AliCDBGrid::QueryCDB: 301 valid files found!
------------ Run 249537 ------------
I-AliCDBGrid::QueryCDB: Querying files valid for run 249537 and path "*" into CDB storage  "alien:///alice/data/2016/OCDB/"
I-AliCDBGrid::QueryValidFiles: Only latest version will be returned
I-AliCDBGrid::QueryCDB: 301 valid files found!
``` 


With a reset, calls look like
```bash
I-TAlienFile::Open: Accessing image 2 of alien:///alice/data/OCDBFoldervsRunRange.xml?filetype=raw&cachesz=4000000&readaheadsz=2000000&rmpolicy=1 in SE <ALICE::Kosice::SE>
[TFile::Cp] Total 0.00 MB	|====================| 100.00 % [0.1 MB/s]
I-AliCDBHandler::OnStartDocument: Reading XML file for LHCPeriod <-> Run Range correspondence
I-AliCDBManager::GetLHCPeriodAgainstAlienFile:  LHC folder = alien://folder=/alice/data/2016/OCDB
I-AliCDBManager::GetLHCPeriodAgainstAlienFile:  LHC period start run = 247171
I-AliCDBManager::GetLHCPeriodAgainstAlienFile:  LHC period end run = 267257
------------ Run 249533 ------------
I-AliCDBGrid::QueryCDB: Querying files valid for run 249533 and path "*" into CDB storage  "alien:///alice/data/2016/OCDB/"
I-AliCDBGrid::QueryValidFiles: Only latest version will be returned
I-AliCDBGrid::QueryCDB: 301 valid files found!
I-TAlienFile::Open: Accessing image 1 of alien:///alice/data/2016/OCDB/TRD/Calib/DCS/Run249533_999999999_v2_s0.root in SE <ALICE::CERN::OCDB>
I-AliTRDcalibDB::LoadTrapConfig: looking for TRAPconfig "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b0-fs1e24-ht200-qs0e24s24e23-pidlinear_ptrg.r5570"
I-TAlienFile::Open: Accessing image 1 of alien:///alice/data/2016/OCDB/TRD/Calib/TrapConfig/Run0_999999999_v3_s0.root in SE <ALICE::CERN::OCDB>
I-AliTRDcalibDB::GetTrapConfig: using TRAPconfig "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b0-fs1e24-ht200-qs0e24s24e23-pidlinear_ptrg.r5570"
I-AliTRDcalibDB::GetOnlineGainTableID: looking for gaintable: Krypton_2015-02 (id 10)
I-TAlienFile::Open: Accessing image 1 of alien:///alice/data/2016/OCDB/TRD/Calib/Krypton_2015-02/Run0_999999999_v1_s0.root in SE <ALICE::CERN::OCDB>
I-AliTRDcalibDB::CacheCDBEntry: loaded gain table: TRD/Calib/Krypton_2015-02
------------ Run 249536 ------------
I-AliCDBGrid::QueryCDB: Querying files valid for run 249536 and path "*" into CDB storage  "alien:///alice/data/2016/OCDB/"
I-AliCDBGrid::QueryValidFiles: Only latest version will be returned
I-AliCDBGrid::QueryCDB: 301 valid files found!
I-TAlienFile::Open: Accessing image 1 of alien:///alice/data/2016/OCDB/TRD/Calib/DCS/Run249536_999999999_v3_s0.root in SE <ALICE::CERN::OCDB>
I-AliTRDcalibDB::LoadTrapConfig: looking for TRAPconfig "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b0-fs1e24-ht200-qs0e24s24e23-pidlinear_ptrg.r5570"
I-TAlienFile::Open: Accessing image 1 of alien:///alice/data/2016/OCDB/TRD/Calib/TrapConfig/Run0_999999999_v3_s0.root in SE <ALICE::CERN::OCDB>
I-AliTRDcalibDB::GetTrapConfig: using TRAPconfig "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b0-fs1e24-ht200-qs0e24s24e23-pidlinear_ptrg.r5570"
I-AliTRDcalibDB::GetOnlineGainTableID: looking for gaintable: Krypton_2015-02 (id 10)
I-TAlienFile::Open: Accessing image 1 of alien:///alice/data/2016/OCDB/TRD/Calib/Krypton_2015-02/Run0_999999999_v1_s0.root in SE <ALICE::CERN::OCDB>
I-AliTRDcalibDB::CacheCDBEntry: loaded gain table: TRD/Calib/Krypton_2015-02

```

What are Tom Dietel's and Hannah Klingenmeyer's username on github? I haven't discussed this PR with anybody.

Cheers,
Hans