### PR TITLE
Geometry updates for AD

### DIFF
--- a/AD/ADsim/AliAD.cxx
+++ b/AD/ADsim/AliAD.cxx
@@ -65,7 +65,7 @@
 #include "AliADCalibData.h"
 #include "AliADConst.h"
 
-ClassImp(AliAD);
+ClassImp(AliAD)
 //__________________________________________________________________
 AliAD::AliAD()
   : AliDetector()
@@ -110,7 +110,13 @@ void AliAD::CreateMaterials()
   Float_t  density,  as[11], zs[11], ws[11];
   Double_t radLength, absLength, a_ad, z_ad;
   Int_t    id;
-
+  // PVC (C2H3Cl)n - Stealed from ITSsim/AliITSv11.cxx
+  Float_t aPVC[3] = { 12.0107, 1.00794, 35.4527};
+  Float_t zPVC[3] = {  6.    , 1.     , 35.   };
+  Float_t wPVC[3] = {  2.    , 3.     ,  1.   };
+  Float_t dPVC    = 1.3;
+  AliMixture(47,"PVC",aPVC,zPVC,dPVC,-3,wPVC);
+  
   //
   // Air
   //
@@ -150,11 +156,16 @@ void AliAD::CreateMaterials()
   AliMixture(16, "VACUUM1 ", aAir, zAir, dAir1, 4, wAir);
   AliMixture(36, "VACUUM2 ", aAir, zAir, dAir1, 4, wAir);
   AliMixture(56, "VACUUM3 ", aAir, zAir, dAir1, 4, wAir);
+  AliMixture(76, "VACUUM4 ", aAir, zAir, dAir1, 4, wAir);
 
   //     Stainless Steel
   AliMixture(19, "STAINLESS STEEL1", asteel, zsteel, 7.88, 4, wsteel);
   AliMixture(39, "STAINLESS STEEL2", asteel, zsteel, 7.88, 4, wsteel);
   AliMixture(59, "STAINLESS STEEL3", asteel, zsteel, 7.88, 4, wsteel);
+  //     Lead
+  AliMaterial(13, "LEAD1     ", 207.19, 82., 11.35, .56, 18.5);
+  AliMaterial(33, "LEAD2     ", 207.19, 82., 11.35, .56, 18.5);
+  AliMaterial(53, "LEAD3     ", 207.19, 82., 11.35, .56, 18.5);
 
   //     Cast iron
   AliMixture(18, "CAST IRON1", acasti, zcasti, 7.2, 4, wcasti);
@@ -171,6 +182,8 @@ void AliAD::CreateMaterials()
   deemax = -.3;   // Maximum fractional energy loss, DLS
   stmin  = -.8;
   // ***************
+  // PVC
+  AliMedium(47, "PVC"              , 47 , 0 , fieldType , maxField , tmaxfd , stemax , deemax , epsil , stmin);
 
   //    Aluminum
   AliMedium(9,  "ALU_C0          ", 9, 0,  fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
@@ -191,6 +204,13 @@ void AliAD::CreateMaterials()
   AliMedium(16, "VA_C0           ", 16, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
   AliMedium(36, "VA_C1           ", 36, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
   AliMedium(56, "VA_C2           ", 56, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
+  AliMedium(76, "VA_SENSITIVE    ", 76, 1, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
+
+  //    Lead
+  AliMedium(13, "PB_C0           ", 13, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
+  AliMedium(33, "PB_C1           ", 33, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
+  AliMedium(53, "PB_C2           ", 53, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
+  
 
   //    Steel
   AliMedium(19, "ST_C0           ", 19, 0, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
@@ -242,8 +262,7 @@ void AliAD::CreateMaterials()
   density = 1.032;
   id      = 1;
   AliMixture( id, "BC404", as, zs, density, -2, ws );
-  AliMedium ( id, "BC404", id, 1, fieldType, maxField, maxBending, maxStepSize,
-              maxEnergyLoss, precision, minStepSize );
+  AliMedium ( id, "BC404", id, 1, fieldType, maxField, maxBending, maxStepSize, maxEnergyLoss, precision, minStepSize );
   // parameters AliMedium: numed  name   nmat   isvol  ifield fieldm tmaxfd stemax deemax epsil  stmin
   // ...
   // isvol       sensitive volume if isvol!=0
@@ -276,7 +295,7 @@ void AliAD::CreateMaterials()
   id      = 2;
   AliMixture( id, "PMMA", as, zs, density, 3, ws );
   AliMedium( id,"PMMA", id, 1, fieldType, maxField, maxBending, maxStepSize,
-             maxEnergyLoss, precision, minStepSize );
+      maxEnergyLoss, precision, minStepSize );
 
 
   // mu-metal
@@ -306,8 +325,8 @@ void AliAD::CreateMaterials()
   absLength = 37.2;
   id = 4;
   AliMaterial (id, "Alum",  a_ad, z_ad, density, radLength, absLength, 0, 0 );
-  AliMedium( id, "Alum", id, 1, fieldType, maxField, maxBending, maxStepSize,
-             maxEnergyLoss, precision, minStepSize );
+  AliMedium   (id, "Alum", id, 1, fieldType, maxField, maxBending, maxStepSize,
+               maxEnergyLoss, precision, minStepSize );
 
   // Parameters for ADCPMG: Glass for the simulation Aluminium
   // TODO fix material
@@ -318,8 +337,8 @@ void AliAD::CreateMaterials()
   absLength = 37.2;
   id = 5;
   AliMaterial( id, "Glass",  a_ad, z_ad, density, radLength, absLength, 0, 0 );
-  AliMedium( id, "Glass", id, 1, fieldType, maxField, maxBending, maxStepSize,
-             maxEnergyLoss, precision, minStepSize );
+  AliMedium  ( id, "Glass", id, 1, fieldType, maxField, maxBending, maxStepSize,
+               maxEnergyLoss, precision, minStepSize );
 
 
 }
@@ -336,8 +355,7 @@ void AliAD::SetTreeAddress()
   TTree *treeH = fLoader->TreeH();
   if (treeH) {
     branch = treeH->GetBranch(branchname);
-    if (branch)
-      branch->SetAddress(&fHits);
+    if (branch) branch->SetAddress(&fHits);
   }
 }
 
@@ -346,7 +364,8 @@ void AliAD::SetTreeAddress()
 void AliAD::MakeBranch(Option_t* opt)
 {
   const char* oH = strstr(opt,"H");
-  if (fLoader->TreeH() && oH && !fHits) {
+  if (fLoader->TreeH() && oH && !fHits) 
+  {
     fHits = new TClonesArray("AliADhit",1000);
     fNhits = 0;
   }

--- a/AD/ADsim/AliADv1.cxx
+++ b/AD/ADsim/AliADv1.cxx
@@ -30,23 +30,26 @@
 #include <Riostream.h>
 
 // --- ROOT libraries ---
-#include <TMath.h>
 #include <TString.h>
 #include <TVirtualMC.h>
 #include <TGeoManager.h>
 #include <TGeoMatrix.h>
+#include <TGeoCompositeShape.h> 
+#include <TGeoTorus.h>
 #include <TGeoTube.h>
 #include <TGeoPcon.h>
 #include <TGeoCone.h>
 #include <TGeoShape.h>
 #include <TGeoXtru.h>
+#include "TGeoShape.h"
+#include "TGeoBBox.h"
+#include "TGeoPara.h"
+#include "TGeoTrd1.h"
 #include <TTree.h>
 #include <TSystem.h>
-// #include <TGeoCompositeShape.h> // included in .h
 #include <TGeoGlobalMagField.h>
 #include <TGeoMaterial.h>
 #include <TGeoMedium.h>
-#include <TGeoVolume.h>
 #include <TGeoArb8.h>
 #include <TClonesArray.h>
 #include <TGeoTrd2.h>
@@ -69,14 +72,27 @@
 
 ClassImp(AliADv1);
 
+ClassImp(AliADv1)
+const Double_t AliADv1::kZwall        = 1895.9 ;  // Aluminium plate z position 
+const Double_t AliADv1::kZendAbs      = 1880.75;  // End of CC block absorber
+const Double_t AliADv1::kZbegVMAOI    = 1919.2 ;  // Begining of Warm Module
+const Double_t AliADv1::kZbegValve    = 1910.7 ;  // Begining of Valve
+const Double_t AliADv1::kZbegFrontBar = 1949.1 ;  // Begining of Front Bar
+const Double_t AliADv1::kZbegCoil     = 1959.4 ;  // Begining of compensator coil
+const char * AliADv1::s_where[] = {
+  "kCSideFiberNearWLSTop", "kCSideFiberNearWLSBot", "kCSideFiberPmtTop", "kCSideFiberPmtBot", 
+  "kASideFiberShort", "kASideFiberLong" }; 
 //__________________________________________________________________
 AliADv1::AliADv1()
   : AliAD()
   , fADCstruct(kTRUE)
+  , fADAstruct(kTRUE)
   , fADCPosition(kADCInTunnel)
-  , fADCLightYield(93.75)
+  // , fADCLightYield(93.75) // Energy required to produce a photon in BC408 (used in VZERO)
+  // , fADALightYield(93.75) // Energy required to produce a photon in BC408 (used in VZERO)
+  , fADCLightYield(88.23) // Energy required to produce a photon in BC404 (used in AD)
+  , fADALightYield(88.23) // Energy required to produce a photon in BC404 (used in AD)
   , fADCPhotoCathodeEfficiency(0.18)
-  , fADALightYield(93.75)
   , fADAPhotoCathodeEfficiency(0.18)
   , fKeepHistory(kFALSE)
 {
@@ -87,18 +103,21 @@ AliADv1::AliADv1()
 AliADv1::AliADv1(const char *name, const char *title)
   : AliAD(name, title)
   , fADCstruct(kTRUE)
+  , fADAstruct(kTRUE)
   , fADCPosition(kADCInTunnel)
-  , fADCLightYield(93.75)
+  // , fADCLightYield(93.75) // Energy required to produce a photon in BC408 (used in VZERO)
+  // , fADALightYield(93.75) // Energy required to produce a photon in BC408 (used in VZERO)
+  , fADCLightYield(88.23) // Energy required to produce a photon in BC404 (used in AD)
+  , fADALightYield(88.23) // Energy required to produce a photon in BC404 (used in AD)
   , fADCPhotoCathodeEfficiency(0.18)
-  , fADALightYield(93.75)
   , fADAPhotoCathodeEfficiency(0.18)
   , fKeepHistory(kFALSE)
 {
-  AliModule* pipe = gAlice->GetModule("PIPE");
-  if( (!pipe) ) {
-    Error("Constructor","AD needs PIPE!!!\n");
-    exit(1);
-  }
+  // AliModule* pipe = gAlice->GetModule("PIPE");
+  // if( (!pipe) ) {
+  //   Error("Constructor","AD needs PIPE!!!\n");
+  //   exit(1);
+  // }
   fHits = new TClonesArray("AliADhit",400);
   gAlice->GetMCApp()->AddHitList(fHits);
 }
@@ -181,33 +200,241 @@ TGeoCompositeShape * AliADv1::MakeShapeADCpadH(const Double_t W, const Double_t 
 //_____________________________________________________________________________
 void AliADv1::CreateAD()
 {
-  printf("===> AliADv1::CreateAD(): ver=[Feb 3st, 2015]; contact=[ecalvovi@cern.ch]\n");
+  Printf("AliADv1::CreateAD(): update=[Jun 5th, 2017] [ecalvovi@cern.ch]");
+  Printf("Please use together with ((AliPIPv3*)pipe)->SetBeamBackgroundSimulation() in Config.C");
+
+  TGeoVolumeAssembly * ad = new TGeoVolumeAssembly("AD");
+  Int_t nvertices;
   //
   // Define Rotations used
   //
-  TGeoRotation * Rx180, * Rz180, * Ry180, * Rx90, * Rx90m, * Ry90m;
   Rx90m = new TGeoRotation("Rx90m",   0., -90.,   0.) ;
   Rx90  = new TGeoRotation("Rx90" ,   0.,  90.,   0.) ;
   Rx180 = new TGeoRotation("Rx180",   0., 180.,   0.) ;  //   4    |   1
   Rz180 = new TGeoRotation("Rz180", 180.,   0.,   0.) ;  // --------------->  x
   Ry180 = new TGeoRotation("Ry180", 180., 180.,   0.) ;  //   3    |   2
   Ry90m = new TGeoRotation("Ry90m",  90., -90., -90.) ;
-  // Get Mediums needed.
-  TGeoMedium * kMedAlu       = gGeoManager->GetMedium("AD_Alum");   // Aluminium
-  TGeoMedium * kMedSteelSh   = gGeoManager->GetMedium("AD_ST_C0");  // Stainless Steel
-  TGeoMedium * kMedVacuum    = gGeoManager->GetMedium("AD_VA_C0");  // Stainless Steel
-  //
-  // Private comunication by Arturo Tauro (2014, Apr 23)
-  // According to last survey measurement done this morning,
-  // the C-side wall is at Z = - 18959mm.
-  //
-  const Double_t kZwall        = 1895.9 ;  // Aluminium plate z position
-  const Double_t kZendAbs      = 1880.75;  // End of CC block absorber
-  const Double_t kZbegVMAOI    = 1919.2 ;  // Begining of Warm Module
-  const Double_t kZbegValve    = 1910.7 ;  // Begining of Valve
-  const Double_t kZbegFrontBar = 1949.1 ;  // Begining of Front Bar
-  const Double_t kZbegCoil     = 1959.4 ;  // Begining of compensator coil
+  Ry90  = new TGeoRotation("Ry90" ,  90.,  90., -90.) ;
+  Rz90  = new TGeoRotation("Rz90" ,  90.,   0.,   0.) ;  
+  // Get Mediums needed. 
+  TGeoMedium * kMedAlu       = gGeoManager->GetMedium("AD_Alum");   // Aluminium 
+  TGeoMedium * kMedSteelSh   = gGeoManager->GetMedium("AD_ST_C0");  // Stainless Steel 
+  TGeoMedium * kMedVacuum    = gGeoManager->GetMedium("AD_VA_C0");  // Stainless Steel 
+  TGeoMedium * kMedCopper    = gGeoManager->GetMedium("AD_Cu_C0");  // Stainless Steel 
+  TGeoMedium * kMedPVC       = gGeoManager->GetMedium("AD_PVC"  );  // Stainless Steel
+  // TGeoMedium * kSensitiveVac = gGeoManager->GetMedium("AD_VA_SENSITIVE");  // Stainless Steel 
 
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // Add Cables for A-Side
+  // No LHC drawing found!
+  //
+  new TGeoBBox("shADACablingVBar1", 2.0, 100.0, 2.0);
+  new TGeoBBox("shADACablingVBar0", 1.8, 102.0, 1.8);
+  TGeoVolume* voADACablingVBar = new TGeoVolume("voADACablingVBar", 
+    new TGeoCompositeShape("shADACablingVBar", "shADACablingVBar1-shADACablingVBar0"), kMedSteelSh);
+  new TGeoBBox("shADACablingHBar1",  70.0/2.0, 2.0, 2.0);
+  new TGeoBBox("shADACablingHBar0",  72.0/2.0, 1.8, 1.8);
+  TGeoVolume* voADACablingHBar = new TGeoVolume("voADACablingHBar", 
+    new TGeoCompositeShape("shADACablingHBar", "shADACablingHBar1-shADACablingHBar0"), kMedSteelSh);
+  voADACablingVBar->SetLineColor(kGray+1);
+  voADACablingHBar->SetLineColor(kGray+1);
+
+  /////////////////////////////////////////////////////////////////////////////
+  // 
+  // Vertical Cables A-Side
+  // No LHC drawing found!
+  // There are ~ 37 cables in a dx space of 74 cm. That makes cables of 2 cm diameter
+  // No info about the cable. Taking as an aproximation a cable from Riyadh catalog:
+  // model: 000101xx15 
+  // nominal cross section: 1 x 120 
+  // number of wires in conductor: 37 
+  // diameter of conductor: 14.21 
+  // Insulation thickness: 1.6 
+  // Overall diameter: 18.8
+  //
+  // It has 37 17.64
+  //
+  Double_t rCable     = 2.0/2.;
+  Double_t rCableCore = 1.4/2.; 
+  Double_t lCable     = 200.;
+  // TGeoTube   * shADCableExt  = new TGeoTube   ("shADCableExt" , rCableCore, rCable, lCable/2.);
+  // TGeoTube   * shADCableCore = new TGeoTube   ("shADCableCore",         0., rCable, lCable/2.);
+  TGeoVolume * voADCableExt  = new TGeoVolume ( "voADCableExt"  , new TGeoTube ( "shADCableExt"  , rCableCore+0.01 , rCable          , lCable/2. )  , kMedPVC) ;
+  TGeoVolume * voADCableCore = new TGeoVolume ( "voADCableCore" , new TGeoTube ( "shADCableCore" , 0.              , rCableCore-0.01 , lCable/2. )  , kMedCopper);
+  voADCableExt  -> SetLineColor(kGray+3);
+  voADCableCore -> SetLineColor(kOrange+2);
+  TGeoVolumeAssembly * voADAMagnetCable = new TGeoVolumeAssembly("voADAMagnetCable");
+  voADAMagnetCable->AddNode(voADCableExt , 1, Rx90);
+  voADAMagnetCable->AddNode(voADCableCore, 1, Rx90);
+
+
+
+  TGeoVolumeAssembly * voADAMagnetCableArray= new TGeoVolumeAssembly("voADAMagnetCableArray");
+  
+  for (Int_t i=0; i<37; i++)
+  {
+    voADAMagnetCableArray -> AddNode(voADAMagnetCable, i+1, new TGeoTranslation(+rCable + 2.*rCable*i,0,0));
+  }
+  // Make I-Beam support structure in RB24/3 (A-Side)
+  // LHC Drawing: LHCVC2U_0034
+  // Dimensions are approximated.
+  // Probably a type "HE 100 A" Wide Flange Beam.
+  // flange web      :  0.5 cm
+  // flange width    : 10.0 cm
+  // flange height   :  9.6 cm
+  // flange thickness:  0.8 cm
+  TGeoXtru * shADsuppIBeam = new TGeoXtru(2);
+  shADsuppIBeam->SetNameTitle("shADsuppIBeam","shADsuppIBeam");
+  Double_t HIBeam, hIBeam, h2, W, w;
+  HIBeam  = 9.6/2.;
+  hIBeam  = 0.8;
+  h2 = hIBeam;
+  w  =  0.5/2.;
+  W  = 10.5/2.;
+  Double_t xIBeam[] = { -W      , -W            , -w        , -w        , -W            , -W     , W      , W             , w         , w         , W             , W       }; 
+  Double_t yIBeam[] = { -HIBeam , hIBeam-HIBeam , h2-HIBeam , HIBeam-h2 , HIBeam-hIBeam , HIBeam , HIBeam , HIBeam-hIBeam , HIBeam-h2 , h2-HIBeam , hIBeam-HIBeam , -HIBeam }; 
+  nvertices = sizeof(xIBeam)/sizeof(Double_t);
+  shADsuppIBeam->DefinePolygon(nvertices,xIBeam,yIBeam);
+  shADsuppIBeam->DefineSection(0, -430., 0., -HIBeam, 1.0); // index, Z position, offset (x,y) and scale for first section
+  shADsuppIBeam->DefineSection(1,    0., 0., -HIBeam, 1.0); // idem, second section
+  Double_t fOriginBeamCut1[3] = { 3.25, -HIBeam, -4.5};
+  Double_t fOriginBeamCut2[3] = {-3.25, -HIBeam, -4.5};
+  new TGeoBBox("shADBeamCut1", W/2., HIBeam + hIBeam, 3., fOriginBeamCut1);
+  new TGeoBBox("shADBeamCut2", W/2., HIBeam + hIBeam, 3., fOriginBeamCut2);
+  TGeoCompositeShape * shADsuppIBeamCutted = new TGeoCompositeShape("shADsuppIBeamCutted", "(shADsuppIBeam-shADBeamCut1)-shADBeamCut2");
+  TGeoVolume * voADsuppIBeam = new TGeoVolume("voADsuppIBeam", shADsuppIBeamCutted, kMedSteelSh);
+
+  // Vertical I-Beam:
+  TGeoVolume * voADsuppIBeamV = MakeVolIBeam("voADsuppIBeamV"    , kMedSteelSh, 10.5, 9.6, 0.5, 1.6,81.8-9.6);
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // Make Top Bracket, part of 
+  // Sliding support (structure 18 in RB24/3)
+  // LHC Drawing: LHCVC2U_0026 (item 5)
+  // 
+  new TGeoBBox("shADsupp1Box",                  11./2., 15./2., 1. );
+  new TGeoBBox("shADsupp1HoleSqr",               8./2.,  4./2., 1.2);  // larger y (4 instead of 3) just in case
+  new TGeoTube("shADsupp1HoleCircle",               0.,    0.5, 1.2);
+  new TGeoBBox("shADsupp1HoleRectangle",            1.,    0.5, 1.2);
+  TGeoArb8 * shADsupp1HoleTrg = new TGeoArb8("shADsupp1HoleTrg", 1.2);
+  Float_t trgX[] = { -2.5, 0.0, 2.5,  0.0 };
+  Float_t trgY[] = {  0.0, 2.5, 0.0, -2.5 };
+  for (Int_t i=0; i<4; i++) 
+  {
+    shADsupp1HoleTrg -> SetVertex(i,   trgX[i], trgY[i]);
+    shADsupp1HoleTrg -> SetVertex(i+4, trgX[i], trgY[i]);
+  }
+  (new TGeoTranslation("trADsupp1Box",              0., 15./2., 0. ))->RegisterYourself();
+  (new TGeoTranslation("trADsupp1HoleSqr",          0.,    14., 0. ))->RegisterYourself();
+  (new TGeoTranslation("trADsupp1HoleRndRecL1",     3.,    2.5, 0. ))->RegisterYourself();
+  (new TGeoTranslation("trADsupp1HoleRndRecL2",     3.,    5.5, 0. ))->RegisterYourself();
+  (new TGeoTranslation("trADsupp1HoleRndRecL3",     3.,    8.5, 0. ))->RegisterYourself();
+  (new TGeoTranslation("trADsupp1HoleRndRecR1",    -3.,    2.5, 0. ))->RegisterYourself();
+  (new TGeoTranslation("trADsupp1HoleRndRecR2",    -3.,    5.5, 0. ))->RegisterYourself();
+  (new TGeoTranslation("trADsupp1HoleRndRecR3",    -3.,    8.5, 0. ))->RegisterYourself();
+  (new TGeoTranslation("trADsupp1HoleCircleL",      1.,     0., 0. ))->RegisterYourself();
+  (new TGeoTranslation("trADsupp1HoleCircleR",     -1.,     0., 0. ))->RegisterYourself();
+  new TGeoCompositeShape("shADsupp1HoleRoundedRectangle", 
+      "shADsupp1HoleCircle:trADsupp1HoleCircleL + "
+      "shADsupp1HoleCircle:trADsupp1HoleCircleR + "
+      "shADsupp1HoleRectangle");
+  TGeoCompositeShape * shADsuppTopBracket = new TGeoCompositeShape("shADsuppTopBracket", 
+      "shADsupp1Box:trADsupp1Box - "
+      "shADsupp1HoleRoundedRectangle:trADsupp1HoleRndRecL1 - "
+      "shADsupp1HoleRoundedRectangle:trADsupp1HoleRndRecL2 - "
+      "shADsupp1HoleRoundedRectangle:trADsupp1HoleRndRecL3 - "
+      "shADsupp1HoleRoundedRectangle:trADsupp1HoleRndRecR1 - "
+      "shADsupp1HoleRoundedRectangle:trADsupp1HoleRndRecR2 - "
+      "shADsupp1HoleRoundedRectangle:trADsupp1HoleRndRecR3 - "
+      "shADsupp1HoleSqr:trADsupp1HoleSqr - "
+      "shADsupp1HoleTrg");
+  TGeoVolume * voADsuppTopBracket = new TGeoVolume("voADsuppTopBracket", shADsuppTopBracket, kMedAlu);
+  
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // Make support BASE for structure 17 and 18 in RB24/3 (A-Side)
+  // LHC Drawing: LHCVC2U_0024
+  
+  new TGeoBBox("shADsupp17BaseBox",   16./2., 0.65/2., 33./2. );
+  new TGeoBBox("shADsupp17VertXBox",  16./2.,   8./2., 0.65/2. );
+  new TGeoBBox("shADsupp17VertZBox",  1.3/2.,   8./2.,  25./2. );
+  (new TGeoTranslation("trADsupp17BaseBox",  0., 0.65/2., -12.15 ))->RegisterYourself();
+  (new TGeoTranslation("trADsupp17VertXBox", 0.,  8.0/2., -12.15 +  8.5 + 0.65/2. ))->RegisterYourself();
+  (new TGeoTranslation("trADsupp17VertZBox", 0.,  8.0/2., -12.15 -4. ))->RegisterYourself();
+  TGeoCompositeShape * shADsupp17Base = new TGeoCompositeShape("shADsupp17Base", 
+      "shADsupp17BaseBox:trADsupp17BaseBox + "
+      "shADsupp17VertXBox:trADsupp17VertXBox + "
+      "shADsupp17VertZBox:trADsupp17VertZBox");
+  TGeoVolume * voADsupp17Base = new TGeoVolume("voADsupp17Base", shADsupp17Base, kMedAlu);
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // Make support structure 17 in RB24/3 (A-Side)
+  // Fixed support
+  // LHC Drawing: LHCVC2U_0028
+  // LHC Drawing: LHCVC2U_0032
+  
+  // Main Prop
+  TGeoXtru * shADsupp17MainPropLat = new TGeoXtru(2);
+  shADsupp17MainPropLat->SetNameTitle("shADsupp17MainPropLat","shADsupp17MainPropLat");
+  Double_t x17[] = {  0.0 , 3 , 3.  , 3.   , 3.6  , 5.   , 5.  , 0. };
+  Double_t y17[] = {  0.0 , 0 , 0.8 , 7.55 , 7.55 , 8.95 , 28. , 28.};
+  nvertices = sizeof(x17)/sizeof(Double_t);
+  shADsupp17MainPropLat->DefinePolygon(nvertices,x17,y17);
+  shADsupp17MainPropLat->DefineSection(0, 0.00, 0., 0., 1.0); // Z position, offset and scale for first section
+  shADsupp17MainPropLat->DefineSection(1, 0.65, 0., 0., 1.0); // idem, second section
+  (new TGeoCombiTrans("ctADsupp17BaseLatL"      , 5. - 0.65 , 0.65          , 0. , Ry90 ))->RegisterYourself();
+  (new TGeoCombiTrans("ctADsupp17BaseLatR"      , -5.       , 0.65          , 0. , Ry90 ))->RegisterYourself();
+  (new TGeoTranslation("trADsupp17MainPropVBox" , 0.        , 28./2. + 0.65 , -0.65/2.  ))->RegisterYourself();
+  new TGeoBBox("shADsupp17MainPropVBox", 10./2., 28./2., 0.65/2.);
+  TGeoCompositeShape * shADsupp17MainProp = new TGeoCompositeShape("shADsupp17MainProp",
+      "shADsupp17MainPropLat:ctADsupp17BaseLatL + "
+      "shADsupp17MainPropLat:ctADsupp17BaseLatR + "
+      "shADsupp17MainPropVBox:trADsupp17MainPropVBox");
+  TGeoVolume * voADsupp17MainProp = new TGeoVolume("voADsupp17MainProp", shADsupp17MainProp, kMedAlu);
+  TGeoVolumeAssembly * voADsupp17 = new TGeoVolumeAssembly("voADsupp17");
+  voADsupp17 -> AddNode(voADsupp17MainProp, 1);
+  voADsupp17 -> AddNode(voADsupp17Base,     1);
+  voADsupp17 -> AddNode(voADsuppTopBracket, 1, new TGeoTranslation(0., 15.90, 0.1 + 2./2.));
+  
+
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // Make support structure 2: part of 
+  // Sliding support
+  // LHC Drawing: LHCVC2U_0026
+  // 
+  Float_t htrp   = 4.3;  // real value??
+  Float_t trpX[] = {0.  , 5.0 , 4.3,0.  };
+  Float_t trpY[] = {htrp, htrp, 0. ,0.  };
+  TGeoArb8 * shADsupp2trp = new TGeoArb8("shADsupp2trp", 0.6/2.);
+  for (Int_t i=0; i<4; i++) 
+  {
+    shADsupp2trp -> SetVertex(i,   trpX[i], trpY[i]);
+    shADsupp2trp -> SetVertex(i+4, trpX[i], trpY[i]);
+  }
+  new TGeoBBox("shADsupp2latbox", 5.0/2., (19.-htrp)/2.,  0.6/2.);
+  new TGeoBBox("shADsupp2box",    0.6/2.,        19./2., 10.0/2.);
+  (new TGeoTranslation("trADsupp2B"   , 0.6/2.,              19./2.,              0.))->RegisterYourself();
+  (new TGeoTranslation("trADsupp2L"   , 5.0/2., (19-htrp)/2. + htrp, -10.0/2.+0.6/2.))->RegisterYourself();
+  (new TGeoTranslation("trADsupp2R"   , 5.0/2., (19-htrp)/2. + htrp,  10.0/2.-0.6/2.))->RegisterYourself();
+  (new TGeoTranslation("trADsupp2trpL",     0.,                  0., -10.0/2.+0.6/2.))->RegisterYourself();
+  (new TGeoTranslation("trADsupp2trpR",     0.,                  0.,  10.0/2.-0.6/2.))->RegisterYourself();
+  TGeoCompositeShape * shADsupp18MainProp = new TGeoCompositeShape("shADsupp18MainProp", 
+      "shADsupp2trp:trADsupp2trpL + "
+      "shADsupp2trp:trADsupp2trpR + "
+      "shADsupp2latbox:trADsupp2L + "
+      "shADsupp2latbox:trADsupp2R + "
+      "shADsupp2box:trADsupp2B");
+  TGeoVolume * voADsupp18MainProp = new TGeoVolume("voADsupp18MainProp", shADsupp18MainProp, kMedAlu);
+  TGeoVolumeAssembly * voADsupp18 = new TGeoVolumeAssembly("voADsupp18");
+  voADsupp18 -> AddNode(voADsupp18MainProp, 1, new TGeoCombiTrans (0., 9.65, 0., Ry90m));
+  voADsupp18 -> AddNode(voADsupp17Base,     1, Ry180);
+  voADsupp18 -> AddNode(voADsuppTopBracket, 1, new TGeoTranslation(0., 16.25, -0.1 - 2./2.));
+  /////////////////////////////////////////////////////////////////////////////
   // Define Ion Pump ??
   // Drawing LHCVBU__0052
   // Vacuum - Bellows - U type
@@ -224,8 +451,8 @@ void AliADv1::CreateAD()
   //
   new TGeoCompositeShape("shIonPumpVBi", "shIonPumpVB1i+shIonPumpVB2i:ctPumpVB2");
   TGeoShape * sh3 = new TGeoCompositeShape("shIonPumpVB",  "shIonPumpVBo-shIonPumpVBi");
-  TGeoVolume * voIonPumpVB = new TGeoVolume("voIonPumpVB", sh3, kMedAlu);
-  // Variables
+  TGeoVolume * voIonPumpVB = new TGeoVolume("voIonPumpVB", sh3, kMedSteelSh);
+  // Variables 
   Double_t alpha, beta, tga2, tga, sa, ca, ctgb, d, Ro, Ri, phi1, dphi, H, L, z;
   // Drawing: LHCVSR__0054
   // Vacuum Screen - RF
@@ -248,19 +475,20 @@ void AliADv1::CreateAD()
   Ri = 6.3/2.; Ro = Ri + h;
   z = (9.71/2. - Ri) / tga;
   shVSRflange->DefineSection(3,            z,   Ri, Ro);
-  //
+  // 
   Double_t   Dtga = 6.6*tga - 0.5*(9.71-6.3)    ;
   Double_t x = (h - 0.11 - Dtga) / (ctgb - tga) ;
   Double_t y = x * ctgb;
   z  = 6.6 - x;
   Ro = Ri + 0.11 + y;
   shVSRflange->DefineSection(4,            z,   Ri, Ro);
-  z  = 6.6;
+  z  = 6.6; 
   Ro = Ri + 0.11;
   shVSRflange->DefineSection(5,            z,   Ri, Ro);
-  z  = 7.1;
+  z  = 7.1; 
   shVSRflange->DefineSection(6,            z,   Ri, Ro);
-  TGeoVolume * voVSRflange = new TGeoVolume("voVSRflange", shVSRflange, kMedAlu);
+  // TGeoVolume * voVSRflange = new TGeoVolume("voVSRflange", shVSRflange, kMedAlu);
+  TGeoVolume * voVSRflange = new TGeoVolume("voVSRflange", shVSRflange, kMedCopper);
   //
   // Drawing: LHCVSR__0053
   // Vacuum Screen - RF
@@ -286,7 +514,7 @@ void AliADv1::CreateAD()
   Ro  = Ri + d/ca;
   shVSR0->DefineSection(5,        14.0 ,      Ri, Ro);
   // printf("  Ro: %8.2f\n", Ro);
-  // Make holes
+  // Make holes 
   new TGeoBBox("shHoleBody"    , 0.15, 0.60, 0.3);
   new TGeoTube("shHoleEnd", 0.  , 0.15, 0.3);
   (new TGeoTranslation("trHoleBody", 0., -0.6, 0.))->RegisterYourself();
@@ -303,21 +531,22 @@ void AliADv1::CreateAD()
   (new TGeoCombiTrans("ctHole4", 0., Ro , z, Rx90m))->RegisterYourself();
   // Now make a sector of RF transition tube
   new TGeoCompositeShape("shVSRsec",
-                         "shVSR0 - (shHole:ctHole1 + shHole:ctHole2 + shHole:ctHole3 + shHole:ctHole4)");
+   "shVSR0 - (shHole:ctHole1 + shHole:ctHole2 + shHole:ctHole3 + shHole:ctHole4)");
   // Now define rotations for each sector
   TString strSh = "shVSRsec ";
   for (Int_t i=1; i<=11; i++) {
-    (new TGeoRotation(Form("rSec%d",i), 30. * i, 0. , 0.))->RegisterYourself();
-    strSh+=Form("+ shVSRsec:rSec%d",i);
+   (new TGeoRotation(Form("rSec%d",i), 30. * i, 0. , 0.))->RegisterYourself();
+   strSh+=Form("+ shVSRsec:rSec%d",i);
   }
   // printf("%s\n", strSh.Data());
   TGeoCompositeShape * shVSR = new TGeoCompositeShape("shVSR", strSh.Data());
   // Now assembly the sector to form VSR RF transition tube !
-  TGeoVolume * voVSR = new TGeoVolume("voVSR", shVSR, kMedAlu);
-  //
+  // TGeoVolume * voVSR = new TGeoVolume("voVSR", shVSR, kMedAlu);
+  TGeoVolume * voVSR = new TGeoVolume("voVSR", shVSR, kMedCopper);
+  // 
   // Drawing: LHCVSR__0057
   // RF CONTACT
-  //
+  // 
   Ro = 0.5 * 6.3;
   d  = 0.03;
   Ri = Ro - d;
@@ -335,7 +564,7 @@ void AliADv1::CreateAD()
   Double_t R0 =  1.75;
   Double_t R1 = 10.48;
   Double_t R2 =  0.81 + 0.28;
-  phi1 = 0.; dphi = 360.;
+  phi1 = 0.; dphi = 360.; 
 
   TGeoPcon * shVSRcontact = new TGeoPcon("shVSRcont", phi1, dphi, 6);
   z = 0.;
@@ -364,7 +593,8 @@ void AliADv1::CreateAD()
   Ri += R2 * sab;
   Ro  = Ri + d/cab;
   shVSRcontact->DefineSection(5, -z, Ri, Ro);
-  TGeoVolume * voVSRcontD = new TGeoVolume("voVSRcontD", shVSRcontact, kMedAlu);
+  TGeoVolume * voVSRcontD = new TGeoVolume("voVSRcontD", shVSRcontact, kMedCopper);
+  // TGeoVolume * voVSRcontD = new TGeoVolume("voVSRcontD", shVSRcontact, kMedAlu);
   // Drawing: LHCVSR__0017
   // Vacuum Screen - RF
   // RF Contact flange
@@ -394,7 +624,8 @@ void AliADv1::CreateAD()
   shVSRcontFlange->DefineSection( 9, -z, Ri, Ro);
   Ri = 6.36 /2.; Ro =  6.50 /2.; z = 1.30;
   shVSRcontFlange->DefineSection(10, -z, Ri, Ro);
-  TGeoVolume * voVSRcontF = new TGeoVolume("voVSRcontF", shVSRcontFlange, kMedAlu);
+  TGeoVolume * voVSRcontF = new TGeoVolume("voVSRcontF", shVSRcontFlange, kMedCopper);
+  // TGeoVolume * voVSRcontF = new TGeoVolume("voVSRcontF", shVSRcontFlange, kMedAlu);
   // Drawing: LHCVBU__0002
   // Bellows + End Parts
   // Vacuum - Bellows - U type
@@ -438,9 +669,9 @@ void AliADv1::CreateAD()
   Double_t az [nsec] = {0.9, 0.915, 0.915, 11.885, 11.885, 11.9};
   Double_t aRi[nsec] = {5.0, 5.0  , 5.685,  5.685,  5.0  ,  5.0};
   for (Int_t i=0; i<nsec; i++) {
-    z=az[i]; Ri = aRi[i]; Ro = 5.7;
-    //printf("  i: %2d  z: %8.2f  Ri: %8.2f  Ro: %8.2f\n", i, z, Ri, Ro );
-    shVBUcent ->DefineSection( i, z, Ri, Ro);
+   z=az[i]; Ri = aRi[i]; Ro = 5.7;
+   //printf("  i: %2d  z: %8.2f  Ri: %8.2f  Ro: %8.2f\n", i, z, Ri, Ro );
+   shVBUcent ->DefineSection( i, z, Ri, Ro);
   }
 
   ( new TGeoCombiTrans("ctEnd9mm", 0., 0., 0.9, Ry180)) -> RegisterYourself();
@@ -453,27 +684,29 @@ void AliADv1::CreateAD()
   Double_t aRi2[nsec2] = {5.15, 5.15, 5.03, 5.03, 5.455, 5.455, 5.03, 5.03, 5.59, 5.59} ;
   TGeoPcon * shVBUrotFlg  = new TGeoPcon("shVBUrotFlg" , 0., 360., nsec2);
   for (Int_t i=0; i<nsec2; i++) {
-    z=az2[i]; Ri = aRi2[i]; Ro = 6.02;
-    //printf("  i: %2d  z: %8.2f  Ri: %8.2f  Ro: %8.2f\n", i, z, Ri, Ro );
-    shVBUrotFlg ->DefineSection( i, z, Ri, Ro);
+   z=az2[i]; Ri = aRi2[i]; Ro = 6.02;
+   //printf("  i: %2d  z: %8.2f  Ri: %8.2f  Ro: %8.2f\n", i, z, Ri, Ro );
+   shVBUrotFlg ->DefineSection( i, z, Ri, Ro);
   }
-  TGeoVolume * voVBUrotFlg = new TGeoVolume("voVBUrotFlg", shVBUrotFlg, kMedAlu);
+  TGeoVolume * voVBUrotFlg = new TGeoVolume("voVBUrotFlg", shVBUrotFlg, kMedSteelSh);
+  // TGeoVolume * voVBUrotFlg = new TGeoVolume("voVBUrotFlg", shVBUrotFlg, kMedAlu);
 
-  // Flange
+  // Flange 
   TGeoPcon * shVBUflg  = new TGeoPcon("shVBUflg" , 0., 360., 4);
-  z  = 0;
-  Ri = 6.02; Ro = 7.6;
+  z  = 0; 
+  Ri = 6.02; Ro = 7.6; 
   shVBUflg->DefineSection(0, z, Ri, Ro);
-  z  = 1.31;
+  z  = 1.31; 
   shVBUflg->DefineSection(1, z, Ri, Ro);
-  z  = 1.31;
-  Ri = 5.15;
+  z  = 1.31; 
+  Ri = 5.15; 
   shVBUflg->DefineSection(2, z, Ri, Ro);
   z  = 2.0;
   shVBUflg->DefineSection(3, z, Ri, Ro);
-  TGeoVolume * voVBUflg = new TGeoVolume("voVBUflg", shVBUflg, kMedAlu);
+  TGeoVolume * voVBUflg = new TGeoVolume("voVBUflg", shVBUflg, kMedSteelSh);
+  // TGeoVolume * voVBUflg = new TGeoVolume("voVBUflg", shVBUflg, kMedAlu);
 
-
+   
   // Add the metal plate at the end of Absorber
   // Plate:  80 cm x 80 cm x 1.95 cm (Thickness is aproximatted) (ernesto.calvo@pucp.edu.pe)
   // The End of the concrete abosorber is at kZendAbs = 1880.75
@@ -481,8 +714,8 @@ void AliADv1::CreateAD()
   new TGeoBBox("shBasePlate", 80./2., 80./2.,  1.95/2.);
   new TGeoTube("shHolePlate",  0.   , 12.3  ,  1.95   );
   TGeoVolume* voSaa3EndPlate  =  new TGeoVolume("voYSaa3EndPlate",
-                                                new TGeoCompositeShape("shYSaa3EndPlate","shBasePlate-shHolePlate"),
-                                                kMedSteelSh);
+      new TGeoCompositeShape("shYSaa3EndPlate","shBasePlate-shHolePlate"),
+      kMedSteelSh);
   //
   // Add Rods
   //
@@ -498,58 +731,59 @@ void AliADv1::CreateAD()
   ( new TGeoTranslation("trRod2", 0., 0., -dzRodL/2. + dzRodA + dzRodB/2.) )->RegisterYourself();
   ( new TGeoTranslation("trRod3", 0., 0.,  dzRodL/2. - dzRodB/2.)          )->RegisterYourself();
   TGeoVolume * voSaa3Rod = new TGeoVolume("YSAA3Rod",
-                                          new TGeoCompositeShape("shLargeRod+shRodA:trRod1 + shRodB:trRod2 + shRodB:trRod3"),
-                                          kMedSteelSh);
+      new TGeoCompositeShape("shLargeRod+shRodA:trRod1 + shRodB:trRod2 + shRodB:trRod3"),
+      kMedSteelSh);
   //
-  // Define Valve support (VS)  (ernesto.calvo@pucp.edu.pe)
+  // Define Valve support (VS)  (ernesto.calvo@pucp.edu.pe) 
   //
-  const Double_t dyVS =  5.5;
-  const Double_t dxVS = 30.0;
+  const Double_t dyVS =  5.5; 
+  const Double_t dxVS = 30.0; 
   const Double_t dzVS =  1.0;
   TGeoVolume * voVS = new TGeoVolume("voVS",
-                                     new TGeoBBox("shVS", dxVS/2., dyVS/2., dzVS/2.),
-                                     kMedSteelSh);
+      new TGeoBBox("shVS", dxVS/2., dyVS/2., dzVS/2.),
+      kMedSteelSh);
+  voVS->SetLineColor(kGray);
 
-  // Add Valve (Valve is divided in parts VA,VB,VC and VD)  (ernesto.calvo@pucp.edu.pe)
+  // Add Valve (Valve is divided in parts VA,VB,VC and VD)  (ernesto.calvo@pucp.edu.pe) 
   TGeoVolumeAssembly * voValve = new TGeoVolumeAssembly("voValve");
   //
-  // Define volume VA  (ernesto.calvo@pucp.edu.pe)
-  const Double_t dxVA  = 20.3;
-  const Double_t dyVA  = 48.0;
-  const Double_t dzVA  =  6.0; // Width
+  // Define volume VA  (ernesto.calvo@pucp.edu.pe) 
+  const Double_t dxVA  = 20.3; 
+  const Double_t dyVA  = 48.0; 
+  const Double_t dzVA  =  6.0; // Width 
   const Double_t dz2VA =  8.5; // Full width including protuding boxes
-  // Valve position  (ernesto.calvo@pucp.edu.pe)
+  // Valve position  (ernesto.calvo@pucp.edu.pe) 
   const Double_t zPosValve =  kZbegValve + dz2VA/2.;
   //
   new TGeoBBox("shVAbox",       dxVA/2., dyVA/2.,     dzVA/2.);
   new TGeoBBox("shVAHbox",  -1.+dxVA/2.,   3./2.,    dz2VA/2.);
   new TGeoTube("shVAC",              0.,     7.9,    dz2VA/2.);
   new TGeoTube("shVACh",             0.,     5.3,    dz2VA   );
-  // translation for shVAHbox (ernesto.calvo@pucp.edu.pe)
+  // translation for shVAHbox (ernesto.calvo@pucp.edu.pe) 
   ( new TGeoTranslation("trVAH1", 0.,  12.75, 0.) )->RegisterYourself();
   ( new TGeoTranslation("trVAH2", 0., -12.75, 0.) )->RegisterYourself();
 
   TGeoVolume * voValveVA = new TGeoVolume("voValveVA",
-                                          new TGeoCompositeShape("(shVAbox + shVAHbox:trVAH1 + shVAHbox:trVAH2 + shVAC)-shVACh"),
-                                          kMedSteelSh);
+      new TGeoCompositeShape("(shVAbox + shVAHbox:trVAH1 + shVAHbox:trVAH2 + shVAC)-shVACh"),
+      kMedSteelSh);
   voValve->AddNode(voValveVA, 1, 0);
   // Define Vacuum Hole of Valve
   TGeoTube   * shVACvach   = new TGeoTube("shVACvach", 0., 5.3, dz2VA/2.);
   TGeoVolume * voValveVAvh = new TGeoVolume("voValveVAvacuum", shVACvach, kMedVacuum);
   voValve->AddNode(voValveVAvh,1,0);
-  // Also add valve Support (ernesto.calvo@pucp.edu.pe)
+  // Also add valve Support (ernesto.calvo@pucp.edu.pe) 
   voValve->AddNode(voVS, 1, new TGeoTranslation(0.,  12.75, -dz2VA/2.-dzVS/2.));
   voValve->AddNode(voVS, 2, new TGeoTranslation(0., -12.75, -dz2VA/2.-dzVS/2.));
 
-  // Define Volume VB (ernesto.calvo@pucp.edu.pe)
-  const Double_t dxVB = 23.5;
-  const Double_t dyVB =  5.0;
-  const Double_t dzVB =  9.4;
-  TGeoVolume * voValveVB = new TGeoVolume("voValveVB",
-                                          new TGeoBBox("shVBbox", dxVB/2., dyVB/2., dzVB/2.),
-                                          kMedSteelSh);
+  // Define Volume VB (ernesto.calvo@pucp.edu.pe) 
+  const Double_t dxVB = 23.5; 
+  const Double_t dyVB =  5.0; 
+  const Double_t dzVB =  9.4; 
+  TGeoVolume * voValveVB = new TGeoVolume("voValveVB", 
+      new TGeoBBox("shVBbox", dxVB/2., dyVB/2., dzVB/2.),
+      kMedSteelSh);
   voValve->AddNode(voValveVB, 1, new TGeoTranslation(  0., dyVA/2. +dyVB/2. , 0));
-  // Define Volume VC (ernesto.calvo@pucp.edu.pe)
+  // Define Volume VC (ernesto.calvo@pucp.edu.pe) 
   const Double_t R1VC  =  4.5 /2.;
   const Double_t R2VC  =  8.1 /2.;
   const Double_t dy1VC  = 10.0;
@@ -559,42 +793,42 @@ void AliADv1::CreateAD()
   ( new TGeoTranslation("trVC21", 0., 0.,  dy1VC/2. - dy2VC/2.) )->RegisterYourself();
   ( new TGeoTranslation("trVC22", 0., 0., -dy1VC/2. + dy2VC/2.) )->RegisterYourself();
   TGeoVolume * voValveVC = new TGeoVolume("voValveVC",
-                                          new TGeoCompositeShape("shVC1  + shVC2:trVC21 + shVC2:trVC22"),
-                                          kMedSteelSh);
-  voValve->AddNode(voValveVC, 1, new TGeoCombiTrans(
-                                                    0., dyVA/2. + dyVB + dy1VC/2. , 0, Rx90) );
-  // Define volume VD (ernesto.calvo@pucp.edu.pe)
+      new TGeoCompositeShape("shVC1  + shVC2:trVC21 + shVC2:trVC22"),
+      kMedSteelSh);
+  voValve->AddNode(voValveVC, 1, new TGeoCombiTrans( 
+        0., dyVA/2. + dyVB + dy1VC/2. , 0, Rx90) );
+  // Define volume VD (ernesto.calvo@pucp.edu.pe) 
   const Double_t dxVD = 15.9;
   const Double_t dyVD = 23.0;
   const Double_t dzVD = 14.0;
   TGeoVolume * voValveVD = new TGeoVolume("voValveVD",
-                                          new TGeoBBox("shVD", dxVD/2., dyVD/2., dzVD/2.),
-                                          kMedSteelSh);
-  voValve->AddNode(voValveVD, 1,
-                   new TGeoTranslation( 1.25, dyVA/2. + dyVB + dy1VC + dyVD/2. , 0) );
+      new TGeoBBox("shVD", dxVD/2., dyVD/2., dzVD/2.),
+      kMedSteelSh);
+  voValve->AddNode(voValveVD, 1, 
+      new TGeoTranslation( 1.25, dyVA/2. + dyVB + dy1VC + dyVD/2. , 0) );
 
   //
-  // Define volume Front Bar (ernesto.calvo@pucp.edu.pe)
+  // Define volume Front Bar (ernesto.calvo@pucp.edu.pe) 
   //
-  const Double_t dxF  = 67.4;
-  const Double_t dyF  =  4.0;
-  const Double_t dzF  =  2.0;
+  const Double_t dxF  = 67.4; 
+  const Double_t dyF  =  4.0; 
+  const Double_t dzF  =  2.0; 
   const Double_t R1FC =  8.1;
   const Double_t R2FC = 11.5;
-  const Double_t dxFA  = (dxF-R1FC)/2.;
-
+  const Double_t dxFA  = (dxF-R1FC)/2.; 
+ 
   new TGeoBBox("shFA", dxFA/2., dyF/2., dzF/2.);
   new TGeoTube("shFC",      0.,   R2FC, dzF/2.);
   new TGeoTube("shFCH",     0.,   R1FC, 2.*dzF);
   ( new TGeoTranslation("trFA1",  R1FC +dxFA/2., 0., 0.) )->RegisterYourself();
   ( new TGeoTranslation("trFA2", -R1FC -dxFA/2., 0., 0.) )->RegisterYourself();
   TGeoVolume * voFrontBar = new TGeoVolume("voFrontBar",
-                                           new TGeoCompositeShape("shFA:trFA1 + shFA:trFA2 + (shFC - shFCH)"),
-                                           kMedSteelSh);
+      new TGeoCompositeShape("shFA:trFA1 + shFA:trFA2 + (shFC - shFCH)"),
+      kMedSteelSh);
   // Make Lateral Bars
   const Double_t kdzLatBar = 22.9;
-  TGeoVolume * voLatBar = new TGeoVolume("voLatBar",
-                                         new TGeoTube("shLatBar",0., dyF/2., kdzLatBar/2.), kMedSteelSh);
+  TGeoVolume * voLatBar = new TGeoVolume("voLatBar", 
+    new TGeoTube("shLatBar",0., dyF/2., kdzLatBar/2.), kMedSteelSh);
   //
   // Define Compensator Magnet coils
   //
@@ -618,14 +852,14 @@ void AliADv1::CreateAD()
   TGeoCompositeShape * shCoil = new TGeoCompositeShape("shCoil0", strSh);
   TGeoVolume * voCoil = new TGeoVolume("voCoil", shCoil, kMedSteelSh);
 
-  //
-  // ALUMINIUM PLATES
+  // 
+  // ALUMINIUM PLATES 
   //
 
   // Shape for aluminium Plate separating cavern and LHC tunnel
   const Double_t dAlWallThick = 0.5; // thickness of aluminium plates (cm)
   //
-  // RB24/26 Tunnel Floor
+  // RB24/26 Tunnel Floor 
   R   = 220.;
   // h   = 140.;
   // phi = TMath::ACos(h / r);
@@ -636,23 +870,27 @@ void AliADv1::CreateAD()
 
   new TGeoTube("shWallBase",    0.,    R, dAlWallThick*0.5);  // base shape for shWallBigPlate
   new TGeoBBox("shWallCutBot",270., 110., dAlWallThick    );  // to be substracted from base
+  Double_t origin[3] = {+120.+1.5+3.25, 0., 0.};
+  new TGeoBBox("shWallBundleHole", 3.25,  7.5, dAlWallThick, origin);  // to be substracted from base
   // Translation for cutting circular and square hole in the plates
   (new TGeoTranslation("trAntiBeamAxis",   -70.,               40., 0.)) -> RegisterYourself();
   (new TGeoTranslation("trHUWAT3",         -70., -110. - 140. +40., 0.)) -> RegisterYourself();
 
   //
-  //  Wall Big Aluminium Plate with Squared Hole
+  //  Wall Big Aluminium Plate with Squared Hole 
   //
   const Double_t dSqrHoleSide = 33.0; // Side
   new TGeoBBox("shWallSqrHole", dSqrHoleSide*0.5, dSqrHoleSide*0.5, dAlWallThick);
-  strSh  = "";
+  strSh  = ""; 
   strSh += "shWallBase:trAntiBeamAxis - ";
   strSh += " ( shWallCutBot:trHUWAT3" ;
-  strSh += " + shWallSqrHole )";
-  TGeoVolume* voWallBigPlate = new TGeoVolume("voWallBigPlate",
-                                              new TGeoCompositeShape("shWallBigPlate", strSh), kMedAlu );
+  strSh += " + shWallSqrHole";
+  strSh += " + shWallBundleHole)";
+  TGeoVolume* voWallBigPlate = new TGeoVolume("voWallBigPlate", 
+    new TGeoCompositeShape("shWallBigPlate", strSh), kMedAlu ); // commented on: 2016-Dec-05
+    // new TGeoCompositeShape("shWallBigPlate", strSh), kMedSteelSh); // Added     on: 2016-Dec-05
   //
-  // Wall Squared Aluminium Plate
+  // Wall Squared Aluminium Plate 
   //
   const Double_t dCircHoleRad = 9.5; // Radius
   new TGeoTube("shCircHole", 0., dCircHoleRad, dAlWallThick);
@@ -664,13 +902,13 @@ void AliADv1::CreateAD()
   ( new TGeoTranslation("trWallRod4", -12.5,  12.75, 0.)) -> RegisterYourself();
   new TGeoBBox("shWallSqrPlateBase", dSqrHoleSide*0.5 + 5.0, dSqrHoleSide*0.5 + 5.0, dAlWallThick/2.);
   strSh  = " ((((";
-  strSh += " ( shWallSqrPlateBase - shCircHole )";
+  strSh += " ( shWallSqrPlateBase - shCircHole )"; 
   strSh += " - shRodHole:trWallRod1)"  ;
   strSh += " - shRodHole:trWallRod2)"  ;
   strSh += " - shRodHole:trWallRod3)"  ;
   strSh += " - shRodHole:trWallRod4)"  ;
-  TGeoVolume* voWallSqrPlate = new TGeoVolume("HUWAT_AlWall02",
-                                              new TGeoCompositeShape("shWallSqrPlate", strSh ), kMedAlu);
+  TGeoVolume* voWallSqrPlate = new TGeoVolume("HUWAT_AlWall02", 
+    new TGeoCompositeShape("shWallSqrPlate", strSh ), kMedAlu);
   // ==========================================================================
   //
   // Define Mother Vacuum volume of VMAOI  (need shIonPumpVBo)
@@ -686,42 +924,55 @@ void AliADv1::CreateAD()
   (new TGeoTranslation("trMoFlange2", 0., 0., 28.0 - 0.5*kdzMoFlange     )) -> RegisterYourself();
   (new TGeoTranslation("trMoBellow" , 0., 0., 28.0 - 0.5*kdzMoBellow     )) -> RegisterYourself();
   (new TGeoTranslation("trMoTTube"  , 0., 0., kziTTube +  0.5*kdzTTube   )) -> RegisterYourself();
-
-  TGeoCompositeShape * shMoVMAOI =
-    new TGeoCompositeShape("shMoVMAOI",
-                           "shMoFlange:trMoFlange1 + shMoBellow:trMoBellow + shMoFlange:trMoFlange2 + shIonPumpVBo:trMoTTube");
+  
+  TGeoCompositeShape * shMoVMAOI =  
+      new TGeoCompositeShape("shMoVMAOI", 
+      "shMoFlange:trMoFlange1 + shMoBellow:trMoBellow + shMoFlange:trMoFlange2 + shIonPumpVBo:trMoTTube");
   TGeoVolume * voMoVMAOI = new TGeoVolume("voMoVMAOI", shMoVMAOI, kMedVacuum);
+  //
+  // TGeoVolume * voVBU9mm  = new TGeoVolume("voVBU9mm" , shVBU9mm , kMedAlu);
+  // TGeoVolume * voVBU26mm = new TGeoVolume("voVBU26mm", shVBU26mm, kMedAlu);
+  // TGeoVolume * voVBUcent = new TGeoVolume("voVBUcent", shVBUcent, kMedAlu);
+  //
+  TGeoVolume * voVBU9mm  = new TGeoVolume("voVBU9mm" , shVBU9mm , kMedSteelSh);
+  TGeoVolume * voVBU26mm = new TGeoVolume("voVBU26mm", shVBU26mm, kMedSteelSh);
+  TGeoVolume * voVBUcent = new TGeoVolume("voVBUcent", shVBUcent, kMedSteelSh);
+  voVSR      ->SetLineColor(kViolet+6);
+  voIonPumpVB->SetLineColor(kViolet+6);
+  voVSRflange->SetLineColor(kViolet+6);
+  voVSRcontD ->SetLineColor(kViolet+6);
+  voVSRcontF ->SetLineColor(kViolet+6);
+  voVBUrotFlg->SetLineColor(kViolet+6); 
+  voVBUrotFlg->SetLineColor(kViolet+6); 
+  voVBUflg   ->SetLineColor(kViolet+6); 
+  voVBU9mm   ->SetLineColor(kViolet+6);
+  voVBU26mm  ->SetLineColor(kViolet+6);
+  voVBUcent  ->SetLineColor(kViolet+6);
+  //         
   voMoVMAOI->AddNode(voVSR      ,1, new TGeoTranslation(0., 0., 7.1 - 0.45));
   voMoVMAOI->AddNode(voIonPumpVB,1, new TGeoTranslation(0., 0., 1 + 11.5/2.));
   voMoVMAOI->AddNode(voVSRflange,1, new TGeoTranslation(0.,0.,0.));
   voMoVMAOI->AddNode(voVSRcontD ,1, new TGeoTranslation(0.,0.,28.));
   voMoVMAOI->AddNode(voVSRcontF ,1, new TGeoTranslation(0.,0.,28.));
   z = 1.0 + 11.5;
-  voMoVMAOI->AddNode( new TGeoVolume("voVBU9mm", shVBU9mm, kMedAlu),
-                      1, new TGeoTranslation(0.,0., z) );
-  voMoVMAOI->AddNode( new TGeoVolume("voVBU26mm", shVBU26mm, kMedAlu),
-                      1, new TGeoTranslation(0.,0., z + 11.9) );
-  voMoVMAOI->AddNode( new TGeoVolume("voVBUcent", shVBUcent, kMedAlu),
-                      1, new TGeoTranslation(0.,0., z) );
-  voMoVMAOI->AddNode( voVBUrotFlg, 1,
-                      new TGeoCombiTrans(0.,0.,1.31, Ry180) );
-  voMoVMAOI->AddNode( voVBUrotFlg, 2,
-                      new TGeoTranslation(0.,0.,28. - 1.31) );
-  voMoVMAOI->AddNode( voVBUflg, 1,
-                      new TGeoTranslation(0.,0.,0.) );
-  voMoVMAOI->AddNode( voVBUflg, 2,
-                      new TGeoCombiTrans(0.,0.,28., Ry180) );
+  voMoVMAOI->AddNode( voVBU9mm   , 1, new TGeoTranslation(0.,0., z) );
+  voMoVMAOI->AddNode( voVBU26mm  , 1, new TGeoTranslation(0.,0., z + 11.9) );
+  voMoVMAOI->AddNode( voVBUcent  , 1, new TGeoTranslation(0.,0., z) );
+  voMoVMAOI->AddNode( voVBUrotFlg, 1, new TGeoCombiTrans (0.,0.,1.31, Ry180) );
+  voMoVMAOI->AddNode( voVBUrotFlg, 2, new TGeoTranslation(0.,0.,28. - 1.31) );
+  voMoVMAOI->AddNode( voVBUflg   , 1, new TGeoTranslation(0.,0.,0.) );
+  voMoVMAOI->AddNode( voVBUflg   , 2, new TGeoCombiTrans (0.,0.,28., Ry180) );
   // ==========================================================================
   //
   // AD Support structure by Pieter Ijzerman
   // ecalvovi@cern.ch
   // ==========================================================================
-  Int_t nvertices=0;
+  nvertices=0;
   // Cover plate_______________________________________________________________
   TGeoXtru * shADcoverplate = new TGeoXtru(2);
   shADcoverplate->SetNameTitle("shADcoverplate","shADcoverplate");
-  Double_t y1[] = {  0.0, 18.50, 18.50, 22.50, 22.50, 18.50, 18.50, 22.50, 22.50, 18.50, 18.50,   .00 ,  .00, 15.25, 15.25,  .00 };
-  Double_t x1[] = {  0.0,   .00,  5.15,  5.15, 17.15, 17.15, 24.25, 24.25, 36.25, 36.25, 41.40, 41.40 ,35.70, 35.70,  5.70, 5.70 };
+  Double_t y1[] = {  0.0, 18.50, 18.50, 22.50, 22.50, 18.50, 18.50, 22.50, 22.50, 18.50, 18.50,   .00 ,  .00, 15.25, 15.25,  .00 }; 
+  Double_t x1[] = {  0.0,   .00,  5.15,  5.15, 17.15, 17.15, 24.25, 24.25, 36.25, 36.25, 41.40, 41.40 ,35.70, 35.70,  5.70, 5.70 }; 
   nvertices = sizeof(x1)/sizeof(Double_t);
   shADcoverplate->DefinePolygon(nvertices,x1,y1);
   shADcoverplate->DefineSection(0, -0.1, -20.7, 0.0, 1.0); // Z position, offset and scale for first section
@@ -741,18 +992,21 @@ void AliADv1::CreateAD()
   TGeoVolume * voADsidebox = new TGeoVolume("voADsidebox", shADsidebox, kMedAlu);
 
 
-  // Define a TNode where this example resides in the TGeometry
-  // Draw the TGeometry
   TGeoVolume * voADhorizontalside = new TGeoVolume("voADhorizontalside", shADhorizontalside, kMedAlu);
   TGeoVolume * voADcoverplate = new TGeoVolume("voADcoverplate", shADcoverplate, kMedAlu);
   //
-  TGeoVolume *voADsupport = new TGeoVolumeAssembly("voADsupport");
+  TGeoVolume *voADsupport = new TGeoVolumeAssembly("voADsupport"); 
   voADsupport->AddNode(voADcoverplate,  1, new TGeoTranslation( 0., 0., -5.66/2.-0.23));
   voADsupport->AddNode(voADcoverplate,  2, new TGeoTranslation( 0., 0., +5.66/2.+0.23));
   voADsupport->AddNode(voADhorizontalside,  1, new TGeoCombiTrans( -6.0 - 7.1/2., 22.5-0.4, -5.66/2., Rx90));
   voADsupport->AddNode(voADhorizontalside,  2, new TGeoCombiTrans( +6.0 + 7.1/2., 22.5-0.4, -5.66/2., Rx90));
   voADsupport->AddNode(voADsidebox,  1, new TGeoTranslation( -20.7 +0.4, 18.55/2., 0.));
   voADsupport->AddNode(voADsidebox,  2, new TGeoTranslation( +20.7 -0.4, 18.55/2., 0.));
+  // Add Color
+  voADcoverplate     ->SetLineColor(kGray + 1);
+  voADhorizontalside ->SetLineColor(kGray + 1);
+  voADsidebox        ->SetLineColor(kGray + 1);
+  voADsupport->SetLineColor(kGray+1);
 
   // ==========================================================================
   //
@@ -760,24 +1014,23 @@ void AliADv1::CreateAD()
   //
   // ==========================================================================
 
-  TGeoVolume *ad = new TGeoVolumeAssembly("AD");
-
+  
   // Get medium for ADA
   TGeoMedium * medADASci        = gGeoManager->GetMedium("AD_BC404"); // AD Scin.
   // TGeoMedium * medADALG      = gGeoManager->GetMedium("AD_PMMA");  // lightGuide
   // TGeoMedium * medADAPMGlass = gGeoManager->GetMedium("AD_Glass"); // Glass for Aluminium simulation
   // TGeoMedium * medADAPMAlum  = gGeoManager->GetMedium("AD_Alum");
-
-  // Get Medium for ADC
+  
+  // Get Medium for ADC 
   TGeoMedium * medADCSci     = gGeoManager->GetMedium("AD_BC404");
   // TGeoMedium * medADCLG      = gGeoManager->GetMedium("AD_PMMA");
   // TGeoMedium * medADCPMGlass = gGeoManager->GetMedium("AD_Glass");
   // TGeoMedium * medADCPMAlum  = gGeoManager->GetMedium("AD_Alum");
-
-  // ADA Scintillator Pad
+  
+  // ADA Scintillator Pad 
   const Double_t kADACellSideY = 21.6;
   const Double_t kADACellSideX = 18.1;
-  // ADC Scintillator Pad
+  // ADC Scintillator Pad 
   const Double_t kADCCellSideY = 21.6;
   const Double_t kADCCellSideX = 18.1;
   // WLS bar          :  0.40 cm ( 4.0 mm )
@@ -800,61 +1053,186 @@ void AliADv1::CreateAD()
   Double_t WLS_dz =  2.5;
   Double_t WLS_SideA_Long_dy  = 24.20; // 24.2;
   Double_t WLS_SideC_Long_dy  = 24.20; // 24.2;
-  Double_t WLS_SideA_Short_dy = 18.20; // 18.41;
-  Double_t WLS_SideC_Short_dy = 20.70; // 20.91;
+  Double_t WLS_SideA_Short_dy = 18.20; // 18.41; 
+  Double_t WLS_SideC_Short_dy = 20.70; // 20.91; 
   // Creating ADA WLS bars_____________________________________________________
-  TGeoVolume * vADA_WLS_s = new TGeoVolume( "ADAWLSshort",
-                                            new TGeoBBox( "shADAWLSbarShort" , WLS_dx/2.0, WLS_SideA_Short_dy/2.0, WLS_dz/2.0),
-                                            medADASci);
-  TGeoVolume * vADA_WLS_l = new TGeoVolume( "ADAWLSlong" ,
-                                            new TGeoBBox( "shADAWLSbarLong"  , WLS_dx/2.0, WLS_SideA_Long_dy /2.0, WLS_dz/2.0),
-                                            medADASci);
+  TGeoVolume * vADA_WLS_s = new TGeoVolume( "ADAWLSshort", 
+      new TGeoBBox( "shADAWLSbarShort" , WLS_dx/2.0, WLS_SideA_Short_dy/2.0, WLS_dz/2.0),
+      medADASci);      
+  TGeoVolume * vADA_WLS_l = new TGeoVolume( "ADAWLSlong" , 
+      new TGeoBBox( "shADAWLSbarLong"  , WLS_dx/2.0, WLS_SideA_Long_dy /2.0, WLS_dz/2.0),
+      medADASci);      
   vADA_WLS_l->SetLineColor( kRed );
   vADA_WLS_s->SetLineColor( kRed );
   // Creating ADC WLS bars_____________________________________________________
-  TGeoVolume * vADC_WLS_s = new TGeoVolume( "ADCWLSshort",
-                                            new TGeoBBox( "shADCWLSbarShort" , WLS_dx/2.0, WLS_SideC_Short_dy/2.0, WLS_dz/2.0),
-                                            medADCSci);
-  TGeoVolume * vADC_WLS_l = new TGeoVolume( "ADCWLSlong" ,
-                                            new TGeoBBox( "shADCWLSbarLong"  , WLS_dx/2.0, WLS_SideC_Long_dy /2.0, WLS_dz/2.0),
-                                            medADCSci);
+  TGeoVolume * vADC_WLS_s = new TGeoVolume( "ADCWLSshort", 
+      new TGeoBBox( "shADCWLSbarShort" , WLS_dx/2.0, WLS_SideC_Short_dy/2.0, WLS_dz/2.0),
+      medADCSci);      
+  TGeoVolume * vADC_WLS_l = new TGeoVolume( "ADCWLSlong" , 
+      new TGeoBBox( "shADCWLSbarLong"  , WLS_dx/2.0, WLS_SideC_Long_dy /2.0, WLS_dz/2.0),
+      medADCSci);      
   vADC_WLS_l->SetLineColor(kRed);
   vADC_WLS_s->SetLineColor(kRed);
   // Make ADA scintillator pad_________________________________________________
   new TGeoBBox( "shADAbox" , kADACellSideX/2.0, kADACellSideY/2.0, kADACelldz/2.0 );
   new TGeoTube( "shADAHole",               0. , kADABeamPipeR    , kADACelldz     );
   ( new TGeoTranslation("trADAbox", X, Y, 0.)) -> RegisterYourself();
-  //
-  TGeoVolume * vADA1 = new TGeoVolume( "ADApad",
-                                       new TGeoCompositeShape("shADApad", "shADAbox:trADAbox-shADAHole"), medADASci );
+  // 
+  TGeoVolume * vADA1 = new TGeoVolume( "ADApad", 
+    new TGeoCompositeShape("shADApad", "shADAbox:trADAbox-shADAHole"), medADASci );      
   vADA1->SetLineColor( kColorADA );
-
-  TGeoVolume *secADA  = new TGeoVolumeAssembly( "ADAsec" );
+  
+  TGeoVolume *secADA  = new TGeoVolumeAssembly( "ADAsec" ); 
   // Add PAD
-  secADA->AddNode( vADA1, 1, 0);
-  secADA->AddNode( vADA_WLS_s, 1,
-                   new TGeoTranslation(0.1 + WLS_dx/2.0, kADABeamPipeR + WLS_SideA_Short_dy/2.0, 0.0) );
-  secADA->AddNode( vADA_WLS_l, 1,
-                   new TGeoTranslation(kShiftX + WLS_dx/2.0 + kADACellSideX + 0.04, kShiftY + WLS_SideA_Long_dy/2.0, 0.0) );
+  Double_t fX_ADA_WLS_s = 0.1 + WLS_dx/2.0;
+  Double_t fX_ADA_WLS_l = kShiftX + WLS_dx/2.0 + kADACellSideX + 0.04;
+  secADA->AddNode( vADA1, 1, 0); 
+  secADA->AddNode( vADA_WLS_s, 1, new TGeoTranslation(fX_ADA_WLS_s, kADABeamPipeR + WLS_SideA_Short_dy/2.0, 0.0) ); 
+  secADA->AddNode( vADA_WLS_l, 1, new TGeoTranslation(fX_ADA_WLS_l,        kShiftY + WLS_SideA_Long_dy/2.0, 0.0) ); 
 
   /// Assembling ADA adding 4 sectors                                       //  Sectors
   TGeoVolume *vADAarray = new TGeoVolumeAssembly( "ADA" );                  //        ^ y
-  vADAarray->AddNode( secADA, 1 );                                          //        |
+  vADAarray->AddNode( secADA, 1 );                                          //        |   
   vADAarray->AddNode( secADA, 2, Ry180 );                                   //   2    |   1
-  vADAarray->AddNode( secADA, 3, Rz180 );                                   // --------------->  x
+  vADAarray->AddNode( secADA, 3, Rz180 );                                   // --------------->  x     
   vADAarray->AddNode( secADA, 4, Rx180 );                                   //   3    |   4
-  //                                                                        //        |
-  // Add ADA layer 2 and 3 to AD volume
-  // const Float_t kPosAD2 = 1695.0;
-  // const Float_t kPosAD3 = 1700.0;
-  // ad->AddNode(vADAarray,1, new TGeoTranslation(0., 0., kPosAD2));
-  // ad->AddNode(vADAarray,2, new TGeoTranslation(0., 0., kPosAD3));
-  // const Float_t kPosADA = 1699.7;  // z-center of assembly (cm) Old
-  const Float_t kPosADA = 1696.67;  // z-center of assembly (cm) New, according to Survey by F. Klumb and E.Calvo 2015 Sept 4th.
-  ad->AddNode(vADAarray,    1, new TGeoTranslation(0., 0., kPosADA - kADACelldz/2. -0.23));
-  ad->AddNode(vADAarray,    2, new TGeoTranslation(0., 0., kPosADA + kADACelldz/2. +0.23));
-  ad->AddNode(voADsupport,  1, new TGeoTranslation(0., 0., kPosADA));
-  ad->AddNode(voADsupport,  2, new TGeoCombiTrans (0., 0., kPosADA, Rz180));
+  // 
+  // PMT-BOX A-Side
+  //
+  const Float_t  kPosADA = 1696.67;  // z-center of assembly (cm) New, according to Survey by F. Klumb and E.Calvo 2015 Sept 4th.
+  const Double_t kzEndPMboxA = 1701.65;
+  const Double_t kdzPMboxA   = 15.6;
+  Float_t thickbox = 0.3; // in cm
+  Float_t pmbox_x = 60.;
+  Float_t pmbox_y = 45.;
+  Float_t pmbox_z = kdzPMboxA;
+  // Float_t pmbox_z = 10.;
+  Double_t obox3[3] = {0., -2., 0.};
+  new TGeoBBox("shPMTbox1" , pmbox_x/2.             , pmbox_y/2.           , pmbox_z/2.           );
+  new TGeoBBox("shPMTbox2" , pmbox_x/2. -  thickbox , pmbox_y/2. -thickbox , pmbox_z/2. -thickbox );
+  new TGeoBBox("shPMTbox3" , pmbox_x/2. -2*thickbox , pmbox_y/2. -thickbox , (pmbox_z-4.)/2.         , obox3);
+  TGeoVolume * voPMTbox = new TGeoVolume("voPMTbox", new TGeoCompositeShape("shPMTbox","(shPMTbox1-shPMTbox2)-shPMTbox3"), kMedAlu);
+  voPMTbox -> SetLineColor(kGray + 1);
+  //
+  // PMT's  A-Side
+  //
+  Double_t fPMTdz = 2.0; // Length
+  Double_t fPMTDi = 2.7; // Diameter
+  TGeoVolume * voADApmt = new TGeoVolume("voADApmt", new TGeoTube("shADApmt", 0., fPMTDi/2., fPMTdz/2.), medADASci);
+  voADApmt -> SetLineColor(kGray);
+  // PMT boxes 
+  // Double_t aX_PMT[8] = {6, -12, -12, 6, 12, -6, -6, 12};
+  // Double_t aY_PMT[8] = {
+  //    82.0+ fPMTdz/2.,
+  //    82.0+ fPMTdz/2.,
+  //  -124.6- fPMTdz/2.,
+  //  -124.6- fPMTdz/2.,
+  //    82.0+ fPMTdz/2.,
+  //    82.0+ fPMTdz/2.,
+  //  -124.6- fPMTdz/2.,
+  //  -124.6- fPMTdz/2.
+  // };
+  Double_t aX_PMT[8] = { 6.5, -11.5, -12.0, 6.0, 12.5, -6.0, -6.0, 12.0 };
+  Double_t aY_PMT[8] = {
+      +77.2 + fPMTdz/2. , 
+      +79.0 + fPMTdz/2. , 
+     -120.5 - fPMTdz/2. , 
+     -121.9 - fPMTdz/2. , 
+      +78.1 + fPMTdz/2. , 
+      +77.4 + fPMTdz/2. , 
+     -123.0 - fPMTdz/2. , 
+     -121.0 - fPMTdz/2.
+  };
+ 
+
+  // Layer closer to IP is shifted to the right in picture (i.e. towards negative x axis) 
+  // sector 1: Inner PMT @ x=  6cm 
+  // sector 2: Inner PMT @ x=-12cm 
+  // sector 3: Inner PMT @ x=-12cm
+  // sector 4: Inner PMT @ x=  6cm 
+  //
+  // sector 1: Outer PMT @ x= 12cm 
+  // sector 2: Outer PMT @ x= -6cm 
+  // sector 3: Outer PMT @ x= -6cm
+  // sector 4: Outer PMT @ x= 12cm 
+  //
+  TGeoVolumeAssembly * voADAPMTarray = new TGeoVolumeAssembly("voADAPMTarray");
+  // Add PMT Boxes
+
+  Double_t zCen_PMbox_wrt_AD = (kzEndPMboxA - kPosADA) - 0.5 * kdzPMboxA;
+  // Double_t zBeg_PMbox_wrt_AD = (kzEndPMboxA - kPosADA) - 1.0 * kdzPMboxA;
+  // Double_t zEnd_PMbox_wrt_AD = (kzEndPMboxA - kPosADA);
+  voADAPMTarray->AddNode( voPMTbox,    1, new TGeoTranslation( 4.5,   51.+ pmbox_y/2., zCen_PMbox_wrt_AD)); 
+  voADAPMTarray->AddNode( voPMTbox,    2, new TGeoCombiTrans ( 3.5, -145.+ pmbox_y/2., zCen_PMbox_wrt_AD, Rz180)); 
+
+
+  // PMT's
+  for (Int_t i=0; i<8; i++) {
+    Double_t Z1 = 0;
+    if (i<4) Z1 = +kADACelldz/2. +0.23;
+    else     Z1 = +kADACelldz/2. +0.23; 
+    voADAPMTarray->AddNode( voADApmt, i+1, new TGeoCombiTrans(aX_PMT[i], aY_PMT[i], Z1, Rx90)); 
+  }
+  //
+  // Add the Fiber-Bundles (A-Side)
+  //
+  // Double_t X1;
+  /*
+  Double_t Y1 = 24.3;
+  Double_t Y2 = 0;
+  Double_t Z1 = 0;
+  for (Int_t i=0; i<8; i++)
+  {
+    Double_t sign = 1.;
+    Double_t X2;
+    if (i==1||i==2||i==5||i==6) sign = -1;
+    X2 = aX_PMT[i];
+    if (aY_PMT[i]>0) { Y1 =  24.3; Y2 = aY_PMT[i]-fPMTdz/2.; }
+    else             { Y1 = -24.3; Y2 = aY_PMT[i]+fPMTdz/2.; }
+    // if (i<4) Z1 = -kADACelldz/2. -0.1;
+    if (i<4) Z1 = +kADACelldz/2. +0.1;
+    else     Z1 = +kADACelldz/2. +0.1; 
+    TGeoVolume * voFiber_ADA = 0;
+    fX1FiberShort[i] = sign*fX_ADA_WLS_s;
+    fX1FiberLong [i] = sign*fX_ADA_WLS_l;
+    fX2Fiber[i] = X2;
+    fY1Fiber[i] = Y1;
+    fY2Fiber[i] = Y2;
+    voFiber_ADA = new TGeoVolume(Form("voFiberADAShort_%d",i), MakeFiberBundle(Form("FiberADAShort_%d",i), fX1FiberShort[i], X2, Y1, Y2, Z1), medADASci);
+    voFiber_ADA -> SetLineColor(kCyan);
+    voADAPMTarray->AddNode (voFiber_ADA, 1); 
+    voFiber_ADA = new TGeoVolume(Form("voFiberADALong_%d",i) , MakeFiberBundle(Form("FiberADALong_%d",i) , fX1FiberLong [i], X2, Y1, Y2, Z1), medADASci);
+    voFiber_ADA -> SetLineColor(kCyan);
+    voADAPMTarray->AddNode (voFiber_ADA, 1); 
+  }
+  printf( " [ADA] %14s %14s %14s %14s %14s\n", "fX1FiberShort", "fX1FiberLong", "fX2Fiber", "fY1Fiber", "fY2Fiber" );
+  for (Int_t i=0; i<8; i++) {
+    printf( " [%3d] %14f %14f %14f %14f %14f\n", i, fX1FiberShort[i] , fX1FiberLong [i] , fX2Fiber[i] , fY1Fiber[i] , fY2Fiber[i] );
+
+  }
+  */
+
+  new TGeoBBox("shADAWallPlate1", 25., 25., 0.15);
+  new TGeoTube("shADAWallPlate2",  0.,  7., 0.30);
+  TGeoCompositeShape * shADAWallPlate = new TGeoCompositeShape("shADAWallPlate", "shADAWallPlate1-shADAWallPlate2");
+  TGeoVolume * voADAWallPlate = new TGeoVolume("voADAWallPlate", shADAWallPlate, kMedSteelSh);
+  // TGeoVolume * voADAWallPlate = new TGeoVolume("voADAWallPlate", new TGeoBBox(25., 25., 0.15), kMedSteelSh);
+  voADAWallPlate -> SetLineColor(kGray+3);
+  ad->AddNode ( voADAWallPlate  , 1 , new TGeoTranslation ( 0. , 0. , 1701.5                      ) ); 
+  ad->AddNode ( vADAarray       , 1 , new TGeoTranslation ( 0. , 0. , kPosADA - kADACelldz/2. -0.1) ); 
+  ad->AddNode ( vADAarray       , 2 , new TGeoTranslation ( 0. , 0. , kPosADA + kADACelldz/2. +0.1) ); 
+  ad->AddNode ( voADsupport     , 1 , new TGeoTranslation ( 0. , 0. , kPosADA                     ) ); 
+  ad->AddNode ( voADsupport     , 2 , new TGeoCombiTrans  ( 0. , 0. , kPosADA,  Rz180             ) ); 
+  ad->AddNode ( voADAPMTarray   , 1 , new TGeoTranslation ( 0. , 0. , kPosADA                     ) ); 
+  // FAKE-VOL
+  //--------------------------------------------------------------------------------//
+  // ad->AddNode ( voFakeVol       , 1 , new TGeoTranslation ( 0. , 0. , 1685.0) );  // before A-Side AD
+  // ad->AddNode ( voFakeVol       , 2 , new TGeoTranslation ( 0. , 0. , 1260.0) );  // after A-Side Magnet
+  // ad->AddNode ( voFakeVol       , 3 , new TGeoTranslation ( 0. , 0. ,  850.0) );  // before A-Side Magnet
+  // ad->AddNode ( voFakeVol       , 4 , new TGeoTranslation ( 0. , 0. ,-1885.0) );  // after  C-Side Muon concrete shielding
+  // ad->AddNode ( voFakeVol       , 5 , new TGeoTranslation ( 0. , 0. ,-1948.0) );  // after  C-Side Trigger Shield
+  // ad->AddNode ( voFakeVol       , 6 , new TGeoTranslation ( 0. , 0. ,-1951.5) );  // before C-Side Trigger Shield
+  //--------------------------------------------------------------------------------//
 
   // ==========================================================================
   //
@@ -870,39 +1248,39 @@ void AliADv1::CreateAD()
   X = kShiftX + kADCCellSideX * 0.5;
   Y = kShiftY + kADCCellSideY * 0.5;
   ( new TGeoTranslation("trADCbox", X, Y, 0.) ) -> RegisterYourself();
-  //
-  TGeoVolume * vADCpad = new TGeoVolume( "ADCpad",
-                                         new TGeoCompositeShape("shADCpad", "shADCbox:trADCbox-shADCHole"), medADCSci );
+  // 
+  TGeoVolume * vADCpad = new TGeoVolume( "ADCpad", 
+    new TGeoCompositeShape("shADCpad", "shADCbox:trADCbox-shADCHole"), medADCSci );      
   vADCpad->SetLineColor( kColorADC );
-
+  
   /// Creating Sector for Tunnel (Asembly:  Scintillator Pad + Light guide + PM )
   TGeoVolume *voADC  = new TGeoVolumeAssembly("ADCsec");
   // Add PAD
   voADC->AddNode( vADCpad, 1, 0);
   // Add ADC WLS Short bar
-  voADC->AddNode( vADC_WLS_s, 1,
-                  new TGeoTranslation( 0.1 + WLS_dx/2.0, kADCBeamPipeR + WLS_SideC_Short_dy/2.0, 0.0) );
+  voADC->AddNode( vADC_WLS_s, 1, 
+      new TGeoTranslation( 0.1 + WLS_dx/2.0, kADCBeamPipeR + WLS_SideC_Short_dy/2.0, 0.0) ); 
   // Add ADC WLS Long  bar
-  voADC->AddNode( vADC_WLS_l, 1,
-                  new TGeoTranslation( 0.04 + WLS_dx/2.0 + kADCCellSideX + kShiftX, kShiftY + WLS_SideC_Long_dy/2.0, 0.0) );
-
+  voADC->AddNode( vADC_WLS_l, 1, 
+      new TGeoTranslation( 0.04 + WLS_dx/2.0 + kADCCellSideX + kShiftX, kShiftY + WLS_SideC_Long_dy/2.0, 0.0) ); 
+  
   /// Assembling ADC adding the 4 sectors                 //  Sectors
   TGeoVolume *vADCarray = new TGeoVolumeAssembly("ADC");  //        ^ y
-  vADCarray->AddNode( voADC, 1 );                         //        |
+  vADCarray->AddNode( voADC, 1 );                         //        |   
   vADCarray->AddNode( voADC, 2, Ry180 );                  //   2    |   1
-  vADCarray->AddNode( voADC, 3, Rz180 );                  // --------------->  x
+  vADCarray->AddNode( voADC, 3, Rz180 );                  // --------------->  x  
   vADCarray->AddNode( voADC, 4, Rx180 );                  //   3    |   4
                                                           //        |
-
+                                                                             
 
   // ==========================================================================
   //
   // Add ADC to AD volume
   //
-  // Note to future maintainers:
-  // In previous AliRoot versions the position z = -1900.75 corresponded
-  // to the end of the YSAA3_CC_BLOCK (concrete block shielding just before
-  // the C-Side LHC wall). Now this has been fixed to agree with reality.
+  // Note to future maintainers: 
+  // In previous AliRoot versions the position z = -1900.75 corresponded 
+  // to the end of the YSAA3_CC_BLOCK (concrete block shielding just before 
+  // the C-Side LHC wall). Now this has been fixed to agree with reality. 
   // The YSAA3_CC_BLOCK starts at 1800.75 and ends at 1880.75 cm.
   //
   // Ernesto Calvo and Alberto Gago.
@@ -910,85 +1288,180 @@ void AliADv1::CreateAD()
   // - agago@pucp.edu.pe
   //
   // ==========================================================================
-
+  
   // *  ad -> AddNode(vADCarray , 1, new TGeoTranslation(0., 0., kZendADC2 + kADCCelldz/2.)); // Tunnel
   // *  ad -> AddNode(vADCarray , 2, new TGeoTranslation(0., 0., kZbegADC1 - kADCCelldz/2.)); // Tunnel
   // *  const Float_t kZbegADC1 = -kZbegFrontBar-2.
-  // *  const Float_t kZendADC2 = -1959.0;            // (ecalvovi@cern.ch)
-
+  // *  const Float_t kZendADC2 = -1959.0;            // (ecalvovi@cern.ch) 
+  
   switch (fADCPosition ) {
-  case kADCInTunnel:
-    {
-      // const Float_t kZbegADC1 = -kZbegFrontBar-2.;  // (ecalvovi@cern.ch)
-      // const Float_t kZendADC2 = -1959.0;            // (ecalvovi@cern.ch)
-      // ad -> AddNode(vADCarray , 1, new TGeoTranslation(0., 0., kZendADC2 + kADCCelldz/2.)); // Tunnel
-      // ad -> AddNode(vADCarray , 2, new TGeoTranslation(0., 0., kZbegADC1 - kADCCelldz/2.)); // Tunnel
-      const Float_t kPosADC = -kZbegFrontBar-2.-3.0-0.3;  // 3.0 = (5.6 + 0.2 + 0.2)/2. // (ecalvovi@cern.ch)
-      printf("CreateAD: kPosADC=%8.2f\n", kPosADC);
-      ad -> AddNode(vADCarray,   1, new TGeoTranslation(0., 0., kPosADC - kADCCelldz/2. - 0.23)); // Tunnel // ADC1
-      ad -> AddNode(vADCarray,   2, new TGeoTranslation(0., 0., kPosADC + kADCCelldz/2. + 0.23)); // Tunnel // ADC2
-      ad -> AddNode(voADsupport, 3, new TGeoTranslation(0., 0., kPosADC));
-      ad -> AddNode(voADsupport, 4, new TGeoCombiTrans (0., 0., kPosADC, Rz180));
-      break;
-    }
-  case kADCInCavern:
-    {
-      printf("FATAL: vADCInCavern is now obsolete!");
-      exit(1);
-      // const Float_t kZbegADC1 = -1890.0;  // (ecalvovi@cern.ch)
-      // const Float_t kZbegADC2 = -1885.0;  // (ecalvovi@cern.ch)
-      // ad -> AddNode(vADCarrayH, 1, new TGeoTranslation(0., 0., kZbegADC1 - kADCCelldz/2.)); // Cavern
-      // ad -> AddNode(vADCarrayH, 2, new TGeoTranslation(0., 0., kZbegADC2 - kADCCelldz/2.)); // Cavern
-      break;
-    }
-  case kADCInBoth:
-    {
-      printf("FATAL: vADCInBoth   is now obsolete!");
-      exit(1);
-      // const Float_t kZbegADC1 = -kZbegFrontBar-2.;  // (ecalvovi@cern.ch)
-      // const Float_t kZbegADC2 = -1885.0;            // (ecalvovi@cern.ch)
-      // ad -> AddNode(vADCarray , 1, new TGeoTranslation(0., 0., kZbegADC1 - kADCCelldz/2.)); // Tunnel
-      // ad -> AddNode(vADCarrayH, 2, new TGeoTranslation(0., 0., kZbegADC2 - kADCCelldz/2.)); // Cavern
-      break;
-    }
+    case kADCInTunnel:
+      {
+        // const Float_t kZbegADC1 = -kZbegFrontBar-2.;  // (ecalvovi@cern.ch) 
+        // const Float_t kZendADC2 = -1959.0;            // (ecalvovi@cern.ch) 
+        // ad -> AddNode(vADCarray , 1, new TGeoTranslation(0., 0., kZendADC2 + kADCCelldz/2.)); // Tunnel
+        // ad -> AddNode(vADCarray , 2, new TGeoTranslation(0., 0., kZbegADC1 - kADCCelldz/2.)); // Tunnel
+        const Float_t kPosADC = -kZbegFrontBar-2.-3.0-0.3;  // 3.0 = (5.6 + 0.2 + 0.2)/2. // (ecalvovi@cern.ch) 
+        printf("CreateAD: kPosADC=%8.2f\n", kPosADC);
+        ad -> AddNode(vADCarray,   1, new TGeoTranslation(0., 0., kPosADC - kADCCelldz/2. - 0.23)); // Tunnel // ADC1
+        ad -> AddNode(vADCarray,   2, new TGeoTranslation(0., 0., kPosADC + kADCCelldz/2. + 0.23)); // Tunnel // ADC2
+        ad -> AddNode(voADsupport, 3, new TGeoTranslation(0., 0., kPosADC));
+        ad -> AddNode(voADsupport, 4, new TGeoCombiTrans (0., 0., kPosADC, Rz180));
+        break;
+      }
+    case kADCInCavern:
+      {
+        printf("FATAL: vADCInCavern is now obsolete!");
+        exit(1);
+        break;
+      }
+    case kADCInBoth:
+      {
+        printf("FATAL: vADCInBoth   is now obsolete!");
+        exit(1);
+        break;
+      }
   }
 
 
   // ==========================================================================
-  //
-  // Add structure volumes to top volume
+  // 
+  // Add structure volumes to vADCstruct and vADAstruct volume assemblies
   //
   // ==========================================================================
+  // 
+  // Add some colors:
+  //
+  voWallBigPlate -> SetLineColor(kGray);
+  voWallSqrPlate -> SetLineColor(kGray);
+  voSaa3Rod      -> SetLineColor(kGray);
+  voSaa3EndPlate -> SetLineColor(kGray);
+  voFrontBar     -> SetLineColor(kGray);
+  voLatBar       -> SetLineColor(kGray);
+  voCoil         -> SetLineColor(kOrange+7);
+  voValveVA      -> SetLineColor(kAzure+1);
+  voValveVB      -> SetLineColor(kAzure+1);
+  voValveVC      -> SetLineColor(kAzure+1);
+  voValveVD      -> SetLineColor(kAzure+1);
 
-  TGeoVolumeAssembly * top = new TGeoVolumeAssembly("voADStruct");
-  top->AddNode(voSaa3EndPlate, 1, new TGeoTranslation( 0., 0., kZendAbs + 1.95/2.));
+  // 
+  // Create Grid of U-Profiles Bars near the Wall
+  //
+  const Int_t nvp = 5;
+  TGeoVolume * uprofiles[nvp];
+  uprofiles[0] = Make_UProfile("AD_UProfileV_1", 295.0, kMedSteelSh, 10, 5, 0.85, 0.6);
+  uprofiles[1] = Make_UProfile("AD_UProfileV_2", 457.5, kMedSteelSh, 10, 5, 0.85, 0.6);
+  uprofiles[2] = Make_UProfile("AD_UProfileV_3", 472.5, kMedSteelSh, 10, 5, 0.85, 0.6);
+  uprofiles[3] = Make_UProfile("AD_UProfileV_4", 391.0, kMedSteelSh, 10, 5, 0.85, 0.6);
+  uprofiles[4] = Make_UProfile("AD_UProfileV_5", 295.0, kMedSteelSh, 10, 5, 0.85, 0.6);
+
+  TGeoVolumeAssembly * voADC_UProfileGrid = new TGeoVolumeAssembly("voADC_UProfileGrid");
+  Double_t xv[nvp] = {-119.8 , -19.8 , 80.2 , 180.2 , 280.2 }; 
+  Double_t yv[nvp] = {  43.1 ,   9.4 , 34.6 ,  43.1 ,  43.1 }; 
+  z = -kZwall+dAlWallThick;
+  for (Int_t i=0; i<nvp; i++)
+  {
+    voADC_UProfileGrid->AddNode(uprofiles[i], 1, new TGeoCombiTrans(xv[i],yv[i], z, Rx90));
+  }
+  // 
+  // Create Grid of U-Profiles Bars near the Wall
+  //
+  TGeoVolume * volProfH = Make_UProfileH("AD_UProfileH", kMedSteelSh);
+  Double_t xh[nvp] = {-69.8, 30.2, 130.2, 230.2};
+  Double_t yh[nvp] = {-64.6, 35.4, 135.4, 235.4};
+
+  TGeoRotation * rotXY90 = NULL;
+  rotXY90 = (TGeoRotation*) Rx90 -> MakeClone();
+  rotXY90 -> MultiplyBy(Ry90, 1);
+
+  for (Int_t iy=0; iy<4; iy++)
+  {
+    for (Int_t ix=0; ix<4; ix++)
+    {
+      if (iy==3) if (ix==0 || ix==3) continue;
+      voADC_UProfileGrid->AddNode(volProfH, iy*4 + ix, new TGeoCombiTrans(xh[ix],yh[iy], z, rotXY90));
+    }
+  }
+      
+  TGeoVolumeAssembly * vADCstruct = new TGeoVolumeAssembly("voADCStruct");
+  vADCstruct->AddNode(voSaa3EndPlate, 1, new TGeoTranslation( 0., 0., kZendAbs + 1.95/2.));
   z = kZwall;
-  top->AddNode(voWallBigPlate, 1, new TGeoTranslation(0., 0., z - 0.5 * dAlWallThick ));
-  top->AddNode(voWallSqrPlate, 1, new TGeoTranslation(0., 0., z + 0.5 * dAlWallThick ));
-  z = kZendAbs + 1.95 + dzRodL/2.;
-  top->AddNode(voSaa3Rod,  1, new TGeoTranslation(  12.5, -12.75, z));
-  top->AddNode(voSaa3Rod,  2, new TGeoTranslation(  12.5,  12.75, z));
-  top->AddNode(voSaa3Rod,  3, new TGeoTranslation( -12.5, -12.75, z));
-  top->AddNode(voSaa3Rod,  4, new TGeoTranslation( -12.5,  12.75, z));
-  top->AddNode(voValve,    1, new TGeoTranslation( 0., 0., zPosValve));
-  //
-  top->AddNode(voMoVMAOI,  1, new TGeoTranslation( 0., 0., kZbegVMAOI));
-  //
-  top->AddNode(voFrontBar, 1, new TGeoTranslation( 0., 0., kZbegFrontBar + dzF/2.));
+  vADCstruct->AddNode(voWallBigPlate, 1, new TGeoTranslation(0., 0., z - 0.5 * dAlWallThick ));
+  vADCstruct->AddNode(voWallSqrPlate, 1, new TGeoTranslation(0., 0., z + 0.5 * dAlWallThick ));
+  z = kZendAbs + 1.95 + dzRodL/2.; 
+  vADCstruct->AddNode(voSaa3Rod,  1, new TGeoTranslation(  12.5, -12.75, z));
+  vADCstruct->AddNode(voSaa3Rod,  2, new TGeoTranslation(  12.5,  12.75, z));
+  vADCstruct->AddNode(voSaa3Rod,  3, new TGeoTranslation( -12.5, -12.75, z));
+  vADCstruct->AddNode(voSaa3Rod,  4, new TGeoTranslation( -12.5,  12.75, z));
+  vADCstruct->AddNode(voValve,    1, new TGeoTranslation( 0., 0., zPosValve));
+  vADCstruct->AddNode(voMoVMAOI,  1, new TGeoTranslation( 0., 0., kZbegVMAOI));
+  vADCstruct->AddNode(voFrontBar, 1, new TGeoTranslation( 0., 0., kZbegFrontBar + dzF/2.));
   z = kZbegCoil;
-  top->AddNode(voCoil, 1, new TGeoCombiTrans(  3.6 + dz/2., 0., z, Ry90m));
-  top->AddNode(voCoil, 2, new TGeoCombiTrans(  3.6 + dz/2., 0., z, new TGeoRotation((*Ry90m)*(*Rx180))));
-  top->AddNode(voCoil, 3, new TGeoCombiTrans( -3.6 - dz/2., 0., z, Ry90m));
-  top->AddNode(voCoil, 4, new TGeoCombiTrans( -3.6 - dz/2., 0., z, new TGeoRotation((*Ry90m)*(*Rx180))));
+  vADCstruct->AddNode(voCoil, 1, new TGeoCombiTrans(  3.6 + dz/2., 0., z, Ry90m));
+  vADCstruct->AddNode(voCoil, 2, new TGeoCombiTrans(  3.6 + dz/2., 0., z, new TGeoRotation((*Ry90m)*(*Rx180))));
+  vADCstruct->AddNode(voCoil, 3, new TGeoCombiTrans( -3.6 - dz/2., 0., z, Ry90m));
+  vADCstruct->AddNode(voCoil, 4, new TGeoCombiTrans( -3.6 - dz/2., 0., z, new TGeoRotation((*Ry90m)*(*Rx180))));
   z = kZbegFrontBar + dzF + kdzLatBar/2.;
-  top->AddNode(voLatBar, 1, new TGeoTranslation(  31.9, 0., z));
-  top->AddNode(voLatBar, 2, new TGeoTranslation( -31.9, 0., z));
+  vADCstruct->AddNode(voLatBar, 1, new TGeoTranslation(  31.9, 0., z));
+  vADCstruct->AddNode(voLatBar, 2, new TGeoTranslation( -31.9, 0., z));
+  // vADCstruct->AddNode(CreatePmtBoxC(), 1); 
+  // Create C-Side Fiber Bundles:
+  // CreateCurvedBundles(ad);
   //
-  // Add structures (top) to AD node
+  // Color for voADsupp17 
+  voADsupp17MainProp ->SetLineColor(kGray+1);
+  voADsupp17Base     ->SetLineColor(kGray+1);
+  voADsuppTopBracket ->SetLineColor(kGray+1);
+  // Color for voADsupp18 
+  voADsupp18MainProp -> SetLineColor(kGray+1);
+  // Color for voADsuppIBeam
+  voADsuppIBeam -> SetLineColor(kGreen+3);
+  voADsuppIBeamV -> SetLineColor(kGreen+3);
+  // voADsuppIBeam -> SetLineColorAlpha(kGreen+3, 0.);
+  // voADsuppIBeam -> SetFillColorAlpha(kGreen+3, 0.5);
+  // voADsuppIBeam -> SetTransparency(16);
   //
+  TGeoVolume * voBLMsupport = gGeoManager->MakeBox("voBLMsupport", kMedAlu, 1.5/2.0, 30.0/2.0, 6.0/2.0);
+  voBLMsupport -> SetLineColor(kGray);
+  //
+  TGeoVolume         * voSupportZEM           = CreateSupportZEM(); 
+  TGeoVolumeAssembly * voBLM                  = CreateBLM(); 
+  TGeoVolumeAssembly * voVacuumChamberSupport = CreateVacuumChamberSupport();
+  TGeoVolumeAssembly * voShield               = CreateADAShielding();
+  TGeoVolume         * voWarmModuleSupport    = CreateWarmModuleSupport();
+  TGeoVolume         * voPumpAfterMagnet      = CreatePump();
+  TGeoVolume         * voOldADA               = CreateOldADA();
+  //
+  // FINAL ASSEMBLY 
+  //
+  TGeoVolumeAssembly * vADAstruct = new TGeoVolumeAssembly("voADAStruct");
+  vADAstruct->AddNode(voADACablingVBar      , 1 , new TGeoTranslation(28.25 , 0.00  , 1604.00 )); 
+  vADAstruct->AddNode(voADACablingVBar      , 2 , new TGeoTranslation(98.25 , 0.00  , 1604.00 )); 
+  // FIXME: vADAstruct->AddNode(voADACablingHBar      , 1 , new TGeoTranslation(63.25 , 0.00  , 1604.00 )); 
+  vADAstruct->AddNode(voADACablingHBar      , 2 , new TGeoTranslation(63.25 , 0.00  , 1604.00 )); 
+  vADAstruct->AddNode(voADAMagnetCableArray , 1 , new TGeoTranslation(26.25 , 0.00  , 1608.00 )); 
+  vADAstruct->AddNode(voADsupp17            , 1 , new TGeoTranslation(   0. , -36.5 , 1541.   )); 
+  vADAstruct->AddNode(voADsupp18            , 1 , new TGeoTranslation(   0. , -36.5 , 1612.   )); // As Measured
+  vADAstruct->AddNode(voADsupp18            , 2 , new TGeoTranslation(   0. , -36.5 , 1306.8  )); // As Measured
+  // vADAstruct->AddNode(voADsupp18            , 2 , new TGeoTranslation(   0. , -36.5 , 1295.8  )); // As LHC Drawing
+  vADAstruct->AddNode(voADsuppIBeam         , 1 , new TGeoTranslation(   0. , -36.5 , 1701.   ));
+  vADAstruct->AddNode(voADsuppIBeamV        , 1 , new TGeoCombiTrans (   0. , -36.5-9.6-(81.8-9.6)/2.0,         1295.47+9.6/2.0, Rx90   )  );
+  vADAstruct->AddNode(voADsuppIBeamV        , 2 , new TGeoCombiTrans (   0. , -36.5-9.6-(81.8-9.6)/2.0, 294.0 + 1295.47+9.6/2.0, Rx90   )  );
+  vADAstruct->AddNode(voVacuumChamberSupport, 1 , new TGeoTranslation(   0. ,   0.0 , 1075.+125.         ));
+  vADAstruct->AddNode(voVacuumChamberSupport, 2 , new TGeoCombiTrans (   0. ,   0.0 , 1075.-125. , Ry180 ));
+  vADAstruct->AddNode(voShield              , 1 , new TGeoTranslation(   0. ,   0.0 , 1665.5             ));
+  vADAstruct->AddNode(voBLM                 , 1 , new TGeoTranslation(  12.5,   0.0 , 1459.80 )  );
+  vADAstruct->AddNode(voBLMsupport          , 1 , new TGeoTranslation(  12.5, -21.5 , 1459.80 )  );
+  vADAstruct->AddNode(voSupportZEM          , 1 , new TGeoTranslation(   0. ,   0.0 ,  804.50 )  );
+  vADAstruct->AddNode(voWarmModuleSupport   , 1 , new TGeoTranslation(   0.0,-100.5 ,  882.80 ));
+  vADAstruct->AddNode(voOldADA              , 1 , new TGeoTranslation(   0.0,   0.0 ,  561.00 ));
+  vADAstruct->AddNode(voPumpAfterMagnet     , 1 , new TGeoCombiTrans (   0.0,-(8.0+3.6) , 1260.00 , Rx90));
+
   if (fADCstruct) {
-    ad->AddNode(top,1, Ry180);
+    ad->AddNode(voADC_UProfileGrid, 1       );
+    ad->AddNode(vADCstruct        , 1, Ry180);
   }
+  if (fADAstruct) { ad->AddNode(vADAstruct,1       ); }
 
   //
   // Add Everything to ALICE
@@ -996,15 +1469,8 @@ void AliADv1::CreateAD()
   TGeoVolume *alice = gGeoManager->GetVolume("ALIC");
   alice->AddNode(ad, 1);
 
-
-  // gGeoManager->DefaultColors();
-  // gGeoManager->CloseGeometry();
-  // gGeoManager->SetVisLevel(10);
-  // gGeoManager->SetVisOption(0);
-  // alice->Draw("ogl");
-
-  return;
-  printf("<=== AliADv1::CreateAD(): ver=[Feb 3st, 2015]; contact=[ecalvovi@cern.ch]\n");
+  printf("<=== AliADv1::CreateAD()\n");
+  return ; 
 }
 
 //_____________________________________________________________________________
@@ -1024,18 +1490,18 @@ void AliADv1::AddAlignableVolumes() const
   symname3 = "AD/ADA1";
   symname4 = "AD/ADA2";
   switch (fADCPosition) {
-  case kADCInTunnel:
-    volpath1 = "/ALIC_1/AD_1/ADC_1";
-    volpath2 = "/ALIC_1/AD_1/ADC_2";
-    break;
-  case kADCInCavern:
-    volpath1 = "/ALIC_1/AD_1/ADCh_1";
-    volpath2 = "/ALIC_1/AD_1/ADCh_2";
-    break;
-  case kADCInBoth:
-    volpath1 = "/ALIC_1/AD_1/ADC_1";
-    volpath2 = "/ALIC_1/AD_1/ADCh_2";
-    break;
+    case kADCInTunnel:
+      volpath1 = "/ALIC_1/AD_1/ADC_1";
+      volpath2 = "/ALIC_1/AD_1/ADC_2";
+      break;
+    case kADCInCavern:
+      volpath1 = "/ALIC_1/AD_1/ADCh_1";
+      volpath2 = "/ALIC_1/AD_1/ADCh_2";
+      break;
+    case kADCInBoth:
+      volpath1 = "/ALIC_1/AD_1/ADC_1";
+      volpath2 = "/ALIC_1/AD_1/ADCh_2";
+      break;
   }
   volpath3 = "/ALIC_1/AD_1/ADA_1";
   volpath4 = "/ALIC_1/AD_1/ADA_2";
@@ -1219,13 +1685,985 @@ void AliADv1::MakeBranch(Option_t *option)
   TString branchname(Form("%s",GetName()));
   AliDebugF(2, "fBufferSize = %d",fBufferSize);
   const char *cH = strstr(option,"H");
-  if (fHits && fLoader->TreeH() && cH) {
+  if (fHits && fLoader->TreeH() && cH) 
+  {
     fLoader->TreeH()->Branch(branchname.Data(),&fHits,fBufferSize);
     AliDebugF(2, "Making Branch %s for hits",branchname.Data());
   }
   const char *cD = strstr(option,"D");
-  if (fDigits && fLoader->TreeD() && cD) {
+  if (fDigits && fLoader->TreeD() && cD)
+  {
     fLoader->TreeD()->Branch(branchname.Data(),&fDigits, fBufferSize);
     AliDebugF(2, "Making Branch %s for digits",branchname.Data());
   }
+}
+
+//_________________________________________________________
+TGeoVolume * AliADv1::Make_UProfile(const char * volname, const Double_t L, 
+                           const TGeoMedium * medium, const Double_t W, const Double_t H, 
+                           const Double_t dw, const Double_t dh)
+{
+  const Int_t nvertices = 8;
+  const Double_t W2 = W*0.5;
+
+  Double_t X[nvertices] = {-W2 , -W2 , -W2 + dw , -W2 +dw , W2 -dw , W2 - dw , W2 , W2 }; 
+  Double_t Y[nvertices] = { 0  , H   , H        , dh      , dh     , H       , H  , 0  }; 
+
+  TGeoXtru * shAD_UProfileV = new TGeoXtru(2);
+  // shADsuppIBeam->SetNameTitle("shAD_UProfile","shAD_UProfile");
+  shAD_UProfileV->DefinePolygon(nvertices, X, Y);
+  shAD_UProfileV->DefineSection(0, -0.5*L, 0., 0., 1.0); // index, Z position, offset (x,y) and scale for first section
+  shAD_UProfileV->DefineSection(1,  0.5*L, 0., 0., 1.0); // idem, second section
+
+  TGeoVolume * vol = new TGeoVolume(volname, shAD_UProfileV, medium);
+  vol->SetLineColor(kAzure-3);
+  return vol;
+}
+//_________________________________________________________
+TGeoVolume * AliADv1::Make_UProfileH(const char * volname, TGeoMedium * medium)
+{
+  const Float_t dw = 0.85;
+  const Float_t dh = 0.60;
+  TGeoVolumeAssembly * voprofile = new TGeoVolumeAssembly(volname);
+  TGeoVolume * volH = Make_UProfile(Form("%s_H", volname), 90.-2*dw-0.01, medium, 10, 5, dw, dh);
+  TGeoVolume * volL = gGeoManager->MakeBox(Form("%s_L", volname), medium, 5, 2.5, dw/2.);
+  volH->SetLineColor(kAzure-3);
+  volL->SetLineColor(kAzure-3);
+  voprofile->AddNode(volH, 1);
+  voprofile->AddNode(volL, 1, new TGeoTranslation(0, 2.5, -90./2. + dw/2.));
+  voprofile->AddNode(volL, 2, new TGeoTranslation(0, 2.5, +90./2. - dw/2.));
+  return voprofile;
+}
+//_________________________________________________________
+/*/
+TGeoVolumeAssembly * AliADv1::CreatePmtBoxC() 
+{
+  // Dimensions of the box:
+  // Y: 100 cm
+  // Z:  70 cm
+  // X:  15 cm
+  Float_t thickness = 0.5; // cm
+  TGeoMedium * kMedAlu       = gGeoManager->GetMedium("AD_Alum");   // Aluminium 
+
+  // 
+  // Coordinates of the center of the box:
+  //
+  const Float_t dxBox = 15.0/2.0; // Half-width (X) of the box
+  const Float_t xBox = +120. +dxBox +0.01; // The box is touching the shielding block (which goes from x=-120 to 120 cm)
+  Float_t yBox = 0;           // At the same level as beam pipe?
+  Float_t zBox = kZendAbs - 6.5 - 35.; // The far end of the box is 6.5 cm appart from the far end of shielding block
+
+  TGeoBBox * shBox0 = new TGeoBBox("shAD_PmtBox_C_0", dxBox - thickness, 50.0 - thickness , 35.0 - thickness );
+  TGeoBBox * shBox1 = new TGeoBBox("shAD_PmtBox_C_1", dxBox, 50., 35.);
+  Double_t origin[] = {-1,0,2};
+  TGeoBBox * shBox2 = new TGeoBBox("shAD_PmtBox_C_Entrance", 3, 49., 35., origin);
+  TGeoCompositeShape * shAD_PmtBox_C = new TGeoCompositeShape("shAD_PmtBox_C", "(shAD_PmtBox_C_0-shAD_PmtBox_C_1)-shAD_PmtBox_C_Entrance");
+
+  TGeoVolume * voAD_PmtBox_C = new TGeoVolume("voAD_PmtBox_C", shAD_PmtBox_C, kMedAlu);
+  voAD_PmtBox_C->SetLineColor(kGray);
+  // 
+  // Assemble everything
+  //
+  TGeoVolumeAssembly * volBox = new TGeoVolumeAssembly("voAD_PMTBOX_C");
+  // Make the PM box
+  volBox->AddNode(voAD_PmtBox_C, 1, new TGeoTranslation( xBox, yBox, zBox));
+
+  // Make the PMs
+  Double_t fPMTdz = 2.0; // Length
+  Double_t fPMTDi = 2.7; // Diameter
+  TGeoMedium * medADCSci = gGeoManager->GetMedium("AD_BC404");
+  TGeoVolume * voADCpmt = new TGeoVolume("voADCpmt", new TGeoTube("shADCpmt", 0., fPMTDi/2., fPMTdz/2.), medADCSci);
+  voADCpmt -> SetLineColor(kGray);
+  Float_t x=xBox;
+  // PMT input parameters;
+  Float_t a = 20; // Distance (z) from PMT-Box-Wall to top-PMT-center
+  Float_t b = 30; // Distance (z) from PMT-Box-Wall to bottom-PMT-center
+  Float_t m = 10; // Distance (y) from beam-pipe-center to bottom-PMT-center
+  Float_t d =  8; // Distance between PMT-centers
+  // PMT calculated parameters:
+  Float_t h = TMath::Sqrt((d*3)*(d*3)+(b-a)*(b-a));
+  Float_t dzC = (b-a)/3;
+  Float_t dyC =     h/3;
+  // End of Fiber bundles
+  Double_t zBundle   = +1895.;
+  Double_t xBundle   = +126.5;
+  Double_t yBundle   = 0.;
+  Double_t yB[]      = { 7, 5, 3, 1};
+  x=xBundle;
+  for (Int_t i=0; i<4; i++) 
+  {
+    Double_t y = m + (dyC * i);
+    Double_t z = zBox + 35 - b + (dzC * i);
+    Double_t dz =   zBundle - z;
+    Double_t yBundle = yB[3-i];
+    Double_t dy =   yBundle - y;
+    Double_t angle = -(TMath::ATan2(dy,dz));
+    Double_t l = TMath::Sqrt(dz*dz+dy*dy)-fPMTdz/2.-1;
+    TGeoVolume * voADCfiber = gGeoManager->MakeTube(Form("voAD_FiberPmtC_top_%d", i), medADCSci, 0., 1.6/2., l/2.);
+    voADCfiber -> SetLineColor(kCyan);
+    printf("@@@@: %s: angle[%d]=%f Length: %f\n", __FUNCTION__, i, RadToDeg(angle), l+1.);
+    TGeoRotation * RotXangle = new TGeoRotation(Form("RxADpmtC_top_%d", i),   0., RadToDeg(angle),   0.) ;
+    volBox->AddNode(voADCpmt   , i+1 , new TGeoCombiTrans(x , y, z  , RotXangle)); 
+    y = yBundle + 0.5*(l+1)*TMath::Sin(angle);
+    z = zBundle - 0.5*(l+1)*TMath::Cos(angle);
+    volBox->AddNode(voADCfiber , i+1 , new TGeoCombiTrans(x , y, z,  RotXangle)); 
+    fPmtFiberTop[i] = new PmtFiberInfo();
+    fPmtFiberTop[i]->SetValues(x,y,z,l); 
+  }
+  //
+  for (Int_t i=0; i<4; i++) 
+  {
+    Double_t y = -m - (dyC * i);
+    Double_t z = zBox + 35 - b + (dzC * i);
+    Double_t dz =   zBundle - z;
+    Double_t yBundle = - yB[3-i];
+    Double_t dy =   yBundle - y;
+    Double_t angle = -(TMath::ATan2(dy,dz));
+    Double_t l = TMath::Sqrt(dz*dz+dy*dy)-fPMTdz/2.-1;
+    TGeoVolume * voADCfiber = gGeoManager->MakeTube(Form("voAD_FiberPmtC_bot_%d", i), medADCSci, 0., 1.6/2., l/2.);
+    voADCfiber -> SetLineColor(kCyan);
+    printf("@@@@: %s: angle[%d]=%f Length: %f\n", __FUNCTION__, i, RadToDeg(angle), l+1.);
+    TGeoRotation * RotXangle = new TGeoRotation(Form("RxADpmtC_bot_%d", i),   0., RadToDeg(angle),   0.) ;
+    volBox->AddNode(voADCpmt   , i+5 , new TGeoCombiTrans(x , y, z  , RotXangle)); 
+    y = yBundle + 0.5*(l+1)*TMath::Sin(angle);
+    z = zBundle - 0.5*(l+1)*TMath::Cos(angle);
+    volBox->AddNode(voADCfiber , i+5 , new TGeoCombiTrans(x , y, z,  RotXangle)); 
+    fPmtFiberBot[i] = new PmtFiberInfo();
+    fPmtFiberBot[i]->SetValues(x,y,z,l); 
+  }
+
+  return volBox;
+
+} /*/
+//_____________________________________________________________________________
+/* void AliADv1::CreateCurvedBundles(TGeoVolumeAssembly * ad)
+{
+  if (!ad) AliFatal("TGeoVolumeAssembly * ad = NULL");
+  Double_t fBundleStartZ = -1897;
+  fTopBundles[0] = new CurvedBundle  ( "ADC_BundleTopO_0_0_L" , -127 , 7 , fBundleStartZ , 18  , 25 , -1956 , 15 , 22 , -75 , kFALSE ); 
+  fTopBundles[1] = new CurvedBundle  ( "ADC_BundleTopI_1_0_L" , -124 , 7 , fBundleStartZ , 18  , 25 , -1952 , 14 , 22 , -75 , kFALSE ); 
+  fTopBundles[2] = new CurvedBundle  ( "ADC_BundleTopO_0_0_S" , -127 , 5 , fBundleStartZ , 2   , 25 , -1956 , 15 , 18 , -70 , kFALSE ); 
+  fTopBundles[3] = new CurvedBundle  ( "ADC_BundleTopI_1_0_S" , -124 , 5 , fBundleStartZ , 2   , 25 , -1952 , 14 , 18 , -70 , kFALSE ); 
+  fTopBundles[4] = new CurvedBundle  ( "ADC_BundleTopO_0_1_S" , -127 , 3 , fBundleStartZ , -2  , 25 , -1956 , 20 , 15 , -65 , kFALSE ); 
+  fTopBundles[5] = new CurvedBundle  ( "ADC_BundleTopI_1_1_S" , -124 , 3 , fBundleStartZ , -2  , 25 , -1952 , 19 , 15 , -65 , kFALSE ); 
+  fTopBundles[6] = new CurvedBundle  ( "ADC_BundleTopO_0_1_L" , -127 , 1 , fBundleStartZ , -18 , 25 , -1956 , 20 , 10 , -60 , kFALSE ); 
+  fTopBundles[7] = new CurvedBundle  ( "ADC_BundleTopI_1_1_L" , -124 , 1 , fBundleStartZ , -18 , 25 , -1952 , 19 , 10 , -60 , kFALSE ); 
+  //
+
+  fBotBundles[0] = new CurvedBundle  ( "ADC_BundleBotO_0_3_L" , -127 , 7 , fBundleStartZ , 18  , 25 , -1956 , 15 , 22 , -75 , kTRUE  ); 
+  fBotBundles[1] = new CurvedBundle  ( "ADC_BundleBotI_1_3_L" , -124 , 7 , fBundleStartZ , 18  , 25 , -1952 , 14 , 22 , -75 , kTRUE  ); 
+  fBotBundles[2] = new CurvedBundle  ( "ADC_BundleBotO_0_3_S" , -127 , 5 , fBundleStartZ , 2   , 25 , -1956 , 15 , 18 , -70 , kTRUE  ); 
+  fBotBundles[3] = new CurvedBundle  ( "ADC_BundleBotI_1_3_S" , -124 , 5 , fBundleStartZ , 2   , 25 , -1952 , 14 , 18 , -70 , kTRUE  ); 
+  fBotBundles[4] = new CurvedBundle  ( "ADC_BundleBotO_0_2_S" , -127 , 3 , fBundleStartZ , -2  , 25 , -1956 , 20 , 15 , -65 , kTRUE  ); 
+  fBotBundles[5] = new CurvedBundle  ( "ADC_BundleBotI_1_2_S" , -124 , 3 , fBundleStartZ , -2  , 25 , -1952 , 19 , 15 , -65 , kTRUE  ); 
+  fBotBundles[6] = new CurvedBundle  ( "ADC_BundleBotO_0_2_L" , -127 , 1 , fBundleStartZ , -18 , 25 , -1956 , 20 , 10 , -60 , kTRUE  ); 
+  fBotBundles[7] = new CurvedBundle  ( "ADC_BundleBotI_1_2_L" , -124 , 1 , fBundleStartZ , -18 , 25 , -1952 , 19 , 10 , -60 , kTRUE  ); 
+  //
+
+  for (Int_t i=0; i<fNBundles; i++) 
+  {
+    if (!fTopBundles[i]) continue;
+    ad -> AddNode( fTopBundles[i]->GetVolume(), 1);
+  }
+  for (Int_t i=0; i<fNBundles; i++) 
+  {
+    if (!fBotBundles[i]) continue;
+    ad -> AddNode( fBotBundles[i]->GetVolume(), 1);
+  }
+  // Print Lengths
+  for (Int_t i=0; i<fNBundles; i++) 
+  {
+    if (!fTopBundles[i]) continue;
+    Double_t L = fTopBundles[i]->GetTotalLength();
+    printf("fTopBundles[%d]: L: %6.3f | 250-L: %6.3f\n", i, L, 250. - L);
+  }
+  for (Int_t i=0; i<fNBundles; i++) 
+  {
+    if (!fBotBundles[i]) continue;
+    Double_t L = fBotBundles[i]->GetTotalLength();
+    printf("fBotBundles[%d]: L: %6.3f | 250-L: %6.3f\n", i, L, 250. - L);
+  }
+} */
+
+TGeoVolumeAssembly * AliADv1::CreateVacuumChamberSupport()
+{
+  TGeoMedium * kMedSteelSh   = gGeoManager->GetMedium("AD_ST_C0");  // Stainless Steel 
+  // Drawings used in this section:
+  // LHC Drawing: LHCVC2U_0009
+  // LHC Drawing: LHCVC2U_0018
+  // LHC Drawing: LHCVC2U_0019
+  // LHC Drawing: LHCVC2U_0014
+  // LHC Drawing: LHCVC2U_0016
+  // Originally  made by: Sergio Best.
+  // Edited and Reviewed: Ernesto Calvo.
+  // Support should start +- 125 cm from magnet center
+  //
+  TGeoVolumeAssembly * voVacuumChamberSupport = new TGeoVolumeAssembly("voVacuumChamberSupport");
+  Float_t zpos = 19.;
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // LHC Drawing: LHCVC2U_0013
+  //
+  TGeoXtru * sh_LHCVC2U_0013_a = NULL;
+  // TGeoBBox * sh_LHCVC2U_0013_b = NULL;
+  // TGeoVolume * vol_LHCVC2U_0013 = new TGeoVolume("vol_LHCVC2U_0013", sh_LHCVC2U_0013, kMedSteelSh);
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // sh_LHCVC2U_0013_a:
+  sh_LHCVC2U_0013_a = new TGeoXtru(2);
+  Double_t xpoints[] = { 0. , 0.95 , 22.45 , 24.45 , 24.45 , 22.45 , 0.95 , 0.};
+  Double_t ypoints[] = { 0. ,   0. , 8.25  , 8.25  , 9.75  , 9.75  , 3.   , 3.};
+  Int_t nvertices = sizeof(xpoints)/sizeof(Double_t);
+  sh_LHCVC2U_0013_a -> DefinePolygon(nvertices,xpoints,ypoints);
+  sh_LHCVC2U_0013_a -> DefineSection(0, -1.5, 0., 0., 1.0); // index, Z position, offset (x,y) and scale for first section
+  sh_LHCVC2U_0013_a -> DefineSection(1,  0.0, 0., 0., 1.0); // idem, second section
+  sh_LHCVC2U_0013_a -> SetName("sh_LHCVC2U_0013_a");
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // sh_LHCVC2U_0013_b:
+  new TGeoBBox("sh_LHCVC2U_0013_b", 2.75/2., 3.0/2., 0.95/2.);
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // a+b: sh_LHCVC2U_0013
+  ( new TGeoCombiTrans ("tr_a" , 0.               , 0.     , 0.      ,  Ry90m )) -> RegisterYourself();
+  ( new TGeoTranslation("tr_b" , +1.5 + 2.75/2.   , 3.0/2. , 0.95/2.          )) -> RegisterYourself();
+  TGeoVolume * vol_LHCVC2U_0013   = new TGeoVolume("vol_LHCVC2U_0013", 
+      new TGeoCompositeShape("sh_LHCVC2U_0013", "sh_LHCVC2U_0013_a:tr_a + sh_LHCVC2U_0013_b:tr_b"),
+      kMedSteelSh);
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // a+b: sh_LHCVC2U_0010
+  ( new TGeoCombiTrans ("tr_a10" , -1.5           , 0.     , 0.      ,  Ry90m )) -> RegisterYourself();
+  ( new TGeoTranslation("tr_b10" , -1.5 - 2.75/2. , 3.0/2. , 0.95/2.          )) -> RegisterYourself();
+  TGeoVolume * vol_LHCVC2U_0010   = new TGeoVolume("vol_LHCVC2U_0010", 
+      new TGeoCompositeShape("sh_LHCVC2U_0010", "sh_LHCVC2U_0013_a:tr_a10 + sh_LHCVC2U_0013_b:tr_b10"),
+      kMedSteelSh);
+  
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // LHC Drawing: LHCVC2U_0009
+  //
+  new TGeoBBox("shADclampSup_0" , 5.1/2.  , 7./2. , 1.5/2.);
+  new TGeoBBox("shADclampSup_1" , 2./2.   , 7./2. , 9./2. );
+  new TGeoPara("shADclampSup_2" , 2./2.   , 7./2. , 20./2.   , 0. , +180./TMath::Pi()*atan(12./200.) , 0.);
+  new TGeoBBox("shADclampSup_3" , 2./2.   , 7./2. , 10./2.);
+  new TGeoBBox("shADclampSup_4" , 5.35/2. , 7./2. , 1.5/2.);
+
+  TGeoRotation * RZ180      = new TGeoRotation("RZ180",   180., 0.,   0.);
+
+  (new TGeoTranslation("trADclampSup_0" , 3.10/2. +3.2 , 0. ,    39. - 1.5/2. ))-> RegisterYourself();
+  (new TGeoTranslation("trADclampSup_1" ,         +2.2 , 0. ,    30. + 9.0/2. ))-> RegisterYourself();
+  (new TGeoTranslation("trADclampSup_2" ,         +1.6 , 0. ,    10. +20.0/2.  ))-> RegisterYourself();
+  (new TGeoTranslation("trADclampSup_3" ,         +1.0 , 0. ,        +10.0/2. ))-> RegisterYourself();
+  (new TGeoTranslation("trADclampSup_4" , 5.35/2. +0.0 , 0. ,        + 1.5/2. ))-> RegisterYourself();
+
+  TGeoVolume* vol_LHCVC2U_0009 = new TGeoVolume("vol_LHCVC2U_0009", 
+      // new TGeoCompositeShape("cshape0", "shADclampSup_1:trADclampSup_1 + shADclampSup_2:trADclampSup_2 + shADclampSup_3:trADclampSup_3 + shADclampSup_4:trADclampSup_4"),
+      new TGeoCompositeShape("cshape0", "shADclampSup_0:trADclampSup_0 + shADclampSup_1:trADclampSup_1 + shADclampSup_2:trADclampSup_2 + shADclampSup_3:trADclampSup_3 + shADclampSup_4:trADclampSup_4"),
+      kMedSteelSh);
+  
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // LHC Drawing: LHCVC2U_0018
+  //
+
+  new TGeoBBox("shADspacer_0",  4.5/2., 5.5/2.,  8.92/2.);
+  new TGeoBBox("shADspacer_1",  4.5/2., 1.5/2.,  2.08/2.);
+  new TGeoBBox("shADspacer_2",  4.1/2., 7.0/2.,  2.5 /2.);
+  new TGeoBBox("shADspacer_3",  0.2/2., 5.5/2.,  2.5 /2.);
+
+  (new TGeoTranslation("trADspacerL_0" , 0.                 ,  0.            , 0.             )) ->RegisterYourself();
+  (new TGeoTranslation("trADspacerL_1" , 0.                 ,  (1.5-5.5)/2.  , 11./2.         )) ->RegisterYourself();
+  (new TGeoTranslation("trADspacerL_2" , -4.5/2.-0.2-4.1/2. ,  (7.0-5.5)/2.  , -(8.92-2.5)/2. )) ->RegisterYourself();
+  (new TGeoTranslation("trADspacerL_3" , -4.5/2.-0.1        ,            0.  , -(8.92-2.5)/2. )) ->RegisterYourself();
+
+
+  TGeoVolume* vol_LHCVC2U_0018 = new TGeoVolume("vol_LHCVC2U_0018", 
+      // new TGeoCompositeShape("cshape2", "shADspacer_0:trADspacerL_0+shADspacer_1:trADspacerL_1+shADspacer_2:trADspacerL_2"), kMedSteelSh);
+      new TGeoCompositeShape("cshape2", "shADspacer_0:trADspacerL_0+shADspacer_1:trADspacerL_1+shADspacer_2:trADspacerL_2+shADspacer_3:trADspacerL_3"), kMedSteelSh);
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // LHC Drawing: LHCVC2U_0019
+  //
+  (new TGeoTranslation("trADspacerR_0" , 0.                 ,  0.            , 0.             )) ->RegisterYourself();
+  (new TGeoTranslation("trADspacerR_1" , 0.                 ,  (1.5-5.5)/2.  , 11./2.         )) ->RegisterYourself();
+  (new TGeoTranslation("trADspacerR_2" , +4.5/2.+0.2+4.1/2. ,  (7.0-5.5)/2.  , -(8.92-2.5)/2. )) ->RegisterYourself();
+  (new TGeoTranslation("trADspacerR_3" , +4.5/2.+0.1        ,            0.  , -(8.92-2.5)/2. )) ->RegisterYourself();
+
+  // (new TGeoTranslation("trADspacerR_1",  0.,(1.5+5.5)/2.5,11./2. ))->RegisterYourself();
+  // (new TGeoTranslation("trADspacerR_2",  8.8/2.,-(7.-5.5)/2.,-(8.92-2.5)/2. ))->RegisterYourself();
+
+  TGeoVolume* vol_LHCVC2U_0019 = new TGeoVolume("vol_LHCVC2U_0019", 
+      new TGeoCompositeShape("cshape3", "shADspacer_0:trADspacerR_0+shADspacer_1:trADspacerR_1+shADspacer_2:trADspacerR_2+shADspacer_3:trADspacerR_3"), kMedSteelSh);
+      // new TGeoCompositeShape("cshape3", "shADspacer_0:trADspacerR_0+shADspacer_1:trADspacerR_1+shADspacer_2:trADspacerR_2"), kMedSteelSh);
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // LHC Drawing: LHCVC2U_0014
+  //
+  /////////////////////////////////////////////////////////////////////////////
+
+  Float_t h2_inf=(7.5*sqrt(3.)-7.6)/2.;
+  Float_t h1=7.6-h2_inf;
+  Float_t trp_m=20.-(2.*h1)/sqrt(3.);
+
+  TGeoRotation * RW90      = new TGeoRotation("RW90",   0., -90.,   0.);
+
+  new TGeoBBox("shADInf_0" , 30./2.   , 2./2.    , 4./2.  ); 
+  new TGeoTrd1("shADInf_1" , 20./2.   , trp_m/2. , 2./2.  ,  h1/2.     ); 
+  new TGeoTrd1("shADInf_2" , trp_m/2. , 5./2.    , 2./2.  ,  h2_inf/2. ); 
+  new TGeoTube("shADInf_3" , 0.       , 7.62     , 10./2. ); 
+
+  new TGeoBBox("shADInf_4" , 25./2.   , 3./2.    , 10./2. ); 
+
+  (new TGeoTranslation("trADInf_0" , 0. , 0. , 0.                          )) ->RegisterYourself();
+  (new TGeoTranslation("trADInf_1" , 0. , 0. , 2. + (h1/2.)                )) ->RegisterYourself();
+  (new TGeoTranslation("trADInf_2" , 0. , 0. , 2. + h1+(h2_inf/2.)         )) ->RegisterYourself();
+  (new TGeoCombiTrans ("trADInf_3" , 0. , 0. , 0.0                  , RW90 )) ->RegisterYourself();
+  (new TGeoTranslation("trADInf_4" , 0. , 0. , -(10./2.)+0.1               )) ->RegisterYourself();
+
+  TGeoVolume* vol_LHCVC2U_0014 = new TGeoVolume("vol_LHCVC2U_0014", 
+      new TGeoCompositeShape("shADInf_0:trADInf_0+shADInf_1:trADInf_1+shADInf_2:trADInf_2-shADInf_3:trADInf_3-shADInf_4:trADInf_4"), kMedSteelSh);
+
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // LHC Drawing: LHCVC2U_0016
+  //
+  /////////////////////////////////////////////////////////////////////////////
+
+  TGeoRotation * RW90m      = new TGeoRotation("RW90",   0., 90.,   0.);
+
+  new TGeoBBox("shADSup_0" , 24.8/2.  , 2./2.    , 1.9/2.              ); 
+  new TGeoTrd1("shADSup_1" , 20./2.   , trp_m/2. , 2./2.  ,  h1/2.     ); 
+  new TGeoTrd1("shADSup_2" , trp_m/2. , 5./2.    , 2./2.  ,  h2_inf/2. ); 
+  new TGeoTube("shADSup_3" , 0.       , 7.62     , 10./2.              ); 
+
+  (new TGeoTranslation("trADSup_0" , 0. , 0. , 0.1 + 1.9/2.           )) ->RegisterYourself();
+  (new TGeoTranslation("trADSup_1" , 0. , 0. , (4.+h1)/2.             )) ->RegisterYourself();
+  (new TGeoTranslation("trADSup_2" , 0. , 0. , (4.+2.*h1+h2_inf)/2.   )) ->RegisterYourself();
+  (new TGeoCombiTrans ("trADSup_3" , 0. , 0. , 0. , RW90      )) ->RegisterYourself();
+
+  TGeoVolume * vol_LHCVC2U_0016 = new TGeoVolume("vol_LHCVC2U_0016", 
+      new TGeoCompositeShape("(shADSup_0:trADSup_0+shADSup_1:trADSup_1+shADSup_2:trADSup_2)-shADSup_3:trADSup_3"), kMedSteelSh);
+
+  vol_LHCVC2U_0009->SetLineColor(kCyan     );  // Clamp Support
+  vol_LHCVC2U_0010->SetLineColor(kOrange-3 );  // Left  Stiffener
+  vol_LHCVC2U_0013->SetLineColor(kOrange-3 );  // Right Stiffener
+  vol_LHCVC2U_0016->SetLineColor(kViolet+6 );  // Top      semi-circular support
+  vol_LHCVC2U_0014->SetLineColor(kViolet+8 );  // Inferior semi-circular support
+  vol_LHCVC2U_0019->SetLineColor(kGreen    );  // Right Spacer
+  vol_LHCVC2U_0018->SetLineColor(kSpring-5 );  // Left Spacer
+
+  voVacuumChamberSupport->AddNode ( vol_LHCVC2U_0009 , 1 , new TGeoCombiTrans  (  -3. , 0.00        , 0.              , RZ180 )); 
+  voVacuumChamberSupport->AddNode ( vol_LHCVC2U_0009 , 2 , new TGeoCombiTrans  (  +3. , 0.00        , 0.              , NULL  )); 
+  voVacuumChamberSupport->AddNode ( vol_LHCVC2U_0010 , 1 , new TGeoCombiTrans  ( -4.1 , -14. + 0.75 , 0.              , NULL  )); 
+  voVacuumChamberSupport->AddNode ( vol_LHCVC2U_0013 , 1 , new TGeoCombiTrans  ( +4.1 , -14. + 0.75 , 0.              , NULL  )); 
+  voVacuumChamberSupport->AddNode ( vol_LHCVC2U_0016 , 1 , new TGeoCombiTrans  ( 0.   , 0.          , zpos+10.+9.+11. , RW90  )); 
+  voVacuumChamberSupport->AddNode ( vol_LHCVC2U_0014 , 1 , new TGeoCombiTrans  ( 0.   , 0.          , zpos+10.+9.+11. , RW90m )); 
+  voVacuumChamberSupport->AddNode ( vol_LHCVC2U_0019 , 1 , new TGeoTranslation ( -15.+4.5/2. , -0.75        , zpos+20.+8.92/2.    )); 
+  voVacuumChamberSupport->AddNode ( vol_LHCVC2U_0018 , 1 , new TGeoTranslation (  15.-4.5/2. , -0.75        , zpos+20.+8.92/2.    )); 
+
+  return voVacuumChamberSupport;
+
+}
+
+TGeoVolumeAssembly * AliADv1::CreateADAShielding()
+{
+  TGeoMedium * kMedSteelSh   = gGeoManager->GetMedium("AD_ST_C0");  // Stainless Steel 
+  //
+  TGeoVolumeAssembly * voShieldADA = new TGeoVolumeAssembly("voShieldADA");
+  TGeoVolumeAssembly * voShieldTop = new TGeoVolumeAssembly("voShieldADA_Top");
+  TGeoVolumeAssembly * voShieldBot = new TGeoVolumeAssembly("voShieldADA_Bot");
+  // This section made by Ernesto Calvo (PUCP)
+  // Base Plate (x1):
+  // dx: 45.5 cm
+  // dz: 33.0 cm
+  // dy:  0.5 cm
+  //
+  // Support bars along x axis (x3):
+  // 50x50x48 cm thickness: ??
+  //
+
+  // Shield Cage:
+  // Height  : 25.0 cm
+  // Inner dx: 40.0 cm
+  // Inner dz: 30.0 cm
+  //
+  // F1,2: 50.0 x 25.0 x  0.5 cm
+  // E1,2:  0.5 x 25.0 x 30.0 cm
+  // H1,2:  4.0 x 25.0 x  0.5 cm
+  TGeoVolumeAssembly * voShieldCage = new TGeoVolumeAssembly("voADAShieldCage");
+  TGeoVolume * volF = gGeoManager -> MakeBox("volAD_Sh_F", kMedSteelSh, 50.0/2., 25.0/2.,  0.5/2.); 
+  TGeoVolume * volE = gGeoManager -> MakeBox("volAD_Sh_E", kMedSteelSh,  0.5/2., 25.0/2., 30.0/2.); 
+  TGeoVolume * volH = gGeoManager -> MakeBox("volAD_Sh_H", kMedSteelSh,  4.0/2., 25.0/2.,  0.5/2.); 
+  TGeoVolume * volS = gGeoManager -> MakeBox("volAD_Sh_S", kMedSteelSh, 40.0/2., 30.0/2., 30.0/2.); 
+  // C1  : 47.0 x  5.0 x  5.0 cm
+  new TGeoBBox("shRecTubC_outer" , 47./2. , 5./2.     , 5./2.     ); 
+  new TGeoBBox("shRecTubC_inner" , 47.    , 5./2.-0.3 , 5./2.-0.3 ); 
+  new TGeoBBox("shRecTubD_outer" , 46./2. , 5./2.     , 5./2.     ); 
+  new TGeoBBox("shRecTubD_inner" , 46.    , 5./2.-0.3 , 5./2.-0.3 ); 
+  // B1  : 4.0 x  6.0 x  13.0 cm
+  new TGeoBBox("shRecTubB1_outer" , 4./2.     , 6./2.     , 13./2. ); 
+  new TGeoBBox("shRecTubB1_inner" , 4./2.-0.3 , 6./2.-0.3 , 13.    ); 
+  // B2  : 4.0 x  6.0 x  15.0 cm
+  new TGeoBBox("shRecTubB2_outer" , 4./2.     , 6./2.     , 15./2. ); 
+  new TGeoBBox("shRecTubB2_inner" , 4./2.-0.3 , 6./2.-0.3 , 15.    ); 
+  // A   : 5.0 x  5.0 x  57.0 cm
+  new TGeoBBox("shRecTubA_outer" , 5./2.      , 57./2.    , 5./2.      ); 
+  new TGeoBBox("shRecTubA_inner" , 5./2.-0.3  , 57.       , 5./2. -0.3 ); 
+  //
+  TGeoVolume * volC  = new TGeoVolume("volAD_Sh_C"  , new TGeoCompositeShape("shRecTubC"  , "shRecTubC_outer-shRecTubC_inner"  ) , kMedSteelSh ); 
+  TGeoVolume * volD  = new TGeoVolume("volAD_Sh_D"  , new TGeoCompositeShape("shRecTubD"  , "shRecTubD_outer-shRecTubD_inner"  ) , kMedSteelSh ); 
+  TGeoVolume * volB1 = new TGeoVolume("volAD_Sh_B1" , new TGeoCompositeShape("shRecTubB1" , "shRecTubB1_outer-shRecTubB1_inner") , kMedSteelSh ); 
+  TGeoVolume * volB2 = new TGeoVolume("volAD_Sh_B2" , new TGeoCompositeShape("shRecTubB2" , "shRecTubB2_outer-shRecTubB2_inner") , kMedSteelSh ); 
+  TGeoVolume * volA  = new TGeoVolume("volAD_Sh_A"  , new TGeoCompositeShape("shRecTubA"  , "shRecTubA_outer-shRecTubA_inner"  ) , kMedSteelSh ); 
+  // IBEAMS:
+  const Double_t IBeamLength = 200.;
+  TGeoVolume * volIBeamTop2 = MakeVolIBeam("volAD_Sh_IBeamTop2", kMedSteelSh, 18., 18., 0.8, 1.4, IBeamLength);
+  TGeoVolume * volIBeamTop  = MakeVolIBeam("volAD_Sh_IBeamTop" , kMedSteelSh, 10., 10., 0.6, 1.0, 58.0);
+  TGeoVolume * volIBeamBot  = MakeVolIBeam("volAD_Sh_IBeamBot" , kMedSteelSh, 10., 10., 0.6, 1.0, 33.0);
+  volIBeamBot -> SetLineColor(kGreen+3);
+  volIBeamTop -> SetLineColor(kGreen+3);
+  volIBeamTop2-> SetLineColor(kGreen-3);
+
+  TGeoVolume * volPlateTop = gGeoManager -> MakeBox("volAD_Sh_PlateTop", kMedSteelSh, 45.5/2.,  0.5/2., 33.0/2.); 
+  TGeoVolume * volPlateBot = gGeoManager -> MakeBox("volAD_Sh_PlateBot", kMedSteelSh, 50.0/2.,  0.5/2., 33.0/2.); 
+  volF -> SetLineColor(kOrange);
+  volE -> SetLineColor(kOrange-8);
+  volH -> SetLineColor(kOrange-8);
+  volS -> SetLineColor(kGray+3);
+  volC -> SetLineColor(kGreen-3);
+  volD -> SetLineColor(kGreen-3);
+  volB1-> SetLineColor(kRed-10);
+  volB2-> SetLineColor(kRed-10);
+  volA -> SetLineColor(kTeal);
+  volPlateTop -> SetLineColor(kViolet+7);
+  volPlateBot -> SetLineColor(kViolet+7);
+
+  voShieldCage->AddNode(volF , 1 , new TGeoTranslation(         0.0 , 25.0/2. , -15. -0.25 )); 
+  voShieldCage->AddNode(volF , 2 , new TGeoTranslation(         0.0 , 25.0/2. , +15. +0.25 )); 
+  voShieldCage->AddNode(volE , 1 , new TGeoTranslation( -20.0 -0.25 , 25.0/2. , 0.00       )); 
+  voShieldCage->AddNode(volE , 2 , new TGeoTranslation( +20.0 +0.25 , 25.0/2. , 0.00       )); 
+  voShieldCage->AddNode(volH , 1 , new TGeoTranslation( +22.0 +0.50 , 25.0/2. , -15.0+0.25 )); 
+  voShieldCage->AddNode(volH , 2 , new TGeoTranslation( -22.0 -0.50 , 25.0/2. , -15.0+0.25 )); 
+  voShieldCage->AddNode(volH , 3 , new TGeoTranslation( +22.0 +0.50 , 25.0/2. , +15.0-0.25 )); 
+  voShieldCage->AddNode(volH , 4 , new TGeoTranslation( -22.0 -0.50 , 25.0/2. , +15.0-0.25 )); 
+  voShieldCage->AddNode(volS , 1 , new TGeoTranslation(         0.0 , 30.0/2. , 0.00       )); 
+
+  voShieldTop -> AddNode(voShieldCage , 1 , new TGeoTranslation(  0.   , 0.    , 0.         )); 
+  voShieldTop -> AddNode(volPlateTop  , 1 , new TGeoTranslation( -2.25 , -0.25 , +1.0       )); 
+  voShieldTop -> AddNode(volC         , 1 , new TGeoTranslation( -2.50 , -3.00 , -12.5      )); 
+  voShieldTop -> AddNode(volC         , 2 , new TGeoTranslation( -2.50 , -3.00 , -12.5+25.0 )); 
+  voShieldTop -> AddNode(volD         , 1 , new TGeoTranslation( -2.50 , -3.00 ,  0.0       )); 
+  voShieldTop -> AddNode(volB1        , 1 , new TGeoTranslation(+23.00 , -3.00 , -9.0       )); 
+  voShieldTop -> AddNode(volB1        , 2 , new TGeoTranslation(-28.00 , -3.00 , -9.0       )); 
+  voShieldTop -> AddNode(volB2        , 1 , new TGeoTranslation(+23.00 , -3.00 ,+10.0       )); 
+  voShieldTop -> AddNode(volB2        , 2 , new TGeoTranslation(-28.00 , -3.00 ,+10.0       )); 
+  voShieldTop -> AddNode(volA         , 1 , new TGeoTranslation(+23.00 ,+20.50 ,  0.0       )); 
+  voShieldTop -> AddNode(volA         , 2 , new TGeoTranslation(-28.00 ,+20.50 ,  0.0       )); 
+  voShieldTop -> AddNode(volA         , 3 , new TGeoTranslation(+23.00 ,+20.50 ,+20.0       )); 
+  voShieldTop -> AddNode(volA         , 4 , new TGeoTranslation(-28.00 ,+20.50 ,+20.0       )); 
+  voShieldTop -> AddNode(volIBeamTop  , 1 , new TGeoCombiTrans ( -2.50 ,+60.00 ,  0.0, Ry90 )); 
+  voShieldTop -> AddNode(volIBeamTop  , 2 , new TGeoCombiTrans ( -2.50 ,+60.00 ,+20.0, Ry90 )); 
+  Double_t trz = +(2.25 + IBeamLength/2. -15.5 );
+  voShieldTop -> AddNode(volIBeamTop2 , 1 , new TGeoTranslation( +0.00 ,+50.00 ,trz         )); 
+
+  //
+  voShieldBot -> AddNode(voShieldCage , 1 , new TGeoCombiTrans (0.    , 0.    , 0.  , Ry180 )); 
+  voShieldBot -> AddNode(volPlateBot  , 1 , new TGeoTranslation(0.    , -0.25 , -1.0        )); 
+  voShieldBot -> AddNode(volIBeamBot  , 1 , new TGeoTranslation(-20.0 , -0.50 , -1.0        )); 
+  voShieldBot -> AddNode(volIBeamBot  , 2 , new TGeoTranslation(0.    , -0.50 , -1.0        )); 
+  voShieldBot -> AddNode(volIBeamBot  , 3 , new TGeoTranslation(+20.0 , -0.50 , -1.0        )); 
+  //
+  voShieldADA -> AddNode(voShieldTop  , 1 , new TGeoCombiTrans (0.    ,   82.0 +2.0 -30.0, 0.  , Ry180 ));
+  voShieldADA -> AddNode(voShieldBot  , 1 , new TGeoTranslation(0.    , -124.6 -2.0      , 0.          ));
+  return voShieldADA;
+}
+
+TGeoVolume * AliADv1::MakeVolIBeam(const char * volname, const TGeoMedium * mat, const Double_t x, const Double_t y, const Double_t dx, const Double_t dy, const Double_t dz)
+{
+  TGeoXtru * shIBeam = new TGeoXtru(2);
+  TString shname = "sh";
+  shname += volname;
+  shIBeam->SetNameTitle(shname.Data(), shname.Data());
+  Double_t H, H2, W, W2;
+  W = x/2.; W2 = dx/2.; 
+  H = y/2.; H2 = dy/1.; 
+  Double_t xIBeam[] = { -W , -W   , -W2  , -W2  , -W   , -W , W , W    , W2   , W2   , W    , W  }; 
+  Double_t yIBeam[] = { -H , H2-H , H2-H , H-H2 , H-H2 , H  , H , H-H2 , H-H2 , H2-H , H2-H , -H }; 
+  Int_t nvertices = sizeof(xIBeam)/sizeof(Double_t);
+  shIBeam -> DefinePolygon(nvertices,xIBeam,yIBeam);
+  shIBeam -> DefineSection(0, -dz/2., 0., -H, 1.0); // index, Z position, offset (x,y) and scale for first section
+  shIBeam -> DefineSection(1,  dz/2., 0., -H, 1.0); // idem, second section
+  
+  return new TGeoVolume(volname, shIBeam, mat);
+}
+
+TGeoVolume * AliADv1::CreateSupportZEM()
+{
+  TGeoVolumeAssembly * voSupportZEM = new TGeoVolumeAssembly("voSupportZEM");
+  // TGeoMedium * kMedAlu       = gGeoManager->GetMedium("AD_Alum");   // Aluminium 
+  // TGeoMedium * kMedVacuum    = gGeoManager->GetMedium("AD_VA_C0");  // Stainless Steel 
+  TGeoMedium * kMedSteelSh   = gGeoManager->GetMedium("AD_ST_C0");  
+  //
+  TGeoVolume * voSupportHPlateBig = gGeoManager->MakeBox("voSupportHPlateBig", kMedSteelSh  , 55.0/2.0 , 1.5/2.0 , 110.0/2.0 ); 
+  TGeoVolume * voSupportHPlateSma = gGeoManager->MakeBox("voSupportHPlateSma", kMedSteelSh  , 15.0/2.0 , 3.0/2.0 , 100.0/2.0 ); 
+
+
+  // Add some color:
+  voSupportHPlateBig -> SetLineColor(kGray+1);
+  voSupportHPlateSma -> SetLineColor(kGray+1);
+  // Assembling:
+  
+  voSupportZEM -> AddNode(voSupportHPlateBig , 1 , new TGeoTranslation(  0.0 , -15.25 , 0. )); 
+  voSupportZEM -> AddNode(voSupportHPlateBig , 2 , new TGeoTranslation(  0.0 , -26.75 , 0. )); 
+  voSupportZEM -> AddNode(voSupportHPlateSma , 1 , new TGeoTranslation(-10.0 , -13.00 , 0. )); 
+  voSupportZEM -> AddNode(voSupportHPlateSma , 2 , new TGeoTranslation(+10.0 , -13.00 , 0. )); 
+
+  return (TGeoVolume*) voSupportZEM;
+}
+
+TGeoVolumeAssembly * AliADv1::CreateBLM()
+{
+  TGeoVolumeAssembly * voBLM = new TGeoVolumeAssembly("voBLM");
+  TGeoMedium * kMedAlu       = gGeoManager->GetMedium("AD_Alum");   // Aluminium 
+  // TGeoMedium * kMedVacuum    = gGeoManager->GetMedium("AD_VA_C0");  // Stainless Steel 
+  TGeoMedium * kMedSteelSh   = gGeoManager->GetMedium("AD_ST_C0");  
+
+  // const Double_t cm  =              1.0; // 1 mm = 0.1 cm
+  const Double_t mm  =              0.1; // 1 mm = 0.1 cm
+  const Double_t deg = TMath::Pi()/180.; // 
+// Cilinder
+  // Double_t SourTubeInnerRadius =   0.   * mm             ; // full tube
+  // Double_t SourTubeOuterRadius =  45.   * mm             ; //
+  //   Double_t SourTubeLenght = 615.   * mm             ; //
+  // Double_t SourTubeLenght      = 495.   * mm             ; // without electronicsbox
+  // Double_t SourTubeHalfLenght  =   0.5  * SourTubeLenght ; // half size
+  // Double_t SourTubexpos        =   0.                    ; // -61. * mm * sin(GetRotAngle()) ; //0. ; 
+  // Double_t SourTubezpos        =   0.                    ; //  61. * mm * cos(GetRotAngle()) ; //0. ; 
+
+  // TGeoVolume * solidSourTube = gGeoManager->MakeTube( "voSourChamber", kMedVacuum, SourTubeInnerRadius, SourTubeOuterRadius, SourTubeHalfLenght);
+  //
+  // outer tube	inox
+  //
+  Double_t OuterTubeInnerRadius =  42.45*mm;
+  Double_t OuterTubeOuterRadius =  44.45*mm;
+  Double_t OuterTubeLenght      = 585.00*mm; // As Measured!
+  // Double_t OuterTubeLenght      = 615.00*mm; // As Measured!
+  // Double_t OuterTubeLenght      = 483.  *mm; // Original
+  Double_t OuterTubeHalfLenght  =   0.5 *OuterTubeLenght;	// half size
+  //   Double_t OuterTubezpos = -60.*mm;
+  Double_t OuterTubezpos = 0.*mm;		// without electronicsbox
+
+  TGeoVolume * voOuterTube = gGeoManager->MakeTube("voOuterTube", kMedSteelSh, OuterTubeInnerRadius, OuterTubeOuterRadius, OuterTubeHalfLenght);
+// Create gas
+// Create Electrode With holes
+// Place the 61 electrodes
+//
+  // Electronic box (NO)
+  // new TGeoBBox("shElectronicBoxOuter", 0.5*4.5*cm, 0.5*6.0*cm, 0.5*6.0*cm); //its size
+  // new TGeoBBox("shElectronicBoxInner", 0.5*3.7*cm, 0.5*5.2*cm, 0.5*5.2*cm); //its size
+  // TGeoCompositeShape * shElectronicBox = new TGeoCompositeShape("shElectronicBox", "shElectronicBoxOuter-shElectronicBoxInner");
+  // TGeoVolume * voElectronicBox = new TGeoVolume("voElectronicBox", shElectronicBox, kMedAlu);
+  //
+  // top plate diff inox (part 6)
+  //
+  // const Double_t PlateInnerRadius = 0.  * mm           ; 
+  const Double_t PlateWidth       = 5.  * mm           ; 
+  const Double_t PlateHalfLenght  = 0.5 * PlateWidth ; // half size
+  const Double_t InsulHalfLenght  = 0.5 * 15. * mm ; // half size
+
+  // FIXME: define Aluminim Oxide Al2O3
+  TGeoMedium * kMedAl2O3 = kMedSteelSh;
+
+  TGeoVolume * voEndPlateBLM = gGeoManager->MakeTube("voEndPlateBLM",	kMedSteelSh, 0.0, OuterTubeOuterRadius, PlateHalfLenght);
+  TGeoVolume * voInsPlateBLM = gGeoManager->MakeTube("voInsPlateBLM",	kMedAl2O3  , 0.0, OuterTubeInnerRadius, InsulHalfLenght);
+
+
+
+  //
+  // electrodes
+  //
+  const Double_t ElInnerRadius = 0.   * mm;
+  const Double_t ElOuterRad    = 37.5 * mm;
+  const Double_t Elwidt        = 0.5  * mm;
+  const Double_t Elhalfwidth   = 0.5  * Elwidt;
+  const Double_t TubfixRadius  = 31.5 * mm;
+  
+
+  new TGeoTube("shElect",	ElInnerRadius, ElOuterRad, Elhalfwidth); 
+      
+  //
+  // transformation
+  //
+  Double_t xhole = 0.;
+  Double_t yhole = 0.;
+
+  xhole = TubfixRadius * TMath::Cos( 30.*deg );
+  yhole = TubfixRadius * TMath::Sin( 30.*deg );
+
+  TGeoCompositeShape * shElectrode;
+  //
+  // hole in electrodes
+  //
+  Double_t holeInnerRadius = 0.0 * mm;
+  Double_t holeOuterRad    = 3.0 * mm;
+  Double_t holelenght      = 1.0 * mm;
+  Double_t holehalflenght  = 0.5 * holelenght;
+  new TGeoTube("hole", holeInnerRadius, holeOuterRad, holehalflenght);
+  //
+  for(Int_t rep=0; rep<6; rep++)
+  {
+    xhole = TubfixRadius * TMath::Cos( 30.*deg+rep*60.*deg );
+    yhole = TubfixRadius * TMath::Sin( 30.*deg+rep*60.*deg );
+    (new TGeoTranslation(Form("TrElectrodeHole%d", rep), xhole,yhole,0.)) -> RegisterYourself();
+  }
+
+  shElectrode = new TGeoCompositeShape(
+      "shElectrode", 
+      "shElect-(hole+"
+            "hole:TrElectrodeHole0+"
+            "hole:TrElectrodeHole1+"
+            "hole:TrElectrodeHole2+"
+            "hole:TrElectrodeHole3+"
+            "hole:TrElectrodeHole4+"
+            "hole:TrElectrodeHole5)");
+
+
+  TGeoVolume * voElectrode = new TGeoVolume("electrode", shElectrode, kMedAlu);
+  //
+  // Rods
+  //
+  const Double_t SDGasLenght = 356.5*mm;
+  const Double_t RodLength = SDGasLenght;
+  const Double_t RodHalfLength = 0.5*RodLength;
+  const Double_t deltaPhi = 30.* deg;
+
+  TGeoVolume * voInnerRodBLM = gGeoManager->MakeTube("voInnerRodBLM",	kMedSteelSh, 0.0  , 0.2, RodHalfLength);
+  TGeoVolume * voOuterRodBLM = gGeoManager->MakeTube("voOuterRodBLM",	kMedAlu    , 0.205, 0.3, RodHalfLength);
+  voInnerRodBLM -> SetLineColor(kGray+1);
+  voOuterRodBLM -> SetLineColor(kGray  );
+
+  TGeoVolumeAssembly * voRodBLM = new TGeoVolumeAssembly("voRodBLM");
+  voRodBLM->AddNode(voInnerRodBLM, 1, new TGeoTranslation(0., 0., 0.));
+  voRodBLM->AddNode(voOuterRodBLM, 1, new TGeoTranslation(0., 0., 0.));
+
+
+  for (Int_t Rodrep=0; Rodrep<6; Rodrep++)
+  {
+    Double_t xRod = TubfixRadius * TMath::Cos( deltaPhi+(Rodrep%6)*60.*deg );
+    Double_t yRod = TubfixRadius * TMath::Sin( deltaPhi+(Rodrep%6)*60.*deg );
+
+    voBLM -> AddNode(voRodBLM, Rodrep, new TGeoTranslation(xRod, yRod, 0.));
+  }
+
+
+  
+  // voElectronicBox -> SetLineColor(kGray     ); 
+  voEndPlateBLM   -> SetLineColor(kGray + 1 ); 
+  voInsPlateBLM   -> SetLineColor(kYellow-10); 
+  voElectrode     -> SetLineColor(kGray     ); 
+  voOuterTube     -> SetLineColor(kOrange-2 ); 
+  //
+  // placeing of the electrodes
+  //
+  Double_t zEl = 0.;
+  Double_t ElParamLength = 345.*mm;
+
+  for(Int_t Elparam=0;Elparam<61;Elparam++)
+  {
+    zEl = -0.5*ElParamLength + 5.75*mm*Elparam;
+    voBLM -> AddNode(voElectrode, Elparam+1, new TGeoTranslation(0.,0.,zEl));
+  }
+
+  // voBLM -> AddNode(voElectronicBox , 1 , new TGeoTranslation(0. , 0. , -OuterTubeHalfLenght+6.0+0.1                      )); 
+  voBLM -> AddNode(voOuterTube     , 1 , new TGeoTranslation(0. , 0. , OuterTubezpos                                     )); 
+  voBLM -> AddNode(voEndPlateBLM   , 1 , new TGeoTranslation(0. , 0. , OuterTubezpos-PlateHalfLenght-OuterTubeHalfLenght )); 
+  voBLM -> AddNode(voEndPlateBLM   , 2 , new TGeoTranslation(0. , 0. , OuterTubezpos+PlateHalfLenght+OuterTubeHalfLenght )); 
+  voBLM -> AddNode(voInsPlateBLM   , 1 , new TGeoTranslation(0. , 0. , -InsulHalfLenght-RodHalfLength                    )); 
+  voBLM -> AddNode(voInsPlateBLM   , 2 , new TGeoTranslation(0. , 0. , +InsulHalfLenght+RodHalfLength                    )); 
+  return voBLM;  
+}
+
+TGeoVolume * AliADv1::CreatePump()
+{
+  TGeoMedium * kMedSteelSh   = gGeoManager->GetMedium("AD_ST_C0");  // Stainless Steel 
+  TGeoVolumeAssembly * voPump = new TGeoVolumeAssembly("voVAMQF_Pump");
+  // VAMQF.D1L2.X                 
+  // Position: <12.69; 12.5> m from IP2        
+  // Description: Module with all-metal right angle valve and pinch-off flange
+  const Double_t kDegToRad    = TMath::Pi()/180. ; 
+  const Double_t     alpha    = 45.0 * kDegToRad; // angle
+  const Double_t thickness    = 0.2; 
+  const Double_t TopFlange2RO = 5.8;
+  const Double_t TopFlange2RI = 2.1;
+  const Double_t TopFlange1RO = 5.8;
+  const Double_t TopFlange1RI = 3.7 - thickness;
+  const Double_t    Flange_hdL   = 1.8/2.0;
+  const Int_t ni    = 3;
+  Double_t R[ni+1   ] = {3.7, 4.1, 4.5, 5.0}; // , 5.0, 2.7, 2.7; // External Radius of the segment
+  Double_t L[ni]   = {4.0, 9.0, 2.5     }; // , 0.5, 0.0, 5.0; // Length of the segment
+  const Double_t SideTubeL  = 6.0;
+  const Double_t SideTubeX  = 4.0 + R[1] - SideTubeL/2.0;
+
+  TGeoVolume * voTopFlange1 = gGeoManager->MakeTube( "voTopFlange1" , kMedSteelSh , TopFlange1RI           , TopFlange1RO , Flange_hdL ); 
+  TGeoVolume * voTopFlange2 = gGeoManager->MakeTube( "voTopFlange2" , kMedSteelSh , TopFlange2RI-thickness , TopFlange2RO , Flange_hdL ); 
+
+
+  TGeoPcon * shVAMQF_TubeVTop = new TGeoPcon("shVAMQF_TubeVTop", 0.0, 360.0, 8);
+  Double_t z=0.;
+  Int_t iplane = 0;
+  for (Int_t i=0; i<ni; i++)
+  {
+
+    Double_t dR = (R[i+1]-R[i]); dR = TMath::Abs(dR);
+    Double_t dL = dR / TMath::Tan(alpha);
+
+    if (i==0  ) {
+      Printf("i: %4d z: %9.5f", i, z); fflush(stdout);
+      shVAMQF_TubeVTop -> DefineSection(iplane++, z, R[i  ] - thickness, R[i  ] );
+    }
+
+    //
+    z += L[i]-dL ;    
+    Printf("i: %4d z: %9.5f L[%d]: %9.5f dL: %9.5f", i, z, i, L[i], dL); fflush(stdout);
+    shVAMQF_TubeVTop -> DefineSection(iplane++, z, R[i  ] - thickness, R[i  ] ); 
+
+    //
+    z += dL      ;
+    Printf("i: %4d z: %9.5f", i, z); fflush(stdout);
+    shVAMQF_TubeVTop -> DefineSection(iplane++, z, R[i+1] - thickness, R[i+1] ); 
+    Printf("=============================");
+  }
+  z=16.0;
+  Int_t i=ni;
+  shVAMQF_TubeVTop -> DefineSection(iplane++, z, R[i  ] - thickness, R[i  ] ); 
+  Printf("nplanes: %4d", iplane);
+
+  new TGeoTube ("shSideHole", 0.0, 3.4, SideTubeL/2.0);
+  TGeoCombiTrans * cbSideHole = new TGeoCombiTrans ("cbSideHole", SideTubeX , 0. , 8.5  , Ry90 );
+  cbSideHole->RegisterYourself();
+
+  TGeoCompositeShape * shCentralPart = new TGeoCompositeShape("shVAMQF_CentralPart", "shVAMQF_TubeVTop-shSideHole:cbSideHole");
+  TGeoVolume * voCentralPart =  new TGeoVolume("voVAMQF_CentralPart", shCentralPart, kMedSteelSh);
+
+  TGeoVolume * voTubeVBot        = gGeoManager->MakeTube( "voVAMQF_TubeVBot"   , kMedSteelSh , 2.7-thickness , 2.7           , 5.0/2.0       ); 
+  TGeoVolume * voCircPlate1      = gGeoManager->MakeTube( "voVAMQF_CircPlate1" , kMedSteelSh , 2.7-thickness , 5.0-thickness , thickness/2.0 ); 
+  TGeoVolume * voCircPlate2      = gGeoManager->MakeTube( "voVAMQF_CircPlate2" , kMedSteelSh , 0.0           , 2.7-thickness , thickness/2.0 ); 
+  TGeoVolume * voSideTube        = gGeoManager->MakeTube( "voVAMQF_Sidetube"   , kMedSteelSh , 3.4-thickness , 3.4           , SideTubeL/2.0);
+  TGeoVolume * voSideTubeFlange1 = gGeoManager->MakeTube( "voVAMQF_SidetubeFlange1" , kMedSteelSh , 3.4 -thickness, 11.5/2.0 , 2.0/2.0);
+  TGeoVolume * voSideTubeFlange2 = gGeoManager->MakeTube( "voVAMQF_SidetubeFlange2" , kMedSteelSh , 0.0           , 11.5/2.0 , 1.5/2.0);
+
+  voCentralPart -> SetLineColor(kGray);
+  voTopFlange2  -> SetLineColor(kGray);
+  voTopFlange1  -> SetLineColor(kGray);
+  voTubeVBot    -> SetLineColor(kGray);
+  voCircPlate1  -> SetLineColor(kGray);
+  voCircPlate2  -> SetLineColor(kGray);
+  voSideTube    -> SetLineColor(kGray);
+  voSideTubeFlange1 -> SetLineColor(kGreen);
+  voSideTubeFlange2 -> SetLineColor(kAzure-7);
+
+  voPump->AddNode(voCentralPart   , 1 , new TGeoTranslation(0. , 0. , 0.                    )); 
+  voPump->AddNode(voTopFlange1    , 1 , new TGeoTranslation(0. , 0. , -1.0 * Flange_hdL     )); 
+  voPump->AddNode(voTopFlange2    , 1 , new TGeoTranslation(0. , 0. , -3.0 * Flange_hdL     )); 
+  voPump->AddNode(voTubeVBot      , 1 , new TGeoTranslation(0. , 0. , 16.0 + 5.0/2.0        )); 
+  voPump->AddNode(voCircPlate1    , 1 , new TGeoTranslation(0. , 0. , 16.0 - thickness/2.0  )); 
+  voPump->AddNode(voCircPlate2    , 1 , new TGeoTranslation(0. , 0. , 21.0 - thickness/2.0  )); 
+  // Side Part
+  voPump->AddNode(voSideTube        , 1 , cbSideHole);
+  voPump->AddNode(voSideTubeFlange1 , 1 , new TGeoCombiTrans(R[1]+ 4.0 + 2.0/2.0       , 0. , 8.5, Ry90 )); 
+  voPump->AddNode(voSideTubeFlange2 , 1 , new TGeoCombiTrans(R[1]+ 4.0 + 2.0 + 1.5/2.0 , 0. , 8.5, Ry90 )); 
+  return (TGeoVolume*) voPump;
+}
+
+TGeoVolume * AliADv1::CreateOldADA()
+{
+  TGeoVolumeAssembly * voOldADA = new TGeoVolumeAssembly("voOldADA");
+  // Materials
+  TGeoMedium * kMedSteelSh   = gGeoManager->GetMedium("AD_ST_C0");  // Stainless Steel 
+  TGeoMedium * matbar = kMedSteelSh;
+  TGeoMedium * medADASci     = gGeoManager->GetMedium("AD_BC404");
+  TGeoMedium * matsci = medADASci;
+
+  // Square Tubes 4.0 cm side, thickness 3.0 mm
+  Double_t thickness = 0.3;
+  Double_t SqOuterDx =   4.0/2.0; 
+  Double_t SqOuterDz =   4.0/2.0; 
+  Double_t SqOuterDy = 188.0/2.0; 
+
+  Double_t SqInnerDx = SqOuterDx - thickness; 
+  Double_t SqInnerDz = SqOuterDz - thickness; 
+  Double_t SqInnerDy = SqOuterDy + thickness; 
+
+  new TGeoBBox("shSqTubeVOuter", SqOuterDx, SqOuterDy, SqOuterDz); 
+  new TGeoBBox("shSqTubeVInner", SqInnerDx, SqInnerDy, SqInnerDz); 
+  TGeoVolume * voSqTubeV = new TGeoVolume("voSqTubeV", new TGeoCompositeShape("shSqTubeV", "shSqTubeVOuter-shSqTubeVInner"), matbar);
+
+  new TGeoBBox("shUTube25mmOuter", 2.5/2.0, 44.0/2.0, 2.5/2.0    ); 
+  new TGeoBBox("shUTube25mmInner", 2.5/2.0, 44.0/1.0, 2.5/2.0-0.3); 
+  (new TGeoTranslation("trUTube25mmInner", -0.3, 0.0, 0.0))->RegisterYourself();
+  TGeoVolume * voUTube25mm = new TGeoVolume("voUTube25mm", new TGeoCompositeShape("shUTube25mm", "shUTube25mmOuter-shUTube25mmInner:trUTube25mmInner"), matbar);
+
+  // Metal sheet with rombic hole
+  thickness = 0.1; // Metal sheet thickness
+  const Double_t holeL = 11.0 * 0.5 * TMath::Sqrt(2.0);
+  new TGeoBBox("shMetalSheetM", 58.0/2.0, 100.0/2.0, thickness/2.0);
+  new TGeoBBox("shMetalSheet1",  2.0/2.0, 100.0/1.0, thickness);
+  new TGeoBBox("shMetalSheet2", holeL/2.0, holeL/2.0, 3.0);
+  (new TGeoRotation("rot45z", 45., 0., 0.))->RegisterYourself();
+  TGeoCompositeShape * shMetalSheet = new TGeoCompositeShape("shMetalSheet", "((shMetalSheetM-shMetalSheet1)-shMetalSheet2:rot45z)");
+  TGeoVolume * voMetalSheet = new TGeoVolume("voMetalSheet", shMetalSheet, matbar);
+
+  // PMT Metal Sheet Covers
+  TGeoVolume * voPmtSheetCover = gGeoManager->MakeBox("voPmtSheetCover", matbar, 58.0/2.0, 44.0/2.0, thickness/2.0);
+
+  // Scintillators fo old AD
+  new TGeoBBox("shSciOldADAmo", 25.0/2.0, 25.0/2.0, 4.0/2.0);
+  (new TGeoTranslation("trSciOldADAmo", 25.0/2.0, 25.0/2.0, 0.0))->RegisterYourself();
+
+  TGeoCompositeShape * shSciOldADA = new TGeoCompositeShape("shSciOldADA", "(shSciOldADAmo:trSciOldADAmo-shMetalSheet2:rot45z)");
+
+  TGeoVolume * voSciOldADA = new TGeoVolume("voSciOldADA", shSciOldADA, matsci);
+  
+
+  voSqTubeV       -> SetLineColor(kGray);
+  voMetalSheet    -> SetLineColor(kAzure-7);
+  voUTube25mm     -> SetLineColor(kGreen+3);
+  voPmtSheetCover -> SetLineColor(kAzure-7);
+  voSciOldADA     -> SetLineColor(kSpring-5);
+
+  voOldADA -> AddNode(voSqTubeV, 1, new TGeoTranslation( 27.0, 0.0, 0.0));
+  voOldADA -> AddNode(voSqTubeV, 2, new TGeoTranslation(-27.0, 0.0, 0.0));
+  // Add Metal Sheets
+  Double_t z =  SqOuterDz + 0.5 * thickness;
+  voOldADA -> AddNode(voMetalSheet, 1, new TGeoTranslation(  0.0, 0.0, +z));
+  voOldADA -> AddNode(voMetalSheet, 2, new TGeoTranslation(  0.0, 0.0, -z));
+  // Add 25mm x 25mm x 44cm U-Bars
+  // X>0 Side
+  voOldADA -> AddNode(voUTube25mm, 1, new TGeoTranslation(  58.0/2.0 - 2.5/2.0,  100.0/2.0 + 44.0/2.0, +(4.0+2.5)/2.0));
+  voOldADA -> AddNode(voUTube25mm, 2, new TGeoTranslation(  58.0/2.0 - 2.5/2.0,  100.0/2.0 + 44.0/2.0, -(4.0+2.5)/2.0));
+  voOldADA -> AddNode(voUTube25mm, 3, new TGeoTranslation(  58.0/2.0 - 2.5/2.0, -100.0/2.0 - 44.0/2.0, +(4.0+2.5)/2.0));
+  voOldADA -> AddNode(voUTube25mm, 4, new TGeoTranslation(  58.0/2.0 - 2.5/2.0, -100.0/2.0 - 44.0/2.0, -(4.0+2.5)/2.0));
+  // Add 25mm x 25mm x 44cm U-Bars
+  // X<0 Side (needs a 180° rotation aroud Y
+  voOldADA -> AddNode(voUTube25mm, 1, new TGeoCombiTrans ( -58.0/2.0 + 2.5/2.0,  100.0/2.0 + 44.0/2.0, +(4.0+2.5)/2.0, Ry180));
+  voOldADA -> AddNode(voUTube25mm, 2, new TGeoCombiTrans ( -58.0/2.0 + 2.5/2.0,  100.0/2.0 + 44.0/2.0, -(4.0+2.5)/2.0, Ry180));
+  voOldADA -> AddNode(voUTube25mm, 3, new TGeoCombiTrans ( -58.0/2.0 + 2.5/2.0, -100.0/2.0 - 44.0/2.0, +(4.0+2.5)/2.0, Ry180));
+  voOldADA -> AddNode(voUTube25mm, 4, new TGeoCombiTrans ( -58.0/2.0 + 2.5/2.0, -100.0/2.0 - 44.0/2.0, -(4.0+2.5)/2.0, Ry180));
+  // Add Pmt Metal Sheet Covers
+  voOldADA -> AddNode(voPmtSheetCover, 1, new TGeoTranslation(0.0, +(100.0+44.0)/2.0, +(2.0+2.5+thickness/2.0)));
+  voOldADA -> AddNode(voPmtSheetCover, 2, new TGeoTranslation(0.0, +(100.0+44.0)/2.0, -(2.0+2.5+thickness/2.0)));
+  voOldADA -> AddNode(voPmtSheetCover, 3, new TGeoTranslation(0.0, -(100.0+44.0)/2.0, +(2.0+2.5+thickness/2.0)));
+  voOldADA -> AddNode(voPmtSheetCover, 4, new TGeoTranslation(0.0, -(100.0+44.0)/2.0, -(2.0+2.5+thickness/2.0)));
+  // Add Old ADA Scintillators
+  voOldADA -> AddNode(voSciOldADA, 1);
+  voOldADA -> AddNode(voSciOldADA, 2, new TGeoCombiTrans(0.0, 0.0, 0.0, Ry180));
+  voOldADA -> AddNode(voSciOldADA, 3, new TGeoCombiTrans(0.0, 0.0, 0.0, Rx180));
+  voOldADA -> AddNode(voSciOldADA, 4, new TGeoCombiTrans(0.0, 0.0, 0.0, Rz180));
+
+  return (TGeoVolume *) voOldADA;
+}
+
+
+TGeoVolume * AliADv1::CreateWarmModuleSupport()
+{
+  // Top Node:     LHCVC2U_0030
+  // General view: LHCVHL__0027
+  TGeoVolumeAssembly * voWarmModuleSupport = new TGeoVolumeAssembly("voWarmModuleSupport");
+  // Material
+  TGeoMedium * kMedSteelSh   = gGeoManager->GetMedium("AD_ST_C0");  // Stainless Steel 
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // Make Vacuum Suport Vab foot base plate15 in RB24/1 FP (B-Side) /marvin.ascencio@pucp.edu.pe
+  // Flat Bar
+  // https://edms.cern.ch/ui/file/373462/AA/lhcvhl__0007-vAA.pdf
+  // https://edms.cern.ch/file/439918/AA/lhcvhl__0027-vAA.pdf
+  // Foot tube: LHCVHL__0007
+  // LHC Drawing: LHCVHL__0005
+  Double_t paf    = TMath::Pi()/4;
+  Double_t sqrtt  = TMath::Sqrt(3);
+  Double_t ds     = 2* (TMath::Sin(paf));
+  Double_t fxt    = -25 + (3/sqrtt - 0.9);
+  Double_t fxt2   = -25 - (3/sqrtt + 3.9);
+  Double_t fxtd   =  25 - (3/sqrtt - 0.9);
+  Double_t fxtd2  =  25 + (3/sqrtt + 3.9);
+  Double_t fyt    =  - (sqrtt*(3/sqrtt -0.9));
+  Double_t fyt2   =  (sqrtt*(3/sqrtt - 0.9)) ;
+  Double_t trFx[] = {fxt , -25 , fxt2, -25. };
+  Double_t trFy[] = {0.  , fyt, 0, fyt2 };
+  Double_t trFx2[] = {fxtd , 25. , fxtd2, 25. };
+  Double_t trFy2[] = {0.  , fyt, 0, fyt2 };
+  /* TGeoBBox * ShADFlatBar   = */ new TGeoBBox("ShADFlatBar"   , 50/2  ,  35/2 , 2/2   ); 
+  /* TGeoBBox * ShADFlatBarb  = */ new TGeoBBox("ShADFlatBarb"  , ds    ,  7/2  , 8/2   ); 
+  TGeoArb8 * shADFlatBara  = new TGeoArb8("shADFlatBara"  , 10/2. ); 
+  TGeoArb8 * shADFlatBara2 = new TGeoArb8("shADFlatBara2" , 10/2. ); 
+  TGeoTube * ShADBolts     = new TGeoTube("ShADBolts"     , 0.    ,  0.7  , 5.4/2 ); 
+      for (Int_t i=3; i>=0; i--)
+  {
+      shADFlatBara  -> SetVertex(i   , trFx[i]  , trFy[i]  ); 
+      shADFlatBara  -> SetVertex(i+4 , trFx[i]  , trFy[i]  ); 
+      shADFlatBara2 -> SetVertex(i   , trFx2[i] , trFy2[i] ); 
+      shADFlatBara2 -> SetVertex(i+4 , trFx2[i] , trFy2[i] ); 
+  }
+
+  TGeoRotation * Rx45  = new TGeoRotation("Rx45" ,   0.,   0.,  45.) ;
+  TGeoRotation * Rx45m = new TGeoRotation("Rx45m",   0.,   0., -45.) ;
+  (new TGeoCombiTrans("trFlatBar1", -25.,  35/2., 0., Rx45m)) -> RegisterYourself();
+  (new TGeoCombiTrans("trFlatBar2",  25., -35/2., 0., Rx45m)) -> RegisterYourself();
+  (new TGeoCombiTrans("trFlatBar3",  25.,  35/2., 0,  Rx45 )) -> RegisterYourself();
+  (new TGeoCombiTrans("trFlatBar4", -25., -35/2., 0., Rx45 )) -> RegisterYourself();
+  TGeoCompositeShape * shFlatBarc = new TGeoCompositeShape("shFlatBarc", 
+      "ShADFlatBar - ShADFlatBarb:trFlatBar4 - ShADFlatBarb:trFlatBar3 - ShADFlatBarb:trFlatBar2 - ShADFlatBarb:trFlatBar1 - shADFlatBara - shADFlatBara2");
+  TGeoVolume * voADFlatBar = new TGeoVolume("voADFlatBar", shFlatBarc, kMedSteelSh);
+  voADFlatBar -> SetLineColor(kGray);
+  TGeoVolume * voADBolt   = new TGeoVolume("voADBolt", ShADBolts, kMedSteelSh);
+  voADBolt -> SetLineColor(kGray);
+  
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // Make Vacuum Suport Vab 15 in RB24/1 FP (B-Side) /marvin.ascencio@pucp.edu.oe
+  // Sheet (15x200x220)
+  // LHC Drawing: LHCVHL__0024
+  
+  /* TGeoBBox * ShADSheet  = */ new TGeoBBox("ShADSheet"  , 11 , 10  , 1.5/2 ); 
+  /* TGeoBBox * ShADSheetb = */ new TGeoBBox("ShADSheetb" , ds , 7/2 , 8/2   ); 
+
+  (new TGeoCombiTrans("trSheet1" , -11. ,  10. , 0. , Rx45m ))  -> RegisterYourself();
+  (new TGeoCombiTrans("trSheet2" ,  11. , -10. , 0. , Rx45m ))  -> RegisterYourself();
+  (new TGeoCombiTrans("trSheet3" ,  11. ,  10. , 0. , Rx45  ))  -> RegisterYourself();
+  (new TGeoCombiTrans("trSheet4" , -11. , -10. , 0. , Rx45  ))  -> RegisterYourself();
+  TGeoCompositeShape * shSheet = new TGeoCompositeShape("shSheet", 
+      "ShADSheet - ShADSheetb:trSheet4 - ShADSheetb:trSheet3 - ShADSheetb:trSheet2 - ShADSheetb:trSheet1");
+  TGeoVolume * voADSheet = new TGeoVolume("voADSheet", shSheet, kMedSteelSh);
+  voADSheet -> SetLineColor(kGray);
+  //voWarmModuleSupport ->AddNode(voADSheet,2, new TGeoTranslation(0., 14.3,78.65));
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  // Make Vacuum Suport Vab 15 in RB24/1 FP (B-Side) /marvin.ascencio@pucp.edu.pe
+  // TUBE epr.5 (100x80x700)
+  // LHC Drawing: LHCVHL__0024
+  // FOOT UPPER PLATE
+  
+  /* TGeoBBox * ShADTubeepr  = */ new TGeoBBox("ShADTubeepr"  , 5.0 , 4.  , 39.0 ); 
+  /* TGeoBBox * ShADTubeeprb = */ new TGeoBBox("ShADTubeeprb" , 4.0 , 3.0 , 39.0     ); 
+  TGeoCompositeShape * shTubeepr = new TGeoCompositeShape("shTubeepr", "ShADTubeepr - ShADTubeeprb");
+  TGeoVolume * voADTubeepr = new TGeoVolume("voADTubeepr", shTubeepr, kMedSteelSh);
+  voADTubeepr -> SetLineColor(kGreen);
+  TGeoVolumeAssembly * voADsuppVab15 = new TGeoVolumeAssembly("voADsuppVab15");
+  voADsuppVab15 -> AddNode(voADFlatBar , 1 , new TGeoCombiTrans(14.3      , 10.0+8.8 , 0.    , Rz90 )); 
+  voADsuppVab15 -> AddNode(voADSheet   , 1 , new TGeoTranslation(14.3     , 0.       , 86.65 ));
+  voADsuppVab15 -> AddNode(voADSheet   , 2 , new TGeoTranslation(14.3     , 0.       , 79.75 )); 
+  voADsuppVab15 -> AddNode(voADTubeepr , 1 , new TGeoTranslation(14.3     , 0.       , 40.   )); 
+  voADsuppVab15 -> AddNode(voADBolt    , 1 , new TGeoTranslation(14.3+7.7 , 8.3      , 83.2  )); 
+  voADsuppVab15 -> AddNode(voADBolt    , 2 , new TGeoTranslation(14.3-7.7 , 8.3      , 83.2  )); 
+  voADsuppVab15 -> AddNode(voADBolt    , 3 , new TGeoTranslation(14.3+7.7 , -8.3     , 83.2  )); 
+  voADsuppVab15 -> AddNode(voADBolt    , 4 , new TGeoTranslation(14.3-7.7 , -8.3     , 83.2  )); 
+  new TGeoVolumeAssembly("voADsuppVab15_a");
+  voWarmModuleSupport ->AddNode(voADsuppVab15, 1, new TGeoCombiTrans(0., 0., 0., Rx90m ));
+
+  return (TGeoVolume*) voWarmModuleSupport;
 }

--- a/AD/ADsim/AliADv1.h
+++ b/AD/ADsim/AliADv1.h
@@ -21,15 +21,30 @@
 ///////////////////////////////////////////////////////////////////////////
 
 #include "AliAD.h"
-#include "TGeoCompositeShape.h"
+#include <TMath.h>
+// #include <TGeoCompositeShape.h> 
+// #include <TGeoMatrix.h>
+
+class TGeoVolumeAssembly;
+class TGeoCompositeShape;
+class TGeoRotation;
+class TGeoVolume;
+class TGeoMedium;
+//
+class CurvedBundle; 
+class PmtFiberInfo;
+//
+enum {
+  kCSideFiberNearWLSTop, kCSideFiberNearWLSBot, kCSideFiberPmtTop, kCSideFiberPmtBot, 
+  kASideFiberShort, kASideFiberLong }; 
+//
 
 class AliADv1 : public AliAD {
 public:
   AliADv1();
   AliADv1(const char *name, const char *title);
   virtual ~AliADv1();
-
-  virtual void   AddAlignableVolumes() const;
+  virtual    void  AddAlignableVolumes() const;
 
   virtual TString  Version() { return TString("v1"); }
   virtual   Int_t  IsVersion() const { return 1; }
@@ -40,11 +55,76 @@ public:
   virtual    void  Init();
   virtual    void  StepManager();
   virtual    void  DisableTunnelStruct() { fADCstruct = kFALSE; }
+  virtual    void  DisableStructuresSideC() { fADCstruct = kFALSE; }
+  virtual    void  DisableStructuresSideA() { fADAstruct = kFALSE; }
   virtual    void  KeepHistory() { fKeepHistory = kTRUE; }
 
   enum ADCPosition_t { kADCInTunnel, kADCInCavern, kADCInBoth};
 
 protected:
+
+  ///////////////////////////////////////////////////////////////////////////////////
+  // 
+  // Geometry update
+  //
+  TGeoRotation * Rx180 ;  //! 
+  TGeoRotation * Rz180 ;  //! 
+  TGeoRotation * Ry180 ;  //! 
+  TGeoRotation * Rx90  ;  //! 
+  TGeoRotation * Rx90m ;  //! 
+  TGeoRotation * Ry90m ;  //! 
+  TGeoRotation * Ry90  ;  //! 
+  TGeoRotation * Rz90  ;  //! 
+   
+  // Position of Fiber bundles A-Side:
+  Double_t fX1FiberShort[8]; //!
+  Double_t fX1FiberLong [8]; //!
+  Double_t fX2Fiber     [8]; //!
+  Double_t fY1Fiber     [8]; //!
+  Double_t fY2Fiber     [8]; //!
+  // 
+  static const char * s_where[];          //!
+  static const Int_t fNBundles = 8;       //!
+  CurvedBundle * fTopBundles[fNBundles];  //!
+  CurvedBundle * fBotBundles[fNBundles];  //!
+  PmtFiberInfo * fPmtFiberTop[4];  //!
+  PmtFiberInfo * fPmtFiberBot[4];  //!
+  //
+  // Private comunication by Arturo Tauro (2014, Apr 23)
+  // According to last survey measurement done this morning, 
+  // the C-Side wall is at Z = - 18959mm.
+  //
+  static const Double_t kZwall        ;  // Aluminium plate z position 
+  static const Double_t kZendAbs      ;  // End of CC block absorber
+  static const Double_t kZbegVMAOI    ;  // Begining of Warm Module
+  static const Double_t kZbegValve    ;  // Begining of Valve
+  static const Double_t kZbegFrontBar ;  // Begining of Front Bar
+  static const Double_t kZbegCoil     ;  // Begining of compensator coil
+  Double_t             RadToDeg(Double_t rad) { return rad * (180./TMath::Pi()); }
+  Double_t             DegToRad(Double_t deg) { return deg * (TMath::Pi()/180.); }
+  TGeoVolume         * Make_UProfile(const char * volname, const Double_t L, 
+                           const TGeoMedium * medium, const Double_t W, const Double_t H, 
+                           const Double_t dw, const Double_t dh);
+  TGeoVolume         * Make_UProfileH(const char * volname, TGeoMedium * medium);
+  TGeoVolume         * MakeVolIBeam(const char * volname, const TGeoMedium * mat, 
+                           const Double_t x, const Double_t y, 
+                           const Double_t dx, const Double_t dy, const Double_t dz);
+  TGeoVolume         * CreateWarmModuleSupport();
+  TGeoVolume         * CreateOldADA();
+  TGeoVolume         * CreatePump();
+  TGeoVolume         * CreateSupportZEM();
+  TGeoVolumeAssembly * CreateBLM();
+  TGeoVolumeAssembly * CreateADAShielding();
+  TGeoVolumeAssembly * CreateVacuumChamberSupport();
+  // void                 CreateCurvedBundles(TGeoVolumeAssembly * ad=0);
+  TGeoVolumeAssembly * CreatePmtBoxC() ;
+  TGeoCompositeShape * MakeFiberBundle (const char * shName, const Double_t xWLS, const Double_t xPMT, const Double_t yWLS, const Double_t yPMT, const Double_t Z1);
+  // Bool_t               FindInArray(Int_t & , const Int_t , const Int_t nel, const Int_t * arr);
+  // Float_t              GetDistanceFromFibersToWLSADC(Int_t where, Int_t arrayindex, Double_t * x);
+  // Float_t              GetDistanceFromFibersToWLSADA(Int_t ADmodule, Bool_t IsShort, Float_t fHitY);
+  //
+public:
+  ///////////////////////////////////////////////////////////////////////////////////
   // functions for ADA and ADC
   void ReadADCFromEnv(void);
   TGeoCompositeShape * MakeShapeADCpadH(const Double_t W, const Double_t H, const Double_t dz);
@@ -52,16 +132,14 @@ protected:
 
 private:
   // Position of ADC: In the Tunnel, In the Cavern, or in Both
-  Bool_t        fADCstruct;
+  Bool_t      fADCstruct;
+  Bool_t      fADAstruct;
   ADCPosition_t fADCPosition;
-  //! ADC Geometrical & Optical parameters :
 
-  Double_t    fADCLightYield;       //! Lightyield in NE102
+  //! AD Optical parameters :
+  Double_t    fADCLightYield;       //! Lightyield in BC404
+  Double_t    fADALightYield;       //! Lightyield in BC404
   Double_t    fADCPhotoCathodeEfficiency;
-
-  //! ADA Geometrical & Optical parameters :
-
-  Double_t    fADALightYield;       //! Lightyield in NE102
   Double_t    fADAPhotoCathodeEfficiency;
 
   Bool_t      fKeepHistory;
@@ -69,7 +147,7 @@ private:
   AliADv1(const AliAD&);
   AliADv1& operator = (const AliADv1&);
 
-  ClassDef(AliADv1, 1);  //Class for the AD detector
+  ClassDef(AliADv1, 1)  // Class for the AD detector
 };
 
 #endif

--- a/STRUCT/AliDIPOv2.cxx
+++ b/STRUCT/AliDIPOv2.cxx
@@ -44,6 +44,11 @@
 #include "AliDIPOv2.h"
 #include "AliMagF.h"
 #include "AliRun.h"
+
+#include "TGeoXtru.h"
+#include "TGeoTube.h"
+#include "TGeoBBox.h"
+#include "TGeoCompositeShape.h"
  
 ClassImp(AliDIPOv2)
  
@@ -652,9 +657,10 @@ void AliDIPOv2::CreateCompensatorDipole()
 //
     Float_t pbox[3];
 //  Mother volumes
+/*    
+    goto ECV_CODE;
     TGeoVolumeAssembly* asDCM0 = new TGeoVolumeAssembly("DCM0");
     asDCM0->SetName("DCM0");
-    
 //
 //  Mother volume containing lower coil
     pbox[0] = kWLYoke / 2.;
@@ -802,9 +808,218 @@ void AliDIPOv2::CreateCompensatorDipole()
 
 
     AliMatrix(idrotm[1816], 270., 0., 90., 90.,  180., 0.);  
-    TVirtualMC::GetMC()->Gspos("DCM0", 1, "ALIC",  0., -12.,  1075., idrotm[1816], "ONLY");
+    // TVirtualMC::GetMC()->Gspos("DCM0", 1, "ALIC",  0., -12.,  1075., idrotm[1816], "ONLY");
+
+*/
+    // ECV:
+ECV_CODE: 
+    // asDCM0->SetName("DCM0");
+    TGeoVolume * ALIC = gGeoManager->GetVolume("ALIC");
+    ALIC->AddNode(CreateMagnetYoke(), 1, new TGeoTranslation(0., 0., 1075.));
+    //
 }
 
+TGeoVolume * AliDIPOv2::CreateMagnetYoke()
+{
+  TGeoVolumeAssembly * voMagnet = new TGeoVolumeAssembly("DCM0");
+  voMagnet->SetName("DCM0");
+  TGeoRotation * Ry180 = new TGeoRotation("Ry180", 180., 180.,   0.);  
+  TGeoMedium * kMedAlu     = gGeoManager->GetMedium("DCM0_ALU_C0");
+  TGeoMedium * kMedCooper  = gGeoManager->GetMedium("DCM0_Cu_C0");
+  TGeoMedium * kMedIron    = gGeoManager->GetMedium("DCM0_FE_C0");
+
+  new TGeoBBox("shMagnetYokeOuter"   , 116.4/2.0 , 90.2/2.0 , 250.0/2.0 ); 
+  new TGeoBBox("shMagnetYokeInnerUp" ,   8.0/2.0 , 32.2/2.0 , 250.0/1.0  ); 
+  new TGeoBBox("shMagnetYokeInnerDw" ,  46.0/2.0 , 23.0/2.0 , 250.0/1.0  ); 
+  (new TGeoTranslation("trMagnetYokeOuter"  ,  0.0, -29.1, 0.0)) -> RegisterYourself();
+  (new TGeoTranslation("trMagnetYokeInnerUp",  0.0,   0.0, 0.0)) -> RegisterYourself();
+  (new TGeoTranslation("trMagnetYokeInnerDw",  0.0, -27.5, 0.0)) -> RegisterYourself();
+
+  TGeoCompositeShape * shMagnetYoke = new TGeoCompositeShape("shMagnet", "shMagnetYokeOuter:trMagnetYokeOuter-(shMagnetYokeInnerUp:trMagnetYokeInnerUp+shMagnetYokeInnerDw:trMagnetYokeInnerDw)");
+  TGeoVolume * voMagnetYoke = new TGeoVolume("voMagnetYoke", shMagnetYoke, kMedIron);
+
+  // Make the coils:
+  TGeoVolume * voCoilH = gGeoManager -> MakeBox("voCoilH", kMedCooper, 12.64/2.0,  21.46/2.0, 310.5/2.0);
+  TGeoVolume * voCoilV = gGeoManager -> MakeBox("voCoilV", kMedCooper, 12.64/2.0,  35.80/2.0,  26.9/2.0);
+
+  // Make the top coil supports:
+  // Polygone Coordinates (x,y)
+  Double_t x, y;
+  const Double_t kDegToRad  = TMath::Pi()/180. ; 
+  const Double_t AngleInner = 4.5 * kDegToRad  ; 
+  const Double_t AngleOuter = 56.0 * kDegToRad ; 
+  const Double_t ArcStart   = 90. - AngleOuter / kDegToRad ; 
+  const Double_t ArcEnd     = 90. + AngleInner / kDegToRad ; 
+  const Double_t b          = 13.6             ; 
+  const Double_t Lx         = 37.2             ; 
+  const Double_t Ly         = 25.7             ; 
+  const Double_t LxV        = 14.9; 
+  const Double_t R          = 9.50;
+  const Double_t dz         = 2.00/2.0;
+  const Int_t npoints = 8;
+  Double_t CenterX; Double_t CenterY; 
+  Double_t PointsX[npoints] = {0.};
+  Double_t PointsY[npoints] = {0.};
+  Int_t ip = 0;
+  // Start point: 
+  x = 0.0; y = 0.0;
+  PointsX[ip]=x; PointsY[ip]=y; ip++;
+  // 1st step: 
+  x = 0.00;
+  y = 1.95;
+  PointsX[ip]=x; PointsY[ip]=y; ip++;
+  // 2nd step: 
+  x+= b;
+  y+= b * TMath::Tan(AngleInner);
+  PointsX[ip]=x; PointsY[ip]=y; ip++;
+  // Center of Arc:
+  x+= R * TMath::Sin(AngleInner);
+  y-= R * TMath::Cos(AngleInner);
+  CenterX=x; CenterY=y; 
+  TGeoTubeSeg * shPolygonArc = new TGeoTubeSeg("shPolygonArc", R-2.0, R, dz , ArcStart, ArcEnd);
+  (new TGeoTranslation("trPolygonArc", x,y,0.))->RegisterYourself();
+  // 3rd Step:
+  x+= R * TMath::Sin(AngleOuter);
+  y+= R * TMath::Cos(AngleOuter);
+  PointsX[ip]=x; PointsY[ip]=y; ip++;
+  // 4th Step:
+  Double_t a = Lx  - b - R * TMath::Sin(AngleInner) - R * TMath::Sin(AngleOuter);
+  x = Lx; 
+  y-= a * TMath::Tan(AngleOuter);
+  PointsX[ip]=x; PointsY[ip]=y; ip++;
+  // 5th Step:
+  x =  Lx;
+  y = -Ly;
+  PointsX[ip]=x; PointsY[ip]=y; ip++;
+  // 6th Step:
+  x =   LxV;
+  y =   -Ly;
+  PointsX[ip]=x; PointsY[ip]=y; ip++;
+  // 7th Step:
+  x =   LxV;
+  y =   0.0;
+  PointsX[ip]=x; PointsY[ip]=y; ip++;
+  // 
+  //
+  //
+  TGeoXtru * shPolygon = new TGeoXtru(2);
+  shPolygon->SetNameTitle("shPolygon","shPolygon");
+  shPolygon->DefinePolygon(npoints,PointsX,PointsY);
+  shPolygon->DefineSection(0, -dz, 0., 0., 1.0); // index, Z position, offset (x,y) and scale for first section
+  shPolygon->DefineSection(1, +dz, 0., 0., 1.0); // idem, second section
+
+  TGeoCompositeShape * shCoilSupportV = new TGeoCompositeShape("shCoilSupportV", "shPolygon+shPolygonArc:trPolygonArc");
+  TGeoVolume * voCoilSupportV = new TGeoVolume("voCoilSupportV", shCoilSupportV, kMedAlu);
+  
+  const Double_t MagCoilDx = 12.64/2.;
+  const Double_t MagCoilDy = 21.46/2.;
+  const Double_t SqOuterDx = MagCoilDx + 2.8;
+  const Double_t SqInnerDx = MagCoilDx + 0.6;
+  const Double_t SqOuterDy =  29.2/2.;
+  const Double_t SqInnerDy =  24.8/2.;
+  const Double_t SqOuterDz =  15.5/2.;
+  const Double_t SqInnerDz = SqOuterDz * 2.;
+  TGeoBBox * shCoilSupportSqOuter = new TGeoBBox("shCoilSupportSqOuter", SqOuterDx, SqOuterDy, SqOuterDz);
+  TGeoBBox * shCoilSupportSqInner = new TGeoBBox("shCoilSupportSqInner", SqInnerDx, SqInnerDy, SqInnerDz);
+  TGeoCompositeShape * shCoilSupportSq = new TGeoCompositeShape("shCoilSupportSq", "shCoilSupportSqOuter - shCoilSupportSqInner");
+  TGeoVolume * voCoilSupportSq = new TGeoVolume("voCoilSupportSq", shCoilSupportSq, kMedAlu);
+
+  const Double_t HSuppDx = (Lx - LxV + 0.6)/2.0;
+  const Double_t HSuppDy = 2.2/2.0;
+  const Double_t HSuppDz = SqOuterDz; 
+
+  TGeoVolume * voCoilSupportH = gGeoManager -> MakeBox("voCoilSupportH", kMedAlu, HSuppDx, HSuppDy, HSuppDz);
+  
+  TGeoVolumeAssembly * voCoilSupport = new TGeoVolumeAssembly("voCoilSupport");
+  voCoilSupportV  -> SetLineColor(kViolet+9);
+  voCoilSupportSq -> SetLineColor(kBlue-5);
+  voCoilSupportH  -> SetLineColor(kPink);
+  // voCoilSupportH  -> SetTransparency(16);
+  voCoilSupport->AddNode(voCoilSupportV  , 1 , new TGeoTranslation(SqOuterDx - LxV     , SqOuterDy                , 0. )); 
+  voCoilSupport->AddNode(voCoilSupportSq , 1 , new TGeoTranslation(0.                  , 0.                       , 0. )); 
+  voCoilSupport->AddNode(voCoilSupportH  , 1 , new TGeoTranslation(SqOuterDx + HSuppDx , SqOuterDy - Ly - HSuppDy , 0. )); 
+
+  // Make the Top Support for Geodesic reference points:
+  TGeoVolume * voSupportHTop = gGeoManager -> MakeBox("voSupportHTop", kMedAlu, 66.0/2.0,   2.0/2.0, 17.0/2.0);
+  TGeoVolume * voSupportHBot = gGeoManager -> MakeBox("voSupportHBot", kMedAlu, 14.0/2.0,   2.0/2.0, 17.0/2.0);
+  TGeoVolume * voSupportVert = gGeoManager -> MakeBox("voSupportVert", kMedAlu,  3.0/2.0,  25.0/2.0, 17.0/2.0);
+
+  TGeoVolumeAssembly * voSupportGeoRefPoint = new TGeoVolumeAssembly("voSupportGeoRefPoint");
+  voSupportHTop -> SetLineColor(kGreen);
+  voSupportHBot -> SetLineColor(kGreen);
+  voSupportVert -> SetLineColor(kGreen);
+  voSupportGeoRefPoint -> AddNode( voSupportHTop , 1 , new TGeoTranslation(  0.0 , 28.0 , 0. )); 
+  voSupportGeoRefPoint -> AddNode( voSupportHBot , 1 , new TGeoTranslation(+33.0 ,  1.0 , 0. )); 
+  voSupportGeoRefPoint -> AddNode( voSupportHBot , 2 , new TGeoTranslation(-33.0 ,  1.0 , 0. )); 
+  voSupportGeoRefPoint -> AddNode( voSupportVert , 1 , new TGeoTranslation(+31.5 , 14.5 , 0. )); 
+  voSupportGeoRefPoint -> AddNode( voSupportVert , 2 , new TGeoTranslation(-31.5 , 14.5 , 0. )); 
+
+  // Add some color:
+  voMagnetYoke  -> SetLineColor(kAzure-7);
+  voCoilH       -> SetLineColor(kOrange-3);
+  voCoilV       -> SetLineColor(kOrange-3);
+  // Assembling:
+  
+  voMagnet -> AddNode(voMagnetYoke         , 1 , new TGeoTranslation(0.     , 0.     ,    0.0 )); 
+  voMagnet -> AddNode(voCoilH              , 1 , new TGeoTranslation(+16.14 , +29.83 ,    0.0 )); 
+  voMagnet -> AddNode(voCoilH              , 2 , new TGeoTranslation(-16.14 , +29.83 ,    0.0 )); 
+  voMagnet -> AddNode(voCoilH              , 3 , new TGeoTranslation(+16.14 , -27.43 ,    0.0 )); 
+  voMagnet -> AddNode(voCoilH              , 4 , new TGeoTranslation(-16.14 , -27.43 ,    0.0 )); 
+  voMagnet -> AddNode(voCoilV              , 1 , new TGeoTranslation(+16.14 , 1.20   , +141.8 )); 
+  voMagnet -> AddNode(voCoilV              , 2 , new TGeoTranslation(-16.14 , 1.20   , +141.8 )); 
+  voMagnet -> AddNode(voCoilV              , 3 , new TGeoTranslation(+16.14 , 1.20   , -141.8 )); 
+  voMagnet -> AddNode(voCoilV              , 4 , new TGeoTranslation(-16.14 , 1.20   , -141.8 )); 
+  Double_t zGeoRef = 74.0/2. + SqOuterDz + 9.0 + 17.0/2.0;
+  voMagnet -> AddNode(voSupportGeoRefPoint , 1 , new TGeoTranslation( 0.    , 16.0   , +zGeoRef)); 
+  voMagnet -> AddNode(voSupportGeoRefPoint , 2 , new TGeoTranslation( 0.    , 16.0   , -zGeoRef)); 
+  Double_t zCoilSupp  = 29.83 - MagCoilDy -0.6 + SqInnerDy;
+  voMagnet -> AddNode(voCoilSupport        , 1 , new TGeoTranslation(+16.14 , zCoilSupp ,   74.0*0.5 )); 
+  voMagnet -> AddNode(voCoilSupport        , 2 , new TGeoTranslation(+16.14 , zCoilSupp ,  -74.0*0.5 )); 
+  voMagnet -> AddNode(voCoilSupport        , 3 , new TGeoTranslation(+16.14 , zCoilSupp ,   74.0*1.5 )); 
+  voMagnet -> AddNode(voCoilSupport        , 4 , new TGeoTranslation(+16.14 , zCoilSupp ,  -74.0*1.5 )); 
+  // 
+  voMagnet -> AddNode(voCoilSupport        , 5 , new TGeoCombiTrans (-16.14 , zCoilSupp ,   74.0*0.5, Ry180)); 
+  voMagnet -> AddNode(voCoilSupport        , 6 , new TGeoCombiTrans (-16.14 , zCoilSupp ,  -74.0*0.5, Ry180)); 
+  voMagnet -> AddNode(voCoilSupport        , 7 , new TGeoCombiTrans (-16.14 , zCoilSupp ,   74.0*1.5, Ry180)); 
+  voMagnet -> AddNode(voCoilSupport        , 8 , new TGeoCombiTrans (-16.14 , zCoilSupp ,  -74.0*1.5, Ry180)); 
+
+  return (TGeoVolume*) voMagnet;
+
+/*
+  // TGeoVolumeAssembly * voMagnet = new TGeoVolumeAssembly("voMagnet");
+  new TGeoBBox("shMagnetYokeOuter"   , 116.4/2.0 , 90.2/2.0 , 250.0/2.0 ); 
+  new TGeoBBox("shMagnetYokeInnerUp" ,   8.0/2.0 , 32.2/2.0 , 250.0/1.0  ); 
+  new TGeoBBox("shMagnetYokeInnerDw" ,  46.0/2.0 , 23.0/2.0 , 250.0/1.0  ); 
+  (new TGeoTranslation("trMagnetYokeOuter"  ,  0.0, -29.1, 0.0)) -> RegisterYourself();
+  (new TGeoTranslation("trMagnetYokeInnerUp",  0.0,   0.0, 0.0)) -> RegisterYourself();
+  (new TGeoTranslation("trMagnetYokeInnerDw",  0.0, -27.5, 0.0)) -> RegisterYourself();
+
+  TGeoCompositeShape * shMagnetYoke = new TGeoCompositeShape("shMagnet", "shMagnetYokeOuter:trMagnetYokeOuter-(shMagnetYokeInnerUp:trMagnetYokeInnerUp+shMagnetYokeInnerDw:trMagnetYokeInnerDw)");
+  TGeoVolume * voMagnetYoke = new TGeoVolume("voMagnetYoke", shMagnetYoke, kMedIron   );
+
+  // Make the coils:
+  TGeoVolume * voCoilH = gGeoManager -> MakeBox("voCoilH", kMedCooper, 12.64/2.0,  21.46/2.0, 310.5/2.0);
+  TGeoVolume * voCoilV = gGeoManager -> MakeBox("voCoilV", kMedCooper, 12.64/2.0,  35.80/2.0,  26.9/2.0);
+
+  // Add some color:
+  voMagnetYoke -> SetLineColor(kAzure-7);
+  voCoilH      -> SetLineColor(kOrange-3);
+  voCoilV      -> SetLineColor(kOrange-3);
+  // Assembling:
+  
+  voMagnet -> AddNode(voMagnetYoke, 1, new TGeoTranslation(0., 0., 0.));
+  voMagnet -> AddNode(voCoilH,      1, new TGeoTranslation(+16.14,+29.83,   0.0));
+  voMagnet -> AddNode(voCoilH,      2, new TGeoTranslation(-16.14,+29.83,   0.0));
+  voMagnet -> AddNode(voCoilH,      3, new TGeoTranslation(+16.14,-27.43,   0.0));
+  voMagnet -> AddNode(voCoilH,      4, new TGeoTranslation(-16.14,-27.43,   0.0));
+  voMagnet -> AddNode(voCoilV,      1, new TGeoTranslation(+16.14,  1.20,+141.8));
+  voMagnet -> AddNode(voCoilV,      2, new TGeoTranslation(-16.14,  1.20,+141.8));
+  voMagnet -> AddNode(voCoilV,      3, new TGeoTranslation(+16.14,  1.20,-141.8));
+  voMagnet -> AddNode(voCoilV,      4, new TGeoTranslation(-16.14,  1.20,-141.8));
+
+  return (TGeoVolume*) voMagnet;
+*/
+}
 
 //_____________________________________________________________________________
 void AliDIPOv2::CreateMaterials()

--- a/STRUCT/AliDIPOv2.h
+++ b/STRUCT/AliDIPOv2.h
@@ -10,6 +10,7 @@
 /////////////////////////////////////////////////
  
 #include "AliDIPO.h"
+class TGeoVolume;
   
 class AliDIPOv2 : public AliDIPO {
   
@@ -23,6 +24,7 @@ public:
  private:
   virtual void  CreateSpectrometerDipole();
   virtual void  CreateCompensatorDipole();
+  TGeoVolume *  CreateMagnetYoke();
   
   ClassDef(AliDIPOv2,1)  //Class manager for magnetic dipole version 2
 };

--- a/STRUCT/AliPIPEv3.cxx
+++ b/STRUCT/AliPIPEv3.cxx
@@ -35,6 +35,7 @@
 #include <TGeoTube.h>
 #include <TGeoVolume.h>
 #include <TGeoXtru.h>
+#include <TGeoEltu.h>
 #include <TSystem.h>
 #include <TVirtualMC.h>
 
@@ -43,2668 +44,2674 @@
 #include "AliPIPEv3.h"
 #include "AliRun.h"
 #include "AliLog.h"
- 
+
 ClassImp(AliPIPEv3)
 
- 
-//_____________________________________________________________________________
-AliPIPEv3::AliPIPEv3() : fBeamBackground(0)
+
+  //_____________________________________________________________________________
+  AliPIPEv3::AliPIPEv3() : fBeamBackground(0)
 {
-// Constructor
+  // Constructor
 }
 
 //_____________________________________________________________________________
-AliPIPEv3::AliPIPEv3(const char *name, const char *title)
+  AliPIPEv3::AliPIPEv3(const char *name, const char *title)
   : AliPIPE(name,title), fBeamBackground(0)
 {
-// Constructor
+  // Constructor
 }
 
- 
+
 //___________________________________________
 void AliPIPEv3::CreateGeometry()
 {
-//
-//  Method describing the beam pipe geometry
-//
-    AliDebug(1,"Create PIPEv3 geometry");
-    Float_t dz, z, zsh, z0;
-//
-// Rotation Matrices
-//
-    const Float_t  kDegRad = TMath::Pi() / 180.;
-// Rotation by 180 deg
-    TGeoRotation* rot180        = new TGeoRotation("rot180", 90., 180.,  90.,  90., 180.,   0.);
-    TGeoRotation* rotyz         = new TGeoRotation("rotyz",  90., 180.,   0., 180.,  90.,  90.);
-    TGeoRotation* rotxz         = new TGeoRotation("rotxz",   0.,   0.,  90.,  90.,  90., 180.);
-    TGeoRotation* rot045        = new TGeoRotation("rot045", 90.,  45.,  90., 135.,   0.,   0.);
-    TGeoRotation* rot135        = new TGeoRotation("rot135", 90. ,135.,  90., 225.,   0.,   0.);
-    TGeoRotation* rot225        = new TGeoRotation("rot225", 90. ,225.,  90., 315.,   0.,   0.);
-    TGeoRotation* rot315        = new TGeoRotation("rot315", 90. ,315.,  90.,  45.,   0.,   0.);    
-//
-// Media
-    const TGeoMedium* kMedAir     =  gGeoManager->GetMedium("PIPE_AIR1");
-    const TGeoMedium* kMedAirH    =  gGeoManager->GetMedium("PIPE_AIR2");
-    const TGeoMedium* kMedAirHigh =  gGeoManager->GetMedium("PIPE_AIR_HIGH");
+  //
+  //  Method describing the beam pipe geometry
+  //
+  AliDebug(1,"Create PIPEv3 geometry");
+  Float_t dz, z, zsh, z0;
+  //
+  // Rotation Matrices
+  //
+  const Float_t  kDegRad = TMath::Pi() / 180.;
+  // Rotation by 180 deg
+  TGeoRotation* rot180        = new TGeoRotation("rot180", 90., 180.,  90.,  90., 180.,   0.);
+  TGeoRotation* rotyz         = new TGeoRotation("rotyz",  90., 180.,   0., 180.,  90.,  90.);
+  TGeoRotation* rotxz         = new TGeoRotation("rotxz",   0.,   0.,  90.,  90.,  90., 180.);
+  TGeoRotation* rot045        = new TGeoRotation("rot045", 90.,  45.,  90., 135.,   0.,   0.);
+  TGeoRotation* rot135        = new TGeoRotation("rot135", 90. ,135.,  90., 225.,   0.,   0.);
+  TGeoRotation* rot225        = new TGeoRotation("rot225", 90. ,225.,  90., 315.,   0.,   0.);
+  TGeoRotation* rot315        = new TGeoRotation("rot315", 90. ,315.,  90.,  45.,   0.,   0.);    
+  //
+  // Media
+  const TGeoMedium* kMedAir     =  gGeoManager->GetMedium("PIPE_AIR1");
+  const TGeoMedium* kMedAirH    =  gGeoManager->GetMedium("PIPE_AIR2");
+  const TGeoMedium* kMedAirHigh =  gGeoManager->GetMedium("PIPE_AIR_HIGH");
 
-    const TGeoMedium* kMedVac     =  gGeoManager->GetMedium("PIPE_VACUUM1");    
-    const TGeoMedium* kMedVacH    =  gGeoManager->GetMedium("PIPE_VACUUM2");    
-    const TGeoMedium* kMedVacM    =  gGeoManager->GetMedium("PIPE_VACUUMM");    
+  const TGeoMedium* kMedVac     =  gGeoManager->GetMedium("PIPE_VACUUM1");    
+  const TGeoMedium* kMedVacH    =  gGeoManager->GetMedium("PIPE_VACUUM2");    
+  const TGeoMedium* kMedVacM    =  gGeoManager->GetMedium("PIPE_VACUUMM");    
 
-    const TGeoMedium* kMedInsu    =  gGeoManager->GetMedium("PIPE_INS_C0");    
-    const TGeoMedium* kMedInsuH   =  gGeoManager->GetMedium("PIPE_INS_C2");    
+  const TGeoMedium* kMedInsu    =  gGeoManager->GetMedium("PIPE_INS_C0");    
+  const TGeoMedium* kMedInsuH   =  gGeoManager->GetMedium("PIPE_INS_C2");    
 
-    const TGeoMedium* kMedSteel   =  gGeoManager->GetMedium("PIPE_INOX1");        
-    const TGeoMedium* kMedSteelH  =  gGeoManager->GetMedium("PIPE_INOX2");        
+  const TGeoMedium* kMedSteel   =  gGeoManager->GetMedium("PIPE_INOX1");        
+  const TGeoMedium* kMedSteelH  =  gGeoManager->GetMedium("PIPE_INOX2");        
 
-    const TGeoMedium* kMedBe      =  gGeoManager->GetMedium("PIPE_BE1"); 
-    const TGeoMedium* kMedBeH     =  gGeoManager->GetMedium("PIPE_BE2"); 
-      
-    const TGeoMedium* kMedCu      =  gGeoManager->GetMedium("PIPE_CU1");        
-    const TGeoMedium* kMedCuH     =  gGeoManager->GetMedium("PIPE_CU2");        
-    
-    const TGeoMedium* kMedKapton  =  gGeoManager->GetMedium("PIPE_KAPTON1");   
-    const TGeoMedium* kMedKaptonH =  gGeoManager->GetMedium("PIPE_KAPTON2");   
- 
-    const TGeoMedium* kMedAco     =  gGeoManager->GetMedium("PIPE_ANTICORODAL1");        
-    const TGeoMedium* kMedAcoH    =  gGeoManager->GetMedium("PIPE_ANTICORODAL2");        
+  const TGeoMedium* kMedBe      =  gGeoManager->GetMedium("PIPE_BE1"); 
+  const TGeoMedium* kMedBeH     =  gGeoManager->GetMedium("PIPE_BE2"); 
 
-    const TGeoMedium* kMedNEG      =  gGeoManager->GetMedium("PIPE_NEG COATING1"); 
-    const TGeoMedium* kMedNEGH     =  gGeoManager->GetMedium("PIPE_NEG COATING2"); 
-       
-// Top volume
-    TGeoVolume* top    = gGeoManager->GetVolume("ALIC");
-//
-//
-////////////////////////////////////////////////////////////////////////////////     
-//                                                                            //
-//                                  The Central Vacuum system                 // 
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
-//
-//
-//  The ALICE central beam-pipe according to drawing         LHCVC2C_0001 
-//  Drawings of sub-elements:
-//  
-//  Pos 7 - Minimised Flange:                                LHCVFX_P0025
-//  Pos 6 - Standard Flange:                                 STDVFUHV0009
-//  Pos 8 - Bellow:                                          LHCVBX__0001
-//
-//  Absolute z-coordinates -82.0 - 400.0 cm 
-//  Total length:                                          482.0 cm
-//  It consists of 3 main parts:
-//  CP/2 The flange on the non-absorber side:               36.5 cm  
-//  CP/1 The central Be pipe:                              405.0 cm 
-//  CP/3 The double-bellow and flange on the absorber side: 40.5 cm 
-//
-//
+  const TGeoMedium* kMedCu      =  gGeoManager->GetMedium("PIPE_CU1");        
+  const TGeoMedium* kMedCuH     =  gGeoManager->GetMedium("PIPE_CU2");        
 
-//
-//
-//  Starting position in z
-    const Float_t kCPz0      = -400.0;
-//  Length of the CP/1 section
-    const Float_t kCP1Length =  405.0;    
-//  Length of the CP/2 section    
-    const Float_t kCP2Length =   36.5;
-//  Length of the CP/3 section    
-    const Float_t kCP3Length =   40.5;
-//  Position of the CP/2 section    
-//    const Float_t kCP2pos    = kCPz0 + kCP2Length / 2.;
-//  Position of the CP/3 section
-    const Float_t kCP3pos    = kCPz0 + kCP2Length + kCP1Length + kCP3Length/2.;
+  const TGeoMedium* kMedKapton  =  gGeoManager->GetMedium("PIPE_KAPTON1");   
+  const TGeoMedium* kMedKaptonH =  gGeoManager->GetMedium("PIPE_KAPTON2");   
 
+  const TGeoMedium* kMedAco     =  gGeoManager->GetMedium("PIPE_ANTICORODAL1");        
+  const TGeoMedium* kMedAcoH    =  gGeoManager->GetMedium("PIPE_ANTICORODAL2");        
 
-///////////////////
-//      CP/1     //
-///////////////////
-//  Inner and outer radii of the Be-section [Pos 1]
-    const Float_t kCP1NegRo                      = 2.90 + 0.0002;
-    const Float_t kCP1BeRi                       = 2.90;
-    const Float_t kCP1BeRo                       = 2.98;
-    const Float_t kCP1KaRo                       = 2.99;    
-//
-// Be-Stainless Steel adaptor tube [Pos 2] at both ends of the Be-section. Length 5 cm
-    const Float_t kCP1BeStAdaptorLength          = 5.00;
-//
-// Bulge of the Be-Stainless Steel adaptor Tube [Pos 2]
-    const Float_t kCP1BeStRo                     = 3.05;
-//
-//  Length of bulge [Pos 2]
-    const Float_t kCP1BulgeLength                = 0.50;
-//
-//  Distance between bulges [Pos 2]
-    const Float_t kCP1BulgeBulgeDistance         = 1.00;
-//
-// Length of Be-pipe
-    const Float_t kCP1BeLength =  kCP1Length - 2. *  kCP1BeStAdaptorLength;
+  const TGeoMedium* kMedNEG      =  gGeoManager->GetMedium("PIPE_NEG COATING1"); 
+  const TGeoMedium* kMedNEGH     =  gGeoManager->GetMedium("PIPE_NEG COATING2"); 
 
-//    
-// CP/1 Mother volume 
-    TGeoVolume* voCp1Mo = new TGeoVolume("CP1MO", 
-					 new TGeoTube(0., kCP1BeStRo,  kCP1Length / 2.), 
-					 kMedAir);
-    voCp1Mo->SetVisibility(0);
-    
-/////////////////////////////////////////////
-// CP/1 Be-Section                         //
-/////////////////////////////////////////////
-    TGeoVolume* voCp1Vac = new TGeoVolume("CP1VAC", 
-					  new TGeoTube(0., kCP1BeRi,  kCP1BeLength / 2.), 
-					  kMedVac);
-    TGeoVolume* voCp1Be  = new TGeoVolume("CP1BE", 
-					  new TGeoTube(0., kCP1BeRo,  kCP1BeLength / 2.), 
-					  kMedBe);
-    // Outer Kapton foil
-    TGeoVolume* voCp1Ka  = new TGeoVolume("CP1KA", 
-					  new TGeoTube(0., kCP1KaRo,  kCP1BeLength / 2.), 
-					  kMedKapton);
-    // Inner NEG coating
-    TGeoVolume* voCp1NEG = new TGeoVolume("CP1NEG", 
-					  new TGeoTube(kCP1BeRi, kCP1NegRo, kCP1BeLength / 2.), 
-					  kMedNEG);
+  // Top volume
+  TGeoVolume* top    = gGeoManager->GetVolume("ALIC");
+  //
+  //
+  ////////////////////////////////////////////////////////////////////////////////     
+  //                                                                            //
+  //                                  The Central Vacuum system                 // 
+  //                                                                            //
+  ////////////////////////////////////////////////////////////////////////////////
+  //
+  //
+  //  The ALICE central beam-pipe according to drawing         LHCVC2C_0001 
+  //  Drawings of sub-elements:
+  //  
+  //  Pos 7 - Minimised Flange:                                LHCVFX_P0025
+  //  Pos 6 - Standard Flange:                                 STDVFUHV0009
+  //  Pos 8 - Bellow:                                          LHCVBX__0001
+  //
+  //  Absolute z-coordinates -82.0 - 400.0 cm 
+  //  Total length:                                          482.0 cm
+  //  It consists of 3 main parts:
+  //  CP/2 The flange on the non-absorber side:               36.5 cm  
+  //  CP/1 The central Be pipe:                              405.0 cm 
+  //  CP/3 The double-bellow and flange on the absorber side: 40.5 cm 
+  //
+  //
 
-    voCp1Ka->AddNode(voCp1Be,  1, gGeoIdentity);
-    voCp1Be->AddNode(voCp1Vac, 1, gGeoIdentity);
-    voCp1Be->AddNode(voCp1NEG, 1, gGeoIdentity);
-    voCp1Mo->AddNode(voCp1Ka,  1, gGeoIdentity);
-
-/////////////////////////////////////////////
-// CP/1 Be-Stainless Steel adaptor tube    //
-/////////////////////////////////////////////
-    TGeoPcon* shCp1At = new TGeoPcon(0., 360., 8);
-//  First Bulge 
-    z = - kCP1BeStAdaptorLength / 2.;
-    shCp1At->DefineSection(0, z, 0., kCP1BeStRo);
-    z += kCP1BulgeLength;
-    shCp1At->DefineSection(1, z, 0., kCP1BeStRo);
-    shCp1At->DefineSection(2, z, 0., kCP1BeRo);
-//  Between the bulges
-    z += kCP1BulgeBulgeDistance;
-    shCp1At->DefineSection(3, z, 0., kCP1BeRo);
-    shCp1At->DefineSection(4, z, 0., kCP1BeStRo);
-//  Second bulge
-    z += kCP1BulgeLength;
-    shCp1At->DefineSection(5, z, 0., kCP1BeStRo);
-    shCp1At->DefineSection(6, z, 0., kCP1BeRo);
-//  Straight piece
-    z = kCP1BeStAdaptorLength / 2.;
-    shCp1At->DefineSection(7, z, 0., kCP1BeRo);
-//
-    TGeoVolume* voCp1At  = new TGeoVolume("CP1AT",  shCp1At, kMedSteel);
-    TGeoVolume* voCp1AtV = new TGeoVolume("CP1ATV", new TGeoTube(0., kCP1BeRi, kCP1BeStAdaptorLength / 2.), kMedVac);
-    voCp1At->AddNode(voCp1AtV, 1, gGeoIdentity);
-    
-//  Position adaptor tube at both ends
-    dz = kCP1Length / 2. -  kCP1BeStAdaptorLength / 2.;
-    voCp1Mo->AddNode(voCp1At,    1, new TGeoTranslation(0., 0., -dz));
-    voCp1Mo->AddNode(voCp1At,    2, new TGeoCombiTrans(0., 0.,  dz, rot180));
-    TGeoVolumeAssembly* voCp1 = new TGeoVolumeAssembly("Cp1");
-    voCp1->AddNode(voCp1Mo, 1, gGeoIdentity);
-    
-//
-///////////////////
-//      CP/2     //
-///////////////////
-//
-// Fixed Point tube [Pos 5]
-//
-// Inner and outer radii of the Stainless Steel pipe    
-    const Float_t kCP2StRi               =      2.90;
-    const Float_t kCP2StRo               =      2.98;
-//  
-// Transition to central Be-pipe (Bulge)   
-// Length
-    const Float_t kCP2BulgeLength        =      0.80;
-//     
-// Bulge outer radius
-    const Float_t kCP2BulgeRo            =      3.05;
-//
-// Fixed Point at z = 391.7 (IP)
-//
-// Position of fixed point
-    const Float_t kCP2FixedPointZ        =      8.30;
-//
-// Outer radius of fixed point
-    const Float_t kCP2FixedPointRo       =      3.50;
-//
-// Length of fixed point
-    const Float_t kCP2FixedPointLength   =      0.60;
-//
-// Fixed Flange [Pos 6]    
-//
-// Fixed flange outer radius
-    const Float_t kCP2FixedFlangeRo      =      7.60;
-//
-// Fixed flange inner radius
-    const Float_t kCP2FixedFlangeRi      =      3.00;
-// Fixed flange inner radius bulge
-    const Float_t kCP2FixedFlangeBulgeRi =      2.90;
-// Fixed flange lengths of sections at inner radius
-    const Float_t kCP2FixedFlangeRecessLengths[3] ={1., 0.08, 0.9};
-// Fixed flange length
-    const Float_t kCP2FixedFlangeLength =       1.98;
-//
-// Fixed flange bulge
-// Outer radius
-     const Float_t kCP2FixedFlangeBulgeRo =     3.00;
-//
-// Length    
-     const Float_t kCP2FixedFlangeBulgeLength = 2.00;
-
-//
-// CP/2 Mother Volume
-//
-    TGeoPcon* shCp2Mo = new TGeoPcon(0., 360., 14);
-//  Flange
-    z = - kCP2Length / 2.;
-    shCp2Mo->DefineSection( 0, z, kCP2FixedFlangeRi, kCP2FixedFlangeRo);
-    z +=  kCP2FixedFlangeRecessLengths[0];
-    shCp2Mo->DefineSection( 1, z, kCP2FixedFlangeRi, kCP2FixedFlangeRo);
-    shCp2Mo->DefineSection( 2, z, 0.,                kCP2FixedFlangeRo);
-    z +=  (kCP2FixedFlangeRecessLengths[1] + kCP2FixedFlangeRecessLengths[2]) ;
-    shCp2Mo->DefineSection( 3, z, 0., kCP2FixedFlangeRo);
-//  Straight section between Flange and Fixed Point
-    shCp2Mo->DefineSection( 4, z, 0., kCP2FixedFlangeBulgeRo);
-    z += kCP2FixedFlangeBulgeLength;
-    shCp2Mo->DefineSection( 5, z, 0., kCP2FixedFlangeBulgeRo);
-    shCp2Mo->DefineSection( 6, z, 0., kCP2StRo);
-    z =  - kCP2Length / 2 +  kCP2FixedPointZ - kCP2FixedPointLength / 2.;
-    shCp2Mo->DefineSection( 7, z, 0., kCP2StRo);
-//  Fixed Point
-    shCp2Mo->DefineSection( 8, z, 0., kCP2FixedPointRo);
-    z +=  kCP2FixedPointLength;
-    shCp2Mo->DefineSection( 9, z, 0., kCP2FixedPointRo);
-//  Straight section between Fixed Point and transition bulge
-    shCp2Mo->DefineSection(10, z, 0., kCP2StRo);
-    z  =  kCP2Length / 2. - kCP2BulgeLength;
-    shCp2Mo->DefineSection(11, z, 0., kCP2StRo);
-    shCp2Mo->DefineSection(12, z, 0., kCP2BulgeRo);
-    z = kCP2Length / 2.;
-    shCp2Mo->DefineSection(13, z, 0., kCP2BulgeRo);
-    
-    TGeoVolume* voCp2Mo = new TGeoVolume("CP2MO", shCp2Mo, kMedAir);
-    voCp2Mo->SetVisibility(0);
-//
-// CP/1 Vacuum
-    TGeoTube*   shCp2Va = new TGeoTube(0., kCP2StRi, (kCP2Length - kCP2FixedFlangeRecessLengths[0])/2.);
-    TGeoVolume* voCp2Va = new TGeoVolume("CP2VA", shCp2Va, kMedVac);
-    
-    voCp2Mo->AddNode(voCp2Va, 1, new TGeoTranslation(0., 0., kCP2FixedFlangeRecessLengths[0]/2.));
-    
-/////////////////////////////////////////////
-//  CP/2 Fixed Flange [Pos 6]              //
-/////////////////////////////////////////////
-
-    TGeoPcon* shCp2Fl = new TGeoPcon(0., 360., 6);
-    z = - kCP2FixedFlangeLength / 2.;
-    shCp2Fl->DefineSection(0, z, kCP2FixedFlangeRi,      kCP2FixedFlangeRo);
-    z +=  kCP2FixedFlangeRecessLengths[0];
-    shCp2Fl->DefineSection(1, z, kCP2FixedFlangeRi,      kCP2FixedFlangeRo);
-    shCp2Fl->DefineSection(2, z, kCP2FixedFlangeBulgeRi, kCP2FixedFlangeRo);
-    z +=  kCP2FixedFlangeRecessLengths[1];
-    shCp2Fl->DefineSection(3, z, kCP2FixedFlangeBulgeRi, kCP2FixedFlangeRo);
-    shCp2Fl->DefineSection(4, z, kCP2FixedFlangeRi,      kCP2FixedFlangeRo);
-    z = kCP2FixedFlangeLength / 2.;
-    shCp2Fl->DefineSection(5, z, kCP2FixedFlangeRi,      kCP2FixedFlangeRo);
-    TGeoVolume* voCp2Fl = new TGeoVolume("CP2FL", shCp2Fl, kMedSteel);
-// 
-    dz =  - kCP2Length / 2. +  kCP2FixedFlangeLength / 2.;
-    voCp2Mo->AddNode(voCp2Fl, 1, new TGeoTranslation(0., 0., dz));
+  //
+  //
+  //  Starting position in z
+  const Float_t kCPz0      = -400.0;
+  //  Length of the CP/1 section
+  const Float_t kCP1Length =  405.0;    
+  //  Length of the CP/2 section    
+  const Float_t kCP2Length =   36.5;
+  //  Length of the CP/3 section    
+  const Float_t kCP3Length =   40.5;
+  //  Position of the CP/2 section    
+  //    const Float_t kCP2pos    = kCPz0 + kCP2Length / 2.;
+  //  Position of the CP/3 section
+  const Float_t kCP3pos    = kCPz0 + kCP2Length + kCP1Length + kCP3Length/2.;
 
 
-/////////////////////////////////////////////////////////////
-//  CP/2 Beam pipe with fixed point and transition bulges  //
-/////////////////////////////////////////////////////////////
-    TGeoPcon* shCp2Pi = new TGeoPcon(0., 360., 10);
-//  Bulge at transition to flange 
-    z =  - (kCP2Length -  kCP2FixedFlangeRecessLengths[0] - kCP2FixedFlangeRecessLengths[1]) / 2.;
-    z0 = z;
-    shCp2Pi->DefineSection(0, z, kCP2StRi, kCP2FixedFlangeBulgeRo);
-    z += kCP2FixedFlangeBulgeLength;
-    shCp2Pi->DefineSection(1, z, kCP2StRi, kCP2FixedFlangeBulgeRo);
-//  Straight section between Bulge and Fixed Point
-    shCp2Pi->DefineSection(2, z, kCP2StRi, kCP2StRo);
-    z  += (kCP2FixedPointZ - kCP2FixedPointLength / 2. - kCP2FixedFlangeRecessLengths[0]
-	   - kCP2FixedFlangeRecessLengths[1] - 
-	kCP2FixedFlangeBulgeLength);
-    shCp2Pi->DefineSection(3, z, kCP2StRi, kCP2StRo);
-//  Fixed Point
-    shCp2Pi->DefineSection(4, z, kCP2StRi, kCP2FixedPointRo);
-    z +=  kCP2FixedPointLength;
-    shCp2Pi->DefineSection(5, z, kCP2StRi, kCP2FixedPointRo);
-//  Straight section between Fixed Point and transition bulge
-    shCp2Pi->DefineSection(6, z, kCP2StRi, kCP2StRo);
-    z = - shCp2Pi->GetZ(0) - kCP2BulgeLength;
-    shCp2Pi->DefineSection(7, z, kCP2StRi, kCP2StRo);
-//  Bulge at transition to Be pipe
-    shCp2Pi->DefineSection(8, z, kCP2StRi, kCP2BulgeRo);
-    z = - shCp2Pi->GetZ(0);
-    shCp2Pi->DefineSection(9, z, kCP2StRi, kCP2BulgeRo);
+  ///////////////////
+  //      CP/1     //
+  ///////////////////
+  //  Inner and outer radii of the Be-section [Pos 1]
+  const Float_t kCP1NegRo                      = 2.90 + 0.0002;
+  const Float_t kCP1BeRi                       = 2.90;
+  const Float_t kCP1BeRo                       = 2.98;
+  const Float_t kCP1KaRo                       = 2.99;    
+  //
+  // Be-Stainless Steel adaptor tube [Pos 2] at both ends of the Be-section. Length 5 cm
+  const Float_t kCP1BeStAdaptorLength          = 5.00;
+  //
+  // Bulge of the Be-Stainless Steel adaptor Tube [Pos 2]
+  const Float_t kCP1BeStRo                     = 3.05;
+  //
+  //  Length of bulge [Pos 2]
+  const Float_t kCP1BulgeLength                = 0.50;
+  //
+  //  Distance between bulges [Pos 2]
+  const Float_t kCP1BulgeBulgeDistance         = 1.00;
+  //
+  // Length of Be-pipe
+  const Float_t kCP1BeLength =  kCP1Length - 2. *  kCP1BeStAdaptorLength;
 
-    TGeoVolume* voCp2Pi = new TGeoVolume("CP2PI", shCp2Pi, kMedSteel);
-    dz = (kCP2FixedFlangeRecessLengths[0] + kCP2FixedFlangeRecessLengths[1]) / 2.;
-    voCp2Mo->AddNode(voCp2Pi, 1, new TGeoTranslation(0., 0., dz));
+  //    
+  // CP/1 Mother volume 
+  TGeoVolume* voCp1Mo = new TGeoVolume("CP1MO", 
+      new TGeoTube(0., kCP1BeStRo,  kCP1Length / 2.), 
+      kMedAir);
+  voCp1Mo->SetVisibility(0);
 
-//
-//  Central beam pipe support collars
-//  LHCVC2C_0019
-//  cp1l = 405.
-//  Position at z = -46., 40., 150.
-    TGeoVolume* voCpSupC = new TGeoVolume("CpSupC", new TGeoTube(3.051, 4.00, 0.35), kMedAco);
-    voCp1->AddNode(voCpSupC, 1, new TGeoTranslation(0., 0.,  kCP1Length / 2. - 98.2 - 34.77 + 0.49));
-//    voCp1->AddNode(voCpSupC, 2, new TGeoTranslation(0., 0.,  kCP1Length / 2.- 191.5));
-//  Beam Pipe Protection Tube
-//
-//  ALIFWDA_0025
-//    
-//  Plaque de Centrage  ALIFWDA_0019
-    const Float_t kFwdaBPPTXL = 3.;
-    TGeoXtru* shFwdaBPPTX = new TGeoXtru(2);
-    Double_t xBPPTX[8] = {12.5,  7.5, -7.5, -12.5, -12.5,  -7.5,   7.5, 12.5};
-    Double_t yBPPTX[8] = { 7.0, 12.0, 12.0,  7.0, -7.0, -12.0, -12.0,  -7.0};
-    shFwdaBPPTX->DefinePolygon(8, xBPPTX, yBPPTX);
-    shFwdaBPPTX->DefineSection(0, 0.,         0., 0., 1.);
-    shFwdaBPPTX->DefineSection(1, kFwdaBPPTXL, 0., 0., 1.);
-    shFwdaBPPTX->SetName("FwdaBPPTX");
-    TGeoTube* shFwdaBPPTY = new TGeoTube(0., 8.5, 3.2);
-    shFwdaBPPTY->SetName("FwdaBPPTY");
-    TGeoCompositeShape*  shFwdaBPPTPC = new TGeoCompositeShape("shFwdaBPPTPC", "FwdaBPPTX-FwdaBPPTY");
-    TGeoVolume* voFwdaBPPTPC =  new TGeoVolume("FwdaBPPTPC", shFwdaBPPTPC, kMedAco);
-//    
-//  Tube  ALIFWDA_0020  
-//    const Float_t kFwdaBPPTTL = 48.;
-    const Float_t kFwdaBPPTTL = 35.;
-    TGeoVolume* voFwdaBPPTT =  new TGeoVolume("FwdaBPPTT", new TGeoTube(8.85, 9.0, kFwdaBPPTTL/2.), kMedAco);
-    TGeoVolumeAssembly* voFwdaBPPT = new TGeoVolumeAssembly("FwdaBPPT");
-    voFwdaBPPT->AddNode(voFwdaBPPTPC, 1, gGeoIdentity);
-    voFwdaBPPT->AddNode(voFwdaBPPTT,  1, new TGeoTranslation(0., 0., kFwdaBPPTTL/2. + kFwdaBPPTXL));
+  /////////////////////////////////////////////
+  // CP/1 Be-Section                         //
+  /////////////////////////////////////////////
+  TGeoVolume* voCp1Vac = new TGeoVolume("CP1VAC", 
+      new TGeoTube(0., kCP1BeRi,  kCP1BeLength / 2.), 
+      kMedVac);
+  TGeoVolume* voCp1Be  = new TGeoVolume("CP1BE", 
+      new TGeoTube(0., kCP1BeRo,  kCP1BeLength / 2.), 
+      kMedBe);
+  // Outer Kapton foil
+  TGeoVolume* voCp1Ka  = new TGeoVolume("CP1KA", 
+      new TGeoTube(0., kCP1KaRo,  kCP1BeLength / 2.), 
+      kMedKapton);
+  // Inner NEG coating
+  TGeoVolume* voCp1NEG = new TGeoVolume("CP1NEG", 
+      new TGeoTube(kCP1BeRi, kCP1NegRo, kCP1BeLength / 2.), 
+      kMedNEG);
 
-    
-//  BeamPipe and T0A Support
-//
-//  ALIFWDA_0033
-//    
-//  Support  Plate ALIFWDA_0026
-    const Float_t kFwdaBPSPL = 4.0;
-    TGeoXtru* shFwdaBPSPX = new TGeoXtru(2);
-    Double_t xBPSPX[8] = {10.0,  6.0 , -6.0, -10.0, -10.0,  -6.0,   6.0, 10.0};
-    Double_t yBPSPX[8] = { 6.0, 10.0,  10.0,   6.0, - 6.0, -10.0, -10.0, -6.0};
-    shFwdaBPSPX->DefinePolygon(8, xBPSPX, yBPSPX);
-    shFwdaBPSPX->DefineSection(0, 0.,         0., 0., 1.);
-    shFwdaBPSPX->DefineSection(1, kFwdaBPSPL, 0., 0., 1.);
-    shFwdaBPSPX->SetName("FwdaBPSPX");
-    TGeoPcon* shFwdaBPSPY = new TGeoPcon(0., 360., 6);
-    shFwdaBPSPY->DefineSection(0, -1.00, 0., 5.5);
-    shFwdaBPSPY->DefineSection(1,  3.50, 0., 5.5);    
-    shFwdaBPSPY->DefineSection(2,  3.50, 0., 5.0);    
-    shFwdaBPSPY->DefineSection(3,  3.86, 0., 5.0);    
-    shFwdaBPSPY->DefineSection(4,  3.86, 0., 5.5);    
-    shFwdaBPSPY->DefineSection(5,  5.00, 0., 5.5);    
-    shFwdaBPSPY->SetName("FwdaBPSPY");
-    TGeoCompositeShape*  shFwdaBPSP = new TGeoCompositeShape("shFwdaBPSP", "FwdaBPSPX-FwdaBPSPY");
-    TGeoVolume* voFwdaBPSP =  new TGeoVolume("FwdaBPSP", shFwdaBPSP, kMedAco);
-//    
-//  Flasque  ALIFWDA_00027
+  voCp1Ka->AddNode(voCp1Be,  1, gGeoIdentity);
+  voCp1Be->AddNode(voCp1Vac, 1, gGeoIdentity);
+  voCp1Be->AddNode(voCp1NEG, 1, gGeoIdentity);
+  voCp1Mo->AddNode(voCp1Ka,  1, gGeoIdentity);
+
+  /////////////////////////////////////////////
+  // CP/1 Be-Stainless Steel adaptor tube    //
+  /////////////////////////////////////////////
+  TGeoPcon* shCp1At = new TGeoPcon(0., 360., 8);
+  //  First Bulge 
+  z = - kCP1BeStAdaptorLength / 2.;
+  shCp1At->DefineSection(0, z, 0., kCP1BeStRo);
+  z += kCP1BulgeLength;
+  shCp1At->DefineSection(1, z, 0., kCP1BeStRo);
+  shCp1At->DefineSection(2, z, 0., kCP1BeRo);
+  //  Between the bulges
+  z += kCP1BulgeBulgeDistance;
+  shCp1At->DefineSection(3, z, 0., kCP1BeRo);
+  shCp1At->DefineSection(4, z, 0., kCP1BeStRo);
+  //  Second bulge
+  z += kCP1BulgeLength;
+  shCp1At->DefineSection(5, z, 0., kCP1BeStRo);
+  shCp1At->DefineSection(6, z, 0., kCP1BeRo);
+  //  Straight piece
+  z = kCP1BeStAdaptorLength / 2.;
+  shCp1At->DefineSection(7, z, 0., kCP1BeRo);
+  //
+  TGeoVolume* voCp1At  = new TGeoVolume("CP1AT",  shCp1At, kMedSteel);
+  TGeoVolume* voCp1AtV = new TGeoVolume("CP1ATV", new TGeoTube(0., kCP1BeRi, kCP1BeStAdaptorLength / 2.), kMedVac);
+  voCp1At->AddNode(voCp1AtV, 1, gGeoIdentity);
+
+  //  Position adaptor tube at both ends
+  dz = kCP1Length / 2. -  kCP1BeStAdaptorLength / 2.;
+  voCp1Mo->AddNode(voCp1At,    1, new TGeoTranslation(0., 0., -dz));
+  voCp1Mo->AddNode(voCp1At,    2, new TGeoCombiTrans(0., 0.,  dz, rot180));
+  TGeoVolumeAssembly* voCp1 = new TGeoVolumeAssembly("Cp1");
+  voCp1->AddNode(voCp1Mo, 1, gGeoIdentity);
+
+  //
+  ///////////////////
+  //      CP/2     //
+  ///////////////////
+  //
+  // Fixed Point tube [Pos 5]
+  //
+  // Inner and outer radii of the Stainless Steel pipe    
+  const Float_t kCP2StRi               =      2.90;
+  const Float_t kCP2StRo               =      2.98;
+  //  
+  // Transition to central Be-pipe (Bulge)   
+  // Length
+  const Float_t kCP2BulgeLength        =      0.80;
+  //     
+  // Bulge outer radius
+  const Float_t kCP2BulgeRo            =      3.05;
+  //
+  // Fixed Point at z = 391.7 (IP)
+  //
+  // Position of fixed point
+  const Float_t kCP2FixedPointZ        =      8.30;
+  //
+  // Outer radius of fixed point
+  const Float_t kCP2FixedPointRo       =      3.50;
+  //
+  // Length of fixed point
+  const Float_t kCP2FixedPointLength   =      0.60;
+  //
+  // Fixed Flange [Pos 6]    
+  //
+  // Fixed flange outer radius
+  const Float_t kCP2FixedFlangeRo      =      7.60;
+  //
+  // Fixed flange inner radius
+  const Float_t kCP2FixedFlangeRi      =      3.00;
+  // Fixed flange inner radius bulge
+  const Float_t kCP2FixedFlangeBulgeRi =      2.90;
+  // Fixed flange lengths of sections at inner radius
+  const Float_t kCP2FixedFlangeRecessLengths[3] ={1., 0.08, 0.9};
+  // Fixed flange length
+  const Float_t kCP2FixedFlangeLength =       1.98;
+  //
+  // Fixed flange bulge
+  // Outer radius
+  const Float_t kCP2FixedFlangeBulgeRo =     3.00;
+  //
+  // Length    
+  const Float_t kCP2FixedFlangeBulgeLength = 2.00;
+
+  //
+  // CP/2 Mother Volume
+  //
+  TGeoPcon* shCp2Mo = new TGeoPcon(0., 360., 14);
+  //  Flange
+  z = - kCP2Length / 2.;
+  shCp2Mo->DefineSection( 0, z, kCP2FixedFlangeRi, kCP2FixedFlangeRo);
+  z +=  kCP2FixedFlangeRecessLengths[0];
+  shCp2Mo->DefineSection( 1, z, kCP2FixedFlangeRi, kCP2FixedFlangeRo);
+  shCp2Mo->DefineSection( 2, z, 0.,                kCP2FixedFlangeRo);
+  z +=  (kCP2FixedFlangeRecessLengths[1] + kCP2FixedFlangeRecessLengths[2]) ;
+  shCp2Mo->DefineSection( 3, z, 0., kCP2FixedFlangeRo);
+  //  Straight section between Flange and Fixed Point
+  shCp2Mo->DefineSection( 4, z, 0., kCP2FixedFlangeBulgeRo);
+  z += kCP2FixedFlangeBulgeLength;
+  shCp2Mo->DefineSection( 5, z, 0., kCP2FixedFlangeBulgeRo);
+  shCp2Mo->DefineSection( 6, z, 0., kCP2StRo);
+  z =  - kCP2Length / 2 +  kCP2FixedPointZ - kCP2FixedPointLength / 2.;
+  shCp2Mo->DefineSection( 7, z, 0., kCP2StRo);
+  //  Fixed Point
+  shCp2Mo->DefineSection( 8, z, 0., kCP2FixedPointRo);
+  z +=  kCP2FixedPointLength;
+  shCp2Mo->DefineSection( 9, z, 0., kCP2FixedPointRo);
+  //  Straight section between Fixed Point and transition bulge
+  shCp2Mo->DefineSection(10, z, 0., kCP2StRo);
+  z  =  kCP2Length / 2. - kCP2BulgeLength;
+  shCp2Mo->DefineSection(11, z, 0., kCP2StRo);
+  shCp2Mo->DefineSection(12, z, 0., kCP2BulgeRo);
+  z = kCP2Length / 2.;
+  shCp2Mo->DefineSection(13, z, 0., kCP2BulgeRo);
+
+  TGeoVolume* voCp2Mo = new TGeoVolume("CP2MO", shCp2Mo, kMedAir);
+  voCp2Mo->SetVisibility(0);
+  //
+  // CP/1 Vacuum
+  TGeoTube*   shCp2Va = new TGeoTube(0., kCP2StRi, (kCP2Length - kCP2FixedFlangeRecessLengths[0])/2.);
+  TGeoVolume* voCp2Va = new TGeoVolume("CP2VA", shCp2Va, kMedVac);
+
+  voCp2Mo->AddNode(voCp2Va, 1, new TGeoTranslation(0., 0., kCP2FixedFlangeRecessLengths[0]/2.));
+
+  /////////////////////////////////////////////
+  //  CP/2 Fixed Flange [Pos 6]              //
+  /////////////////////////////////////////////
+
+  TGeoPcon* shCp2Fl = new TGeoPcon(0., 360., 6);
+  z = - kCP2FixedFlangeLength / 2.;
+  shCp2Fl->DefineSection(0, z, kCP2FixedFlangeRi,      kCP2FixedFlangeRo);
+  z +=  kCP2FixedFlangeRecessLengths[0];
+  shCp2Fl->DefineSection(1, z, kCP2FixedFlangeRi,      kCP2FixedFlangeRo);
+  shCp2Fl->DefineSection(2, z, kCP2FixedFlangeBulgeRi, kCP2FixedFlangeRo);
+  z +=  kCP2FixedFlangeRecessLengths[1];
+  shCp2Fl->DefineSection(3, z, kCP2FixedFlangeBulgeRi, kCP2FixedFlangeRo);
+  shCp2Fl->DefineSection(4, z, kCP2FixedFlangeRi,      kCP2FixedFlangeRo);
+  z = kCP2FixedFlangeLength / 2.;
+  shCp2Fl->DefineSection(5, z, kCP2FixedFlangeRi,      kCP2FixedFlangeRo);
+  TGeoVolume* voCp2Fl = new TGeoVolume("CP2FL", shCp2Fl, kMedSteel);
+  // 
+  dz =  - kCP2Length / 2. +  kCP2FixedFlangeLength / 2.;
+  voCp2Mo->AddNode(voCp2Fl, 1, new TGeoTranslation(0., 0., dz));
 
 
-    const Float_t kFwdaBPSTTRi  =  7.6/2.;
-    const Float_t kFwdaBPSTTRo1 = 13.9/2.;
-    const Float_t kFwdaBPSTTRo2 =  8.2/2.;
-    const Float_t kFwdaBPSTTRo3 =  9.4/2.;
-    
-    TGeoPcon* shFwdaBPSFL = new TGeoPcon(0., 360., 8);
-    z = 0., 
+  /////////////////////////////////////////////////////////////
+  //  CP/2 Beam pipe with fixed point and transition bulges  //
+  /////////////////////////////////////////////////////////////
+  TGeoPcon* shCp2Pi = new TGeoPcon(0., 360., 10);
+  //  Bulge at transition to flange 
+  z =  - (kCP2Length -  kCP2FixedFlangeRecessLengths[0] - kCP2FixedFlangeRecessLengths[1]) / 2.;
+  z0 = z;
+  shCp2Pi->DefineSection(0, z, kCP2StRi, kCP2FixedFlangeBulgeRo);
+  z += kCP2FixedFlangeBulgeLength;
+  shCp2Pi->DefineSection(1, z, kCP2StRi, kCP2FixedFlangeBulgeRo);
+  //  Straight section between Bulge and Fixed Point
+  shCp2Pi->DefineSection(2, z, kCP2StRi, kCP2StRo);
+  z  += (kCP2FixedPointZ - kCP2FixedPointLength / 2. - kCP2FixedFlangeRecessLengths[0]
+      - kCP2FixedFlangeRecessLengths[1] - 
+      kCP2FixedFlangeBulgeLength);
+  shCp2Pi->DefineSection(3, z, kCP2StRi, kCP2StRo);
+  //  Fixed Point
+  shCp2Pi->DefineSection(4, z, kCP2StRi, kCP2FixedPointRo);
+  z +=  kCP2FixedPointLength;
+  shCp2Pi->DefineSection(5, z, kCP2StRi, kCP2FixedPointRo);
+  //  Straight section between Fixed Point and transition bulge
+  shCp2Pi->DefineSection(6, z, kCP2StRi, kCP2StRo);
+  z = - shCp2Pi->GetZ(0) - kCP2BulgeLength;
+  shCp2Pi->DefineSection(7, z, kCP2StRi, kCP2StRo);
+  //  Bulge at transition to Be pipe
+  shCp2Pi->DefineSection(8, z, kCP2StRi, kCP2BulgeRo);
+  z = - shCp2Pi->GetZ(0);
+  shCp2Pi->DefineSection(9, z, kCP2StRi, kCP2BulgeRo);
+
+  TGeoVolume* voCp2Pi = new TGeoVolume("CP2PI", shCp2Pi, kMedSteel);
+  dz = (kCP2FixedFlangeRecessLengths[0] + kCP2FixedFlangeRecessLengths[1]) / 2.;
+  voCp2Mo->AddNode(voCp2Pi, 1, new TGeoTranslation(0., 0., dz));
+
+  //
+  //  Central beam pipe support collars
+  //  LHCVC2C_0019
+  //  cp1l = 405.
+  //  Position at z = -46., 40., 150.
+  TGeoVolume* voCpSupC = new TGeoVolume("CpSupC", new TGeoTube(3.051, 4.00, 0.35), kMedAco);
+  voCp1->AddNode(voCpSupC, 1, new TGeoTranslation(0., 0.,  kCP1Length / 2. - 98.2 - 34.77 + 0.49));
+  //    voCp1->AddNode(voCpSupC, 2, new TGeoTranslation(0., 0.,  kCP1Length / 2.- 191.5));
+  //  Beam Pipe Protection Tube
+  //
+  //  ALIFWDA_0025
+  //    
+  //  Plaque de Centrage  ALIFWDA_0019
+  const Float_t kFwdaBPPTXL = 3.;
+  TGeoXtru* shFwdaBPPTX = new TGeoXtru(2);
+  Double_t xBPPTX[8] = {12.5,  7.5, -7.5, -12.5, -12.5,  -7.5,   7.5, 12.5};
+  Double_t yBPPTX[8] = { 7.0, 12.0, 12.0,  7.0, -7.0, -12.0, -12.0,  -7.0};
+  shFwdaBPPTX->DefinePolygon(8, xBPPTX, yBPPTX);
+  shFwdaBPPTX->DefineSection(0, 0.,         0., 0., 1.);
+  shFwdaBPPTX->DefineSection(1, kFwdaBPPTXL, 0., 0., 1.);
+  shFwdaBPPTX->SetName("FwdaBPPTX");
+  TGeoTube* shFwdaBPPTY = new TGeoTube(0., 8.5, 3.2);
+  shFwdaBPPTY->SetName("FwdaBPPTY");
+  TGeoCompositeShape*  shFwdaBPPTPC = new TGeoCompositeShape("shFwdaBPPTPC", "FwdaBPPTX-FwdaBPPTY");
+  TGeoVolume* voFwdaBPPTPC =  new TGeoVolume("FwdaBPPTPC", shFwdaBPPTPC, kMedAco);
+  //    
+  //  Tube  ALIFWDA_0020  
+  //    const Float_t kFwdaBPPTTL = 48.;
+  const Float_t kFwdaBPPTTL = 35.;
+  TGeoVolume* voFwdaBPPTT =  new TGeoVolume("FwdaBPPTT", new TGeoTube(8.85, 9.0, kFwdaBPPTTL/2.), kMedAco);
+  TGeoVolumeAssembly* voFwdaBPPT = new TGeoVolumeAssembly("FwdaBPPT");
+  voFwdaBPPT->AddNode(voFwdaBPPTPC, 1, gGeoIdentity);
+  voFwdaBPPT->AddNode(voFwdaBPPTT,  1, new TGeoTranslation(0., 0., kFwdaBPPTTL/2. + kFwdaBPPTXL));
+
+
+  //  BeamPipe and T0A Support
+  //
+  //  ALIFWDA_0033
+  //    
+  //  Support  Plate ALIFWDA_0026
+  const Float_t kFwdaBPSPL = 4.0;
+  TGeoXtru* shFwdaBPSPX = new TGeoXtru(2);
+  Double_t xBPSPX[8] = {10.0,  6.0 , -6.0, -10.0, -10.0,  -6.0,   6.0, 10.0};
+  Double_t yBPSPX[8] = { 6.0, 10.0,  10.0,   6.0, - 6.0, -10.0, -10.0, -6.0};
+  shFwdaBPSPX->DefinePolygon(8, xBPSPX, yBPSPX);
+  shFwdaBPSPX->DefineSection(0, 0.,         0., 0., 1.);
+  shFwdaBPSPX->DefineSection(1, kFwdaBPSPL, 0., 0., 1.);
+  shFwdaBPSPX->SetName("FwdaBPSPX");
+  TGeoPcon* shFwdaBPSPY = new TGeoPcon(0., 360., 6);
+  shFwdaBPSPY->DefineSection(0, -1.00, 0., 5.5);
+  shFwdaBPSPY->DefineSection(1,  3.50, 0., 5.5);    
+  shFwdaBPSPY->DefineSection(2,  3.50, 0., 5.0);    
+  shFwdaBPSPY->DefineSection(3,  3.86, 0., 5.0);    
+  shFwdaBPSPY->DefineSection(4,  3.86, 0., 5.5);    
+  shFwdaBPSPY->DefineSection(5,  5.00, 0., 5.5);    
+  shFwdaBPSPY->SetName("FwdaBPSPY");
+  TGeoCompositeShape*  shFwdaBPSP = new TGeoCompositeShape("shFwdaBPSP", "FwdaBPSPX-FwdaBPSPY");
+  TGeoVolume* voFwdaBPSP =  new TGeoVolume("FwdaBPSP", shFwdaBPSP, kMedAco);
+  //    
+  //  Flasque  ALIFWDA_00027
+
+
+  const Float_t kFwdaBPSTTRi  =  7.6/2.;
+  const Float_t kFwdaBPSTTRo1 = 13.9/2.;
+  const Float_t kFwdaBPSTTRo2 =  8.2/2.;
+  const Float_t kFwdaBPSTTRo3 =  9.4/2.;
+
+  TGeoPcon* shFwdaBPSFL = new TGeoPcon(0., 360., 8);
+  z = 0., 
     shFwdaBPSFL->DefineSection(0, z, kFwdaBPSTTRi, kFwdaBPSTTRo1);
-    z += 0.64;
-    shFwdaBPSFL->DefineSection(1, z, kFwdaBPSTTRi, kFwdaBPSTTRo1);
-    shFwdaBPSFL->DefineSection(2, z, kFwdaBPSTTRi, kFwdaBPSTTRo2);
-    z += 2.55;
-    shFwdaBPSFL->DefineSection(3, z, kFwdaBPSTTRi, kFwdaBPSTTRo2);
-    shFwdaBPSFL->DefineSection(4, z, kFwdaBPSTTRi, kFwdaBPSTTRo3);
-    z += 0.4;
-    shFwdaBPSFL->DefineSection(5, z, kFwdaBPSTTRi, kFwdaBPSTTRo3);
-    shFwdaBPSFL->DefineSection(6, z, kFwdaBPSTTRi, kFwdaBPSTTRo2);
-    z += 1.2;
-    shFwdaBPSFL->DefineSection(7, z, kFwdaBPSTTRi, kFwdaBPSTTRo2);
+  z += 0.64;
+  shFwdaBPSFL->DefineSection(1, z, kFwdaBPSTTRi, kFwdaBPSTTRo1);
+  shFwdaBPSFL->DefineSection(2, z, kFwdaBPSTTRi, kFwdaBPSTTRo2);
+  z += 2.55;
+  shFwdaBPSFL->DefineSection(3, z, kFwdaBPSTTRi, kFwdaBPSTTRo2);
+  shFwdaBPSFL->DefineSection(4, z, kFwdaBPSTTRi, kFwdaBPSTTRo3);
+  z += 0.4;
+  shFwdaBPSFL->DefineSection(5, z, kFwdaBPSTTRi, kFwdaBPSTTRo3);
+  shFwdaBPSFL->DefineSection(6, z, kFwdaBPSTTRi, kFwdaBPSTTRo2);
+  z += 1.2;
+  shFwdaBPSFL->DefineSection(7, z, kFwdaBPSTTRi, kFwdaBPSTTRo2);
 
-    TGeoVolume* voFwdaBPSFL =  new TGeoVolume("FwdaBPSFL", shFwdaBPSFL, kMedAco);
+  TGeoVolume* voFwdaBPSFL =  new TGeoVolume("FwdaBPSFL", shFwdaBPSFL, kMedAco);
 
-    
-    //
-    // Cable support 
-    TGeoBBox* shFwdaBPSCSa = new TGeoBBox(3.0, 8.75, 0.5);
-    shFwdaBPSCSa->SetName("FwdaBPSCSa");
-    TGeoBBox* shFwdaBPSCSb = new TGeoBBox(1.25, 4.00, 1.0);
-    shFwdaBPSCSb->SetName("FwdaBPSCSb");   
-    TGeoTranslation* tFwdaBPSCSb = new TGeoTranslation(0., 5.25 - 8.75, 0.);
-    tFwdaBPSCSb->SetName("tFwdaBPSCSb");
-    tFwdaBPSCSb->RegisterYourself();
-    TGeoBBox* shFwdaBPSCSc = new TGeoBBox(3.0, 0.50, 0.70);
-    shFwdaBPSCSc->SetName("FwdaBPSCSc");
-    TGeoTranslation* tFwdaBPSCSc = new TGeoTranslation(0., 0.5 - 8.75, 1.2);
-    tFwdaBPSCSc->SetName("tFwdaBPSCSc");
-    tFwdaBPSCSc->RegisterYourself();
-    TGeoCompositeShape* shFwdaBPSCS = new TGeoCompositeShape("shFwdaBPSCS", "(FwdaBPSCSa-FwdaBPSCSb:tFwdaBPSCSb)+FwdaBPSCSc:tFwdaBPSCSc");
-    TGeoVolume* voFwdaBPSCS = new TGeoVolume("FwdaBPSCS", shFwdaBPSCS, kMedAco);
-    
-    
-    // Assembling the beam pipe support	
-    TGeoVolumeAssembly* voFwdaBPS = new TGeoVolumeAssembly("FwdaBPS");
-    voFwdaBPS->AddNode(voFwdaBPSP,   1,  new TGeoCombiTrans(0., 0., 0., rot045));
-    voFwdaBPS->AddNode(voFwdaBPSFL,  1,  new TGeoTranslation(0., 0., kFwdaBPSPL));
-    const Float_t kFwdaBPSCSdy = 18.75/TMath::Sqrt(2.);
-    
-    voFwdaBPS->AddNode(voFwdaBPSCS,  1,  new TGeoCombiTrans(- kFwdaBPSCSdy,   kFwdaBPSCSdy, 2., rot045));
-    voFwdaBPS->AddNode(voFwdaBPSCS,  2,  new TGeoCombiTrans(- kFwdaBPSCSdy, - kFwdaBPSCSdy, 2., rot135));
-    voFwdaBPS->AddNode(voFwdaBPSCS,  3,  new TGeoCombiTrans(  kFwdaBPSCSdy, - kFwdaBPSCSdy, 2., rot225));
-    voFwdaBPS->AddNode(voFwdaBPSCS,  4,  new TGeoCombiTrans(  kFwdaBPSCSdy,   kFwdaBPSCSdy, 2., rot315));
 
-    TGeoVolumeAssembly* voCp2 = new TGeoVolumeAssembly("CP2");
-    voCp2->AddNode(voCp2Mo, 1, gGeoIdentity);
-    voCp2->AddNode(voFwdaBPPT, 1, new TGeoTranslation(0., 0., -kCP2Length / 2. + 13.8));
-    voCp2->AddNode(voFwdaBPS,  1, new TGeoTranslation(0., 0., -kCP2Length / 2. +  5.1));
+  //
+  // Cable support 
+  TGeoBBox* shFwdaBPSCSa = new TGeoBBox(3.0, 8.75, 0.5);
+  shFwdaBPSCSa->SetName("FwdaBPSCSa");
+  TGeoBBox* shFwdaBPSCSb = new TGeoBBox(1.25, 4.00, 1.0);
+  shFwdaBPSCSb->SetName("FwdaBPSCSb");   
+  TGeoTranslation* tFwdaBPSCSb = new TGeoTranslation(0., 5.25 - 8.75, 0.);
+  tFwdaBPSCSb->SetName("tFwdaBPSCSb");
+  tFwdaBPSCSb->RegisterYourself();
+  TGeoBBox* shFwdaBPSCSc = new TGeoBBox(3.0, 0.50, 0.70);
+  shFwdaBPSCSc->SetName("FwdaBPSCSc");
+  TGeoTranslation* tFwdaBPSCSc = new TGeoTranslation(0., 0.5 - 8.75, 1.2);
+  tFwdaBPSCSc->SetName("tFwdaBPSCSc");
+  tFwdaBPSCSc->RegisterYourself();
+  TGeoCompositeShape* shFwdaBPSCS = new TGeoCompositeShape("shFwdaBPSCS", "(FwdaBPSCSa-FwdaBPSCSb:tFwdaBPSCSb)+FwdaBPSCSc:tFwdaBPSCSc");
+  TGeoVolume* voFwdaBPSCS = new TGeoVolume("FwdaBPSCS", shFwdaBPSCS, kMedAco);
 
-//
-///////////////////
-//      CP/3     //
-///////////////////
-//
-// Adaptor tube [Pos 4]
-// 
-// Adaptor tube length 
-    const Float_t  kCP3AdaptorTubeLength            =  5.50;
-//
-// Inner and outer radii
-     const Float_t kCP3AdaptorTubeRi                =  2.92;
-     const Float_t kCP3AdaptorTubeRo                =  3.00;
-//
-// Bulge at transition point
-// Inner and outer radii
-     const Float_t kCP3AdaptorTubeBulgeRi           =  2.90;
-     const Float_t kCP3AdaptorTubeBulgeRo           =  3.05;    
-//
-// Length of bulge
-    const Float_t  kCP3AdaptorTubeBulgeLength       =  0.80;
-//
-// Bellow [Pos 8]
-//
-//  Total length    
-    const Float_t kCP3BellowLength                  = 13.00;
-//  Outer Radius
-    const Float_t kCP3BellowRo                      =  3.6;
-//  Inner Radius 
-    const Float_t kCP3BellowRi                      =  2.8;
-//  Number of plies
-    const Int_t   kCP3NumberOfPlies                 = 18;
-//  Length of undulated region
-    const Float_t kCP3BellowUndulatedLength         =  8.30; 
-//  Plie thickness
-    const Float_t kCP3PlieThickness                 =  0.02;   
-//  Connection Plie radies (at transition been undulated region and beam pipe)
-    const Float_t kCP3ConnectionPlieR               =  0.21;
-//  Plie radius
-//  const Float_t kCP3PlieR = 0.118286;
-    const Float_t kCP3PlieR = 
-	(kCP3BellowUndulatedLength - 4. *  kCP3ConnectionPlieR + 
-	 2. *  kCP3NumberOfPlies * kCP3PlieThickness) / (4. * kCP3NumberOfPlies - 2.);
-//  Length of connection pipe
-    const Float_t kCP3BellowConnectionLength        =  2.35;
-//
-//  Tube between bellows [Pos 3]  
-//    
-//  Length of tube
-    const Float_t kCP3TubeLength                    =  4.00;
-//
-//  Minimised fixed flange [Pos 7]
-//  
-//  Length of flange connection tube
-    const Float_t kCP3FlangeConnectorLength         =  5.0 - 1.4;
-//  Length of Flange
-    const Float_t kCP3FlangeLength                  =  1.40;
-//  Outer radius    
-    const Float_t kCP3FlangeRo                      =  4.30;
 
-//
-// CP/3 Mother volume
-//
-    TGeoPcon* shCp3Mo = new TGeoPcon(0., 360., 12);
-//  From transition to first bellow
-    z = - kCP3Length / 2.;
-    shCp3Mo->DefineSection( 0, z, 0., kCP3AdaptorTubeBulgeRo);
-    z += kCP3BellowConnectionLength + kCP3AdaptorTubeLength;
-    shCp3Mo->DefineSection( 1, z, 0., kCP3AdaptorTubeBulgeRo);
-//  First Bellow
-    shCp3Mo->DefineSection( 2, z, 0., kCP3BellowRo);
-    z +=  kCP3BellowUndulatedLength;
-    shCp3Mo->DefineSection( 3, z, 0., kCP3BellowRo);
-//  Connection between the two bellows
-    shCp3Mo->DefineSection( 4, z, 0., kCP3AdaptorTubeBulgeRo);
-    z +=  2. * kCP3BellowConnectionLength + kCP3TubeLength;
-    shCp3Mo->DefineSection( 5, z, 0., kCP3AdaptorTubeBulgeRo);
-//  Second bellow
-    shCp3Mo->DefineSection( 6, z, 0., kCP3BellowRo);
-    z += kCP3BellowUndulatedLength;
-    shCp3Mo->DefineSection( 7, z, 0., kCP3BellowRo);
-//  Pipe between second Bellow and Flange
-    shCp3Mo->DefineSection( 8, z, 0., kCP3AdaptorTubeBulgeRo);
-    z +=  kCP3BellowConnectionLength +  kCP3FlangeConnectorLength;
-    shCp3Mo->DefineSection( 9, z, 0., kCP3AdaptorTubeBulgeRo);
-//  Flange 
-    shCp3Mo->DefineSection(10, z, 0., kCP3FlangeRo);
-    z = -shCp3Mo->GetZ(0);
-    shCp3Mo->DefineSection(11, z, 0., kCP3FlangeRo);
-//
-    // TGeoVolume* voCp3Mo = new TGeoVolume("CP3MO", shCp3Mo, kMedAir);
-    TGeoVolume* voCp3Mo = new TGeoVolumeAssembly("CP3MO");
-    voCp3Mo->SetVisibility(0);
-    TGeoVolumeAssembly* voCp3 = new TGeoVolumeAssembly("Cp3");
-    voCp3->AddNode(voCp3Mo,  1, gGeoIdentity);
-    voCp3->AddNode(voCpSupC, 3, new TGeoTranslation(0., 0., - kCP3Length / 2. + 4.6 - 0.49));
-    dz = kCP3pos;
+  // Assembling the beam pipe support	
+  TGeoVolumeAssembly* voFwdaBPS = new TGeoVolumeAssembly("FwdaBPS");
+  voFwdaBPS->AddNode(voFwdaBPSP,   1,  new TGeoCombiTrans(0., 0., 0., rot045));
+  voFwdaBPS->AddNode(voFwdaBPSFL,  1,  new TGeoTranslation(0., 0., kFwdaBPSPL));
+  const Float_t kFwdaBPSCSdy = 18.75/TMath::Sqrt(2.);
 
-//////////////////////////////////////////////
-// CP/3 Adaptor tube                        // 
-//////////////////////////////////////////////
-    TGeoPcon* shCp3AtV = new TGeoPcon(0., 360., 4);
-//  Bulge at transition
-    z =  - kCP3AdaptorTubeLength / 2.;
-    shCp3AtV->DefineSection(0, z, 0., kCP3AdaptorTubeBulgeRo);
-    z += kCP3AdaptorTubeBulgeLength;
-    shCp3AtV->DefineSection(1, z, 0., kCP3AdaptorTubeBulgeRo);
-//  Tube
-    shCp3AtV->DefineSection(2, z, 0., kCP3AdaptorTubeRo);
-    z =  + kCP3AdaptorTubeLength / 2.;
-    shCp3AtV->DefineSection(3, z, 0., kCP3AdaptorTubeRo);
+  voFwdaBPS->AddNode(voFwdaBPSCS,  1,  new TGeoCombiTrans(- kFwdaBPSCSdy,   kFwdaBPSCSdy, 2., rot045));
+  voFwdaBPS->AddNode(voFwdaBPSCS,  2,  new TGeoCombiTrans(- kFwdaBPSCSdy, - kFwdaBPSCSdy, 2., rot135));
+  voFwdaBPS->AddNode(voFwdaBPSCS,  3,  new TGeoCombiTrans(  kFwdaBPSCSdy, - kFwdaBPSCSdy, 2., rot225));
+  voFwdaBPS->AddNode(voFwdaBPSCS,  4,  new TGeoCombiTrans(  kFwdaBPSCSdy,   kFwdaBPSCSdy, 2., rot315));
 
-    TGeoVolume* voCp3AtV = new TGeoVolume("CP3ATV", shCp3AtV, kMedVac);
+  TGeoVolumeAssembly* voCp2 = new TGeoVolumeAssembly("CP2");
+  voCp2->AddNode(voCp2Mo, 1, gGeoIdentity);
+  voCp2->AddNode(voFwdaBPPT, 1, new TGeoTranslation(0., 0., -kCP2Length / 2. + 13.8));
+  voCp2->AddNode(voFwdaBPS,  1, new TGeoTranslation(0., 0., -kCP2Length / 2. +  5.1));
 
-    TGeoPcon* shCp3AtS = new TGeoPcon(0., 360., 4);
-//  Bulge at transition
-    shCp3AtS->DefineSection(0, shCp3AtV->GetZ(0), kCP3AdaptorTubeBulgeRi, kCP3AdaptorTubeBulgeRo);
-    shCp3AtS->DefineSection(1, shCp3AtV->GetZ(1), kCP3AdaptorTubeBulgeRi, kCP3AdaptorTubeBulgeRo);
-//  Tube
-    shCp3AtS->DefineSection(2, shCp3AtV->GetZ(2), kCP3AdaptorTubeRi,      kCP3AdaptorTubeRo);
-    shCp3AtS->DefineSection(3, shCp3AtV->GetZ(3), kCP3AdaptorTubeRi ,     kCP3AdaptorTubeRo);
-    TGeoVolume* voCp3AtS = new TGeoVolume("CP3ATS", shCp3AtS, kMedSteel);
+  //
+  ///////////////////
+  //      CP/3     //
+  ///////////////////
+  //
+  // Adaptor tube [Pos 4]
+  // 
+  // Adaptor tube length 
+  const Float_t  kCP3AdaptorTubeLength            =  5.50;
+  //
+  // Inner and outer radii
+  const Float_t kCP3AdaptorTubeRi                =  2.92;
+  const Float_t kCP3AdaptorTubeRo                =  3.00;
+  //
+  // Bulge at transition point
+  // Inner and outer radii
+  const Float_t kCP3AdaptorTubeBulgeRi           =  2.90;
+  const Float_t kCP3AdaptorTubeBulgeRo           =  3.05;    
+  //
+  // Length of bulge
+  const Float_t  kCP3AdaptorTubeBulgeLength       =  0.80;
+  //
+  // Bellow [Pos 8]
+  //
+  //  Total length    
+  const Float_t kCP3BellowLength                  = 13.00;
+  //  Outer Radius
+  const Float_t kCP3BellowRo                      =  3.6;
+  //  Inner Radius 
+  const Float_t kCP3BellowRi                      =  2.8;
+  //  Number of plies
+  const Int_t   kCP3NumberOfPlies                 = 18;
+  //  Length of undulated region
+  const Float_t kCP3BellowUndulatedLength         =  8.30; 
+  //  Plie thickness
+  const Float_t kCP3PlieThickness                 =  0.02;   
+  //  Connection Plie radies (at transition been undulated region and beam pipe)
+  const Float_t kCP3ConnectionPlieR               =  0.21;
+  //  Plie radius
+  //  const Float_t kCP3PlieR = 0.118286;
+  const Float_t kCP3PlieR = 
+    (kCP3BellowUndulatedLength - 4. *  kCP3ConnectionPlieR + 
+     2. *  kCP3NumberOfPlies * kCP3PlieThickness) / (4. * kCP3NumberOfPlies - 2.);
+  //  Length of connection pipe
+  const Float_t kCP3BellowConnectionLength        =  2.35;
+  //
+  //  Tube between bellows [Pos 3]  
+  //    
+  //  Length of tube
+  const Float_t kCP3TubeLength                    =  4.00;
+  //
+  //  Minimised fixed flange [Pos 7]
+  //  
+  //  Length of flange connection tube
+  const Float_t kCP3FlangeConnectorLength         =  5.0 - 1.4;
+  //  Length of Flange
+  const Float_t kCP3FlangeLength                  =  1.40;
+  //  Outer radius    
+  const Float_t kCP3FlangeRo                      =  4.30;
 
-    voCp3AtV->AddNode(voCp3AtS, 1, gGeoIdentity);
-    dz = - kCP3Length / 2. +  kCP3AdaptorTubeLength / 2.;
-    voCp3Mo->AddNode(voCp3AtV, 1, new TGeoTranslation(0., 0., dz));
+  //
+  // CP/3 Mother volume
+  //
+  TGeoPcon* shCp3Mo = new TGeoPcon(0., 360., 12);
+  //  From transition to first bellow
+  z = - kCP3Length / 2.;
+  shCp3Mo->DefineSection( 0, z, 0., kCP3AdaptorTubeBulgeRo);
+  z += kCP3BellowConnectionLength + kCP3AdaptorTubeLength;
+  shCp3Mo->DefineSection( 1, z, 0., kCP3AdaptorTubeBulgeRo);
+  //  First Bellow
+  shCp3Mo->DefineSection( 2, z, 0., kCP3BellowRo);
+  z +=  kCP3BellowUndulatedLength;
+  shCp3Mo->DefineSection( 3, z, 0., kCP3BellowRo);
+  //  Connection between the two bellows
+  shCp3Mo->DefineSection( 4, z, 0., kCP3AdaptorTubeBulgeRo);
+  z +=  2. * kCP3BellowConnectionLength + kCP3TubeLength;
+  shCp3Mo->DefineSection( 5, z, 0., kCP3AdaptorTubeBulgeRo);
+  //  Second bellow
+  shCp3Mo->DefineSection( 6, z, 0., kCP3BellowRo);
+  z += kCP3BellowUndulatedLength;
+  shCp3Mo->DefineSection( 7, z, 0., kCP3BellowRo);
+  //  Pipe between second Bellow and Flange
+  shCp3Mo->DefineSection( 8, z, 0., kCP3AdaptorTubeBulgeRo);
+  z +=  kCP3BellowConnectionLength +  kCP3FlangeConnectorLength;
+  shCp3Mo->DefineSection( 9, z, 0., kCP3AdaptorTubeBulgeRo);
+  //  Flange 
+  shCp3Mo->DefineSection(10, z, 0., kCP3FlangeRo);
+  z = -shCp3Mo->GetZ(0);
+  shCp3Mo->DefineSection(11, z, 0., kCP3FlangeRo);
+  //
+  // TGeoVolume* voCp3Mo = new TGeoVolume("CP3MO", shCp3Mo, kMedAir);
+  TGeoVolume* voCp3Mo = new TGeoVolumeAssembly("CP3MO");
+  voCp3Mo->SetVisibility(0);
+  TGeoVolumeAssembly* voCp3 = new TGeoVolumeAssembly("Cp3");
+  voCp3->AddNode(voCp3Mo,  1, gGeoIdentity);
+  voCp3->AddNode(voCpSupC, 3, new TGeoTranslation(0., 0., - kCP3Length / 2. + 4.6 - 0.49));
+  dz = kCP3pos;
 
-/////////////////////////////////
-// CP/3 Bellow section         //
-/////////////////////////////////
+  //////////////////////////////////////////////
+  // CP/3 Adaptor tube                        // 
+  //////////////////////////////////////////////
+  TGeoPcon* shCp3AtV = new TGeoPcon(0., 360., 4);
+  //  Bulge at transition
+  z =  - kCP3AdaptorTubeLength / 2.;
+  shCp3AtV->DefineSection(0, z, 0., kCP3AdaptorTubeBulgeRo);
+  z += kCP3AdaptorTubeBulgeLength;
+  shCp3AtV->DefineSection(1, z, 0., kCP3AdaptorTubeBulgeRo);
+  //  Tube
+  shCp3AtV->DefineSection(2, z, 0., kCP3AdaptorTubeRo);
+  z =  + kCP3AdaptorTubeLength / 2.;
+  shCp3AtV->DefineSection(3, z, 0., kCP3AdaptorTubeRo);
 
-//
-//  Upper part of the undulation
-    TGeoTorus* plieTorusUO =  new TGeoTorus(kCP3BellowRo - kCP3PlieR, 0. , kCP3PlieR);
-    plieTorusUO->SetName("TorusUO");
-    TGeoTorus* plieTorusUI =  new TGeoTorus(kCP3BellowRo - kCP3PlieR, kCP3PlieR - kCP3PlieThickness, kCP3PlieR);
-    plieTorusUI->SetName("TorusUI");
-    TGeoTube*  plieTubeU   =  new TGeoTube (kCP3BellowRo - kCP3PlieR, kCP3BellowRo, kCP3PlieR);
-    plieTubeU->SetName("TubeU");
-    
-    TGeoCompositeShape*  shUpperPlieO = new TGeoCompositeShape("upperPlieO", "TorusUO*TubeU");
-    TGeoCompositeShape*  shUpperPlieI = new TGeoCompositeShape("upperPlieI", "TorusUI*TubeU");
- 
-    TGeoVolume* voWiggleUO = new TGeoVolume("CP3WUO", shUpperPlieO, kMedVac);
-    TGeoVolume* voWiggleUI = new TGeoVolume("CP3WUI", shUpperPlieI, kMedSteel);
-    voWiggleUO->AddNode(voWiggleUI, 1,  gGeoIdentity);    
-//
-// Lower part of the undulation
-    TGeoTorus* plieTorusLO =  new TGeoTorus(kCP3BellowRi + kCP3PlieR, 0. , kCP3PlieR);
-    plieTorusLO->SetName("TorusLO");
-    TGeoTorus* plieTorusLI =  new TGeoTorus(kCP3BellowRi + kCP3PlieR, kCP3PlieR - kCP3PlieThickness, kCP3PlieR);
-    plieTorusLI->SetName("TorusLI");
-    TGeoTube*  plieTubeL   =  new TGeoTube (kCP3BellowRi, kCP3BellowRi + kCP3PlieR, kCP3PlieR);
-    plieTubeL->SetName("TubeL");
+  TGeoVolume* voCp3AtV = new TGeoVolume("CP3ATV", shCp3AtV, kMedVac);
 
-    TGeoCompositeShape*  shLowerPlieO = new TGeoCompositeShape("lowerPlieO", "TorusLO*TubeL");
-    TGeoCompositeShape*  shLowerPlieI = new TGeoCompositeShape("lowerPlieI", "TorusLI*TubeL");
+  TGeoPcon* shCp3AtS = new TGeoPcon(0., 360., 4);
+  //  Bulge at transition
+  shCp3AtS->DefineSection(0, shCp3AtV->GetZ(0), kCP3AdaptorTubeBulgeRi, kCP3AdaptorTubeBulgeRo);
+  shCp3AtS->DefineSection(1, shCp3AtV->GetZ(1), kCP3AdaptorTubeBulgeRi, kCP3AdaptorTubeBulgeRo);
+  //  Tube
+  shCp3AtS->DefineSection(2, shCp3AtV->GetZ(2), kCP3AdaptorTubeRi,      kCP3AdaptorTubeRo);
+  shCp3AtS->DefineSection(3, shCp3AtV->GetZ(3), kCP3AdaptorTubeRi ,     kCP3AdaptorTubeRo);
+  TGeoVolume* voCp3AtS = new TGeoVolume("CP3ATS", shCp3AtS, kMedSteel);
 
-    TGeoVolume* voWiggleLO = new TGeoVolume("CP3WLO", shLowerPlieO, kMedVac);
-    TGeoVolume* voWiggleLI = new TGeoVolume("CP3WLI", shLowerPlieI, kMedSteel);
-    voWiggleLO->AddNode(voWiggleLI, 1,  gGeoIdentity);    
+  voCp3AtV->AddNode(voCp3AtS, 1, gGeoIdentity);
+  dz = - kCP3Length / 2. +  kCP3AdaptorTubeLength / 2.;
+  voCp3Mo->AddNode(voCp3AtV, 1, new TGeoTranslation(0., 0., dz));
 
-//
-// Connection between upper and lower part of undulation
-    TGeoVolume* voWiggleC1 = new TGeoVolume("Q3WCO1",  
-					  new TGeoTube(kCP3BellowRi + kCP3PlieR, kCP3BellowRo - kCP3PlieR, kCP3PlieThickness / 2.),
-					  kMedSteel);
-    TGeoVolume* voWiggleC2 = new TGeoVolume("Q3WCO2",  
-					  new TGeoTube(kCP3BellowRi + kCP3ConnectionPlieR, kCP3BellowRo - kCP3PlieR, kCP3PlieThickness / 2.),
-					  kMedSteel);
-//
-// Conncetion between undulated section and beam pipe
-    TGeoTorus* plieTorusCO =  new TGeoTorus(kCP3BellowRi + kCP3ConnectionPlieR, 0. , kCP3ConnectionPlieR);
-    plieTorusCO->SetName("TorusCO");
-    TGeoTorus* plieTorusCI =  new TGeoTorus(kCP3BellowRi + kCP3ConnectionPlieR, kCP3ConnectionPlieR - kCP3PlieThickness, kCP3ConnectionPlieR);
-    plieTorusCI->SetName("TorusCI");
-    TGeoTube*  plieTubeC   =  new TGeoTube (kCP3BellowRi, kCP3BellowRi + kCP3ConnectionPlieR, kCP3ConnectionPlieR);
-    plieTubeC->SetName("TubeC");
+  /////////////////////////////////
+  // CP/3 Bellow section         //
+  /////////////////////////////////
 
-    TGeoCompositeShape*  shConnectionPlieO = new TGeoCompositeShape("connectionPlieO", "TorusCO*TubeC");
-    TGeoCompositeShape*  shConnectionPlieI = new TGeoCompositeShape("connectionPlieI", "TorusCI*TubeC");
+  //
+  //  Upper part of the undulation
+  TGeoTorus* plieTorusUO =  new TGeoTorus(kCP3BellowRo - kCP3PlieR, 0. , kCP3PlieR);
+  plieTorusUO->SetName("TorusUO");
+  TGeoTorus* plieTorusUI =  new TGeoTorus(kCP3BellowRo - kCP3PlieR, kCP3PlieR - kCP3PlieThickness, kCP3PlieR);
+  plieTorusUI->SetName("TorusUI");
+  TGeoTube*  plieTubeU   =  new TGeoTube (kCP3BellowRo - kCP3PlieR, kCP3BellowRo, kCP3PlieR);
+  plieTubeU->SetName("TubeU");
 
-    TGeoVolume* voConnectionPO = new TGeoVolume("CP3CPO", shConnectionPlieO, kMedVac);
-    TGeoVolume* voConnectionPI = new TGeoVolume("CP3CPI", shConnectionPlieI, kMedSteel);
-    voConnectionPO->AddNode(voConnectionPI, 1,  gGeoIdentity);    
-//
-// Connecting pipes
-    TGeoVolume* voConnectionPipeO = new TGeoVolume("CP3BECO",  
-						   new TGeoTube(0., kCP3AdaptorTubeRo, kCP3BellowConnectionLength / 2.),
-						   kMedVac);
-    TGeoVolume* voConnectionPipeI = new TGeoVolume("CP3BECI",  
-						   new TGeoTube(kCP3AdaptorTubeRi, kCP3AdaptorTubeRo, kCP3BellowConnectionLength / 2.),
-						   kMedSteel);
-    
-    voConnectionPipeO->AddNode(voConnectionPipeI, 1,  gGeoIdentity);
-    
-//
-// Bellow mother
-    TGeoPcon* shBellowMotherPC = new TGeoPcon(0., 360., 6);
-    dz =  - kCP3BellowLength / 2;
-    shBellowMotherPC->DefineSection(0, dz, 0.,  kCP3AdaptorTubeRo);
-    dz +=  kCP3BellowConnectionLength;
-    shBellowMotherPC->DefineSection(1, dz, 0.,  kCP3AdaptorTubeRo);
-    shBellowMotherPC->DefineSection(2, dz, 0.,  kCP3BellowRo);
-    dz =  kCP3BellowLength /2. -  kCP3BellowConnectionLength;;
-    shBellowMotherPC->DefineSection(3, dz, 0.,  kCP3BellowRo);
-    shBellowMotherPC->DefineSection(4, dz, 0.,  kCP3AdaptorTubeRo);
-    dz +=  kCP3BellowConnectionLength;
-    shBellowMotherPC->DefineSection(5, dz, 0.,  kCP3AdaptorTubeRo);
+  TGeoCompositeShape*  shUpperPlieO = new TGeoCompositeShape("upperPlieO", "TorusUO*TubeU");
+  TGeoCompositeShape*  shUpperPlieI = new TGeoCompositeShape("upperPlieI", "TorusUI*TubeU");
 
-    TGeoVolume* voBellowMother = new TGeoVolume("CP3BeMO", shBellowMotherPC, kMedVac);
-    voBellowMother->SetVisibility(0);
-    
-//
-// Add undulations
-    z0   =  - kCP3BellowLength / 2. +  kCP3BellowConnectionLength + 2. * kCP3ConnectionPlieR - kCP3PlieThickness;
-    zsh  = 4. *  kCP3PlieR -  2. * kCP3PlieThickness;
-    for (Int_t iw = 0; iw < 18; iw++) {
-	Float_t zpos =  z0 + iw * zsh;	
-	if (iw > 0) 
-	    voBellowMother->AddNode(voWiggleC1,  iw + 1 , new TGeoTranslation(0., 0., zpos + kCP3PlieThickness / 2.));	
-	else
-	    voBellowMother->AddNode(voWiggleC2,  iw + 1 , new TGeoTranslation(0., 0., zpos + kCP3PlieThickness / 2.));	
+  TGeoVolume* voWiggleUO = new TGeoVolume("CP3WUO", shUpperPlieO, kMedVac);
+  TGeoVolume* voWiggleUI = new TGeoVolume("CP3WUI", shUpperPlieI, kMedSteel);
+  voWiggleUO->AddNode(voWiggleUI, 1,  gGeoIdentity);    
+  //
+  // Lower part of the undulation
+  TGeoTorus* plieTorusLO =  new TGeoTorus(kCP3BellowRi + kCP3PlieR, 0. , kCP3PlieR);
+  plieTorusLO->SetName("TorusLO");
+  TGeoTorus* plieTorusLI =  new TGeoTorus(kCP3BellowRi + kCP3PlieR, kCP3PlieR - kCP3PlieThickness, kCP3PlieR);
+  plieTorusLI->SetName("TorusLI");
+  TGeoTube*  plieTubeL   =  new TGeoTube (kCP3BellowRi, kCP3BellowRi + kCP3PlieR, kCP3PlieR);
+  plieTubeL->SetName("TubeL");
 
-	zpos += kCP3PlieR;
-	voBellowMother->AddNode(voWiggleUO, iw + 1,  new TGeoTranslation(0., 0., zpos));	
+  TGeoCompositeShape*  shLowerPlieO = new TGeoCompositeShape("lowerPlieO", "TorusLO*TubeL");
+  TGeoCompositeShape*  shLowerPlieI = new TGeoCompositeShape("lowerPlieI", "TorusLI*TubeL");
 
-	zpos += kCP3PlieR;
-	if (iw < 17) 
-	    voBellowMother->AddNode(voWiggleC1,  iw + 19, new TGeoTranslation(0., 0., zpos - kCP3PlieThickness / 2.));
-	else
-	    voBellowMother->AddNode(voWiggleC2,  iw + 19, new TGeoTranslation(0., 0., zpos - kCP3PlieThickness / 2.));
+  TGeoVolume* voWiggleLO = new TGeoVolume("CP3WLO", shLowerPlieO, kMedVac);
+  TGeoVolume* voWiggleLI = new TGeoVolume("CP3WLI", shLowerPlieI, kMedSteel);
+  voWiggleLO->AddNode(voWiggleLI, 1,  gGeoIdentity);    
 
-	if (iw < 17) {
-	    zpos += kCP3PlieR;
-	    voBellowMother->AddNode(voWiggleLO, iw + 1, new TGeoTranslation(0., 0., zpos -  kCP3PlieThickness));
-	}
+  //
+  // Connection between upper and lower part of undulation
+  TGeoVolume* voWiggleC1 = new TGeoVolume("Q3WCO1",  
+      new TGeoTube(kCP3BellowRi + kCP3PlieR, kCP3BellowRo - kCP3PlieR, kCP3PlieThickness / 2.),
+      kMedSteel);
+  TGeoVolume* voWiggleC2 = new TGeoVolume("Q3WCO2",  
+      new TGeoTube(kCP3BellowRi + kCP3ConnectionPlieR, kCP3BellowRo - kCP3PlieR, kCP3PlieThickness / 2.),
+      kMedSteel);
+  //
+  // Conncetion between undulated section and beam pipe
+  TGeoTorus* plieTorusCO =  new TGeoTorus(kCP3BellowRi + kCP3ConnectionPlieR, 0. , kCP3ConnectionPlieR);
+  plieTorusCO->SetName("TorusCO");
+  TGeoTorus* plieTorusCI =  new TGeoTorus(kCP3BellowRi + kCP3ConnectionPlieR, kCP3ConnectionPlieR - kCP3PlieThickness, kCP3ConnectionPlieR);
+  plieTorusCI->SetName("TorusCI");
+  TGeoTube*  plieTubeC   =  new TGeoTube (kCP3BellowRi, kCP3BellowRi + kCP3ConnectionPlieR, kCP3ConnectionPlieR);
+  plieTubeC->SetName("TubeC");
+
+  TGeoCompositeShape*  shConnectionPlieO = new TGeoCompositeShape("connectionPlieO", "TorusCO*TubeC");
+  TGeoCompositeShape*  shConnectionPlieI = new TGeoCompositeShape("connectionPlieI", "TorusCI*TubeC");
+
+  TGeoVolume* voConnectionPO = new TGeoVolume("CP3CPO", shConnectionPlieO, kMedVac);
+  TGeoVolume* voConnectionPI = new TGeoVolume("CP3CPI", shConnectionPlieI, kMedSteel);
+  voConnectionPO->AddNode(voConnectionPI, 1,  gGeoIdentity);    
+  //
+  // Connecting pipes
+  TGeoVolume* voConnectionPipeO = new TGeoVolume("CP3BECO",  
+      new TGeoTube(0., kCP3AdaptorTubeRo, kCP3BellowConnectionLength / 2.),
+      kMedVac);
+  TGeoVolume* voConnectionPipeI = new TGeoVolume("CP3BECI",  
+      new TGeoTube(kCP3AdaptorTubeRi, kCP3AdaptorTubeRo, kCP3BellowConnectionLength / 2.),
+      kMedSteel);
+
+  voConnectionPipeO->AddNode(voConnectionPipeI, 1,  gGeoIdentity);
+
+  //
+  // Bellow mother
+  TGeoPcon* shBellowMotherPC = new TGeoPcon(0., 360., 6);
+  dz =  - kCP3BellowLength / 2;
+  shBellowMotherPC->DefineSection(0, dz, 0.,  kCP3AdaptorTubeRo);
+  dz +=  kCP3BellowConnectionLength;
+  shBellowMotherPC->DefineSection(1, dz, 0.,  kCP3AdaptorTubeRo);
+  shBellowMotherPC->DefineSection(2, dz, 0.,  kCP3BellowRo);
+  dz =  kCP3BellowLength /2. -  kCP3BellowConnectionLength;;
+  shBellowMotherPC->DefineSection(3, dz, 0.,  kCP3BellowRo);
+  shBellowMotherPC->DefineSection(4, dz, 0.,  kCP3AdaptorTubeRo);
+  dz +=  kCP3BellowConnectionLength;
+  shBellowMotherPC->DefineSection(5, dz, 0.,  kCP3AdaptorTubeRo);
+
+  TGeoVolume* voBellowMother = new TGeoVolume("CP3BeMO", shBellowMotherPC, kMedVac);
+  voBellowMother->SetVisibility(0);
+
+  //
+  // Add undulations
+  z0   =  - kCP3BellowLength / 2. +  kCP3BellowConnectionLength + 2. * kCP3ConnectionPlieR - kCP3PlieThickness;
+  zsh  = 4. *  kCP3PlieR -  2. * kCP3PlieThickness;
+  for (Int_t iw = 0; iw < 18; iw++) {
+    Float_t zpos =  z0 + iw * zsh;	
+    if (iw > 0) 
+      voBellowMother->AddNode(voWiggleC1,  iw + 1 , new TGeoTranslation(0., 0., zpos + kCP3PlieThickness / 2.));	
+    else
+      voBellowMother->AddNode(voWiggleC2,  iw + 1 , new TGeoTranslation(0., 0., zpos + kCP3PlieThickness / 2.));	
+
+    zpos += kCP3PlieR;
+    voBellowMother->AddNode(voWiggleUO, iw + 1,  new TGeoTranslation(0., 0., zpos));	
+
+    zpos += kCP3PlieR;
+    if (iw < 17) 
+      voBellowMother->AddNode(voWiggleC1,  iw + 19, new TGeoTranslation(0., 0., zpos - kCP3PlieThickness / 2.));
+    else
+      voBellowMother->AddNode(voWiggleC2,  iw + 19, new TGeoTranslation(0., 0., zpos - kCP3PlieThickness / 2.));
+
+    if (iw < 17) {
+      zpos += kCP3PlieR;
+      voBellowMother->AddNode(voWiggleLO, iw + 1, new TGeoTranslation(0., 0., zpos -  kCP3PlieThickness));
     }
-//
-// Add connecting undulation between bellow and connecting pipe
-    dz = - kCP3BellowUndulatedLength / 2. + kCP3ConnectionPlieR;
-    voBellowMother->AddNode(voConnectionPO, 1,  new TGeoTranslation(0., 0.,  dz));
-    voBellowMother->AddNode(voConnectionPO, 2,  new TGeoTranslation(0., 0., -dz));
-//
-// Add connecting pipe
-    dz =  - kCP3BellowLength / 2. +  kCP3BellowConnectionLength / 2.;
-    voBellowMother->AddNode(voConnectionPipeO, 1,  new TGeoTranslation(0., 0.,   dz));
-    voBellowMother->AddNode(voConnectionPipeO, 2,  new TGeoTranslation(0., 0.,  -dz));
-//
-// Add bellow to CP/3 mother    
-    dz = - kCP3Length / 2. +  kCP3AdaptorTubeLength +  kCP3BellowLength / 2.;
-    voCp3Mo->AddNode(voBellowMother, 1,  new TGeoTranslation(0., 0., dz));
-    dz += (kCP3BellowLength +  kCP3TubeLength);
-    voCp3Mo->AddNode(voBellowMother, 2,  new TGeoTranslation(0., 0., dz));
-
-
-///////////////////////////////////////////
-// Beam pipe section between bellows     //
-///////////////////////////////////////////
-
-    TGeoVolume* voCp3Bco = new TGeoVolume("CP3BCO",
-					  new TGeoTube(0.,  kCP3AdaptorTubeRo,  kCP3TubeLength / 2.),
-					  kMedVac);
-   
-    TGeoVolume* voCp3Bci = new TGeoVolume("CP3BCI",
-					  new TGeoTube(kCP3AdaptorTubeRi, kCP3AdaptorTubeRo, kCP3TubeLength / 2.), 
-					  kMedSteel);
-    
-    voCp3Bco->AddNode(voCp3Bci, 1, gGeoIdentity);
-    dz = - kCP3Length / 2. +   kCP3AdaptorTubeLength +  kCP3BellowLength +  kCP3TubeLength / 2.;
-    voCp3Mo->AddNode(voCp3Bco, 1, new TGeoTranslation(0., 0., dz));
-
-
-///////////////////////////////////////////		  
-// CP3 Minimised Flange                  //
-///////////////////////////////////////////
-
-    TGeoPcon* shCp3mfo = new TGeoPcon(0., 360., 4);
-    z = - (kCP3FlangeConnectorLength + kCP3FlangeLength) / 2.;
-//  Connection Tube
-    shCp3mfo->DefineSection(0, z, 0., kCP3AdaptorTubeRo);
-    z +=  kCP3FlangeConnectorLength;
-    shCp3mfo->DefineSection(1, z, 0., kCP3AdaptorTubeRo);
-//  Flange
-    shCp3mfo->DefineSection(2, z, 0., kCP3FlangeRo);
-    z = - shCp3mfo->GetZ(0);
-    shCp3mfo->DefineSection(3, z, 0., kCP3FlangeRo);
-
-    TGeoVolume* voCp3mfo = new TGeoVolume("CP3MFO", shCp3mfo, kMedVac);
-
-
-    TGeoPcon* shCp3mfi = new TGeoPcon(0., 360., 4);
-//  Connection Tube
-    shCp3mfi->DefineSection(0, shCp3mfo->GetZ(0), kCP3AdaptorTubeRi, kCP3AdaptorTubeRo);
-    shCp3mfi->DefineSection(1, shCp3mfo->GetZ(1), kCP3AdaptorTubeRi, kCP3AdaptorTubeRo);
-//  Flange
-    shCp3mfi->DefineSection(2, shCp3mfo->GetZ(2), kCP3AdaptorTubeRi, kCP3FlangeRo);
-    shCp3mfi->DefineSection(3, shCp3mfo->GetZ(3), kCP3AdaptorTubeRi, kCP3FlangeRo);
-
-    TGeoVolume* voCp3mfi = new TGeoVolume("CP3MFI", shCp3mfi, kMedSteel);
-
-    voCp3mfo->AddNode(voCp3mfi, 1, gGeoIdentity);
-    dz =  kCP3Length / 2. - (kCP3FlangeConnectorLength + kCP3FlangeLength) / 2.;
-    voCp3Mo->AddNode(voCp3mfo, 1, new TGeoTranslation(0., 0., dz));
-
-
-//
-//  Assemble the central beam pipe
-//
-    TGeoVolumeAssembly* asCP = new TGeoVolumeAssembly("CP");
-    z = 0.;
-    asCP->AddNode(voCp2,   1, gGeoIdentity);
-    z +=  kCP2Length / 2. + kCP1Length / 2.;
-    asCP->AddNode(voCp1, 1, new TGeoTranslation(0., 0., z));
-    z +=  kCP1Length / 2.  + kCP3Length / 2.;
-    asCP->AddNode(voCp3, 1, new TGeoTranslation(0., 0., z));
-    top->AddNode(asCP, 1,  new TGeoCombiTrans(0., 0., 400. -  kCP2Length / 2, rot180));
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////     
-//                                                                            //
-//                                  RB24/1                                    // 
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
-//
-//
-// Drawing LHCVC2U_0001
-// Copper Tube RB24/1      393.5 cm 
-// Warm module VMACA        18.0 cm
-// Annular Ion Pump         35.0 cm
-// Valve                     7.5 cm
-// Warm module VMABC        28.0 cm
-// ================================
-//                         462.0 cm
-//
-
-    
-// Copper Tube RB24/1
-    const Float_t  kRB24CuTubeL   = 393.5;
-    const Float_t  kRB24CuTubeRi  = 8.0/2.;
-    const Float_t  kRB24CuTubeRo  = 8.4/2.;
-    const Float_t  kRB24CuTubeFRo = 7.6;
-    const Float_t  kRB24CuTubeFL  = 1.86;
-
-    TGeoVolume* voRB24CuTubeM = new TGeoVolume("voRB24CuTubeM", 
-					       new TGeoTube(0., kRB24CuTubeRo, kRB24CuTubeL/2.), kMedVacH);
-    voRB24CuTubeM->SetVisibility(0);
-    TGeoVolume* voRB24CuTube  = new TGeoVolume("voRB24CuTube", 
-					       new TGeoTube(kRB24CuTubeRi, kRB24CuTubeRo, kRB24CuTubeL/2.), kMedCuH);
-    voRB24CuTubeM->AddNode(voRB24CuTube, 1, gGeoIdentity);
-    // Air outside tube with higher transport cuts
-    TGeoVolume* voRB24CuTubeA  = new TGeoVolume("voRB24CuTubeA", 
-						new TGeoTube(25., 100., kRB24CuTubeL/2.), kMedAirHigh);
-    voRB24CuTubeA->SetVisibility(0);
-    // Simplified DN 100 Flange
-    TGeoVolume* voRB24CuTubeF  = new TGeoVolume("voRB24CuTubeF",
-                                                new TGeoTube(kRB24CuTubeRo, kRB24CuTubeFRo, kRB24CuTubeFL/2.), kMedSteelH);
-
-// Warm Module Type VMACA
-// LHCVMACA_0002
-// 
-// Pos 1 Warm Bellows DN100       LHCVBU__0012
-// Pos 2 RF Contact   D80         LHCVSR__0005
-// Pos 3 Trans. Tube Flange       LHCVSR__0065
-// [Pos 4 Hex. Countersunk Screw   Bossard BN4719]
-// [Pos 5 Tension spring           LHCVSR__0011]
-//
-//
-//
-// Pos1    Warm Bellows DN100
-// Pos1.1  Bellows                  LHCVBU__0006
-//
-//
-// Connection Tubes    
-// Connection tube inner r
-    const Float_t kRB24B1ConTubeRin        = 10.0/2.;
-// Connection tube outer r
-    const Float_t kRB24B1ConTubeRou        = 10.3/2.;
-// Connection tube length
-    const Float_t kRB24B1ConTubeL          =  2.5;
-// 
-    const Float_t kRB24B1CompL             = 16.00;    // Length of the compensator
-    const Float_t kRB24B1BellowRi          = 10.25/2.; // Bellow inner radius        
-    const Float_t kRB24B1BellowRo          = 11.40/2.; // Bellow outer radius        
-    const Int_t   kRB24B1NumberOfPlies     = 27;       // Number of plies            
-    const Float_t kRB24B1BellowUndL        = 11.00;    // Length of undulated region 
-    const Float_t kRB24B1PlieThickness     =  0.015;   // Plie thickness             
-
-    const Float_t kRB24B1PlieRadius = 
-      (kRB24B1BellowUndL + (2. *  kRB24B1NumberOfPlies+ 1.) * kRB24B1PlieThickness) / (4. * kRB24B1NumberOfPlies + 2.);
-    
-    const Float_t kRB24B1ProtTubeThickness = 0.02;     // Thickness of the protection tube
-    const Float_t kRB24B1ProtTubeLength    = 4.2;      // Length of the protection tube
-
-    const Float_t kRB24B1RFlangeL          = 1.86;     // Length of the flanges
-    const Float_t kRB24B1RFlangeLO         = 0.26;     // Flange overlap
-    const Float_t kRB24B1RFlangeRO         = 11.18/2;  // Inner radius at Flange overlap    
-    const Float_t kRB24B1RFlangeRou        = 15.20/2.; // Outer radius of flange
-    const Float_t kRB24B1RFlangeRecess     = 0.98;     // Flange recess
-    const Float_t kRB24B1L                 = kRB24B1CompL +  2. * (kRB24B1RFlangeL - kRB24B1RFlangeRecess);
-    
-///      
-//
-// Bellow mother volume
-    TGeoPcon* shRB24B1BellowM = new TGeoPcon(0., 360., 14);
-    // Connection Tube and Flange
-    z = 0.;
-    shRB24B1BellowM->DefineSection( 0, z, 0.,               kRB24B1RFlangeRou);
-    z += kRB24B1RFlangeLO;
-    shRB24B1BellowM->DefineSection( 1, z, 0.,               kRB24B1RFlangeRou);
-    shRB24B1BellowM->DefineSection( 2, z, 0.,               kRB24B1RFlangeRou);    
-    z = kRB24B1RFlangeL;
-    shRB24B1BellowM->DefineSection( 3, z, 0.,               kRB24B1RFlangeRou);    
-    shRB24B1BellowM->DefineSection( 4, z, 0.,               kRB24B1ConTubeRou);
-    z = kRB24B1ConTubeL +  kRB24B1RFlangeL - kRB24B1RFlangeRecess;
-    shRB24B1BellowM->DefineSection( 5, z, 0.,               kRB24B1ConTubeRou);
-    // Plie
-    shRB24B1BellowM->DefineSection( 6, z, 0.,               kRB24B1BellowRo + kRB24B1ProtTubeThickness);
-    z += kRB24B1BellowUndL;
-    shRB24B1BellowM->DefineSection( 7, z, 0.,               kRB24B1BellowRo + kRB24B1ProtTubeThickness);
-    shRB24B1BellowM->DefineSection( 8, z, 0.,               kRB24B1ConTubeRou);
-    // Connection Tube and Flange
-    z = kRB24B1L - shRB24B1BellowM->GetZ(3);
-    shRB24B1BellowM->DefineSection( 9, z, 0.,               kRB24B1ConTubeRou);
-    shRB24B1BellowM->DefineSection(10, z, 0.,               kRB24B1RFlangeRou);
-    z = kRB24B1L - shRB24B1BellowM->GetZ(1);
-    shRB24B1BellowM->DefineSection(11, z, 0.,               kRB24B1RFlangeRou);
-    shRB24B1BellowM->DefineSection(12, z, 0.,               kRB24B1RFlangeRou);
-    z = kRB24B1L - shRB24B1BellowM->GetZ(0);
-    shRB24B1BellowM->DefineSection(13, z, 0.,               kRB24B1RFlangeRou);
-
-    TGeoVolume* voRB24B1BellowM = new TGeoVolume("RB24B1BellowM", shRB24B1BellowM, kMedVacH);
-    voRB24B1BellowM->SetVisibility(0);
-//
-// Bellow Section    
-    TGeoVolume* voRB24B1Bellow 
-	= MakeBellow("RB24B1", kRB24B1NumberOfPlies, kRB24B1BellowRi, kRB24B1BellowRo, 
-		     kRB24B1BellowUndL, kRB24B1PlieRadius ,kRB24B1PlieThickness);
-    voRB24B1Bellow->SetVisibility(0);
-    
-//
-// End Parts (connection tube)
-    TGeoVolume* voRB24B1CT = new TGeoVolume("RB24B1CT", new TGeoTube(kRB24B1ConTubeRin, kRB24B1ConTubeRou,  kRB24B1ConTubeL/2.), kMedSteelH); 
-//
-// Protection Tube      
-    TGeoVolume* voRB24B1PT = new TGeoVolume("RB24B1PT", new TGeoTube(kRB24B1BellowRo, kRB24B1BellowRo + kRB24B1ProtTubeThickness,  
-								     kRB24B1ProtTubeLength / 2.), kMedSteelH);
-    
-    z = kRB24B1ConTubeL/2. +  (kRB24B1RFlangeL - kRB24B1RFlangeRecess);
-    
-    voRB24B1BellowM->AddNode(voRB24B1CT, 1, new TGeoTranslation(0., 0., z));
-    z += (kRB24B1ConTubeL/2.+ kRB24B1BellowUndL/2.);
-    voRB24B1BellowM->AddNode(voRB24B1Bellow, 1, new TGeoTranslation(0., 0., z));
-    z += (kRB24B1BellowUndL/2. + kRB24B1ConTubeL/2);
-    voRB24B1BellowM->AddNode(voRB24B1CT, 2, new TGeoTranslation(0., 0., z));
-    z =  kRB24B1ConTubeL +  kRB24B1ProtTubeLength / 2. + 1. + kRB24B1RFlangeLO;
-    voRB24B1BellowM->AddNode(voRB24B1PT, 1, new TGeoTranslation(0., 0., z));
-    z +=  kRB24B1ProtTubeLength + 0.6;
-    voRB24B1BellowM->AddNode(voRB24B1PT, 2, new TGeoTranslation(0., 0., z));
-
-                 
-
-// Pos 1/2 Rotatable Flange         LHCVBU__0013
-// Pos 1/3 Flange DN100/103         LHCVBU__0018
-// The two flanges can be represented by the same volume
-    // Outer Radius (including the outer movable ring).
-    // The inner ring has a diameter of 12.04 cm
-
-  
-    TGeoPcon* shRB24B1RFlange = new TGeoPcon(0., 360., 10);
-    z = 0.;
-    shRB24B1RFlange->DefineSection(0, z, 10.30/2., kRB24B1RFlangeRou);
-    z += 0.55;  // 5.5 mm added for outer ring
-    z += 0.43;
-    shRB24B1RFlange->DefineSection(1, z, 10.30/2., kRB24B1RFlangeRou);
-    shRB24B1RFlange->DefineSection(2, z, 10.06/2., kRB24B1RFlangeRou);    
-    z += 0.15;
-    shRB24B1RFlange->DefineSection(3, z, 10.06/2., kRB24B1RFlangeRou);    
-    // In reality this part is rounded
-    shRB24B1RFlange->DefineSection(4, z, 10.91/2., kRB24B1RFlangeRou);    
-    z += 0.15;
-    shRB24B1RFlange->DefineSection(5, z, 10.91/2., kRB24B1RFlangeRou);    
-    shRB24B1RFlange->DefineSection(6, z, 10.06/2., kRB24B1RFlangeRou);    
-    z += 0.32;
-    shRB24B1RFlange->DefineSection(7, z, 10.06/2., kRB24B1RFlangeRou);    
-    shRB24B1RFlange->DefineSection(8, z, kRB24B1RFlangeRO, kRB24B1RFlangeRou);    
-    z += kRB24B1RFlangeLO;
-    shRB24B1RFlange->DefineSection(9, z, kRB24B1RFlangeRO, kRB24B1RFlangeRou);    
-    
-    TGeoVolume* voRB24B1RFlange = new TGeoVolume("RB24B1RFlange", shRB24B1RFlange, kMedSteelH);
-
-    
-    z = kRB24B1L - kRB24B1RFlangeL;
-    voRB24B1BellowM->AddNode(voRB24B1RFlange, 1, new TGeoTranslation(0., 0., z));
-    z = kRB24B1RFlangeL;
-    voRB24B1BellowM->AddNode(voRB24B1RFlange, 2, new TGeoCombiTrans(0., 0., z, rot180));
-//
-// Pos 2 RF Contact   D80         LHCVSR__0005
-//
-// Pos 2.1 RF Contact Flange      LHCVSR__0003
-//
-    TGeoPcon* shRB24B1RCTFlange = new TGeoPcon(0., 360., 6);
-    const Float_t kRB24B1RCTFlangeRin  = 8.06/2. + 0.05;  // Inner radius
-    const Float_t kRB24B1RCTFlangeL    = 1.45;            // Length
-    
-    z = 0.;
-    shRB24B1RCTFlange->DefineSection(0, z, kRB24B1RCTFlangeRin,  8.20/2.);
-    z += 0.15;
-    shRB24B1RCTFlange->DefineSection(1, z, kRB24B1RCTFlangeRin,  8.20/2.);
-    shRB24B1RCTFlange->DefineSection(2, z, kRB24B1RCTFlangeRin,  8.60/2.);
-    z += 1.05;
-    shRB24B1RCTFlange->DefineSection(3, z, kRB24B1RCTFlangeRin,  8.60/2.);
-    shRB24B1RCTFlange->DefineSection(4, z, kRB24B1RCTFlangeRin, 11.16/2.);
-    z += 0.25;
-    shRB24B1RCTFlange->DefineSection(5, z, kRB24B1RCTFlangeRin, 11.16/2.);
-    TGeoVolume* voRB24B1RCTFlange = new TGeoVolume("RB24B1RCTFlange", shRB24B1RCTFlange, kMedCuH);
-    z = kRB24B1L - kRB24B1RCTFlangeL;
-    
-    voRB24B1BellowM->AddNode(voRB24B1RCTFlange, 1, new TGeoTranslation(0., 0., z));
-//
-// Pos 2.2 RF-Contact        LHCVSR__0004
-//
-    TGeoPcon* shRB24B1RCT = new TGeoPcon(0., 360., 3);
-    const Float_t kRB24B1RCTRin  = 8.00/2.;        // Inner radius
-    const Float_t kRB24B1RCTCRin = 8.99/2.;        // Max. inner radius conical section
-    const Float_t kRB24B1RCTL    = 11.78;          // Length
-    const Float_t kRB24B1RCTSL   = 10.48;          // Length of straight section
-    const Float_t kRB24B1RCTd    =  0.03;          // Thickness
-    
-    z = 0;
-    shRB24B1RCT->DefineSection(0, z,  kRB24B1RCTCRin,  kRB24B1RCTCRin + kRB24B1RCTd);
-    z =  kRB24B1RCTL -  kRB24B1RCTSL;
-    // In the (VSR0004) this section is straight in (LHCVC2U_0001) it is conical ????
-    shRB24B1RCT->DefineSection(1, z,  kRB24B1RCTRin + 0.35,  kRB24B1RCTRin + 0.35 + kRB24B1RCTd);
-    z = kRB24B1RCTL - 0.03;
-    shRB24B1RCT->DefineSection(2, z,  kRB24B1RCTRin,  kRB24B1RCTRin + kRB24B1RCTd);
-
-    TGeoVolume* voRB24B1RCT = new TGeoVolume("RB24B1RCT", shRB24B1RCT, kMedCuH);
-    z = kRB24B1L - kRB24B1RCTL - 0.45;
-    voRB24B1BellowM->AddNode(voRB24B1RCT, 1, new TGeoTranslation(0., 0., z));    
-
-//
-// Pos 3 Trans. Tube Flange       LHCVSR__0065
-//
-// Pos 3.1 Transition Tube D53    LHCVSR__0064
-// Pos 3.2 Transition Flange      LHCVSR__0060
-// Pos 3.3 Transition Tube        LHCVSR__0058
-    TGeoPcon* shRB24B1TTF = new TGeoPcon(0., 360., 7);
-    // Flange
-    z = 0.;
-    shRB24B1TTF->DefineSection(0, z,  6.30/2., 11.16/2.);
-    z += 0.25;
-    shRB24B1TTF->DefineSection(1, z,  6.30/2., 11.16/2.);
-    shRB24B1TTF->DefineSection(2, z,  6.30/2.,  9.3/2.);
-    z += 0.55;
-    shRB24B1TTF->DefineSection(3, z,  6.30/2.,  9.3/2.);
-    // Tube
-    shRB24B1TTF->DefineSection(4, z,  6.30/2.,  6.7/2.);
-    z += 5.80;
-    shRB24B1TTF->DefineSection(5, z,  6.30/2.,  6.7/2.);
-    // Transition Tube
-    z += 3.75;
-    shRB24B1TTF->DefineSection(6, z,  8.05/2.,  8.45/2.);
-    TGeoVolume* voRB24B1TTF = new TGeoVolume("RB24B1TTF", shRB24B1TTF, kMedSteelH);
-    z =  0.;
-    voRB24B1BellowM->AddNode(voRB24B1TTF, 1, new TGeoTranslation(0., 0., z));    
-
-// Annular Ion Pump        
-// LHCVC2U_0003
-//
-// Pos  1 Rotable Flange         LHCVFX__0031
-// Pos  2 RF Screen Tube         LHCVC2U_0005
-// Pos  3 Shell                  LHCVC2U_0007
-// Pos  4 Extruded Shell         LHCVC2U_0006
-// Pos  5 Feedthrough Tube       LHCVC2U_0004
-// Pos  6 Tubulated Flange       STDVFUHV0021
-// Pos  7 Fixed Flange           LHCVFX__0032
-// Pos  8 Pumping Elements
-
-//
-// Pos 1 Rotable Flange          LHCVFX__0031
-// pos 7 Fixed Flange            LHCVFX__0032
-//
-//  Mother volume
-    const Float_t kRB24AIpML = 35.;
-    
-    TGeoVolume* voRB24AIpM = new TGeoVolume("voRB24AIpM", new TGeoTube(0., 10., kRB24AIpML/2.), kMedAirH);
-    voRB24AIpM->SetVisibility(0);
-    
-    //
-    // Length 35 cm
-    // Flange 2 x 1.98 =   3.96
-    // Tube            =  32.84
-    //==========================
-    //                    36.80
-    // Overlap 2 * 0.90 =  1.80
-                        
-    const Float_t kRB24IpRFD1     =  0.68;    // Length of section 1
-    const Float_t kRB24IpRFD2     =  0.30;    // Length of section 2						     
-    const Float_t kRB24IpRFD3     =  0.10;    // Length of section 3						           
-    const Float_t kRB24IpRFD4     =  0.35;    // Length of section 4						           
-    const Float_t kRB24IpRFD5     =  0.55;    // Length of section 5						           
-    
-    const Float_t kRB24IpRFRo     = 15.20/2.; // Flange outer radius 
-    const Float_t kRB24IpRFRi1    =  6.30/2.; // Flange inner radius section 1
-    const Float_t kRB24IpRFRi2    =  6.00/2.; // Flange inner radius section 2
-    const Float_t kRB24IpRFRi3    =  5.84/2.; // Flange inner radius section 3    
-    const Float_t kRB24IpRFRi4    =  6.00/2.; // Flange inner radius section 1
-    const Float_t kRB24IpRFRi5    = 10.50/2.; // Flange inner radius section 2
-
-    TGeoPcon* shRB24IpRF = new TGeoPcon(0., 360., 9);
-    z0 = 0.;
-    shRB24IpRF->DefineSection(0, z0, kRB24IpRFRi1, kRB24IpRFRo);
-    z0 += kRB24IpRFD1;
-    shRB24IpRF->DefineSection(1, z0, kRB24IpRFRi2, kRB24IpRFRo);
-    z0 += kRB24IpRFD2;
-    shRB24IpRF->DefineSection(2, z0, kRB24IpRFRi2, kRB24IpRFRo);
-    shRB24IpRF->DefineSection(3, z0, kRB24IpRFRi3, kRB24IpRFRo);
-    z0 += kRB24IpRFD3;
-    shRB24IpRF->DefineSection(4, z0, kRB24IpRFRi3, kRB24IpRFRo);
-    shRB24IpRF->DefineSection(5, z0, kRB24IpRFRi4, kRB24IpRFRo);
-    z0 += kRB24IpRFD4;
-    shRB24IpRF->DefineSection(6, z0, kRB24IpRFRi4, kRB24IpRFRo);
-    shRB24IpRF->DefineSection(7, z0, kRB24IpRFRi5, kRB24IpRFRo);
-    z0 += kRB24IpRFD5;
-    shRB24IpRF->DefineSection(8, z0, kRB24IpRFRi5, kRB24IpRFRo);
-
-    TGeoVolume* voRB24IpRF = new TGeoVolume("RB24IpRF", shRB24IpRF, kMedSteelH);
-    
-//
-// Pos  2 RF Screen Tube         LHCVC2U_0005
-//
-
-//
-// Tube
-    Float_t kRB24IpSTTL  = 32.84;            // Total length of the tube
-    Float_t kRB24IpSTTRi =  5.80/2.;         // Inner Radius
-    Float_t kRB24IpSTTRo =  6.00/2.;         // Outer Radius
-    TGeoVolume* voRB24IpSTT = new TGeoVolume("RB24IpSTT", new TGeoTube(kRB24IpSTTRi, kRB24IpSTTRo, kRB24IpSTTL/2.), kMedSteelH);
-// Screen
-    Float_t kRB24IpSTCL  =  0.4;             // Lenth of the crochet detail
-    // Length of the screen 
-    Float_t kRB24IpSTSL  =  9.00 - 2. * kRB24IpSTCL; 
-    // Rel. position of the screen 
-    Float_t kRB24IpSTSZ  =  7.00 + kRB24IpSTCL; 
-    TGeoVolume* voRB24IpSTS = new TGeoVolume("RB24IpSTS", new TGeoTube(kRB24IpSTTRi, kRB24IpSTTRo, kRB24IpSTSL/2.), kMedSteelH);
-    // Vacuum
-    TGeoVolume* voRB24IpSTV = new TGeoVolume("RB24IpSTV", new TGeoTube(0., kRB24IpSTTRi, kRB24AIpML/2.), kMedVacH);
-    //
-    voRB24IpSTT->AddNode(voRB24IpSTS, 1, new TGeoTranslation(0., 0., kRB24IpSTSZ -  kRB24IpSTTL/2. +  kRB24IpSTSL/2.));
-    
-// Crochets
-    // Inner radius
-    Float_t kRB24IpSTCRi  = kRB24IpSTTRo + 0.25;
-    // Outer radius
-    Float_t kRB24IpSTCRo  = kRB24IpSTTRo + 0.35;
-    // Length of 1stsection
-    Float_t kRB24IpSTCL1  = 0.15;
-    // Length of 2nd section
-    Float_t kRB24IpSTCL2  = 0.15;
-    // Length of 3rd section
-    Float_t kRB24IpSTCL3  = 0.10;
-    // Rel. position of 1st Crochet
-
-
-    TGeoPcon* shRB24IpSTC = new TGeoPcon(0., 360., 5);
-    z0 = 0;
-    shRB24IpSTC->DefineSection(0, z0, kRB24IpSTCRi, kRB24IpSTCRo);
-    z0 += kRB24IpSTCL1;
-    shRB24IpSTC->DefineSection(1, z0, kRB24IpSTCRi, kRB24IpSTCRo);
-    shRB24IpSTC->DefineSection(2, z0, kRB24IpSTTRo, kRB24IpSTCRo);
-    z0 += kRB24IpSTCL2;
-    shRB24IpSTC->DefineSection(3, z0, kRB24IpSTTRo, kRB24IpSTCRo);
-    z0 += kRB24IpSTCL3;
-    shRB24IpSTC->DefineSection(4, z0, kRB24IpSTTRo, kRB24IpSTTRo + 0.001);
-    TGeoVolume* voRB24IpSTC = new TGeoVolume("RB24IpSTC", shRB24IpSTC, kMedSteelH);
-
-// Pos  3 Shell                  LHCVC2U_0007
-// Pos  4 Extruded Shell         LHCVC2U_0006
-    Float_t kRB24IpShellL     =  4.45;    // Length of the Shell
-    Float_t kRB24IpShellD     =  0.10;    // Wall thickness of the shell
-    Float_t kRB24IpShellCTRi  =  6.70/2.; // Inner radius of the connection tube
-    Float_t kRB24IpShellCTL   =  1.56;    // Length of the connection tube
-    Float_t kRB24IpShellCARi  = 17.80/2.; // Inner radius of the cavity
-    Float_t kRB24IpShellCCRo  = 18.20/2.; // Inner radius at the centre
-
-    TGeoPcon* shRB24IpShell = new TGeoPcon(0., 360., 7);
-    z0 = 0;
-    shRB24IpShell->DefineSection(0, z0, kRB24IpShellCTRi, kRB24IpShellCTRi + kRB24IpShellD);
-    z0 +=  kRB24IpShellCTL;
-    shRB24IpShell->DefineSection(1, z0, kRB24IpShellCTRi, kRB24IpShellCTRi + kRB24IpShellD);
-    shRB24IpShell->DefineSection(2, z0, kRB24IpShellCTRi, kRB24IpShellCARi + kRB24IpShellD);
-    z0 += kRB24IpShellD;
-    shRB24IpShell->DefineSection(3, z0, kRB24IpShellCARi, kRB24IpShellCARi + kRB24IpShellD);
-    z0 = kRB24IpShellL - kRB24IpShellD;
-    shRB24IpShell->DefineSection(4, z0, kRB24IpShellCARi, kRB24IpShellCARi + kRB24IpShellD);
-    shRB24IpShell->DefineSection(5, z0, kRB24IpShellCARi, kRB24IpShellCCRo);
-    z0 = kRB24IpShellL;
-    shRB24IpShell->DefineSection(6, z0, kRB24IpShellCARi, kRB24IpShellCCRo);
-    TGeoVolume* voRB24IpShell = new TGeoVolume("RB24IpShell", shRB24IpShell, kMedSteelH);
-    
-    TGeoPcon* shRB24IpShellM   = MakeMotherFromTemplate(shRB24IpShell, 0, 6, kRB24IpShellCTRi , 13);
-    
-    
-    for (Int_t i = 0; i < 6; i++) {
-	z = 2. * kRB24IpShellL  - shRB24IpShellM->GetZ(5-i);
-	Float_t rmin = shRB24IpShellM->GetRmin(5-i);
-	Float_t rmax = shRB24IpShellM->GetRmax(5-i);
-	shRB24IpShellM->DefineSection(7+i, z, rmin, rmax);
-    }
-    
-    TGeoVolume* voRB24IpShellM = new TGeoVolume("RB24IpShellM", shRB24IpShellM, kMedVacH);
-    voRB24IpShellM->SetVisibility(0);
-    voRB24IpShellM->AddNode(voRB24IpShell, 1, gGeoIdentity);
-    voRB24IpShellM->AddNode(voRB24IpShell, 2, new TGeoCombiTrans(0., 0., 2. * kRB24IpShellL, rot180));
-//
-// Pos  8 Pumping Elements
-//
-//  Anode array
-    TGeoVolume* voRB24IpPE = new TGeoVolume("voRB24IpPE", new TGeoTube(0.9, 1., 2.54/2.), kMedSteelH);
-    Float_t kRB24IpPEAR = 5.5;
-    
-    for (Int_t i = 0; i < 15; i++) {
-	Float_t phi = Float_t(i) * 24.;
-	Float_t x   =  kRB24IpPEAR * TMath::Cos(kDegRad * phi);
-	Float_t y   =  kRB24IpPEAR * TMath::Sin(kDegRad * phi);
-	voRB24IpShellM->AddNode(voRB24IpPE, i+1, new TGeoTranslation(x, y, kRB24IpShellL));
-    }
-    
-    
-//
-//  Cathodes
-//
-// Here we could add some Ti strips
-
-// Postioning of elements
-    voRB24AIpM->AddNode(voRB24IpRF,     1, new TGeoTranslation(0., 0., -kRB24AIpML/2.));
-    voRB24AIpM->AddNode(voRB24IpRF,     2, new TGeoCombiTrans (0., 0., +kRB24AIpML/2., rot180));
-    voRB24AIpM->AddNode(voRB24IpSTT,    1, new TGeoTranslation(0., 0., 0.));
-    voRB24AIpM->AddNode(voRB24IpSTV,    1, new TGeoTranslation(0., 0., 0.));
-    voRB24AIpM->AddNode(voRB24IpShellM, 1, new TGeoTranslation(0., 0., -kRB24AIpML/2. +  8.13));
-    voRB24AIpM->AddNode(voRB24IpSTC,    1, new TGeoTranslation(0., 0., 8.13 - kRB24AIpML/2.));
-    voRB24AIpM->AddNode(voRB24IpSTC,    2, new TGeoCombiTrans (0., 0., 8.14 + 8.9 - kRB24AIpML/2., rot180));
-    
-//
-// Valve
-// VAC Series 47 DN 63 with manual actuator
-//
-    const Float_t kRB24ValveWz = 7.5;
-    const Float_t kRB24ValveDN = 10.0/2.;
-//
-//  Body containing the valve plate
-//
-    const Float_t kRB24ValveBoWx =  15.6;
-    const Float_t kRB24ValveBoWy = (21.5 + 23.1 - 5.);
-    const Float_t kRB24ValveBoWz =  4.6;
-    const Float_t kRB24ValveBoD  =  0.5;
-
-    TGeoVolume* voRB24ValveBoM =
-	new TGeoVolume("RB24ValveBoM", 
-		       new TGeoBBox( kRB24ValveBoWx/2.,  kRB24ValveBoWy/2., kRB24ValveBoWz/2.), kMedAirH);
-    voRB24ValveBoM->SetVisibility(0);
-    TGeoVolume* voRB24ValveBo =
-	new TGeoVolume("RB24ValveBo", 
-		       new TGeoBBox( kRB24ValveBoWx/2.,  kRB24ValveBoWy/2., kRB24ValveBoWz/2.), kMedSteelH);
-    voRB24ValveBoM->AddNode(voRB24ValveBo, 1, gGeoIdentity);
-    //
-    // Inner volume
-    //
-    TGeoVolume* voRB24ValveBoI = new TGeoVolume("RB24ValveBoI", 
-						new TGeoBBox( kRB24ValveBoWx/2. -  kRB24ValveBoD,  
-							      kRB24ValveBoWy/2. -  kRB24ValveBoD/2., 
-							      kRB24ValveBoWz/2. -  kRB24ValveBoD), 
-						kMedVacH);
-    voRB24ValveBo->AddNode(voRB24ValveBoI, 1, new TGeoTranslation(0., kRB24ValveBoD/2., 0.));
-    //
-    // Opening and Flanges
-    const Float_t  kRB24ValveFlRo = 18./2.;
-    const Float_t  kRB24ValveFlD  = 1.45;    
-    TGeoVolume* voRB24ValveBoA = new TGeoVolume("RB24ValveBoA", 
-						new TGeoTube(0., kRB24ValveDN/2., kRB24ValveBoD/2.), kMedVacH);
-    voRB24ValveBo->AddNode(voRB24ValveBoA, 1, new TGeoTranslation(0., - kRB24ValveBoWy/2. + 21.5, -kRB24ValveBoWz/2. +  kRB24ValveBoD/2.));
-    voRB24ValveBo->AddNode(voRB24ValveBoA, 2, new TGeoTranslation(0., - kRB24ValveBoWy/2. + 21.5, +kRB24ValveBoWz/2. -  kRB24ValveBoD/2.));
- 
-    TGeoVolume* voRB24ValveFl  = new TGeoVolume("RB24ValveFl",  new TGeoTube(kRB24ValveDN/2.,  kRB24ValveFlRo, kRB24ValveFlD/2.), kMedSteelH);
-    TGeoVolume* voRB24ValveFlI = new TGeoVolume("RB24ValveFlI", new TGeoTube(0.,               kRB24ValveFlRo, kRB24ValveFlD/2.), kMedVacH);
-    voRB24ValveFlI->AddNode(voRB24ValveFl, 1, gGeoIdentity);
-    
-    //
-    // Actuator Flange
-    const Float_t kRB24ValveAFlWx =  18.9;
-    const Float_t kRB24ValveAFlWy =   5.0;
-    const Float_t kRB24ValveAFlWz =   7.7;
-    TGeoVolume* voRB24ValveAFl = new TGeoVolume("RB24ValveAFl", new TGeoBBox(kRB24ValveAFlWx/2., kRB24ValveAFlWy/2., kRB24ValveAFlWz/2.), kMedSteelH);
-    //
-    // Actuator Tube
-    const Float_t kRB24ValveATRo = 9.7/2.;
-    const Float_t kRB24ValveATH  = 16.6;
-    TGeoVolume* voRB24ValveAT = new TGeoVolume("RB24ValveAT", new TGeoTube(kRB24ValveATRo -  2. * kRB24ValveBoD,kRB24ValveATRo,  kRB24ValveATH/2.), 
-					       kMedSteelH);
-    //
-    // Manual Actuator (my best guess)
-    TGeoVolume* voRB24ValveMA1 = new TGeoVolume("RB24ValveMA1", new TGeoCone(2.5/2., 0., 0.5, 4.5, 5.), kMedSteelH);
-    TGeoVolume* voRB24ValveMA2 = new TGeoVolume("RB24ValveMA2", new TGeoTorus(5., 0., 1.25), kMedSteelH);
-    TGeoVolume* voRB24ValveMA3 = new TGeoVolume("RB24ValveMA3", new TGeoTube (0., 1.25, 2.5), kMedSteelH);
-    
-
-    //
-    // Position all volumes
-    Float_t y0;
-    TGeoVolumeAssembly*  voRB24ValveMo = new TGeoVolumeAssembly("RB24ValveMo");
-    voRB24ValveMo->AddNode(voRB24ValveFl,  1, new TGeoTranslation(0., 0., - 7.5/2. + kRB24ValveFlD/2.));
-    voRB24ValveMo->AddNode(voRB24ValveFl,  2, new TGeoTranslation(0., 0., + 7.5/2. - kRB24ValveFlD/2.));
-    y0 = -21.5;
-    voRB24ValveMo->AddNode(voRB24ValveBoM, 1, new TGeoTranslation(0., y0 + kRB24ValveBoWy/2.,   0.));
-    y0 +=  kRB24ValveBoWy;
-    voRB24ValveMo->AddNode(voRB24ValveAFl, 1, new TGeoTranslation(0., y0 +  kRB24ValveAFlWy/2., 0.));
-    y0 +=  kRB24ValveAFlWy;
-    voRB24ValveMo->AddNode(voRB24ValveAT,  1, new TGeoCombiTrans(0.,  y0 + kRB24ValveATH/2.,    0., rotyz));
-    y0 += kRB24ValveATH;
-    voRB24ValveMo->AddNode(voRB24ValveMA1, 1, new TGeoCombiTrans(0.,  y0 + 2.5/2.,    0., rotyz));
-    y0 += 2.5;
-    voRB24ValveMo->AddNode(voRB24ValveMA2, 1, new TGeoCombiTrans(0.,  y0 + 2.5/2.,    0., rotyz));
-    y0 += 2.5;
-    voRB24ValveMo->AddNode(voRB24ValveMA3, 1, new TGeoCombiTrans(5./TMath::Sqrt(2.),  y0 + 5.0/2., 5./TMath::Sqrt(2.), rotyz));
-//
-// Warm Module Type VMABC
-// LHCVMABC_0002
-// 
-//
-//
-// Flange                  1.00
-// Central Piece          11.50
-// Bellow                 14.50
-// End Flange              1.00
-//===================================
-// Total                  28.00 
-//                        
-// Pos 1 Warm Bellows DN100       LHCVBU__0016
-// Pos 2 Trans. Tube Flange       LHCVSR__0062
-// Pos 3 RF Contact   D63         LHCVSR__0057
-// [Pos 4 Hex. Countersunk Screw   Bossard BN4719]
-// [Pos 5 Tension spring           LHCVSR__00239]
-//
-
-// Pos 1 Warm Bellows DN100                   LHCVBU__0016
-// Pos 1.1 Right Body 2 Ports with Support    LHCVBU__0014
-    //
-    // Tube 1
-    const Float_t kRB24VMABCRBT1Ri = 10.0/2.;
-    const Float_t kRB24VMABCRBT1Ro = 10.3/2.;
-    const Float_t kRB24VMABCRBT1L  = 11.5;   
-    const Float_t kRB24VMABCRBT1L2 = 8.;
-    const Float_t kRB24VMABCL      = 28.;
-    
-    TGeoTube* shRB24VMABCRBT1 = new TGeoTube(kRB24VMABCRBT1Ri, kRB24VMABCRBT1Ro, kRB24VMABCRBT1L/2.);
-    shRB24VMABCRBT1->SetName("RB24VMABCRBT1");
-    TGeoTube* shRB24VMABCRBT1o = new TGeoTube(0., kRB24VMABCRBT1Ro,  kRB24VMABCRBT1L/2.);
-    shRB24VMABCRBT1o->SetName("RB24VMABCRBT1o");
-    TGeoTube* shRB24VMABCRBT1o2 = new TGeoTube(0., kRB24VMABCRBT1Ro + 0.3, kRB24VMABCRBT1L/2.);
-    shRB24VMABCRBT1o2->SetName("RB24VMABCRBT1o2");
-    // Lower inforcement 
-    TGeoVolume*  voRB24VMABCRBT12  = new TGeoVolume("RB24VMABCRBT12", 
-						    new TGeoTubeSeg(kRB24VMABCRBT1Ro, kRB24VMABCRBT1Ro + 0.3, kRB24VMABCRBT1L2/2., 220., 320.)
-						    , kMedSteelH);
-    //
-    // Tube 2
-    const Float_t kRB24VMABCRBT2Ri =   6.0/2.;
-    const Float_t kRB24VMABCRBT2Ro =   6.3/2.;
-    const Float_t kRB24VMABCRBF2Ro =  11.4/2.;
-    const Float_t kRB24VMABCRBT2L  =   5.95 + 2.; // 2. cm added for welding    
-    const Float_t kRB24VMABCRBF2L  =   1.75;
-    TGeoTube* shRB24VMABCRBT2 = new TGeoTube(kRB24VMABCRBT2Ri, kRB24VMABCRBT2Ro,  kRB24VMABCRBT2L/2.);
-    shRB24VMABCRBT2->SetName("RB24VMABCRBT2");
-    TGeoTube* shRB24VMABCRBT2i = new TGeoTube(0., kRB24VMABCRBT2Ri, kRB24VMABCRBT2L/2. + 2.);
-    shRB24VMABCRBT2i->SetName("RB24VMABCRBT2i");
-    TGeoCombiTrans* tRBT2 = new TGeoCombiTrans(-11.5 + kRB24VMABCRBT2L/2., 0., 7.2 - kRB24VMABCRBT1L/2.  , rotxz);
-    tRBT2->SetName("tRBT2");
-    tRBT2->RegisterYourself();
-    TGeoCompositeShape* shRB24VMABCRBT2c =  new TGeoCompositeShape("shRB24VMABCRBT2c","RB24VMABCRBT2:tRBT2-RB24VMABCRBT1o");
-    TGeoVolume* voRB24VMABCRBT2 = new TGeoVolume("shRB24VMABCRBT2", shRB24VMABCRBT2c, kMedSteelH);
-    // Flange
-    // Pos 1.4 Flange DN63                        LHCVBU__0008
-    TGeoVolume* voRB24VMABCRBF2 = new TGeoVolume("RB24VMABCRBF2", 
-						 new TGeoTube(kRB24VMABCRBT2Ro, kRB24VMABCRBF2Ro, kRB24VMABCRBF2L/2.), kMedSteelH);
-    // DN63 Blank Flange (my best guess)
-    TGeoVolume* voRB24VMABCRBF2B = new TGeoVolume("RB24VMABCRBF2B", 
-						  new TGeoTube(0., kRB24VMABCRBF2Ro, kRB24VMABCRBF2L/2.), kMedSteelH);
-    //
-    // Tube 3
-    const Float_t kRB24VMABCRBT3Ri =  3.5/2.;
-    const Float_t kRB24VMABCRBT3Ro =  3.8/2.;
-    const Float_t kRB24VMABCRBF3Ro =  7.0/2.;
-    const Float_t kRB24VMABCRBT3L  =  4.95 + 2.; // 2. cm added for welding    
-    const Float_t kRB24VMABCRBF3L  =  1.27;
-    TGeoTube* shRB24VMABCRBT3 = new TGeoTube(kRB24VMABCRBT3Ri, kRB24VMABCRBT3Ro,  kRB24VMABCRBT3L/2);
-    shRB24VMABCRBT3->SetName("RB24VMABCRBT3");
-    TGeoTube* shRB24VMABCRBT3i = new TGeoTube(0., kRB24VMABCRBT3Ri, kRB24VMABCRBT3L/2. + 2.);
-    shRB24VMABCRBT3i->SetName("RB24VMABCRBT3i");
-    TGeoCombiTrans* tRBT3 = new TGeoCombiTrans(0., 10.5 - kRB24VMABCRBT3L/2., 7.2 - kRB24VMABCRBT1L/2.  , rotyz);
-    tRBT3->SetName("tRBT3");
-    tRBT3->RegisterYourself();
-    TGeoCompositeShape* shRB24VMABCRBT3c =  new TGeoCompositeShape("shRB24VMABCRBT3c","RB24VMABCRBT3:tRBT3-RB24VMABCRBT1o");
-    TGeoVolume* voRB24VMABCRBT3 = new TGeoVolume("shRB24VMABCRBT3", shRB24VMABCRBT3c, kMedSteelH);
-    // Flange
-    // Pos 1.4 Flange DN35                        LHCVBU__0007
-    TGeoVolume* voRB24VMABCRBF3 = new TGeoVolume("RB24VMABCRBF3", 
-						 new TGeoTube(kRB24VMABCRBT3Ro, kRB24VMABCRBF3Ro, kRB24VMABCRBF3L/2.), kMedSteelH);
-    //
-    // Tube 4
-    const Float_t kRB24VMABCRBT4Ri =  6.0/2.;
-    const Float_t kRB24VMABCRBT4Ro =  6.4/2.;
-    const Float_t kRB24VMABCRBT4L  =  6.6;    
-    TGeoTube* shRB24VMABCRBT4 = new TGeoTube(kRB24VMABCRBT4Ri, kRB24VMABCRBT4Ro,  kRB24VMABCRBT4L/2.);
-    shRB24VMABCRBT4->SetName("RB24VMABCRBT4");
-    TGeoCombiTrans* tRBT4 = new TGeoCombiTrans(0.,-11.+kRB24VMABCRBT4L/2., 7.2 - kRB24VMABCRBT1L/2.  , rotyz);
-    tRBT4->SetName("tRBT4");
-    tRBT4->RegisterYourself();
-    TGeoCompositeShape* shRB24VMABCRBT4c =  new TGeoCompositeShape("shRB24VMABCRBT4c","RB24VMABCRBT4:tRBT4-RB24VMABCRBT1o2");
-    TGeoVolume* voRB24VMABCRBT4 = new TGeoVolume("shRB24VMABCRBT4", shRB24VMABCRBT4c, kMedSteelH);
-    TGeoCompositeShape* shRB24VMABCRB = new TGeoCompositeShape("shRB24VMABCRB", "RB24VMABCRBT1-(RB24VMABCRBT2i:tRBT2+RB24VMABCRBT3i:tRBT3)");
-    TGeoVolume* voRB24VMABCRBI = new TGeoVolume("RB24VMABCRBI", shRB24VMABCRB, kMedSteelH);
-    //
-    // Plate
-    const Float_t kRB24VMABCRBBx = 16.0;
-    const Float_t kRB24VMABCRBBy =  1.5;
-    const Float_t kRB24VMABCRBBz = 15.0;
-    
-    // Relative position of tubes
-    const Float_t  kRB24VMABCTz =   7.2;
-    // Relative position of plate
-    const Float_t  kRB24VMABCPz =   3.6;
-    const Float_t  kRB24VMABCPy = -12.5;
-    
-    TGeoVolume* voRB24VMABCRBP = new TGeoVolume("RB24VMABCRBP", new TGeoBBox(kRB24VMABCRBBx/2., kRB24VMABCRBBy/2., kRB24VMABCRBBz/2.), kMedSteelH);
-    //
-    // Pirani Gauge (my best guess)
-    //
-    TGeoPcon* shRB24VMABCPirani = new TGeoPcon(0., 360., 15);
-    // DN35/16 Coupling
-    z = 0;
-    shRB24VMABCPirani->DefineSection( 0, z,  0.8 , kRB24VMABCRBF3Ro);
-    z += kRB24VMABCRBF3L; // 1.3
-    shRB24VMABCPirani->DefineSection( 1, z,  0.8 , kRB24VMABCRBF3Ro);
-    shRB24VMABCPirani->DefineSection( 2, z,  0.8 , 1.0);
-    // Pipe
-    z += 2.8;
-    shRB24VMABCPirani->DefineSection( 3, z,  0.8 , 1.0);
-    // Flange
-    shRB24VMABCPirani->DefineSection( 4, z,  0.8 , 1.75);
-    z += 1.6;
-    shRB24VMABCPirani->DefineSection( 5, z,  0.8 , 1.75);
-    shRB24VMABCPirani->DefineSection( 6, z,  0.8 , 1.0);
-    z += 5.2;
-    shRB24VMABCPirani->DefineSection( 7, z,  0.8 , 1.0);
-    shRB24VMABCPirani->DefineSection( 8, z,  0.8 , 2.5);    
-    z += 2.0;
-    shRB24VMABCPirani->DefineSection( 9, z,  0.80, 2.50);    
-    shRB24VMABCPirani->DefineSection(10, z,  1.55, 1.75);    
-    z += 5.7;
-    shRB24VMABCPirani->DefineSection(11, z,  1.55, 1.75);    
-    shRB24VMABCPirani->DefineSection(11, z,  0.00, 1.75);    
-    z += 0.2;
-    shRB24VMABCPirani->DefineSection(12, z,  0.00, 1.75);    
-    shRB24VMABCPirani->DefineSection(13, z,  0.00, 0.75);    
-    z += 0.5;
-    shRB24VMABCPirani->DefineSection(14, z,  0.00, 0.75);  
-    TGeoVolume* voRB24VMABCPirani = new TGeoVolume("RB24VMABCPirani", shRB24VMABCPirani, kMedSteelH);
-    //
-    //
-    // 
-    
-    
-    //
-    // Positioning of elements
-    TGeoVolumeAssembly* voRB24VMABCRB = new TGeoVolumeAssembly("RB24VMABCRB");
-    //
-    voRB24VMABCRB->AddNode(voRB24VMABCRBI,   1, gGeoIdentity);
-    // Plate
-    voRB24VMABCRB->AddNode(voRB24VMABCRBP,   1, new TGeoTranslation(0., kRB24VMABCPy +  kRB24VMABCRBBy /2., 
-								    kRB24VMABCRBBz/2. - kRB24VMABCRBT1L/2. +  kRB24VMABCPz));
-    // Tube 2
-    voRB24VMABCRB->AddNode(voRB24VMABCRBT2,  1, gGeoIdentity);
-    // Flange Tube 2
-    voRB24VMABCRB->AddNode(voRB24VMABCRBF2,  1, new TGeoCombiTrans(kRB24VMABCPy + kRB24VMABCRBF2L/2., 0.,  kRB24VMABCTz - kRB24VMABCRBT1L/2., rotxz));
-    // Blank Flange Tube 2
-    voRB24VMABCRB->AddNode(voRB24VMABCRBF2B, 1, new TGeoCombiTrans(kRB24VMABCPy- kRB24VMABCRBF2L/2., 0.,  kRB24VMABCTz - kRB24VMABCRBT1L/2., rotxz));    
-    // Tube 3
-    voRB24VMABCRB->AddNode(voRB24VMABCRBT3,  1, gGeoIdentity);
-    // Flange Tube 3
-    voRB24VMABCRB->AddNode(voRB24VMABCRBF3,  1, new TGeoCombiTrans(0.,   11.2 - kRB24VMABCRBF3L/2.,  kRB24VMABCTz - kRB24VMABCRBT1L/2., rotyz));
-    // Pirani Gauge
-    voRB24VMABCRB->AddNode(voRB24VMABCPirani, 1, new  TGeoCombiTrans(0., 11.2,  kRB24VMABCTz - kRB24VMABCRBT1L/2., rotyz));
-    // Tube 4
-    voRB24VMABCRB->AddNode(voRB24VMABCRBT4,  1, gGeoIdentity);
-    // Inforcement 
-    voRB24VMABCRB->AddNode(voRB24VMABCRBT12, 1, new TGeoTranslation(0., 0., kRB24VMABCRBT1L2/2. - kRB24VMABCRBT1L/2. + 2.8));
-    
-
-// Pos 1.3 Bellows with end part              LHCVBU__0002
-//
-// Connection Tube    
-// Connection tube inner r
-    const Float_t kRB24VMABBEConTubeRin        = 10.0/2.;
-// Connection tube outer r
-    const Float_t kRB24VMABBEConTubeRou        = 10.3/2.;
-// Connection tube length
-    const Float_t kRB24VMABBEConTubeL1         =  0.9;
-    const Float_t kRB24VMABBEConTubeL2         =  2.6;
-//  const Float_t RB24VMABBEBellowL            =  kRB24VMABBEConTubeL1 + kRB24VMABBEConTubeL2 + kRB24B1BellowUndL;
-    
-// Mother volume
-    TGeoPcon* shRB24VMABBEBellowM = new TGeoPcon(0., 360., 6);
-    // Connection Tube and Flange
-    z = 0.;
-    shRB24VMABBEBellowM->DefineSection( 0, z, kRB24VMABBEConTubeRin,  kRB24VMABBEConTubeRou);
-    z += kRB24VMABBEConTubeL1;
-    shRB24VMABBEBellowM->DefineSection( 1, z, kRB24VMABBEConTubeRin, kRB24VMABBEConTubeRou);
-    shRB24VMABBEBellowM->DefineSection( 2, z, kRB24B1BellowRi,       kRB24B1BellowRo + kRB24B1ProtTubeThickness);
-    z += kRB24B1BellowUndL;
-    shRB24VMABBEBellowM->DefineSection( 3, z, kRB24B1BellowRi,       kRB24B1BellowRo + kRB24B1ProtTubeThickness);
-    shRB24VMABBEBellowM->DefineSection( 4, z, kRB24VMABBEConTubeRin,  kRB24VMABBEConTubeRou);
-    z += kRB24VMABBEConTubeL2;
-    shRB24VMABBEBellowM->DefineSection( 5, z, kRB24VMABBEConTubeRin,  kRB24VMABBEConTubeRou);
-    TGeoVolume* voRB24VMABBEBellowM = new TGeoVolume("RB24VMABBEBellowM", shRB24VMABBEBellowM, kMedVacH);
-    voRB24VMABBEBellowM->SetVisibility(0);
-    
-//  Connection tube left
-    TGeoVolume* voRB24VMABBECT1 = new TGeoVolume("RB24VMABBECT1", 
-					      new TGeoTube(kRB24VMABBEConTubeRin, kRB24VMABBEConTubeRou,kRB24VMABBEConTubeL1/2.),
-					      kMedSteelH);
-//  Connection tube right
-    TGeoVolume* voRB24VMABBECT2 = new TGeoVolume("RB24VMABBECT2", 
-					      new TGeoTube(kRB24VMABBEConTubeRin, kRB24VMABBEConTubeRou,kRB24VMABBEConTubeL2/2.),
-					      kMedSteelH);
-    z = kRB24VMABBEConTubeL1/2.;
-    voRB24VMABBEBellowM->AddNode(voRB24VMABBECT1, 1, new TGeoTranslation(0., 0., z));
-    z += kRB24VMABBEConTubeL1/2.;
-    z += kRB24B1BellowUndL/2.;
-    voRB24VMABBEBellowM->AddNode(voRB24B1Bellow, 2, new TGeoTranslation(0., 0., z));
-    z += kRB24B1BellowUndL/2.;
-    z += kRB24VMABBEConTubeL2/2.;
-    voRB24VMABBEBellowM->AddNode(voRB24VMABBECT2, 1, new TGeoTranslation(0., 0., z));
-    z += kRB24VMABBEConTubeL2/2.;
-
-    voRB24VMABCRB->AddNode(voRB24VMABBEBellowM, 1, new TGeoTranslation(0., 0., kRB24VMABCRBT1L/2.));
-
-// Pos 1.2 Rotable flange                     LHCVBU__0013[*]
-// Front
-    voRB24VMABCRB->AddNode(voRB24B1RFlange,  3, new TGeoCombiTrans(0., 0., - kRB24VMABCRBT1L/2. + 0.86, rot180));
-// End
-    z =  kRB24VMABCRBT1L/2. + kRB24B1BellowUndL +kRB24VMABBEConTubeL1 +  kRB24VMABBEConTubeL2;
-    voRB24VMABCRB->AddNode(voRB24B1RFlange,  4, new TGeoTranslation(0., 0., z - 0.86));
-
-
-// Pos 2    Trans. Tube Flange       LHCVSR__0062
-// Pos 2.1  Transition Tube          LHCVSR__0063
-// Pos 2.2  Transition Flange        LHCVSR__0060
-//
-// Transition Tube with Flange
-    TGeoPcon* shRB24VMABCTT = new TGeoPcon(0., 360., 7);
-    z = 0.;
-    shRB24VMABCTT->DefineSection(0, z, 6.3/2., 11.16/2.);
-    z += 0.25;
-    shRB24VMABCTT->DefineSection(1, z, 6.3/2., 11.16/2.);
-    shRB24VMABCTT->DefineSection(2, z, 6.3/2.,  9.30/2.);
-    z += 0.25;
-    shRB24VMABCTT->DefineSection(3, z, 6.3/2.,  9.30/2.);
-    shRB24VMABCTT->DefineSection(4, z, 6.3/2.,  6.70/2.);
-    z += (20.35 - 0.63);
-    shRB24VMABCTT->DefineSection(5, z, 6.3/2.,  6.7/2.);
-    z += 0.63;
-    shRB24VMABCTT->DefineSection(6, z, 6.3/2.,  6.7/2.);
-    TGeoVolume* voRB24VMABCTT = new TGeoVolume("RB24VMABCTT", shRB24VMABCTT, kMedSteelH);
-    voRB24VMABCRB->AddNode(voRB24VMABCTT, 1, new TGeoTranslation(0., 0., - kRB24VMABCRBT1L/2.-1.));
-
-// Pos 3   RF Contact   D63         LHCVSR__0057
-// Pos 3.1 RF Contact Flange        LHCVSR__0017
-//
-    TGeoPcon* shRB24VMABCCTFlange = new TGeoPcon(0., 360., 6);
-    const Float_t kRB24VMABCCTFlangeRin  = 6.36/2.;  // Inner radius
-    const Float_t kRB24VMABCCTFlangeL    = 1.30;     // Length
-    
-    z = 0.;
-    shRB24VMABCCTFlange->DefineSection(0, z, kRB24VMABCCTFlangeRin,  6.5/2.);
-    z += 0.15;
-    shRB24VMABCCTFlange->DefineSection(1, z, kRB24VMABCCTFlangeRin,  6.5/2.);
-    shRB24VMABCCTFlange->DefineSection(2, z, kRB24VMABCCTFlangeRin,  6.9/2.);
-    z += 0.9;
-    shRB24VMABCCTFlange->DefineSection(3, z, kRB24VMABCCTFlangeRin,  6.9/2.);
-    shRB24VMABCCTFlange->DefineSection(4, z, kRB24VMABCCTFlangeRin, 11.16/2.);
-    z += 0.25;
-    shRB24VMABCCTFlange->DefineSection(5, z, kRB24VMABCCTFlangeRin, 11.16/2.);
-    TGeoVolume* voRB24VMABCCTFlange = new TGeoVolume("RB24VMABCCTFlange", shRB24VMABCCTFlange, kMedCuH);
-//
-// Pos 3.2 RF-Contact        LHCVSR__0056
-//
-    TGeoPcon* shRB24VMABCCT = new TGeoPcon(0., 360., 4);
-    const Float_t kRB24VMABCCTRin  = 6.30/2.;        // Inner radius
-    const Float_t kRB24VMABCCTCRin = 7.29/2.;        // Max. inner radius conical section
-    const Float_t kRB24VMABCCTL    = 11.88;          // Length
-    const Float_t kRB24VMABCCTSL   = 10.48;          // Length of straight section
-    const Float_t kRB24VMABCCTd    =  0.03;          // Thickness
-    z = 0;
-    shRB24VMABCCT->DefineSection(0, z,  kRB24VMABCCTCRin,  kRB24VMABCCTCRin + kRB24VMABCCTd);
-    z =  kRB24VMABCCTL -  kRB24VMABCCTSL;
-    shRB24VMABCCT->DefineSection(1, z,  kRB24VMABCCTRin + 0.35,  kRB24VMABCCTRin + 0.35 + kRB24VMABCCTd);
-    z = kRB24VMABCCTL  -  kRB24VMABCCTFlangeL;
-    shRB24VMABCCT->DefineSection(2, z,  kRB24VMABCCTRin,  kRB24VMABCCTRin + kRB24VMABCCTd);
-    z = kRB24VMABCCTL;
-    shRB24VMABCCT->DefineSection(3, z,  kRB24VMABCCTRin,  kRB24VMABCCTRin + kRB24VMABCCTd);
-
-    TGeoVolume* voRB24VMABCCT = new TGeoVolume("RB24VMABCCT", shRB24VMABCCT, kMedCuH);
-    
-    TGeoVolumeAssembly* voRB24VMABRFCT = new TGeoVolumeAssembly("RB24VMABRFCT");
-    voRB24VMABRFCT->AddNode(voRB24VMABCCT,        1, gGeoIdentity);
-    voRB24VMABRFCT->AddNode( voRB24VMABCCTFlange, 1, new TGeoTranslation(0., 0.,  kRB24VMABCCTL - kRB24VMABCCTFlangeL));
-
-    z =  kRB24VMABCRBT1L/2. + kRB24B1BellowUndL + kRB24VMABBEConTubeL1 +  kRB24VMABBEConTubeL2 - kRB24VMABCCTL + 1.;    
-    voRB24VMABCRB->AddNode(voRB24VMABRFCT, 1, new TGeoTranslation(0., 0., z));
-
-
-//
-// Assembling RB24/1
-//    
-    TGeoVolumeAssembly* voRB24 = new TGeoVolumeAssembly("RB24");
-    // Cu Tube with two simplified flanges
-    voRB24->AddNode(voRB24CuTubeM, 1, gGeoIdentity);
-    if (!fBeamBackground) voRB24->AddNode(voRB24CuTubeA, 1, gGeoIdentity);
-    z = - kRB24CuTubeL/2 + kRB24CuTubeFL/2.;
-    voRB24->AddNode(voRB24CuTubeF, 1, new TGeoTranslation(0., 0., z));
-    z = + kRB24CuTubeL/2 - kRB24CuTubeFL/2.;
-    voRB24->AddNode(voRB24CuTubeF, 2, new TGeoTranslation(0., 0., z));
-    // VMABC close to compensator magnet
-    z = - kRB24CuTubeL/2. -  (kRB24VMABCL - kRB24VMABCRBT1L/2) + 1.;
-    
-    voRB24->AddNode(voRB24VMABCRB, 2, new TGeoTranslation(0., 0., z));
-    // Bellow
-    z =  kRB24CuTubeL/2;
-    voRB24->AddNode(voRB24B1BellowM, 1, new TGeoTranslation(0., 0., z));
-    z +=  (kRB24B1L +  kRB24AIpML/2.);
-    // Annular ion pump
-    voRB24->AddNode(voRB24AIpM, 1, new TGeoTranslation(0., 0., z));
-    z +=  (kRB24AIpML/2. +  kRB24ValveWz/2.);
-    // Valve
-    voRB24->AddNode(voRB24ValveMo, 1, new TGeoTranslation(0., 0., z));
-    z += (kRB24ValveWz/2.+ kRB24VMABCRBT1L/2. + 1.);
-    // VMABC close to forward detectors
-    voRB24->AddNode(voRB24VMABCRB, 3, new TGeoTranslation(0., 0., z));
-//
-//   RB24/2
-//     
-// Copper Tube RB24/2
-//
-// This is the part inside the compensator magnet
-    const Float_t  kRB242CuTubeL  = 330.0;
-    
-    TGeoVolume* voRB242CuTubeM = new TGeoVolume("voRB242CuTubeM", 
-						new TGeoTube(0., kRB24CuTubeRo, kRB242CuTubeL/2.), kMedVacM);
-    voRB242CuTubeM->SetVisibility(0);
-    TGeoVolume* voRB242CuTube = new TGeoVolume("voRB242CuTube", 
-					       new TGeoTube(kRB24CuTubeRi, kRB24CuTubeRo, kRB242CuTubeL/2.), kMedCuH);
-    voRB242CuTubeM->AddNode(voRB242CuTube, 1, gGeoIdentity);
-    
-
-    TGeoVolumeAssembly* voRB242 = new TGeoVolumeAssembly("RB242");
-    voRB242->AddNode(voRB242CuTubeM, 1, gGeoIdentity);
-    z = - kRB242CuTubeL/2 + kRB24CuTubeFL/2.;
-    voRB242->AddNode(voRB24CuTubeF, 3, new TGeoTranslation(0., 0., z));
-    z = + kRB242CuTubeL/2 - kRB24CuTubeFL/2.;
-    voRB242->AddNode(voRB24CuTubeF, 4, new TGeoTranslation(0., 0., z));
-    z = - kRB24CuTubeL/2 - kRB24VMABCL - kRB242CuTubeL/2.;
-    voRB24->AddNode(voRB242, 1, new TGeoTranslation(0., 0., z));
-//
-//   RB24/3
-//     
-// Copper Tube RB24/3
-    const Float_t  kRB243CuTubeL  = 303.35;
-    
-    TGeoVolume* voRB243CuTubeM = new TGeoVolume("voRB243CuTubeM", 
-						new TGeoTube(0., kRB24CuTubeRo, kRB243CuTubeL/2.), kMedVacH);
-    voRB24CuTubeM->SetVisibility(0);
-    TGeoVolume* voRB243CuTube = new TGeoVolume("voRB243CuTube", 
-					       new TGeoTube(kRB24CuTubeRi, kRB24CuTubeRo, kRB243CuTubeL/2.), kMedCuH);
-    voRB243CuTubeM->AddNode(voRB243CuTube, 1, gGeoIdentity);
-    
-
-    TGeoVolumeAssembly* voRB243  = new TGeoVolumeAssembly("RB243");
-    TGeoVolumeAssembly* voRB243A = new TGeoVolumeAssembly("RB243A");
-    
-    voRB243A->AddNode(voRB243CuTubeM, 1, gGeoIdentity);
-    z = - kRB243CuTubeL/2 + kRB24CuTubeFL/2.;
-    voRB243A->AddNode(voRB24CuTubeF, 5, new TGeoTranslation(0., 0., z));
-    z = + kRB243CuTubeL/2 - kRB24CuTubeFL/2.;
-    voRB243A->AddNode(voRB24CuTubeF, 6, new TGeoTranslation(0., 0., z));
-    z = + kRB243CuTubeL/2;
-    voRB243A->AddNode(voRB24B1BellowM,  2, new TGeoTranslation(0., 0., z));    
-
-    z = - kRB243CuTubeL/2.  - kRB24B1L;
-    voRB243->AddNode(voRB243A, 1, new TGeoTranslation(0., 0., z));    
-    z = - (1.5 * kRB243CuTubeL + 2. * kRB24B1L);
-    voRB243->AddNode(voRB243A, 2, new TGeoTranslation(0., 0., z));    
-
-    z = - 2. * (kRB243CuTubeL + kRB24B1L) - (kRB24VMABCL - kRB24VMABCRBT1L/2) + 1.;
-    voRB243->AddNode(voRB24VMABCRB, 3, new TGeoTranslation(0., 0., z));    
-    
-    z = - kRB24CuTubeL/2 - kRB24VMABCL - kRB242CuTubeL;
-    voRB24->AddNode(voRB243, 1, new TGeoTranslation(0., 0., z));
-
-
-//
-//
-    top->AddNode(voRB24, 1, new TGeoCombiTrans(0., 0., kRB24CuTubeL/2 + 88.5 + 400., rot180));
-
-
-// 
-////////////////////////////////////////////////////////////////////////////////     
-//                                                                            //
-//                                  The Absorber Vacuum system                // 
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
-//
-//    Rotable Flange starts at:            82.00 cm from IP      
-//    Length of rotable flange section:    10.68 cm             
-//    Weld                                  0.08 cm                  
-//    Length of straight section          207.21 cm
-//    =======================================================================
-//                                        299.97 cm  [0.03 cm missing ?]
-//    Length of opening cone              252.09 cm
-//    Weld                                  0.15 cm                
-//    Length of compensator                30.54 cm
-//    Weld                                  0.15 cm                
-//    Length of fixed flange  2.13 - 0.97   1.16 cm
-//    ======================================================================= 
-//                                        584.06 cm [584.80 installed] [0.74 cm missing]
-//    RB26/3
-//    Length of split flange  2.13 - 1.2    0.93 cm
-//    Weld                                  0.15 cm                
-//    Length of fixed point section        16.07 cm               
-//    Weld                                  0.15 cm                
-//    Length of opening cone              629.20 cm
-//    Weld                                  0.30 cm                
-//    Kength of the compensator            41.70 cm
-//    Weld                                  0.30 cm                
-//    Length of fixed flange  2.99 - 1.72   1.27 cm
-// =================================================
-//    Length of RB26/3                    690.07 cm [689.20 installed] [0.87 cm too much] 
-//
-//    RB26/4-5
-//    Length of split flange  2.13 - 1.2    0.93 cm
-//    Weld                                  0.15 cm                
-//    Length of fixed point section        16.07 cm               
-//    Weld                                  0.15 cm                
-//    Length of opening cone              629.20 cm
-//    Weld                                  0.30 cm                
-//    Length of closing cone
-//    Weld
-//    Lenth of straight section 
-//    Kength of the compensator            41.70 cm
-//    Weld                                  0.30 cm                
-//    Length of fixed flange  2.99 - 1.72   1.27 cm
-// =================================================
-//    Length of RB26/3                    690.07 cm [689.20 installed] [0.87 cm too much] 
-      
-///////////////////////////////////////////
-//                                       //
-//    RB26/1-2                           //  
-//    Drawing LHCV2a_0050 [as installed] //
-//    Drawing LHCV2a_0008                //
-//    Drawing LHCV2a_0001                //
-///////////////////////////////////////////
-//    Pos1 Vacuum Tubes   LHCVC2A__0010
-//    Pos2 Compensator    LHCVC2A__0064
-//    Pos3 Rotable Flange LHCVFX___0016
-//    Pos4 Fixed Flange   LHCVFX___0006
-//    Pos5 Bellow Tooling LHCVFX___0003
-//
-//             
-//
-///////////////////////////////////
-//    RB26/1-2 Vacuum Tubes      //
-//    Drawing  LHCVC2a_0010      //
-///////////////////////////////////
-      const Float_t kRB26s12TubeL = 459.45; // 0.15 cm added for welding       
-      //
-      // Add 1 cm on outer diameter for insulation
-      //
-      TGeoPcon* shRB26s12Tube = new TGeoPcon(0., 360., 5);
-      // Section 1: straight section
-      shRB26s12Tube->DefineSection(0,   0.00,         5.84/2.,  6.00/2.);
-      shRB26s12Tube->DefineSection(1, 207.21,         5.84/2.,  6.00/2.);      
-      // Section 2: 0.72 deg opening cone
-      shRB26s12Tube->DefineSection(2, 207.21,         5.84/2.,  6.14/2.);      
-      shRB26s12Tube->DefineSection(3, 452.30,        12.00/2., 12.30/2.);      
-      shRB26s12Tube->DefineSection(4, kRB26s12TubeL, 12.00/2., 12.30/2.); 
-      TGeoVolume* voRB26s12Tube  = new TGeoVolume("RB26s12Tube", shRB26s12Tube, kMedSteelH);
-      // Add the insulation layer    
-      TGeoVolume* voRB26s12TubeIns = new TGeoVolume("RB26s12TubeIns", MakeInsulationFromTemplate(shRB26s12Tube), kMedInsuH); 
-      voRB26s12Tube->AddNode(voRB26s12TubeIns, 1, gGeoIdentity);
-
- 
-      TGeoVolume* voRB26s12TubeM  = new TGeoVolume("RB26s12TubeM", MakeMotherFromTemplate(shRB26s12Tube), kMedVacH);
-      voRB26s12TubeM->AddNode(voRB26s12Tube, 1, gGeoIdentity);
-      
-
-      
-///////////////////////////////////
-//    RB26/2   Axial Compensator //
-//    Drawing  LHCVC2a_0064      //
-///////////////////////////////////
-      const Float_t kRB26s2CompL             = 30.65;    // Length of the compensator
-      const Float_t kRB26s2BellowRo          = 14.38/2.; // Bellow outer radius        [Pos 1]
-      const Float_t kRB26s2BellowRi          = 12.12/2.; // Bellow inner radius        [Pos 1] 
-      const Int_t   kRB26s2NumberOfPlies     = 14;       // Number of plies            [Pos 1] 
-      const Float_t kRB26s2BellowUndL        = 10.00;    // Length of undulated region [Pos 1]  [+10 mm installed including pretension ?] 
-      const Float_t kRB26s2PlieThickness     =  0.025;   // Plie thickness             [Pos 1]
-      const Float_t kRB26s2ConnectionPlieR   =  0.21;    // Connection plie radius     [Pos 1] 
-//  Plie radius
-      const Float_t kRB26s2PlieR = 
-	(kRB26s2BellowUndL - 4. *  kRB26s2ConnectionPlieR + 
-	 2. *  kRB26s2NumberOfPlies * kRB26s2PlieThickness) / (4. * kRB26s2NumberOfPlies);
-      const Float_t kRB26s2CompTubeInnerR    = 12.00/2.;  // Connection tubes inner radius     [Pos 2 + 3]
-      const Float_t kRB26s2CompTubeOuterR    = 12.30/2.;  // Connection tubes outer radius     [Pos 2 + 3]
-      const Float_t kRB26s2WeldingTubeLeftL  =  9.00/2.;  // Left connection tube half length  [Pos 2]
-      const Float_t kRB26s2WeldingTubeRightL = 11.65/2.;  // Right connection tube half length [Pos 3]  [+ 0.15 cm for welding]
-      const Float_t kRB26s2RingOuterR        = 18.10/2.;  // Ring inner radius                 [Pos 4]
-      const Float_t kRB26s2RingL             =  0.40/2.;  // Ring half length                  [Pos 4]
-      const Float_t kRB26s2RingZ             =  6.50   ;  // Ring z-position                   [Pos 4]
-      const Float_t kRB26s2ProtOuterR        = 18.20/2.;  // Protection tube outer radius      [Pos 5]
-      const Float_t kRB26s2ProtL             = 15.00/2.;  // Protection tube half length       [Pos 5]
-      const Float_t kRB26s2ProtZ             =  6.70   ;  // Protection tube z-position        [Pos 5]
-   
-      
-// Mother volume
-//
-      TGeoPcon* shRB26s2Compensator  = new TGeoPcon(0., 360., 6);
-      shRB26s2Compensator->DefineSection( 0,   0.0, 0., kRB26s2CompTubeOuterR);
-      shRB26s2Compensator->DefineSection( 1,   kRB26s2RingZ, 0., kRB26s2CompTubeOuterR);      
-      shRB26s2Compensator->DefineSection( 2,   kRB26s2RingZ, 0., kRB26s2ProtOuterR);      
-      shRB26s2Compensator->DefineSection( 3,   kRB26s2ProtZ + 2. * kRB26s2ProtL, 0., kRB26s2ProtOuterR);            
-      shRB26s2Compensator->DefineSection( 4,   kRB26s2ProtZ + 2. * kRB26s2ProtL, 0., kRB26s2CompTubeOuterR);
-      shRB26s2Compensator->DefineSection( 5,   kRB26s2CompL                    , 0., kRB26s2CompTubeOuterR);            
-      TGeoVolume* voRB26s2Compensator  = new TGeoVolume("RB26s2Compensator", shRB26s2Compensator, kMedVacH);
-            
-//
-// [Pos 1] Bellow
-//      
-//
-      TGeoVolume* voRB26s2Bellow = new TGeoVolume("RB26s2Bellow", new TGeoTube(kRB26s2BellowRi, kRB26s2BellowRo, kRB26s2BellowUndL/2.), kMedVacH);
-//      
-//  Upper part of the undulation
-//
-      TGeoTorus* shRB26s2PlieTorusU  =  new TGeoTorus(kRB26s2BellowRo - kRB26s2PlieR, kRB26s2PlieR - kRB26s2PlieThickness, kRB26s2PlieR);
-      shRB26s2PlieTorusU->SetName("RB26s2TorusU");
-      TGeoTube*  shRB26s2PlieTubeU   =  new TGeoTube (kRB26s2BellowRo - kRB26s2PlieR, kRB26s2BellowRo, kRB26s2PlieR);
-      shRB26s2PlieTubeU->SetName("RB26s2TubeU");
-      TGeoCompositeShape*  shRB26s2UpperPlie = new TGeoCompositeShape("RB26s2UpperPlie", "RB26s2TorusU*RB26s2TubeU");
- 
-      TGeoVolume* voRB26s2WiggleU = new TGeoVolume("RB26s2UpperPlie", shRB26s2UpperPlie, kMedSteelH);
-//
-// Lower part of the undulation
-      TGeoTorus* shRB26s2PlieTorusL =  new TGeoTorus(kRB26s2BellowRi + kRB26s2PlieR, kRB26s2PlieR - kRB26s2PlieThickness, kRB26s2PlieR);
-      shRB26s2PlieTorusL->SetName("RB26s2TorusL");
-      TGeoTube*  shRB26s2PlieTubeL   =  new TGeoTube (kRB26s2BellowRi, kRB26s2BellowRi + kRB26s2PlieR, kRB26s2PlieR);
-      shRB26s2PlieTubeL->SetName("RB26s2TubeL");
-      TGeoCompositeShape*  shRB26s2LowerPlie = new TGeoCompositeShape("RB26s2LowerPlie", "RB26s2TorusL*RB26s2TubeL");
-      
-      TGeoVolume* voRB26s2WiggleL = new TGeoVolume("RB26s2LowerPlie", shRB26s2LowerPlie, kMedSteelH); 
-
-//
-// Connection between upper and lower part of undulation
-      TGeoVolume* voRB26s2WiggleC1 = new TGeoVolume("RB26s2PlieConn1",  
-						    new TGeoTube(kRB26s2BellowRi + kRB26s2PlieR, 
-								 kRB26s2BellowRo - kRB26s2PlieR, kRB26s2PlieThickness / 2.), kMedSteelH);
-//
-// One wiggle
-      TGeoVolumeAssembly* voRB26s2Wiggle = new TGeoVolumeAssembly("RB26s2Wiggle");
-      z0 =  -  kRB26s2PlieThickness / 2.;
-      voRB26s2Wiggle->AddNode(voRB26s2WiggleC1,  1 , new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s2PlieR -  kRB26s2PlieThickness / 2.;
-      voRB26s2Wiggle->AddNode(voRB26s2WiggleU,   1 , new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s2PlieR -  kRB26s2PlieThickness / 2.;
-      voRB26s2Wiggle->AddNode(voRB26s2WiggleC1,  2 , new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s2PlieR -  kRB26s2PlieThickness;
-      voRB26s2Wiggle->AddNode(voRB26s2WiggleL ,  1 , new TGeoTranslation(0., 0., z0));
-// Positioning of the volumes
-      z0   = - kRB26s2BellowUndL/2.+ kRB26s2ConnectionPlieR;
-      voRB26s2Bellow->AddNode(voRB26s2WiggleL, 1, new TGeoTranslation(0., 0., z0));
-      z0  +=  kRB26s2ConnectionPlieR;
-      zsh  = 4. *  kRB26s2PlieR -  2. * kRB26s2PlieThickness;
-      for (Int_t iw = 0; iw < kRB26s2NumberOfPlies; iw++) {
-	  Float_t zpos =  z0 + iw * zsh;	
-	  voRB26s2Bellow->AddNode(voRB26s2Wiggle,  iw + 1, new TGeoTranslation(0., 0., zpos -  kRB26s2PlieThickness));	
-      }
-
-      voRB26s2Compensator->AddNode(voRB26s2Bellow, 1,  new TGeoTranslation(0., 0., 2. * kRB26s2WeldingTubeLeftL + kRB26s2BellowUndL/2.));
-      
-//
-// [Pos 2] Left Welding Tube
-//      
-      TGeoTube* shRB26s2CompLeftTube = new TGeoTube(kRB26s2CompTubeInnerR, kRB26s2CompTubeOuterR, kRB26s2WeldingTubeLeftL);
-      TGeoVolume* voRB26s2CompLeftTube = new TGeoVolume("RB26s2CompLeftTube", shRB26s2CompLeftTube, kMedSteelH);
-      voRB26s2Compensator->AddNode(voRB26s2CompLeftTube, 1,  new TGeoTranslation(0., 0., kRB26s2WeldingTubeLeftL));
-//
-// [Pos 3] Right Welding Tube
-//      
-      TGeoTube* shRB26s2CompRightTube = new TGeoTube(kRB26s2CompTubeInnerR, kRB26s2CompTubeOuterR, kRB26s2WeldingTubeRightL);
-      TGeoVolume* voRB26s2CompRightTube = new TGeoVolume("RB26s2CompRightTube", shRB26s2CompRightTube, kMedSteelH);
-      voRB26s2Compensator->AddNode(voRB26s2CompRightTube,  1, new TGeoTranslation(0., 0.,  kRB26s2CompL - kRB26s2WeldingTubeRightL));
-//
-// [Pos 4] Ring
-//      
-      TGeoTube* shRB26s2CompRing = new TGeoTube(kRB26s2CompTubeOuterR, kRB26s2RingOuterR, kRB26s2RingL);
-      TGeoVolume* voRB26s2CompRing = new TGeoVolume("RB26s2CompRing", shRB26s2CompRing, kMedSteelH);
-      voRB26s2Compensator->AddNode(voRB26s2CompRing,  1, new TGeoTranslation(0., 0., kRB26s2RingZ + kRB26s2RingL));
-
-//
-// [Pos 5] Outer Protecting Tube
-//      
-      TGeoTube* shRB26s2CompProtTube = new TGeoTube(kRB26s2RingOuterR, kRB26s2ProtOuterR, kRB26s2ProtL);
-      TGeoVolume* voRB26s2CompProtTube = new TGeoVolume("RB26s2CompProtTube", shRB26s2CompProtTube, kMedSteelH);
-      voRB26s2Compensator->AddNode(voRB26s2CompProtTube, 1,  new TGeoTranslation(0., 0., kRB26s2ProtZ + kRB26s2ProtL));
-      
-///////////////////////////////////
-//    Rotable Flange             //
-//    Drawing  LHCVFX_0016       //
-/////////////////////////////////// 
-      const Float_t kRB26s1RFlangeTubeRi    = 5.84/2. ;  // Tube inner radius
-      const Float_t kRB26s1RFlangeTubeRo    = 6.00/2. ;  // Tube outer radius
-
-// Pos 1 Clamp Ring          LHCVFX__0015
-      const Float_t kRB26s1RFlangeCrL       = 1.40     ; // Lenth of the clamp ring
-      const Float_t kRB26s1RFlangeCrRi1     = 6.72/2.  ; // Ring inner radius section 1
-      const Float_t kRB26s1RFlangeCrRi2     = 6.06/2.  ; // Ring inner radius section 2
-      const Float_t kRB26s1RFlangeCrRo      = 8.60/2.  ; // Ring outer radius 
-      const Float_t kRB26s1RFlangeCrD       = 0.800    ; // Width section 1
-      
-      TGeoPcon* shRB26s1RFlangeCr = new TGeoPcon(0., 360., 4);
-      z0 = 0.;
-      shRB26s1RFlangeCr->DefineSection(0, z0, kRB26s1RFlangeCrRi1, kRB26s1RFlangeCrRo);
-      z0 += kRB26s1RFlangeCrD;
-      shRB26s1RFlangeCr->DefineSection(1, z0, kRB26s1RFlangeCrRi1, kRB26s1RFlangeCrRo);
-      shRB26s1RFlangeCr->DefineSection(2, z0, kRB26s1RFlangeCrRi2, kRB26s1RFlangeCrRo);      
-      z0 = kRB26s1RFlangeCrL;
-      shRB26s1RFlangeCr->DefineSection(3, z0, kRB26s1RFlangeCrRi2, kRB26s1RFlangeCrRo);
-      TGeoVolume* voRB26s1RFlangeCr =  
-	  new TGeoVolume("RB26s1RFlangeCr", shRB26s1RFlangeCr, kMedSteelH);
-
-// Pos 2 Insert              LHCVFX__0015
-      const Float_t kRB26s1RFlangeIsL       = 4.88     ; // Lenth of the insert
-      const Float_t kRB26s1RFlangeIsR       = 6.70/2.  ; // Ring radius
-      const Float_t kRB26s1RFlangeIsD       = 0.80     ; // Ring Width
-
-      TGeoPcon* shRB26s1RFlangeIs = new TGeoPcon(0., 360., 4);
-      z0 = 0.;
-      shRB26s1RFlangeIs->DefineSection(0, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeIsR);
-      z0 += kRB26s1RFlangeIsD;
-      shRB26s1RFlangeIs->DefineSection(1, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeIsR);
-      shRB26s1RFlangeIs->DefineSection(2, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeTubeRo);      
-      z0 = kRB26s1RFlangeIsL;
-      shRB26s1RFlangeIs->DefineSection(3, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeTubeRo);
-      TGeoVolume* voRB26s1RFlangeIs =  
-	  new TGeoVolume("RB26s1RFlangeIs", shRB26s1RFlangeIs, kMedSteelH);
-// 4.88 + 3.7 = 8.58 (8.7 to avoid overlap)
-// Pos 3 Fixed Point Section LHCVC2A_0021
-      const Float_t kRB26s1RFlangeFpL       = 5.88     ; // Length of the fixed point section (0.08 cm added for welding)
-      const Float_t kRB26s1RFlangeFpZ       = 3.82     ; // Position of the ring
-      const Float_t kRB26s1RFlangeFpD       = 0.59     ; // Width of the ring
-      const Float_t kRB26s1RFlangeFpR       = 7.00/2.  ; // Radius of the ring
-      
-      TGeoPcon* shRB26s1RFlangeFp = new TGeoPcon(0., 360., 6);
-      z0 = 0.;
-      shRB26s1RFlangeFp->DefineSection(0, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeTubeRo);
-      z0 += kRB26s1RFlangeFpZ;
-      shRB26s1RFlangeFp->DefineSection(1, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeTubeRo);      
-      shRB26s1RFlangeFp->DefineSection(2, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeFpR);      	  
-      z0 += kRB26s1RFlangeFpD;
-      shRB26s1RFlangeFp->DefineSection(3, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeFpR);      	  
-      shRB26s1RFlangeFp->DefineSection(4, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeTubeRo);
-      z0 = kRB26s1RFlangeFpL;
-      shRB26s1RFlangeFp->DefineSection(5, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeTubeRo);
-      TGeoVolume* voRB26s1RFlangeFp = new TGeoVolume("RB26s1RFlangeFp", shRB26s1RFlangeFp, kMedSteelH);
-      	     
-// Put everything in a mother volume
-      TGeoPcon* shRB26s1RFlange = new TGeoPcon(0., 360., 8);
-      z0 =  0.;
-      shRB26s1RFlange->DefineSection(0, z0, 0., kRB26s1RFlangeCrRo);
-      z0 += kRB26s1RFlangeCrL;
-      shRB26s1RFlange->DefineSection(1, z0, 0., kRB26s1RFlangeCrRo);
-      shRB26s1RFlange->DefineSection(2, z0, 0., kRB26s1RFlangeTubeRo);
-      z0 = kRB26s1RFlangeIsL + kRB26s1RFlangeFpZ;
-      shRB26s1RFlange->DefineSection(3, z0, 0., kRB26s1RFlangeTubeRo);      
-      shRB26s1RFlange->DefineSection(4, z0, 0., kRB26s1RFlangeFpR);
-      z0 += kRB26s1RFlangeFpD;
-      shRB26s1RFlange->DefineSection(5, z0, 0., kRB26s1RFlangeFpR);      	  
-      shRB26s1RFlange->DefineSection(6, z0, 0., kRB26s1RFlangeTubeRo);
-      z0 = kRB26s1RFlangeIsL + kRB26s1RFlangeFpL;
-      shRB26s1RFlange->DefineSection(7, z0, 0., kRB26s1RFlangeTubeRo);
-      TGeoVolume* voRB26s1RFlange = new TGeoVolume("RB26s1RFlange", shRB26s1RFlange, kMedVacH);
-
-      voRB26s1RFlange->AddNode(voRB26s1RFlangeIs, 1, gGeoIdentity);
-      voRB26s1RFlange->AddNode(voRB26s1RFlangeCr, 1, gGeoIdentity);
-      voRB26s1RFlange->AddNode(voRB26s1RFlangeFp, 1, new TGeoTranslation(0., 0., kRB26s1RFlangeIsL));
-      
-///////////////////////////////////
-//    Fixed Flange               //
-//    Drawing  LHCVFX_0006       //
-/////////////////////////////////// 
-      const Float_t kRB26s2FFlangeL      =  2.13;    // Length of the flange
-      const Float_t kRB26s2FFlangeD1     =  0.97;    // Length of section 1
-      const Float_t kRB26s2FFlangeD2     =  0.29;    // Length of section 2						     
-      const Float_t kRB26s2FFlangeD3     =  0.87;    // Length of section 3						           
-      const Float_t kRB26s2FFlangeRo     = 17.15/2.; // Flange outer radius 
-      const Float_t kRB26s2FFlangeRi1    = 12.30/2.; // Flange inner radius section 1
-      const Float_t kRB26s2FFlangeRi2    = 12.00/2.; // Flange inner radius section 2
-      const Float_t kRB26s2FFlangeRi3    = 12.30/2.; // Flange inner radius section 3
-      z0 = 0;
-      TGeoPcon* shRB26s2FFlange = new TGeoPcon(0., 360., 6);
-      z0 = 0.;
-      shRB26s2FFlange->DefineSection(0, z0, kRB26s2FFlangeRi1, kRB26s2FFlangeRo);
-      z0 += kRB26s2FFlangeD1;
-      shRB26s2FFlange->DefineSection(1, z0, kRB26s2FFlangeRi1, kRB26s2FFlangeRo);
-      shRB26s2FFlange->DefineSection(2, z0, kRB26s2FFlangeRi2, kRB26s2FFlangeRo);
-      z0 += kRB26s2FFlangeD2;
-      shRB26s2FFlange->DefineSection(3, z0, kRB26s2FFlangeRi2, kRB26s2FFlangeRo);
-      shRB26s2FFlange->DefineSection(4, z0, kRB26s2FFlangeRi3, kRB26s2FFlangeRo);
-      z0 += kRB26s2FFlangeD3;
-      shRB26s2FFlange->DefineSection(5, z0, kRB26s2FFlangeRi3, kRB26s2FFlangeRo);
-      TGeoVolume* voRB26s2FFlange = new TGeoVolume("RB26s2FFlange", shRB26s2FFlange, kMedSteelH);
-
-      TGeoVolume* voRB26s2FFlangeM = new TGeoVolume("RB26s2FFlangeM", MakeMotherFromTemplate(shRB26s2FFlange, 2, 5), kMedVacH);
-      voRB26s2FFlangeM->AddNode(voRB26s2FFlange, 1, gGeoIdentity);
-      
-      
-
-////////////////////////////////////////
-//                                    //
-//    RB26/3                          //  
-//    Drawing LHCV2a_0048             //
-//    Drawing LHCV2a_0002             //
-////////////////////////////////////////    
-//
-//    Pos 1 Vacuum Tubes      LHCVC2A__0003
-//    Pos 2 Fixed Point       LHCVFX___0005
-//    Pos 3 Split Flange      LHCVFX___0007
-//    Pos 4 Fixed Flange      LHCVFX___0004
-//    Pos 5 Axial Compensator LHCVC2A__0065
-//
-//
-//
-//
-///////////////////////////////////
-//    Vacuum Tube                //
-//    Drawing  LHCVC2A_0003      //
-/////////////////////////////////// 
-      const Float_t kRB26s3TubeL  = 629.35 + 0.3; // 0.3 cm added for welding
-      const Float_t kRB26s3TubeR1 =  12./2.;
-      const Float_t kRB26s3TubeR2 =  kRB26s3TubeR1 + 215.8 * TMath::Tan(0.829 / 180. * TMath::Pi());
-      
-      
-      TGeoPcon* shRB26s3Tube = new TGeoPcon(0., 360., 7);
-      // Section 1: straight section
-      shRB26s3Tube->DefineSection(0,   0.00, kRB26s3TubeR1, kRB26s3TubeR1 + 0.15);
-      shRB26s3Tube->DefineSection(1,   2.00, kRB26s3TubeR1, kRB26s3TubeR1 + 0.15);      
-      // Section 2: 0.829 deg opening cone
-      shRB26s3Tube->DefineSection(2,   2.00, kRB26s3TubeR1, kRB26s3TubeR1 + 0.20);
-      
-      shRB26s3Tube->DefineSection(3, 217.80, kRB26s3TubeR2, kRB26s3TubeR2 + 0.20);
-      shRB26s3Tube->DefineSection(4, 217.80, kRB26s3TubeR2, kRB26s3TubeR2 + 0.30);      
-
-      shRB26s3Tube->DefineSection(5, 622.20,       30.00/2., 30.60/2.);      
-      shRB26s3Tube->DefineSection(6, kRB26s3TubeL, 30.00/2., 30.60/2.); 
-
-      TGeoVolume* voRB26s3Tube = new TGeoVolume("RB26s3Tube", shRB26s3Tube, kMedSteelH);
-//    Add the insulation layer
-      TGeoVolume* voRB26s3TubeIns = new TGeoVolume("RB26s3TubeIns", MakeInsulationFromTemplate(shRB26s3Tube), kMedInsuH); 
-      voRB26s3Tube->AddNode(voRB26s3TubeIns, 1, gGeoIdentity);
-
-      TGeoVolume* voRB26s3TubeM  = new TGeoVolume("RB26s3TubeM", MakeMotherFromTemplate(shRB26s3Tube), kMedVacH);
-      voRB26s3TubeM->AddNode(voRB26s3Tube, 1, gGeoIdentity);
-
-      
-
-///////////////////////////////////
-//    Fixed Point                //
-//    Drawing  LHCVFX_0005       //
-/////////////////////////////////// 
-      const Float_t kRB26s3FixedPointL       = 16.37     ; // Length of the fixed point section (0.3 cm added for welding)
-      const Float_t kRB26s3FixedPointZ       =  9.72     ; // Position of the ring (0.15 cm added for welding)
-      const Float_t kRB26s3FixedPointD       =  0.595    ; // Width of the ring
-      const Float_t kRB26s3FixedPointR       = 13.30/2.  ; // Radius of the ring
-      const Float_t kRB26s3FixedPointRi      = 12.00/2.  ; // Inner radius of the tube
-      const Float_t kRB26s3FixedPointRo1     = 12.30/2.  ; // Outer radius of the tube (in)
-      const Float_t kRB26s3FixedPointRo2     = 12.40/2.  ; // Outer radius of the tube (out)
-      const Float_t kRB26s3FixedPointDs      =  1.5      ; // Width of straight section behind ring
-      const Float_t kRB26s3FixedPointDc      =  3.15     ; // Width of conical  section behind ring (0.15 cm added for welding)      
-      
-      TGeoPcon* shRB26s3FixedPoint = new TGeoPcon(0., 360., 8);
-      z0 = 0.;
-      shRB26s3FixedPoint->DefineSection(0, z0, kRB26s3FixedPointRi, kRB26s3FixedPointRo1);
-      z0 += kRB26s3FixedPointZ;
-      shRB26s3FixedPoint->DefineSection(1, z0, kRB26s3FixedPointRi, kRB26s3FixedPointRo1);      
-      shRB26s3FixedPoint->DefineSection(2, z0, kRB26s3FixedPointRi, kRB26s3FixedPointR);      	  
-      z0 += kRB26s3FixedPointD;
-      shRB26s3FixedPoint->DefineSection(3, z0, kRB26s3FixedPointRi, kRB26s3FixedPointR);      	  
-      shRB26s3FixedPoint->DefineSection(4, z0, kRB26s3FixedPointRi, kRB26s3FixedPointRo1);
-      z0 += kRB26s3FixedPointDs;
-      shRB26s3FixedPoint->DefineSection(5, z0, kRB26s3FixedPointRi, kRB26s3FixedPointRo1);
-      z0 += kRB26s3FixedPointDc;
-      shRB26s3FixedPoint->DefineSection(6, z0, kRB26s3FixedPointRi, kRB26s3FixedPointRo2);
-      z0 = kRB26s3FixedPointL;
-      shRB26s3FixedPoint->DefineSection(7, z0, kRB26s3FixedPointRi, kRB26s3FixedPointRo2);
-      TGeoVolume* voRB26s3FixedPoint = new TGeoVolume("RB26s3FixedPoint", shRB26s3FixedPoint, kMedSteelH);
-
-      TGeoVolume* voRB26s3FixedPointM = new TGeoVolume("RB26s3FixedPointM", MakeMotherFromTemplate(shRB26s3FixedPoint), kMedVacH);
-      voRB26s3FixedPointM->AddNode(voRB26s3FixedPoint, 1, gGeoIdentity);
-      
-///////////////////////////////////
-//    Split Flange               //
-//    Drawing  LHCVFX_0005       //
-/////////////////////////////////// 
-      const Float_t kRB26s3SFlangeL      =  2.13;        // Length of the flange
-      const Float_t kRB26s3SFlangeD1     =  0.57;        // Length of section 1
-      const Float_t kRB26s3SFlangeD2     =  0.36;        // Length of section 2						     
-      const Float_t kRB26s3SFlangeD3     =  0.50 + 0.70; // Length of section 3						           
-      const Float_t kRB26s3SFlangeRo     = 17.15/2.;     // Flange outer radius 
-      const Float_t kRB26s3SFlangeRi1    = 12.30/2.;     // Flange inner radius section 1
-      const Float_t kRB26s3SFlangeRi2    = 12.00/2.;     // Flange inner radius section 2
-      const Float_t kRB26s3SFlangeRi3    = 12.30/2.;     // Flange inner radius section 3
-      z0 = 0;
-      TGeoPcon* shRB26s3SFlange = new TGeoPcon(0., 360., 6);
-      z0 = 0.;
-      shRB26s3SFlange->DefineSection(0, z0, kRB26s3SFlangeRi1, kRB26s3SFlangeRo);
-      z0 += kRB26s3SFlangeD1;
-      shRB26s3SFlange->DefineSection(1, z0, kRB26s3SFlangeRi1, kRB26s3SFlangeRo);
-      shRB26s3SFlange->DefineSection(2, z0, kRB26s3SFlangeRi2, kRB26s3SFlangeRo);
-      z0 += kRB26s3SFlangeD2;
-      shRB26s3SFlange->DefineSection(3, z0, kRB26s3SFlangeRi2, kRB26s3SFlangeRo);
-      shRB26s3SFlange->DefineSection(4, z0, kRB26s3SFlangeRi3, kRB26s3SFlangeRo);
-      z0 += kRB26s3SFlangeD3;
-      shRB26s3SFlange->DefineSection(5, z0, kRB26s3SFlangeRi3, kRB26s3SFlangeRo);
-      TGeoVolume* voRB26s3SFlange = new TGeoVolume("RB26s3SFlange", shRB26s3SFlange, kMedSteelH);
-
-      TGeoVolume* voRB26s3SFlangeM = new TGeoVolume("RB26s3SFlangeM", MakeMotherFromTemplate(shRB26s3SFlange, 0, 3), kMedVacH);
-      voRB26s3SFlangeM->AddNode(voRB26s3SFlange, 1, gGeoIdentity);
-        
-///////////////////////////////////
-//    RB26/3   Fixed Flange      //
-//    Drawing  LHCVFX___0004     //
-/////////////////////////////////// 
-      const Float_t kRB26s3FFlangeL      =  2.99;    // Length of the flange
-      const Float_t kRB26s3FFlangeD1     =  1.72;    // Length of section 1
-      const Float_t kRB26s3FFlangeD2     =  0.30;    // Length of section 2						     
-      const Float_t kRB26s3FFlangeD3     =  0.97;    // Length of section 3						           
-      const Float_t kRB26s3FFlangeRo     = 36.20/2.; // Flange outer radius 
-      const Float_t kRB26s3FFlangeRi1    = 30.60/2.; // Flange inner radius section 1
-      const Float_t kRB26s3FFlangeRi2    = 30.00/2.; // Flange inner radius section 2
-      const Float_t kRB26s3FFlangeRi3    = 30.60/2.; // Flange inner radius section 3
-      z0 = 0;
-      TGeoPcon* shRB26s3FFlange = new TGeoPcon(0., 360., 6);
-      z0 = 0.;
-      shRB26s3FFlange->DefineSection(0, z0, kRB26s3FFlangeRi1, kRB26s3FFlangeRo);
-      z0 += kRB26s3FFlangeD1;
-      shRB26s3FFlange->DefineSection(1, z0, kRB26s3FFlangeRi1, kRB26s3FFlangeRo);
-      shRB26s3FFlange->DefineSection(2, z0, kRB26s3FFlangeRi2, kRB26s3FFlangeRo);
-      z0 += kRB26s3FFlangeD2;
-      shRB26s3FFlange->DefineSection(3, z0, kRB26s3FFlangeRi2, kRB26s3FFlangeRo);
-      shRB26s3FFlange->DefineSection(4, z0, kRB26s3FFlangeRi3, kRB26s3FFlangeRo);
-      z0 += kRB26s3FFlangeD3;
-      shRB26s3FFlange->DefineSection(5, z0, kRB26s3FFlangeRi3, kRB26s3FFlangeRo);
-      TGeoVolume* voRB26s3FFlange = new TGeoVolume("RB26s3FFlange", shRB26s3FFlange, kMedSteelH);
-      
-      TGeoVolume* voRB26s3FFlangeM = new TGeoVolume("RB26s3FFlangeM", MakeMotherFromTemplate(shRB26s3FFlange, 2, 5), kMedVacH);
-      voRB26s3FFlangeM->AddNode(voRB26s3FFlange, 1, gGeoIdentity);
-            
-
-
-///////////////////////////////////
-//    RB26/3   Axial Compensator //
-//    Drawing  LHCVC2a_0065      //
-/////////////////////////////////// 
-      const Float_t kRB26s3CompL              = 42.0;     // Length of the compensator (0.3 cm added for welding)
-      const Float_t kRB26s3BellowRo           = 34.00/2.; // Bellow outer radius        [Pos 1]
-      const Float_t kRB26s3BellowRi           = 30.10/2.; // Bellow inner radius        [Pos 1] 
-      const Int_t   kRB26s3NumberOfPlies      = 13;       // Number of plies            [Pos 1] 
-      const Float_t kRB26s3BellowUndL         = 17.70;    // Length of undulated region [Pos 1] 
-      const Float_t kRB26s3PlieThickness      =  0.06;    // Plie thickness             [Pos 1]
-      const Float_t kRB26s3ConnectionPlieR    =  0.21;    // Connection plie radius     [Pos 1] 
-//  Plie radius
-      const Float_t kRB26s3PlieR = 
-	(kRB26s3BellowUndL - 4. *  kRB26s3ConnectionPlieR + 
-	 2. *  kRB26s3NumberOfPlies * kRB26s3PlieThickness) / (4. * kRB26s3NumberOfPlies);
-
-      //
-      // The welding tubes have 3 sections with different radii and 2 transition regions.
-      // Section 1: connection to the outside
-      // Section 2: commection to the bellow
-      // Section 3: between 1 and 2
-      const Float_t kRB26s3CompTubeInnerR1    = 30.0/2.;  // Outer Connection tubes inner radius     [Pos 4 + 3]
-      const Float_t kRB26s3CompTubeOuterR1    = 30.6/2.;  // Outer Connection tubes outer radius     [Pos 4 + 3]
-      const Float_t kRB26s3CompTubeInnerR2    = 29.4/2.;  // Connection tubes inner radius           [Pos 4 + 3]
-      const Float_t kRB26s3CompTubeOuterR2    = 30.0/2.;  // Connection tubes outer radius           [Pos 4 + 3]
-      const Float_t kRB26s3CompTubeInnerR3    = 30.6/2.;  // Connection tubes inner radius at bellow [Pos 4 + 3]
-      const Float_t kRB26s3CompTubeOuterR3    = 32.2/2.;  // Connection tubes outer radius at bellow [Pos 4 + 3]
- 
-      const Float_t kRB26s3WeldingTubeLeftL1  =  2.0;     // Left connection tube length             [Pos 4]
-      const Float_t kRB26s3WeldingTubeLeftL2  =  3.4;     // Left connection tube length             [Pos 4]
-      const Float_t kRB26s3WeldingTubeLeftL   =  7.0;     // Left connection tube total length       [Pos 4]
-      const Float_t kRB26s3WeldingTubeRightL1 =  2.3;     // Right connection tube length            [Pos 3] (0.3 cm added for welding)
-      const Float_t kRB26s3WeldingTubeRightL2 = 13.4;     // Right connection tube length            [Pos 3]
-
-      const Float_t kRB26s3WeldingTubeT1      =  0.6;     // Length of first r-transition            [Pos 4 + 3]
-      const Float_t kRB26s3WeldingTubeT2      =  1.0;     // Length of 2nd   r-transition            [Pos 4 + 3]       
-
-      
-      
-      const Float_t kRB26s3RingOuterR         = 36.1/2.;  // Ring inner radius                       [Pos 4]
-      const Float_t kRB26s3RingL              =  0.8/2.;  // Ring half length                        [Pos 4]
-      const Float_t kRB26s3RingZ              =  3.7   ;  // Ring z-position                         [Pos 4]
-      const Float_t kRB26s3ProtOuterR         = 36.2/2.;  // Protection tube outer radius            [Pos 2]
-      const Float_t kRB26s3ProtL              = 27.0/2.;  // Protection tube half length             [Pos 2]
-      const Float_t kRB26s3ProtZ              =  4.0   ;  // Protection tube z-position              [Pos 2]
-   
-      
-// Mother volume
-//
-      TGeoPcon* shRB26s3Compensator  = new TGeoPcon(0., 360., 6);
-      shRB26s3Compensator->DefineSection( 0,   0.0, 0., kRB26s3CompTubeOuterR1);
-      shRB26s3Compensator->DefineSection( 1,   kRB26s3RingZ, 0., kRB26s3CompTubeOuterR1);      
-      shRB26s3Compensator->DefineSection( 2,   kRB26s3RingZ, 0., kRB26s3ProtOuterR);      
-      shRB26s3Compensator->DefineSection( 3,   kRB26s3ProtZ + 2. * kRB26s3ProtL, 0., kRB26s3ProtOuterR);            
-      shRB26s3Compensator->DefineSection( 4,   kRB26s3ProtZ + 2. * kRB26s3ProtL, 0., kRB26s3CompTubeOuterR1);
-      shRB26s3Compensator->DefineSection( 5,   kRB26s3CompL                    , 0., kRB26s3CompTubeOuterR1);            
-      TGeoVolume* voRB26s3Compensator  =  
-	  new TGeoVolume("RB26s3Compensator", shRB26s3Compensator, kMedVacH);
-            
-//
-// [Pos 1] Bellow
-//      
-//
-      TGeoVolume* voRB26s3Bellow = new TGeoVolume("RB26s3Bellow", 
-						  new TGeoTube(kRB26s3BellowRi, kRB26s3BellowRo, kRB26s3BellowUndL/2.), kMedVacH);
-//      
-//  Upper part of the undulation
-//
-      TGeoTorus* shRB26s3PlieTorusU  =  new TGeoTorus(kRB26s3BellowRo - kRB26s3PlieR, kRB26s3PlieR - kRB26s3PlieThickness, kRB26s3PlieR);
-      shRB26s3PlieTorusU->SetName("RB26s3TorusU");
-      TGeoTube*  shRB26s3PlieTubeU   =  new TGeoTube (kRB26s3BellowRo - kRB26s3PlieR, kRB26s3BellowRo, kRB26s3PlieR);
-      shRB26s3PlieTubeU->SetName("RB26s3TubeU");
-      TGeoCompositeShape*  shRB26s3UpperPlie = new TGeoCompositeShape("RB26s3UpperPlie", "RB26s3TorusU*RB26s3TubeU");
- 
-      TGeoVolume* voRB26s3WiggleU = new TGeoVolume("RB26s3UpperPlie", shRB26s3UpperPlie, kMedSteelH);
-//
-// Lower part of the undulation
-      TGeoTorus* shRB26s3PlieTorusL =  new TGeoTorus(kRB26s3BellowRi + kRB26s3PlieR, kRB26s3PlieR - kRB26s3PlieThickness, kRB26s3PlieR);
-      shRB26s3PlieTorusL->SetName("RB26s3TorusL");
-      TGeoTube*  shRB26s3PlieTubeL   =  new TGeoTube (kRB26s3BellowRi, kRB26s3BellowRi + kRB26s3PlieR, kRB26s3PlieR);
-      shRB26s3PlieTubeL->SetName("RB26s3TubeL");
-      TGeoCompositeShape*  shRB26s3LowerPlie = new TGeoCompositeShape("RB26s3LowerPlie", "RB26s3TorusL*RB26s3TubeL");
-      
-      TGeoVolume* voRB26s3WiggleL = new TGeoVolume("RB26s3LowerPlie", shRB26s3LowerPlie, kMedSteelH); 
-
-//
-// Connection between upper and lower part of undulation
-      TGeoVolume* voRB26s3WiggleC1 = new TGeoVolume("RB26s3PlieConn1",  
-						    new TGeoTube(kRB26s3BellowRi + kRB26s3PlieR, 
-								 kRB26s3BellowRo - kRB26s3PlieR, kRB26s3PlieThickness / 2.), kMedSteelH);
-//
-// One wiggle
-      TGeoVolumeAssembly* voRB26s3Wiggle = new TGeoVolumeAssembly("RB26s3Wiggle");
-      z0 =  -  kRB26s3PlieThickness / 2.;
-      voRB26s3Wiggle->AddNode(voRB26s3WiggleC1,  1 , new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s3PlieR -  kRB26s3PlieThickness / 2.;
-      voRB26s3Wiggle->AddNode(voRB26s3WiggleU,   1 , new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s3PlieR -  kRB26s3PlieThickness / 2.;
-      voRB26s3Wiggle->AddNode(voRB26s3WiggleC1,  2 , new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s3PlieR -  kRB26s3PlieThickness;
-      voRB26s3Wiggle->AddNode(voRB26s3WiggleL,  1 , new TGeoTranslation(0., 0., z0));
-// Positioning of the volumes
-      z0   = - kRB26s3BellowUndL/2.+ kRB26s3PlieR;
-      voRB26s3Bellow->AddNode(voRB26s3WiggleL, 1, new TGeoTranslation(0., 0., z0));
-      z0  +=  kRB26s3PlieR;
-      zsh  = 4. *  kRB26s3PlieR -  2. * kRB26s3PlieThickness;
-      for (Int_t iw = 0; iw < kRB26s3NumberOfPlies; iw++) {
-	  Float_t zpos =  z0 + iw * zsh;	
-	  voRB26s3Bellow->AddNode(voRB26s3Wiggle,  iw + 1, new TGeoTranslation(0., 0., zpos -  kRB26s3PlieThickness));	
-      }
-
-      voRB26s3Compensator->AddNode(voRB26s3Bellow, 1,  new TGeoTranslation(0., 0., kRB26s3WeldingTubeLeftL + kRB26s3BellowUndL/2.));
-
-
-//
-// [Pos 2] Outer Protecting Tube
-//      
-      TGeoTube* shRB26s3CompProtTube = new TGeoTube(kRB26s3RingOuterR, kRB26s3ProtOuterR, kRB26s3ProtL);
-      TGeoVolume* voRB26s3CompProtTube =  
-	  new TGeoVolume("RB26s3CompProtTube", shRB26s3CompProtTube, kMedSteelH);
-      voRB26s3Compensator->AddNode(voRB26s3CompProtTube, 1,  new TGeoTranslation(0., 0., kRB26s3ProtZ + kRB26s3ProtL));
-      
-
-//
-// [Pos 3] Right Welding Tube
-//      
-      TGeoPcon* shRB26s3CompRightTube = new TGeoPcon(0., 360., 5);
-      z0 = 0.;
-      shRB26s3CompRightTube->DefineSection(0, z0,  kRB26s3CompTubeInnerR3, kRB26s3CompTubeOuterR3);
-      z0 += kRB26s3WeldingTubeT2;
-      shRB26s3CompRightTube->DefineSection(1, z0,  kRB26s3CompTubeInnerR2, kRB26s3CompTubeOuterR2);
-      z0 += kRB26s3WeldingTubeRightL2;
-      shRB26s3CompRightTube->DefineSection(2, z0,  kRB26s3CompTubeInnerR2, kRB26s3CompTubeOuterR2);
-      z0 += kRB26s3WeldingTubeT1;
-      shRB26s3CompRightTube->DefineSection(3, z0,  kRB26s3CompTubeInnerR1, kRB26s3CompTubeOuterR1);
-      z0 += kRB26s3WeldingTubeRightL1;
-      shRB26s3CompRightTube->DefineSection(4, z0,  kRB26s3CompTubeInnerR1, kRB26s3CompTubeOuterR1);
-      
-      TGeoVolume* voRB26s3CompRightTube =  
-	  new TGeoVolume("RB26s3CompRightTube", shRB26s3CompRightTube, kMedSteelH);
-      voRB26s3Compensator->AddNode(voRB26s3CompRightTube,  1, new TGeoTranslation(0., 0.,  kRB26s3CompL - z0));
-
-//
-// [Pos 4] Left Welding Tube
-//      
-      TGeoPcon* shRB26s3CompLeftTube = new TGeoPcon(0., 360., 5);
-      z0 = 0.;
-      shRB26s3CompLeftTube->DefineSection(0, z0,  kRB26s3CompTubeInnerR1, kRB26s3CompTubeOuterR1);
-      z0 += kRB26s3WeldingTubeLeftL1;
-      shRB26s3CompLeftTube->DefineSection(1, z0,  kRB26s3CompTubeInnerR1, kRB26s3CompTubeOuterR1);
-      z0 += kRB26s3WeldingTubeT1;
-      shRB26s3CompLeftTube->DefineSection(2, z0,  kRB26s3CompTubeInnerR2, kRB26s3CompTubeOuterR2);
-      z0 += kRB26s3WeldingTubeLeftL2;
-      shRB26s3CompLeftTube->DefineSection(3, z0,  kRB26s3CompTubeInnerR2, kRB26s3CompTubeOuterR2);
-      z0 += kRB26s3WeldingTubeT2;
-      shRB26s3CompLeftTube->DefineSection(4, z0,  kRB26s3CompTubeInnerR3, kRB26s3CompTubeOuterR3);
-
-      TGeoVolume* voRB26s3CompLeftTube =  
-	  new TGeoVolume("RB26s3CompLeftTube", shRB26s3CompLeftTube, kMedSteelH);
-      voRB26s3Compensator->AddNode(voRB26s3CompLeftTube, 1,  gGeoIdentity);
-//
-// [Pos 5] Ring
-//      
-      TGeoTube* shRB26s3CompRing = new TGeoTube(kRB26s3CompTubeOuterR2, kRB26s3RingOuterR, kRB26s3RingL);
-      TGeoVolume* voRB26s3CompRing =  
-	  new TGeoVolume("RB26s3CompRing", shRB26s3CompRing, kMedSteelH);
-      voRB26s3Compensator->AddNode(voRB26s3CompRing,  1, new TGeoTranslation(0., 0., kRB26s3RingZ + kRB26s3RingL));
-
-
-
-///////////////////////////////////////////
-//                                       //
-//    RB26/4-5                           //  
-//    Drawing LHCV2a_0012 [as installed] //
-////////////////////////////////////////////
-//    Pos1 Vacuum Tubes        LHCVC2A__0014
-//    Pos2 Compensator         LHCVC2A__0066
-//    Pos3 Fixed Point Section LHCVC2A__0016
-//    Pos4 Split Flange        LHCVFX___0005
-//    Pos5 RotableFlange       LHCVFX___0009
-////////////////////////////////////////////
-
-///////////////////////////////////
-//    RB26/4-5 Vacuum Tubes      //
-//    Drawing  LHCVC2a_0014      //
-/////////////////////////////////// 
-      const Float_t kRB26s45TubeL = 593.12 + 0.3; // 0.3 cm added for welding
-      
-      TGeoPcon* shRB26s45Tube = new TGeoPcon(0., 360., 11);
-      // Section 1: straight section
-      shRB26s45Tube->DefineSection( 0,   0.00, 30.00/2., 30.60/2.);
-      shRB26s45Tube->DefineSection( 1,   1.20, 30.00/2., 30.60/2.);
-      shRB26s45Tube->DefineSection( 2,   1.20, 30.00/2., 30.80/2.);
-      shRB26s45Tube->DefineSection( 3,  25.10, 30.00/2., 30.80/2.);      
-      // Section 2: 0.932 deg opening cone
-      shRB26s45Tube->DefineSection( 4, 486.10, 45.00/2., 45.80/2.);      
-      // Section 3: straight section 4 mm 
-      shRB26s45Tube->DefineSection( 5, 512.10, 45.00/2., 45.80/2.);
-      // Section 4: straight section 3 mm
-      shRB26s45Tube->DefineSection( 6, 512.10, 45.00/2., 45.60/2.);
-      shRB26s45Tube->DefineSection( 7, 527.70, 45.00/2., 45.60/2.);
-      // Section 4: closing cone 
-      shRB26s45Tube->DefineSection( 8, 591.30, 10.00/2., 10.60/2.);      
-      shRB26s45Tube->DefineSection( 9, 591.89, 10.00/2., 10.30/2.);      
-
-      shRB26s45Tube->DefineSection(10, kRB26s45TubeL, 10.00/2., 10.30/2.);      
-      TGeoVolume* voRB26s45Tube  =  
-	  new TGeoVolume("RB26s45Tube", shRB26s45Tube, kMedSteelH);
-
-      TGeoVolume* voRB26s45TubeM  = new TGeoVolume("RB26s45TubeM", MakeMotherFromTemplate(shRB26s45Tube), kMedVacH);
-      voRB26s45TubeM->AddNode(voRB26s45Tube, 1, gGeoIdentity);
-            
-      
-
-///////////////////////////////////
-//    RB26/5   Axial Compensator //
-//    Drawing  LHCVC2a_0066      //
-/////////////////////////////////// 
-      const Float_t kRB26s5CompL             = 27.60;    // Length of the compensator (0.30 cm added for welding)
-      const Float_t kRB26s5BellowRo          = 12.48/2.; // Bellow outer radius        [Pos 1]
-      const Float_t kRB26s5BellowRi          = 10.32/2.; // Bellow inner radius        [Pos 1] 
-      const Int_t   kRB26s5NumberOfPlies     = 15;       // Number of plies            [Pos 1] 
-      const Float_t kRB26s5BellowUndL        = 10.50;    // Length of undulated region [Pos 1] 
-      const Float_t kRB26s5PlieThickness     =  0.025;   // Plie thickness             [Pos 1]
-      const Float_t kRB26s5ConnectionPlieR   =  0.21;    // Connection plie radius     [Pos 1] 
-      const Float_t kRB26s5ConnectionR       = 11.2/2.;  // Bellow connection radius   [Pos 1] 
-//  Plie radius
-      const Float_t kRB26s5PlieR = 
-	(kRB26s5BellowUndL - 4. *  kRB26s5ConnectionPlieR + 
-	 2. *  kRB26s5NumberOfPlies * kRB26s5PlieThickness) / (4. * kRB26s5NumberOfPlies);
-      const Float_t kRB26s5CompTubeInnerR    = 10.00/2.;  // Connection tubes inner radius     [Pos 2 + 3]
-      const Float_t kRB26s5CompTubeOuterR    = 10.30/2.;  // Connection tubes outer radius     [Pos 2 + 3]
-      const Float_t kRB26s5WeldingTubeLeftL  =  3.70/2.;  // Left connection tube half length  [Pos 2]
-      const Float_t kRB26s5WeldingTubeRightL = 13.40/2.;  // Right connection tube half length [Pos 3]   (0.3 cm added for welding)
-      const Float_t kRB26s5RingInnerR        = 11.2/2.;   // Ring inner radius                 [Pos 4]
-      const Float_t kRB26s5RingOuterR        = 16.0/2.;   // Ring inner radius                 [Pos 4]
-      const Float_t kRB26s5RingL             =  0.4/2.;   // Ring half length                  [Pos 4]
-      const Float_t kRB26s5RingZ             = 14.97;     // Ring z-position                   [Pos 4]
-      const Float_t kRB26s5ProtOuterR        = 16.2/2.;   // Protection tube outer radius      [Pos 5]
-      const Float_t kRB26s5ProtL             = 13.0/2.;   // Protection tube half length       [Pos 5]
-      const Float_t kRB26s5ProtZ             =  2.17;     // Protection tube z-position        [Pos 5]
-      const Float_t kRB26s5DetailZR          = 11.3/2.;   // Detail Z max radius
-      
-      
-// Mother volume
-//
-      TGeoPcon* shRB26s5Compensator  = new TGeoPcon(0., 360., 8);
-      shRB26s5Compensator->DefineSection( 0,   0.0,                                                  0., kRB26s5CompTubeOuterR);
-      shRB26s5Compensator->DefineSection( 1,   kRB26s5ProtZ,                                         0., kRB26s5CompTubeOuterR);      
-      shRB26s5Compensator->DefineSection( 2,   kRB26s5ProtZ,                                         0., kRB26s5ProtOuterR);
-      shRB26s5Compensator->DefineSection( 3,   kRB26s5ProtZ + 2. * kRB26s5ProtL + 2. * kRB26s5RingL, 0., kRB26s5ProtOuterR);      
-      shRB26s5Compensator->DefineSection( 4,   kRB26s5ProtZ + 2. * kRB26s5ProtL + 2. * kRB26s5RingL, 0., kRB26s5DetailZR);
-      shRB26s5Compensator->DefineSection( 5,   kRB26s5CompL - 8.,                                    0., kRB26s5DetailZR);
-      shRB26s5Compensator->DefineSection( 6,   kRB26s5CompL - 8.,                                    0., kRB26s5CompTubeOuterR);            
-      shRB26s5Compensator->DefineSection( 7,   kRB26s5CompL,                                         0., kRB26s5CompTubeOuterR);            
-      TGeoVolume* voRB26s5Compensator  = new TGeoVolume("RB26s5Compensator", shRB26s5Compensator, kMedVacH);
-            
-//
-// [Pos 1] Bellow
-//      
-//
-      TGeoVolume* voRB26s5Bellow = new TGeoVolume("RB26s5Bellow", 
-						  new TGeoTube(kRB26s5BellowRi, kRB26s5BellowRo, kRB26s5BellowUndL/2.), kMedVacH);
-//      
-//  Upper part of the undulation
-//
-      TGeoTorus* shRB26s5PlieTorusU  =  new TGeoTorus(kRB26s5BellowRo - kRB26s5PlieR, kRB26s5PlieR - kRB26s5PlieThickness, kRB26s5PlieR);
-      shRB26s5PlieTorusU->SetName("RB26s5TorusU");
-      TGeoTube*  shRB26s5PlieTubeU   =  new TGeoTube (kRB26s5BellowRo - kRB26s5PlieR, kRB26s5BellowRo, kRB26s5PlieR);
-      shRB26s5PlieTubeU->SetName("RB26s5TubeU");
-      TGeoCompositeShape*  shRB26s5UpperPlie = new TGeoCompositeShape("RB26s5UpperPlie", "RB26s5TorusU*RB26s5TubeU");
- 
-      TGeoVolume* voRB26s5WiggleU = new TGeoVolume("RB26s5UpperPlie", shRB26s5UpperPlie, kMedSteelH);
-//
-// Lower part of the undulation
-      TGeoTorus* shRB26s5PlieTorusL =  new TGeoTorus(kRB26s5BellowRi + kRB26s5PlieR, kRB26s5PlieR - kRB26s5PlieThickness, kRB26s5PlieR);
-      shRB26s5PlieTorusL->SetName("RB26s5TorusL");
-      TGeoTube*  shRB26s5PlieTubeL   =  new TGeoTube (kRB26s5BellowRi, kRB26s5BellowRi + kRB26s5PlieR, kRB26s5PlieR);
-      shRB26s5PlieTubeL->SetName("RB26s5TubeL");
-      TGeoCompositeShape*  shRB26s5LowerPlie = new TGeoCompositeShape("RB26s5LowerPlie", "RB26s5TorusL*RB26s5TubeL");
-      
-      TGeoVolume* voRB26s5WiggleL = new TGeoVolume("RB26s5LowerPlie", shRB26s5LowerPlie, kMedSteelH); 
-
-//
-// Connection between upper and lower part of undulation
-      TGeoVolume* voRB26s5WiggleC1 = new TGeoVolume("RB26s5PlieConn1",  
-						    new TGeoTube(kRB26s5BellowRi + kRB26s5PlieR, 
-								 kRB26s5BellowRo - kRB26s5PlieR, kRB26s5PlieThickness / 2.), kMedSteelH);
-//
-// One wiggle
-      TGeoVolumeAssembly* voRB26s5Wiggle = new TGeoVolumeAssembly("RB26s5Wiggle");
-      z0 =  -  kRB26s5PlieThickness / 2.;
-      voRB26s5Wiggle->AddNode(voRB26s5WiggleC1,  1 , new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s5PlieR -  kRB26s5PlieThickness / 2.;
-      voRB26s5Wiggle->AddNode(voRB26s5WiggleU,   1 , new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s5PlieR -  kRB26s5PlieThickness / 2.;
-      voRB26s5Wiggle->AddNode(voRB26s5WiggleC1,  2 , new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s5PlieR -  kRB26s5PlieThickness;
-      voRB26s5Wiggle->AddNode(voRB26s5WiggleL ,  1 , new TGeoTranslation(0., 0., z0));
-// Positioning of the volumes
-      z0   = - kRB26s5BellowUndL/2.+ kRB26s5ConnectionPlieR;
-      voRB26s5Bellow->AddNode(voRB26s5WiggleL, 1, new TGeoTranslation(0., 0., z0));
-      z0  +=  kRB26s5ConnectionPlieR;
-      zsh  = 4. *  kRB26s5PlieR -  2. * kRB26s5PlieThickness;
-      for (Int_t iw = 0; iw < kRB26s5NumberOfPlies; iw++) {
-	  Float_t zpos =  z0 + iw * zsh;	
-	  voRB26s5Bellow->AddNode(voRB26s5Wiggle,  iw + 1, new TGeoTranslation(0., 0., zpos -  kRB26s5PlieThickness));	
-      }
-
-      voRB26s5Compensator->AddNode(voRB26s5Bellow, 1,  new TGeoTranslation(0., 0., 2. * kRB26s5WeldingTubeLeftL + kRB26s5BellowUndL/2.));
-      
-//
-// [Pos 2] Left Welding Tube
-//      
-      TGeoPcon* shRB26s5CompLeftTube = new TGeoPcon(0., 360., 3);
-      z0 = 0;
-      shRB26s5CompLeftTube->DefineSection(0, z0, kRB26s5CompTubeInnerR, kRB26s5CompTubeOuterR);
-      z0 += 2 * kRB26s5WeldingTubeLeftL - ( kRB26s5ConnectionR - kRB26s5CompTubeOuterR);
-      shRB26s5CompLeftTube->DefineSection(1, z0, kRB26s5CompTubeInnerR, kRB26s5CompTubeOuterR);
-      z0 += ( kRB26s5ConnectionR - kRB26s5CompTubeOuterR);
-      shRB26s5CompLeftTube->DefineSection(2, z0, kRB26s5ConnectionR - 0.15, kRB26s5ConnectionR);
-      TGeoVolume* voRB26s5CompLeftTube = new TGeoVolume("RB26s5CompLeftTube", shRB26s5CompLeftTube, kMedSteelH);
-      voRB26s5Compensator->AddNode(voRB26s5CompLeftTube, 1,  gGeoIdentity);
-//
-// [Pos 3] Right Welding Tube
-//      
-      TGeoPcon* shRB26s5CompRightTube = new TGeoPcon(0., 360., 11);
-      // Detail Z
-      shRB26s5CompRightTube->DefineSection( 0, 0.  , kRB26s5CompTubeInnerR + 0.22, 11.2/2.);
-      shRB26s5CompRightTube->DefineSection( 1, 0.05, kRB26s5CompTubeInnerR + 0.18, 11.2/2.);
-      shRB26s5CompRightTube->DefineSection( 2, 0.22, kRB26s5CompTubeInnerR       , 11.2/2. - 0.22);
-      shRB26s5CompRightTube->DefineSection( 3, 0.44, kRB26s5CompTubeInnerR       , 11.2/2.);
-      shRB26s5CompRightTube->DefineSection( 4, 1.70, kRB26s5CompTubeInnerR       , 11.2/2.);
-      shRB26s5CompRightTube->DefineSection( 5, 2.10, kRB26s5CompTubeInnerR       , kRB26s5CompTubeOuterR);
-      shRB26s5CompRightTube->DefineSection( 6, 2.80, kRB26s5CompTubeInnerR       , kRB26s5CompTubeOuterR);
-      shRB26s5CompRightTube->DefineSection( 7, 2.80, kRB26s5CompTubeInnerR       , 11.3/2.);
-      shRB26s5CompRightTube->DefineSection( 8, 3.40, kRB26s5CompTubeInnerR       , 11.3/2.);
-      // Normal pipe
-      shRB26s5CompRightTube->DefineSection( 9, 3.50, kRB26s5CompTubeInnerR       , kRB26s5CompTubeOuterR);
-      shRB26s5CompRightTube->DefineSection(10, 2. * kRB26s5WeldingTubeRightL, kRB26s5CompTubeInnerR, kRB26s5CompTubeOuterR);
-      
-      TGeoVolume* voRB26s5CompRightTube =  
-	  new TGeoVolume("RB26s5CompRightTube", shRB26s5CompRightTube, kMedSteelH);
-      voRB26s5Compensator->AddNode(voRB26s5CompRightTube,  1, 
-				   new TGeoTranslation(0., 0.,  kRB26s5CompL - 2. * kRB26s5WeldingTubeRightL));
-//
-// [Pos 4] Ring
-//      
-      TGeoTube* shRB26s5CompRing = new TGeoTube(kRB26s5RingInnerR, kRB26s5RingOuterR, kRB26s5RingL);
-      TGeoVolume* voRB26s5CompRing =  
-	  new TGeoVolume("RB26s5CompRing", shRB26s5CompRing, kMedSteelH);
-      voRB26s5Compensator->AddNode(voRB26s5CompRing,  1, new TGeoTranslation(0., 0., kRB26s5RingZ + kRB26s5RingL));
-
-//
-// [Pos 5] Outer Protecting Tube
-//      
-      TGeoTube* shRB26s5CompProtTube = new TGeoTube(kRB26s5RingOuterR, kRB26s5ProtOuterR, kRB26s5ProtL);
-      TGeoVolume* voRB26s5CompProtTube =  
-	  new TGeoVolume("RB26s5CompProtTube", shRB26s5CompProtTube, kMedSteelH);
-      voRB26s5Compensator->AddNode(voRB26s5CompProtTube, 1,  new TGeoTranslation(0., 0., kRB26s5ProtZ + kRB26s5ProtL));
-
-///////////////////////////////////////
-//    RB26/4   Fixed Point Section   //
-//    Drawing  LHCVC2a_0016          //
-/////////////////////////////////////// 
-      const Float_t kRB26s4TubeRi            =  30.30/2. ; // Tube inner radius  (0.3 cm added for welding)
-      const Float_t kRB26s4TubeRo            =  30.60/2. ; // Tube outer radius      
-      const Float_t kRB26s4FixedPointL       =  12.63    ; // Length of the fixed point section
-      const Float_t kRB26s4FixedPointZ       =  10.53    ; // Position of the ring (0.15 added for welding)
-      const Float_t kRB26s4FixedPointD       =   0.595   ; // Width of the ring
-      const Float_t kRB26s4FixedPointR       =  31.60/2. ; // Radius of the ring
-      
-      TGeoPcon* shRB26s4FixedPoint = new TGeoPcon(0., 360., 6);
-      z0 = 0.;
-      shRB26s4FixedPoint->DefineSection(0, z0, kRB26s4TubeRi, kRB26s4TubeRo);
-      z0 += kRB26s4FixedPointZ;
-      shRB26s4FixedPoint->DefineSection(1, z0, kRB26s4TubeRi, kRB26s4TubeRo);      
-      shRB26s4FixedPoint->DefineSection(2, z0, kRB26s4TubeRi, kRB26s4FixedPointR);      	  
-      z0 += kRB26s4FixedPointD;
-      shRB26s4FixedPoint->DefineSection(3, z0, kRB26s4TubeRi, kRB26s4FixedPointR);      	  
-      shRB26s4FixedPoint->DefineSection(4, z0, kRB26s4TubeRi, kRB26s4TubeRo);
-      z0 = kRB26s4FixedPointL;
-      shRB26s4FixedPoint->DefineSection(5, z0, kRB26s4TubeRi, kRB26s4TubeRo);
-      TGeoVolume* voRB26s4FixedPoint = new TGeoVolume("RB26s4FixedPoint", shRB26s4FixedPoint, kMedSteelH);
-      
-      TGeoVolume* voRB26s4FixedPointM = new TGeoVolume("RB26s4FixedPointM", MakeMotherFromTemplate(shRB26s4FixedPoint), kMedVacH);
-      voRB26s4FixedPointM->AddNode(voRB26s4FixedPoint, 1, gGeoIdentity);
-            
-
-///////////////////////////////////////
-//    RB26/4   Split Flange          //
-//    Drawing  LHCVFX__0005          //
-/////////////////////////////////////// 
-      const Float_t kRB26s4SFlangeL      =  2.99;        // Length of the flange
-      const Float_t kRB26s4SFlangeD1     =  0.85;        // Length of section 1
-      const Float_t kRB26s4SFlangeD2     =  0.36;        // Length of section 2						     
-      const Float_t kRB26s4SFlangeD3     =  0.73 + 1.05; // Length of section 3						           
-      const Float_t kRB26s4SFlangeRo     = 36.20/2.;     // Flange outer radius 
-      const Float_t kRB26s4SFlangeRi1    = 30.60/2.;     // Flange inner radius section 1
-      const Float_t kRB26s4SFlangeRi2    = 30.00/2.;     // Flange inner radius section 2
-      const Float_t kRB26s4SFlangeRi3    = 30.60/2.;     // Flange inner radius section 3
-      z0 = 0;
-      TGeoPcon* shRB26s4SFlange = new TGeoPcon(0., 360., 6);
-      z0 = 0.;
-      shRB26s4SFlange->DefineSection(0, z0, kRB26s4SFlangeRi1, kRB26s4SFlangeRo);
-      z0 += kRB26s4SFlangeD1;
-      shRB26s4SFlange->DefineSection(1, z0, kRB26s4SFlangeRi1, kRB26s4SFlangeRo);
-      shRB26s4SFlange->DefineSection(2, z0, kRB26s4SFlangeRi2, kRB26s4SFlangeRo);
-      z0 += kRB26s4SFlangeD2;
-      shRB26s4SFlange->DefineSection(3, z0, kRB26s4SFlangeRi2, kRB26s4SFlangeRo);
-      shRB26s4SFlange->DefineSection(4, z0, kRB26s4SFlangeRi3, kRB26s4SFlangeRo);
-      z0 += kRB26s4SFlangeD3;
-      shRB26s4SFlange->DefineSection(5, z0, kRB26s4SFlangeRi3, kRB26s4SFlangeRo);
-      TGeoVolume* voRB26s4SFlange = new TGeoVolume("RB26s4SFlange", shRB26s4SFlange, kMedSteelH);
-
-      TGeoVolume* voRB26s4SFlangeM = new TGeoVolume("RB26s4SFlangeM", MakeMotherFromTemplate(shRB26s4SFlange, 0, 3), kMedVacH);
-      voRB26s4SFlangeM->AddNode(voRB26s4SFlange, 1, gGeoIdentity);
-      
-///////////////////////////////////////
-//    RB26/5   Rotable Flange        //
-//    Drawing  LHCVFX__0009          //
-/////////////////////////////////////// 
-      const Float_t kRB26s5RFlangeL      =  1.86;    // Length of the flange
-      const Float_t kRB26s5RFlangeD1     =  0.61;    // Length of section 1
-      const Float_t kRB26s5RFlangeD2     =  0.15;    // Length of section 2						     
-      const Float_t kRB26s5RFlangeD3     =  0.60;    // Length of section 3						           
-      const Float_t kRB26s5RFlangeD4     =  0.50;    // Length of section 4						           
-      const Float_t kRB26s5RFlangeRo     = 15.20/2.; // Flange outer radius 
-      const Float_t kRB26s5RFlangeRi1    = 10.30/2.; // Flange inner radius section 1
-      const Float_t kRB26s5RFlangeRi2    = 10.00/2.; // Flange inner radius section 2
-      const Float_t kRB26s5RFlangeRi3    = 10.30/2.; // Flange inner radius section 3
-      const Float_t kRB26s5RFlangeRi4    = 10.50/2.; // Flange inner radius section 4
-
-      z0 = 0;
-      TGeoPcon* shRB26s5RFlange = new TGeoPcon(0., 360., 8);
-      z0 = 0.;
-      shRB26s5RFlange->DefineSection(0, z0, kRB26s5RFlangeRi4, kRB26s5RFlangeRo);
-      z0 += kRB26s5RFlangeD4;
-      shRB26s5RFlange->DefineSection(1, z0, kRB26s5RFlangeRi4, kRB26s5RFlangeRo);
-      shRB26s5RFlange->DefineSection(2, z0, kRB26s5RFlangeRi3, kRB26s5RFlangeRo);
-      z0 += kRB26s5RFlangeD3;
-      shRB26s5RFlange->DefineSection(3, z0, kRB26s5RFlangeRi3, kRB26s5RFlangeRo);
-      shRB26s5RFlange->DefineSection(4, z0, kRB26s5RFlangeRi2, kRB26s5RFlangeRo);
-      z0 += kRB26s5RFlangeD2;
-      shRB26s5RFlange->DefineSection(5, z0, kRB26s5RFlangeRi2, kRB26s5RFlangeRo);
-      shRB26s5RFlange->DefineSection(6, z0, kRB26s5RFlangeRi1, kRB26s5RFlangeRo);
-      z0 += kRB26s5RFlangeD1;
-      shRB26s5RFlange->DefineSection(7, z0, kRB26s5RFlangeRi1, kRB26s5RFlangeRo);
-      TGeoVolume* voRB26s5RFlange = new TGeoVolume("RB26s5RFlange", shRB26s5RFlange, kMedSteelH);
-
-      TGeoVolume* voRB26s5RFlangeM = new TGeoVolume("RB26s5RFlangeM", MakeMotherFromTemplate(shRB26s5RFlange, 4, 7), kMedVacH);
-      voRB26s5RFlangeM->AddNode(voRB26s5RFlange, 1, gGeoIdentity);
-
-//      
-// Assemble RB26/1-2
-//
-      TGeoVolumeAssembly* asRB26s12 = new TGeoVolumeAssembly("RB26s12"); 
-      z0 = 0.;
-      asRB26s12->AddNode(voRB26s1RFlange,       1, gGeoIdentity);
-      z0 += kRB26s1RFlangeIsL + kRB26s1RFlangeFpL;
-      asRB26s12->AddNode(voRB26s12TubeM,         1, new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s12TubeL;
-      asRB26s12->AddNode(voRB26s2Compensator,   1, new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s2CompL;
-      z0 -= kRB26s2FFlangeD1;
-      asRB26s12->AddNode(voRB26s2FFlangeM,       1, new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s2FFlangeL;
-      const Float_t kRB26s12L = z0;
-
-//
-// Assemble RB26/3
-//
-      TGeoVolumeAssembly* asRB26s3 = new TGeoVolumeAssembly("RB26s3"); 
-      z0 = 0.;
-      asRB26s3->AddNode(voRB26s3SFlangeM,      1, gGeoIdentity);
-      z0 +=  kRB26s3SFlangeL;
-      z0 -=  kRB26s3SFlangeD3;
-      asRB26s3->AddNode(voRB26s3FixedPointM,   1, new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s3FixedPointL;
-      asRB26s3->AddNode(voRB26s3TubeM,         1, new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s3TubeL;
-      asRB26s3->AddNode(voRB26s3Compensator,   1, new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s3CompL;
-      z0 -= kRB26s3FFlangeD1;
-      asRB26s3->AddNode(voRB26s3FFlangeM,      1, new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s3FFlangeL;
-      const Float_t kRB26s3L = z0;
-      
-
-//
-// Assemble RB26/4-5
-//
-      TGeoVolumeAssembly* asRB26s45 = new TGeoVolumeAssembly("RB26s45"); 
-      z0 = 0.;
-      asRB26s45->AddNode(voRB26s4SFlangeM,       1, gGeoIdentity);
-      z0 +=  kRB26s4SFlangeL;
-      z0 -=  kRB26s4SFlangeD3;
-      asRB26s45->AddNode(voRB26s4FixedPointM,    1, new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s4FixedPointL;
-      asRB26s45->AddNode(voRB26s45TubeM,         1, new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s45TubeL;
-      asRB26s45->AddNode(voRB26s5Compensator,    1, new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s5CompL;
-      z0 -= kRB26s5RFlangeD3;
-      z0 -= kRB26s5RFlangeD4;
-      asRB26s45->AddNode(voRB26s5RFlangeM,       1, new TGeoTranslation(0., 0., z0));
-      z0 += kRB26s5RFlangeL;
-      const Float_t kRB26s45L = z0;
-      
-//
-// Assemble RB26
-//
-      TGeoVolumeAssembly* asRB26Pipe = new TGeoVolumeAssembly("RB26Pipe"); 
-      z0 = 0.;
-      asRB26Pipe->AddNode(asRB26s12,       1, new TGeoTranslation(0., 0., z0));
-      z0 +=  kRB26s12L;
-      asRB26Pipe->AddNode(asRB26s3,        1, new TGeoTranslation(0., 0., z0));
-      z0 +=  kRB26s3L;
-      asRB26Pipe->AddNode(asRB26s45,       1, new TGeoTranslation(0., 0., z0));
-      z0 +=  kRB26s45L;
-      top->AddNode(asRB26Pipe, 1, new TGeoCombiTrans(0., 0., -82., rot180));
+  }
+  //
+  // Add connecting undulation between bellow and connecting pipe
+  dz = - kCP3BellowUndulatedLength / 2. + kCP3ConnectionPlieR;
+  voBellowMother->AddNode(voConnectionPO, 1,  new TGeoTranslation(0., 0.,  dz));
+  voBellowMother->AddNode(voConnectionPO, 2,  new TGeoTranslation(0., 0., -dz));
+  //
+  // Add connecting pipe
+  dz =  - kCP3BellowLength / 2. +  kCP3BellowConnectionLength / 2.;
+  voBellowMother->AddNode(voConnectionPipeO, 1,  new TGeoTranslation(0., 0.,   dz));
+  voBellowMother->AddNode(voConnectionPipeO, 2,  new TGeoTranslation(0., 0.,  -dz));
+  //
+  // Add bellow to CP/3 mother    
+  dz = - kCP3Length / 2. +  kCP3AdaptorTubeLength +  kCP3BellowLength / 2.;
+  voCp3Mo->AddNode(voBellowMother, 1,  new TGeoTranslation(0., 0., dz));
+  dz += (kCP3BellowLength +  kCP3TubeLength);
+  voCp3Mo->AddNode(voBellowMother, 2,  new TGeoTranslation(0., 0., dz));
+
+
+  ///////////////////////////////////////////
+  // Beam pipe section between bellows     //
+  ///////////////////////////////////////////
+
+  TGeoVolume* voCp3Bco = new TGeoVolume("CP3BCO",
+      new TGeoTube(0.,  kCP3AdaptorTubeRo,  kCP3TubeLength / 2.),
+      kMedVac);
+
+  TGeoVolume* voCp3Bci = new TGeoVolume("CP3BCI",
+      new TGeoTube(kCP3AdaptorTubeRi, kCP3AdaptorTubeRo, kCP3TubeLength / 2.), 
+      kMedSteel);
+
+  voCp3Bco->AddNode(voCp3Bci, 1, gGeoIdentity);
+  dz = - kCP3Length / 2. +   kCP3AdaptorTubeLength +  kCP3BellowLength +  kCP3TubeLength / 2.;
+  voCp3Mo->AddNode(voCp3Bco, 1, new TGeoTranslation(0., 0., dz));
+
+
+  ///////////////////////////////////////////		  
+  // CP3 Minimised Flange                  //
+  ///////////////////////////////////////////
+
+  TGeoPcon* shCp3mfo = new TGeoPcon(0., 360., 4);
+  z = - (kCP3FlangeConnectorLength + kCP3FlangeLength) / 2.;
+  //  Connection Tube
+  shCp3mfo->DefineSection(0, z, 0., kCP3AdaptorTubeRo);
+  z +=  kCP3FlangeConnectorLength;
+  shCp3mfo->DefineSection(1, z, 0., kCP3AdaptorTubeRo);
+  //  Flange
+  shCp3mfo->DefineSection(2, z, 0., kCP3FlangeRo);
+  z = - shCp3mfo->GetZ(0);
+  shCp3mfo->DefineSection(3, z, 0., kCP3FlangeRo);
+
+  TGeoVolume* voCp3mfo = new TGeoVolume("CP3MFO", shCp3mfo, kMedVac);
+
+
+  TGeoPcon* shCp3mfi = new TGeoPcon(0., 360., 4);
+  //  Connection Tube
+  shCp3mfi->DefineSection(0, shCp3mfo->GetZ(0), kCP3AdaptorTubeRi, kCP3AdaptorTubeRo);
+  shCp3mfi->DefineSection(1, shCp3mfo->GetZ(1), kCP3AdaptorTubeRi, kCP3AdaptorTubeRo);
+  //  Flange
+  shCp3mfi->DefineSection(2, shCp3mfo->GetZ(2), kCP3AdaptorTubeRi, kCP3FlangeRo);
+  shCp3mfi->DefineSection(3, shCp3mfo->GetZ(3), kCP3AdaptorTubeRi, kCP3FlangeRo);
+
+  TGeoVolume* voCp3mfi = new TGeoVolume("CP3MFI", shCp3mfi, kMedSteel);
+
+  voCp3mfo->AddNode(voCp3mfi, 1, gGeoIdentity);
+  dz =  kCP3Length / 2. - (kCP3FlangeConnectorLength + kCP3FlangeLength) / 2.;
+  voCp3Mo->AddNode(voCp3mfo, 1, new TGeoTranslation(0., 0., dz));
+
+
+  //
+  //  Assemble the central beam pipe
+  //
+  TGeoVolumeAssembly* asCP = new TGeoVolumeAssembly("CP");
+  z = 0.;
+  asCP->AddNode(voCp2,   1, gGeoIdentity);
+  z +=  kCP2Length / 2. + kCP1Length / 2.;
+  asCP->AddNode(voCp1, 1, new TGeoTranslation(0., 0., z));
+  z +=  kCP1Length / 2.  + kCP3Length / 2.;
+  asCP->AddNode(voCp3, 1, new TGeoTranslation(0., 0., z));
+  top->AddNode(asCP, 1,  new TGeoCombiTrans(0., 0., 400. -  kCP2Length / 2, rot180));
+
+
+
+
+  ////////////////////////////////////////////////////////////////////////////////     
+  //                                                                            //
+  //                                  RB24/1                                    // 
+  //                                                                            //
+  ////////////////////////////////////////////////////////////////////////////////
+  //
+  //
+  // Drawing LHCVC2U_0001
+  // Copper Tube RB24/1      393.5 cm 
+  // Warm module VMACA        18.0 cm
+  // Annular Ion Pump         35.0 cm
+  // Valve                     7.5 cm
+  // Warm module VMABC        28.0 cm
+  // ================================
+  //                         462.0 cm
+  //
+
+
+  // Copper Tube RB24/1
+  const Float_t  kRB24CuTubeL   = 383.5; // ECV FIX. 
+  const Float_t  kRB24CuTubeRi  = 8.0/2.;
+  const Float_t  kRB24CuTubeRo  = 8.4/2.;
+  const Float_t  kRB24CuTubeFRo = 7.6;
+  const Float_t  kRB24CuTubeFL  = 1.86;
+
+  TGeoVolume* voRB24CuTubeM = new TGeoVolume("voRB24CuTubeM", 
+      new TGeoTube(0., kRB24CuTubeRo, kRB24CuTubeL/2.), kMedVacH);
+  voRB24CuTubeM->SetVisibility(0);
+  TGeoVolume* voRB24CuTube  = new TGeoVolume("voRB24CuTube", 
+      new TGeoTube(kRB24CuTubeRi, kRB24CuTubeRo, kRB24CuTubeL/2.), kMedCuH);
+  voRB24CuTubeM->AddNode(voRB24CuTube, 1, gGeoIdentity);
+  // Air outside tube with higher transport cuts
+  TGeoVolume* voRB24CuTubeA  = new TGeoVolume("voRB24CuTubeA", 
+      new TGeoTube(25., 100., kRB24CuTubeL/2.), kMedAirHigh);
+  voRB24CuTubeA->SetVisibility(0);
+  // Simplified DN 100 Flange
+  TGeoVolume* voRB24CuTubeF  = new TGeoVolume("voRB24CuTubeF",
+      new TGeoTube(kRB24CuTubeRo, kRB24CuTubeFRo, kRB24CuTubeFL/2.), kMedSteelH);
+
+  // Warm Module Type VMACA
+  // LHCVMACA_0002
+  // 
+  // Pos 1 Warm Bellows DN100       LHCVBU__0012
+  // Pos 2 RF Contact   D80         LHCVSR__0005
+  // Pos 3 Trans. Tube Flange       LHCVSR__0065
+  // [Pos 4 Hex. Countersunk Screw   Bossard BN4719]
+  // [Pos 5 Tension spring           LHCVSR__0011]
+  //
+  //
+  //
+  // Pos1    Warm Bellows DN100
+  // Pos1.1  Bellows                  LHCVBU__0006
+  //
+  //
+  // Connection Tubes    
+  // Connection tube inner r
+  const Float_t kRB24B1ConTubeRin        = 10.0/2.;
+  // Connection tube outer r
+  const Float_t kRB24B1ConTubeRou        = 10.3/2.;
+  // Connection tube length
+  const Float_t kRB24B1ConTubeL          =  2.5;
+  // 
+  const Float_t kRB24B1CompL             = 16.00;    // Length of the compensator
+  const Float_t kRB24B1BellowRi          = 10.25/2.; // Bellow inner radius        
+  const Float_t kRB24B1BellowRo          = 11.40/2.; // Bellow outer radius        
+  const Int_t   kRB24B1NumberOfPlies     = 27;       // Number of plies            
+  const Float_t kRB24B1BellowUndL        = 11.00;    // Length of undulated region 
+  const Float_t kRB24B1PlieThickness     =  0.015;   // Plie thickness             
+
+  const Float_t kRB24B1PlieRadius = 
+    (kRB24B1BellowUndL + (2. *  kRB24B1NumberOfPlies+ 1.) * kRB24B1PlieThickness) / (4. * kRB24B1NumberOfPlies + 2.);
+
+  const Float_t kRB24B1ProtTubeThickness = 0.02;     // Thickness of the protection tube
+  const Float_t kRB24B1ProtTubeLength    = 4.2;      // Length of the protection tube
+
+  const Float_t kRB24B1RFlangeL          = 1.86;     // Length of the flanges
+  const Float_t kRB24B1RFlangeLO         = 0.26;     // Flange overlap
+  const Float_t kRB24B1RFlangeRO         = 11.18/2;  // Inner radius at Flange overlap    
+  const Float_t kRB24B1RFlangeRou        = 15.20/2.; // Outer radius of flange
+  const Float_t kRB24B1RFlangeRecess     = 0.98;     // Flange recess
+  const Float_t kRB24B1L                 = kRB24B1CompL +  2. * (kRB24B1RFlangeL - kRB24B1RFlangeRecess);
+
+  ///      
+  //
+  // Bellow mother volume
+  TGeoPcon* shRB24B1BellowM = new TGeoPcon(0., 360., 14);
+  // Connection Tube and Flange
+  z = 0.;
+  shRB24B1BellowM->DefineSection( 0, z, 0.,               kRB24B1RFlangeRou);
+  z += kRB24B1RFlangeLO;
+  shRB24B1BellowM->DefineSection( 1, z, 0.,               kRB24B1RFlangeRou);
+  shRB24B1BellowM->DefineSection( 2, z, 0.,               kRB24B1RFlangeRou);    
+  z = kRB24B1RFlangeL;
+  shRB24B1BellowM->DefineSection( 3, z, 0.,               kRB24B1RFlangeRou);    
+  shRB24B1BellowM->DefineSection( 4, z, 0.,               kRB24B1ConTubeRou);
+  z = kRB24B1ConTubeL +  kRB24B1RFlangeL - kRB24B1RFlangeRecess;
+  shRB24B1BellowM->DefineSection( 5, z, 0.,               kRB24B1ConTubeRou);
+  // Plie
+  shRB24B1BellowM->DefineSection( 6, z, 0.,               kRB24B1BellowRo + kRB24B1ProtTubeThickness);
+  z += kRB24B1BellowUndL;
+  shRB24B1BellowM->DefineSection( 7, z, 0.,               kRB24B1BellowRo + kRB24B1ProtTubeThickness);
+  shRB24B1BellowM->DefineSection( 8, z, 0.,               kRB24B1ConTubeRou);
+  // Connection Tube and Flange
+  z = kRB24B1L - shRB24B1BellowM->GetZ(3);
+  shRB24B1BellowM->DefineSection( 9, z, 0.,               kRB24B1ConTubeRou);
+  shRB24B1BellowM->DefineSection(10, z, 0.,               kRB24B1RFlangeRou);
+  z = kRB24B1L - shRB24B1BellowM->GetZ(1);
+  shRB24B1BellowM->DefineSection(11, z, 0.,               kRB24B1RFlangeRou);
+  shRB24B1BellowM->DefineSection(12, z, 0.,               kRB24B1RFlangeRou);
+  z = kRB24B1L - shRB24B1BellowM->GetZ(0);
+  shRB24B1BellowM->DefineSection(13, z, 0.,               kRB24B1RFlangeRou);
+
+  TGeoVolume* voRB24B1BellowM = new TGeoVolume("RB24B1BellowM", shRB24B1BellowM, kMedVacH);
+  voRB24B1BellowM->SetVisibility(0);
+  //
+  // Bellow Section    
+  TGeoVolume* voRB24B1Bellow 
+    = MakeBellow("RB24B1", kRB24B1NumberOfPlies, kRB24B1BellowRi, kRB24B1BellowRo, 
+        kRB24B1BellowUndL, kRB24B1PlieRadius ,kRB24B1PlieThickness);
+  voRB24B1Bellow->SetVisibility(0);
+
+  //
+  // End Parts (connection tube)
+  TGeoVolume* voRB24B1CT = new TGeoVolume("RB24B1CT", new TGeoTube(kRB24B1ConTubeRin, kRB24B1ConTubeRou,  kRB24B1ConTubeL/2.), kMedSteelH); 
+  //
+  // Protection Tube      
+  TGeoVolume* voRB24B1PT = new TGeoVolume("RB24B1PT", new TGeoTube(kRB24B1BellowRo, kRB24B1BellowRo + kRB24B1ProtTubeThickness,  
+        kRB24B1ProtTubeLength / 2.), kMedSteelH);
+
+  z = kRB24B1ConTubeL/2. +  (kRB24B1RFlangeL - kRB24B1RFlangeRecess);
+
+  voRB24B1BellowM->AddNode(voRB24B1CT, 1, new TGeoTranslation(0., 0., z));
+  z += (kRB24B1ConTubeL/2.+ kRB24B1BellowUndL/2.);
+  voRB24B1BellowM->AddNode(voRB24B1Bellow, 1, new TGeoTranslation(0., 0., z));
+  z += (kRB24B1BellowUndL/2. + kRB24B1ConTubeL/2);
+  voRB24B1BellowM->AddNode(voRB24B1CT, 2, new TGeoTranslation(0., 0., z));
+  z =  kRB24B1ConTubeL +  kRB24B1ProtTubeLength / 2. + 1. + kRB24B1RFlangeLO;
+  voRB24B1BellowM->AddNode(voRB24B1PT, 1, new TGeoTranslation(0., 0., z));
+  z +=  kRB24B1ProtTubeLength + 0.6;
+  voRB24B1BellowM->AddNode(voRB24B1PT, 2, new TGeoTranslation(0., 0., z));
+
+
+
+  // Pos 1/2 Rotatable Flange         LHCVBU__0013
+  // Pos 1/3 Flange DN100/103         LHCVBU__0018
+  // The two flanges can be represented by the same volume
+  // Outer Radius (including the outer movable ring).
+  // The inner ring has a diameter of 12.04 cm
+
+
+  TGeoPcon* shRB24B1RFlange = new TGeoPcon(0., 360., 10);
+  z = 0.;
+  shRB24B1RFlange->DefineSection(0, z, 10.30/2., kRB24B1RFlangeRou);
+  z += 0.55;  // 5.5 mm added for outer ring
+  z += 0.43;
+  shRB24B1RFlange->DefineSection(1, z, 10.30/2., kRB24B1RFlangeRou);
+  shRB24B1RFlange->DefineSection(2, z, 10.06/2., kRB24B1RFlangeRou);    
+  z += 0.15;
+  shRB24B1RFlange->DefineSection(3, z, 10.06/2., kRB24B1RFlangeRou);    
+  // In reality this part is rounded
+  shRB24B1RFlange->DefineSection(4, z, 10.91/2., kRB24B1RFlangeRou);    
+  z += 0.15;
+  shRB24B1RFlange->DefineSection(5, z, 10.91/2., kRB24B1RFlangeRou);    
+  shRB24B1RFlange->DefineSection(6, z, 10.06/2., kRB24B1RFlangeRou);    
+  z += 0.32;
+  shRB24B1RFlange->DefineSection(7, z, 10.06/2., kRB24B1RFlangeRou);    
+  shRB24B1RFlange->DefineSection(8, z, kRB24B1RFlangeRO, kRB24B1RFlangeRou);    
+  z += kRB24B1RFlangeLO;
+  shRB24B1RFlange->DefineSection(9, z, kRB24B1RFlangeRO, kRB24B1RFlangeRou);    
+
+  TGeoVolume* voRB24B1RFlange = new TGeoVolume("RB24B1RFlange", shRB24B1RFlange, kMedSteelH);
+
+
+  z = kRB24B1L - kRB24B1RFlangeL;
+  voRB24B1BellowM->AddNode(voRB24B1RFlange, 1, new TGeoTranslation(0., 0., z));
+  z = kRB24B1RFlangeL;
+  voRB24B1BellowM->AddNode(voRB24B1RFlange, 2, new TGeoCombiTrans(0., 0., z, rot180));
+  //
+  // Pos 2 RF Contact   D80         LHCVSR__0005
+  //
+  // Pos 2.1 RF Contact Flange      LHCVSR__0003
+  //
+  TGeoPcon* shRB24B1RCTFlange = new TGeoPcon(0., 360., 6);
+  const Float_t kRB24B1RCTFlangeRin  = 8.06/2. + 0.05;  // Inner radius
+  const Float_t kRB24B1RCTFlangeL    = 1.45;            // Length
+
+  z = 0.;
+  shRB24B1RCTFlange->DefineSection(0, z, kRB24B1RCTFlangeRin,  8.20/2.);
+  z += 0.15;
+  shRB24B1RCTFlange->DefineSection(1, z, kRB24B1RCTFlangeRin,  8.20/2.);
+  shRB24B1RCTFlange->DefineSection(2, z, kRB24B1RCTFlangeRin,  8.60/2.);
+  z += 1.05;
+  shRB24B1RCTFlange->DefineSection(3, z, kRB24B1RCTFlangeRin,  8.60/2.);
+  shRB24B1RCTFlange->DefineSection(4, z, kRB24B1RCTFlangeRin, 11.16/2.);
+  z += 0.25;
+  shRB24B1RCTFlange->DefineSection(5, z, kRB24B1RCTFlangeRin, 11.16/2.);
+  TGeoVolume* voRB24B1RCTFlange = new TGeoVolume("RB24B1RCTFlange", shRB24B1RCTFlange, kMedCuH);
+  z = kRB24B1L - kRB24B1RCTFlangeL;
+
+  voRB24B1BellowM->AddNode(voRB24B1RCTFlange, 1, new TGeoTranslation(0., 0., z));
+  //
+  // Pos 2.2 RF-Contact        LHCVSR__0004
+  //
+  TGeoPcon* shRB24B1RCT = new TGeoPcon(0., 360., 3);
+  const Float_t kRB24B1RCTRin  = 8.00/2.;        // Inner radius
+  const Float_t kRB24B1RCTCRin = 8.99/2.;        // Max. inner radius conical section
+  const Float_t kRB24B1RCTL    = 11.78;          // Length
+  const Float_t kRB24B1RCTSL   = 10.48;          // Length of straight section
+  const Float_t kRB24B1RCTd    =  0.03;          // Thickness
+
+  z = 0;
+  shRB24B1RCT->DefineSection(0, z,  kRB24B1RCTCRin,  kRB24B1RCTCRin + kRB24B1RCTd);
+  z =  kRB24B1RCTL -  kRB24B1RCTSL;
+  // In the (VSR0004) this section is straight in (LHCVC2U_0001) it is conical ????
+  shRB24B1RCT->DefineSection(1, z,  kRB24B1RCTRin + 0.35,  kRB24B1RCTRin + 0.35 + kRB24B1RCTd);
+  z = kRB24B1RCTL - 0.03;
+  shRB24B1RCT->DefineSection(2, z,  kRB24B1RCTRin,  kRB24B1RCTRin + kRB24B1RCTd);
+
+  TGeoVolume* voRB24B1RCT = new TGeoVolume("RB24B1RCT", shRB24B1RCT, kMedCuH);
+  z = kRB24B1L - kRB24B1RCTL - 0.45;
+  voRB24B1BellowM->AddNode(voRB24B1RCT, 1, new TGeoTranslation(0., 0., z));    
+
+  //
+  // Pos 3 Trans. Tube Flange       LHCVSR__0065
+  //
+  // Pos 3.1 Transition Tube D53    LHCVSR__0064
+  // Pos 3.2 Transition Flange      LHCVSR__0060
+  // Pos 3.3 Transition Tube        LHCVSR__0058
+  TGeoPcon* shRB24B1TTF = new TGeoPcon(0., 360., 7);
+  // Flange
+  z = 0.;
+  shRB24B1TTF->DefineSection(0, z,  6.30/2., 11.16/2.);
+  z += 0.25;
+  shRB24B1TTF->DefineSection(1, z,  6.30/2., 11.16/2.);
+  shRB24B1TTF->DefineSection(2, z,  6.30/2.,  9.3/2.);
+  z += 0.55;
+  shRB24B1TTF->DefineSection(3, z,  6.30/2.,  9.3/2.);
+  // Tube
+  shRB24B1TTF->DefineSection(4, z,  6.30/2.,  6.7/2.);
+  z += 5.80;
+  shRB24B1TTF->DefineSection(5, z,  6.30/2.,  6.7/2.);
+  // Transition Tube
+  z += 3.75;
+  shRB24B1TTF->DefineSection(6, z,  8.05/2.,  8.45/2.);
+  TGeoVolume* voRB24B1TTF = new TGeoVolume("RB24B1TTF", shRB24B1TTF, kMedSteelH);
+  z =  0.;
+  voRB24B1BellowM->AddNode(voRB24B1TTF, 1, new TGeoTranslation(0., 0., z));    
+
+  // Annular Ion Pump        
+  // LHCVC2U_0003
+  //
+  // Pos  1 Rotable Flange         LHCVFX__0031
+  // Pos  2 RF Screen Tube         LHCVC2U_0005
+  // Pos  3 Shell                  LHCVC2U_0007
+  // Pos  4 Extruded Shell         LHCVC2U_0006
+  // Pos  5 Feedthrough Tube       LHCVC2U_0004
+  // Pos  6 Tubulated Flange       STDVFUHV0021
+  // Pos  7 Fixed Flange           LHCVFX__0032
+  // Pos  8 Pumping Elements
+
+  //
+  // Pos 1 Rotable Flange          LHCVFX__0031
+  // pos 7 Fixed Flange            LHCVFX__0032
+  //
+  //  Mother volume
+  const Float_t kRB24AIpML = 35.;
+
+  TGeoVolume* voRB24AIpM = new TGeoVolume("voRB24AIpM", new TGeoTube(0., 10., kRB24AIpML/2.), kMedAirH);
+  voRB24AIpM->SetVisibility(0);
+
+  //
+  // Length 35 cm
+  // Flange 2 x 1.98 =   3.96
+  // Tube            =  32.84
+  //==========================
+  //                    36.80
+  // Overlap 2 * 0.90 =  1.80
+
+  const Float_t kRB24IpRFD1     =  0.68;    // Length of section 1
+  const Float_t kRB24IpRFD2     =  0.30;    // Length of section 2						     
+  const Float_t kRB24IpRFD3     =  0.10;    // Length of section 3						           
+  const Float_t kRB24IpRFD4     =  0.35;    // Length of section 4						           
+  const Float_t kRB24IpRFD5     =  0.55;    // Length of section 5						           
+
+  const Float_t kRB24IpRFRo     = 15.20/2.; // Flange outer radius 
+  const Float_t kRB24IpRFRi1    =  6.30/2.; // Flange inner radius section 1
+  const Float_t kRB24IpRFRi2    =  6.00/2.; // Flange inner radius section 2
+  const Float_t kRB24IpRFRi3    =  5.84/2.; // Flange inner radius section 3    
+  const Float_t kRB24IpRFRi4    =  6.00/2.; // Flange inner radius section 1
+  const Float_t kRB24IpRFRi5    = 10.50/2.; // Flange inner radius section 2
+
+  TGeoPcon* shRB24IpRF = new TGeoPcon(0., 360., 9);
+  z0 = 0.;
+  shRB24IpRF->DefineSection(0, z0, kRB24IpRFRi1, kRB24IpRFRo);
+  z0 += kRB24IpRFD1;
+  shRB24IpRF->DefineSection(1, z0, kRB24IpRFRi2, kRB24IpRFRo);
+  z0 += kRB24IpRFD2;
+  shRB24IpRF->DefineSection(2, z0, kRB24IpRFRi2, kRB24IpRFRo);
+  shRB24IpRF->DefineSection(3, z0, kRB24IpRFRi3, kRB24IpRFRo);
+  z0 += kRB24IpRFD3;
+  shRB24IpRF->DefineSection(4, z0, kRB24IpRFRi3, kRB24IpRFRo);
+  shRB24IpRF->DefineSection(5, z0, kRB24IpRFRi4, kRB24IpRFRo);
+  z0 += kRB24IpRFD4;
+  shRB24IpRF->DefineSection(6, z0, kRB24IpRFRi4, kRB24IpRFRo);
+  shRB24IpRF->DefineSection(7, z0, kRB24IpRFRi5, kRB24IpRFRo);
+  z0 += kRB24IpRFD5;
+  shRB24IpRF->DefineSection(8, z0, kRB24IpRFRi5, kRB24IpRFRo);
+
+  TGeoVolume* voRB24IpRF = new TGeoVolume("RB24IpRF", shRB24IpRF, kMedSteelH);
+
+  //
+  // Pos  2 RF Screen Tube         LHCVC2U_0005
+  //
+
+  //
+  // Tube
+  Float_t kRB24IpSTTL  = 32.84;            // Total length of the tube
+  Float_t kRB24IpSTTRi =  5.80/2.;         // Inner Radius
+  Float_t kRB24IpSTTRo =  6.00/2.;         // Outer Radius
+  TGeoVolume* voRB24IpSTT = new TGeoVolume("RB24IpSTT", new TGeoTube(kRB24IpSTTRi, kRB24IpSTTRo, kRB24IpSTTL/2.), kMedSteelH);
+  // Screen
+  Float_t kRB24IpSTCL  =  0.4;             // Lenth of the crochet detail
+  // Length of the screen 
+  Float_t kRB24IpSTSL  =  9.00 - 2. * kRB24IpSTCL; 
+  // Rel. position of the screen 
+  Float_t kRB24IpSTSZ  =  7.00 + kRB24IpSTCL; 
+  TGeoVolume* voRB24IpSTS = new TGeoVolume("RB24IpSTS", new TGeoTube(kRB24IpSTTRi, kRB24IpSTTRo, kRB24IpSTSL/2.), kMedSteelH);
+  // Vacuum
+  TGeoVolume* voRB24IpSTV = new TGeoVolume("RB24IpSTV", new TGeoTube(0., kRB24IpSTTRi, kRB24AIpML/2.), kMedVacH);
+  //
+  voRB24IpSTT->AddNode(voRB24IpSTS, 1, new TGeoTranslation(0., 0., kRB24IpSTSZ -  kRB24IpSTTL/2. +  kRB24IpSTSL/2.));
+
+  // Crochets
+  // Inner radius
+  Float_t kRB24IpSTCRi  = kRB24IpSTTRo + 0.25;
+  // Outer radius
+  Float_t kRB24IpSTCRo  = kRB24IpSTTRo + 0.35;
+  // Length of 1stsection
+  Float_t kRB24IpSTCL1  = 0.15;
+  // Length of 2nd section
+  Float_t kRB24IpSTCL2  = 0.15;
+  // Length of 3rd section
+  Float_t kRB24IpSTCL3  = 0.10;
+  // Rel. position of 1st Crochet
+
+
+  TGeoPcon* shRB24IpSTC = new TGeoPcon(0., 360., 5);
+  z0 = 0;
+  shRB24IpSTC->DefineSection(0, z0, kRB24IpSTCRi, kRB24IpSTCRo);
+  z0 += kRB24IpSTCL1;
+  shRB24IpSTC->DefineSection(1, z0, kRB24IpSTCRi, kRB24IpSTCRo);
+  shRB24IpSTC->DefineSection(2, z0, kRB24IpSTTRo, kRB24IpSTCRo);
+  z0 += kRB24IpSTCL2;
+  shRB24IpSTC->DefineSection(3, z0, kRB24IpSTTRo, kRB24IpSTCRo);
+  z0 += kRB24IpSTCL3;
+  shRB24IpSTC->DefineSection(4, z0, kRB24IpSTTRo, kRB24IpSTTRo + 0.001);
+  TGeoVolume* voRB24IpSTC = new TGeoVolume("RB24IpSTC", shRB24IpSTC, kMedSteelH);
+
+  // Pos  3 Shell                  LHCVC2U_0007
+  // Pos  4 Extruded Shell         LHCVC2U_0006
+  Float_t kRB24IpShellL     =  4.45;    // Length of the Shell
+  Float_t kRB24IpShellD     =  0.10;    // Wall thickness of the shell
+  Float_t kRB24IpShellCTRi  =  6.70/2.; // Inner radius of the connection tube
+  Float_t kRB24IpShellCTL   =  1.56;    // Length of the connection tube
+  Float_t kRB24IpShellCARi  = 17.80/2.; // Inner radius of the cavity
+  Float_t kRB24IpShellCCRo  = 18.20/2.; // Inner radius at the centre
+
+  TGeoPcon* shRB24IpShell = new TGeoPcon(0., 360., 7);
+  z0 = 0;
+  shRB24IpShell->DefineSection(0, z0, kRB24IpShellCTRi, kRB24IpShellCTRi + kRB24IpShellD);
+  z0 +=  kRB24IpShellCTL;
+  shRB24IpShell->DefineSection(1, z0, kRB24IpShellCTRi, kRB24IpShellCTRi + kRB24IpShellD);
+  shRB24IpShell->DefineSection(2, z0, kRB24IpShellCTRi, kRB24IpShellCARi + kRB24IpShellD);
+  z0 += kRB24IpShellD;
+  shRB24IpShell->DefineSection(3, z0, kRB24IpShellCARi, kRB24IpShellCARi + kRB24IpShellD);
+  z0 = kRB24IpShellL - kRB24IpShellD;
+  shRB24IpShell->DefineSection(4, z0, kRB24IpShellCARi, kRB24IpShellCARi + kRB24IpShellD);
+  shRB24IpShell->DefineSection(5, z0, kRB24IpShellCARi, kRB24IpShellCCRo);
+  z0 = kRB24IpShellL;
+  shRB24IpShell->DefineSection(6, z0, kRB24IpShellCARi, kRB24IpShellCCRo);
+  TGeoVolume* voRB24IpShell = new TGeoVolume("RB24IpShell", shRB24IpShell, kMedSteelH);
+
+  TGeoPcon* shRB24IpShellM   = MakeMotherFromTemplate(shRB24IpShell, 0, 6, kRB24IpShellCTRi , 13);
+
+
+  for (Int_t i = 0; i < 6; i++) {
+    z = 2. * kRB24IpShellL  - shRB24IpShellM->GetZ(5-i);
+    Float_t rmin = shRB24IpShellM->GetRmin(5-i);
+    Float_t rmax = shRB24IpShellM->GetRmax(5-i);
+    shRB24IpShellM->DefineSection(7+i, z, rmin, rmax);
+  }
+
+  TGeoVolume* voRB24IpShellM = new TGeoVolume("RB24IpShellM", shRB24IpShellM, kMedVacH);
+  voRB24IpShellM->SetVisibility(0);
+  voRB24IpShellM->AddNode(voRB24IpShell, 1, gGeoIdentity);
+  voRB24IpShellM->AddNode(voRB24IpShell, 2, new TGeoCombiTrans(0., 0., 2. * kRB24IpShellL, rot180));
+  //
+  // Pos  8 Pumping Elements
+  //
+  //  Anode array
+  TGeoVolume* voRB24IpPE = new TGeoVolume("voRB24IpPE", new TGeoTube(0.9, 1., 2.54/2.), kMedSteelH);
+  Float_t kRB24IpPEAR = 5.5;
+
+  for (Int_t i = 0; i < 15; i++) {
+    Float_t phi = Float_t(i) * 24.;
+    Float_t x   =  kRB24IpPEAR * TMath::Cos(kDegRad * phi);
+    Float_t y   =  kRB24IpPEAR * TMath::Sin(kDegRad * phi);
+    voRB24IpShellM->AddNode(voRB24IpPE, i+1, new TGeoTranslation(x, y, kRB24IpShellL));
+  }
+
+
+  //
+  //  Cathodes
+  //
+  // Here we could add some Ti strips
+
+  // Postioning of elements
+  voRB24AIpM->AddNode(voRB24IpRF,     1, new TGeoTranslation(0., 0., -kRB24AIpML/2.));
+  voRB24AIpM->AddNode(voRB24IpRF,     2, new TGeoCombiTrans (0., 0., +kRB24AIpML/2., rot180));
+  voRB24AIpM->AddNode(voRB24IpSTT,    1, new TGeoTranslation(0., 0., 0.));
+  voRB24AIpM->AddNode(voRB24IpSTV,    1, new TGeoTranslation(0., 0., 0.));
+  voRB24AIpM->AddNode(voRB24IpShellM, 1, new TGeoTranslation(0., 0., -kRB24AIpML/2. +  8.13));
+  voRB24AIpM->AddNode(voRB24IpSTC,    1, new TGeoTranslation(0., 0., 8.13 - kRB24AIpML/2.));
+  voRB24AIpM->AddNode(voRB24IpSTC,    2, new TGeoCombiTrans (0., 0., 8.14 + 8.9 - kRB24AIpML/2., rot180));
+
+  //
+  // Valve
+  // VAC Series 47 DN 63 with manual actuator
+  //
+  const Float_t kRB24ValveWz = 7.5;
+  const Float_t kRB24ValveDN = 10.0/2.;
+  //
+  //  Body containing the valve plate
+  //
+  const Float_t kRB24ValveBoWx =  15.6;
+  const Float_t kRB24ValveBoWy = (21.5 + 23.1 - 5.);
+  const Float_t kRB24ValveBoWz =  4.6;
+  const Float_t kRB24ValveBoD  =  0.5;
+
+  TGeoVolume* voRB24ValveBoM =
+    new TGeoVolume("RB24ValveBoM", 
+        new TGeoBBox( kRB24ValveBoWx/2.,  kRB24ValveBoWy/2., kRB24ValveBoWz/2.), kMedAirH);
+  voRB24ValveBoM->SetVisibility(0);
+  TGeoVolume* voRB24ValveBo =
+    new TGeoVolume("RB24ValveBo", 
+        new TGeoBBox( kRB24ValveBoWx/2.,  kRB24ValveBoWy/2., kRB24ValveBoWz/2.), kMedSteelH);
+  voRB24ValveBoM->AddNode(voRB24ValveBo, 1, gGeoIdentity);
+  //
+  // Inner volume
+  //
+  TGeoVolume* voRB24ValveBoI = new TGeoVolume("RB24ValveBoI", 
+      new TGeoBBox( kRB24ValveBoWx/2. -  kRB24ValveBoD,  
+        kRB24ValveBoWy/2. -  kRB24ValveBoD/2., 
+        kRB24ValveBoWz/2. -  kRB24ValveBoD), 
+      kMedVacH);
+  voRB24ValveBo->AddNode(voRB24ValveBoI, 1, new TGeoTranslation(0., kRB24ValveBoD/2., 0.));
+  //
+  // Opening and Flanges
+  const Float_t  kRB24ValveFlRo = 18./2.;
+  const Float_t  kRB24ValveFlD  = 1.45;    
+  TGeoVolume* voRB24ValveBoA = new TGeoVolume("RB24ValveBoA", 
+      new TGeoTube(0., kRB24ValveDN/2., kRB24ValveBoD/2.), kMedVacH);
+  voRB24ValveBo->AddNode(voRB24ValveBoA, 1, new TGeoTranslation(0., - kRB24ValveBoWy/2. + 21.5, -kRB24ValveBoWz/2. +  kRB24ValveBoD/2.));
+  voRB24ValveBo->AddNode(voRB24ValveBoA, 2, new TGeoTranslation(0., - kRB24ValveBoWy/2. + 21.5, +kRB24ValveBoWz/2. -  kRB24ValveBoD/2.));
+
+  TGeoVolume* voRB24ValveFl  = new TGeoVolume("RB24ValveFl",  new TGeoTube(kRB24ValveDN/2.,  kRB24ValveFlRo, kRB24ValveFlD/2.), kMedSteelH);
+  TGeoVolume* voRB24ValveFlI = new TGeoVolume("RB24ValveFlI", new TGeoTube(0.,               kRB24ValveFlRo, kRB24ValveFlD/2.), kMedVacH);
+  voRB24ValveFlI->AddNode(voRB24ValveFl, 1, gGeoIdentity);
+
+  //
+  // Actuator Flange
+  const Float_t kRB24ValveAFlWx =  18.9;
+  const Float_t kRB24ValveAFlWy =   5.0;
+  const Float_t kRB24ValveAFlWz =   7.7;
+  TGeoVolume* voRB24ValveAFl = new TGeoVolume("RB24ValveAFl", new TGeoBBox(kRB24ValveAFlWx/2., kRB24ValveAFlWy/2., kRB24ValveAFlWz/2.), kMedSteelH);
+  //
+  // Actuator Tube
+  const Float_t kRB24ValveATRo = 9.7/2.;
+  const Float_t kRB24ValveATH  = 16.6;
+  TGeoVolume* voRB24ValveAT = new TGeoVolume("RB24ValveAT", new TGeoTube(kRB24ValveATRo -  2. * kRB24ValveBoD,kRB24ValveATRo,  kRB24ValveATH/2.), 
+      kMedSteelH);
+  //
+  // Manual Actuator (my best guess)
+  TGeoVolume* voRB24ValveMA1 = new TGeoVolume("RB24ValveMA1", new TGeoCone(2.5/2., 0., 0.5, 4.5, 5.), kMedSteelH);
+  TGeoVolume* voRB24ValveMA2 = new TGeoVolume("RB24ValveMA2", new TGeoTorus(5., 0., 1.25), kMedSteelH);
+  TGeoVolume* voRB24ValveMA3 = new TGeoVolume("RB24ValveMA3", new TGeoTube (0., 1.25, 2.5), kMedSteelH);
+
+
+  //
+  // Position all volumes
+  Float_t y0;
+  TGeoVolumeAssembly*  voRB24ValveMo = new TGeoVolumeAssembly("RB24ValveMo");
+  voRB24ValveMo->AddNode(voRB24ValveFl,  1, new TGeoTranslation(0., 0., - 7.5/2. + kRB24ValveFlD/2.));
+  voRB24ValveMo->AddNode(voRB24ValveFl,  2, new TGeoTranslation(0., 0., + 7.5/2. - kRB24ValveFlD/2.));
+  y0 = -21.5;
+  voRB24ValveMo->AddNode(voRB24ValveBoM, 1, new TGeoTranslation(0., y0 + kRB24ValveBoWy/2.,   0.));
+  y0 +=  kRB24ValveBoWy;
+  voRB24ValveMo->AddNode(voRB24ValveAFl, 1, new TGeoTranslation(0., y0 +  kRB24ValveAFlWy/2., 0.));
+  y0 +=  kRB24ValveAFlWy;
+  voRB24ValveMo->AddNode(voRB24ValveAT,  1, new TGeoCombiTrans(0.,  y0 + kRB24ValveATH/2.,    0., rotyz));
+  y0 += kRB24ValveATH;
+  voRB24ValveMo->AddNode(voRB24ValveMA1, 1, new TGeoCombiTrans(0.,  y0 + 2.5/2.,    0., rotyz));
+  y0 += 2.5;
+  voRB24ValveMo->AddNode(voRB24ValveMA2, 1, new TGeoCombiTrans(0.,  y0 + 2.5/2.,    0., rotyz));
+  y0 += 2.5;
+  voRB24ValveMo->AddNode(voRB24ValveMA3, 1, new TGeoCombiTrans(5./TMath::Sqrt(2.),  y0 + 5.0/2., 5./TMath::Sqrt(2.), rotyz));
+  //
+  // Warm Module Type VMABC
+  // LHCVMABC_0002
+  // 
+  //
+  //
+  // Flange                  1.00
+  // Central Piece          11.50
+  // Bellow                 14.50
+  // End Flange              1.00
+  //===================================
+  // Total                  28.00 
+  //                        
+  // Pos 1 Warm Bellows DN100       LHCVBU__0016
+  // Pos 2 Trans. Tube Flange       LHCVSR__0062
+  // Pos 3 RF Contact   D63         LHCVSR__0057
+  // [Pos 4 Hex. Countersunk Screw   Bossard BN4719]
+  // [Pos 5 Tension spring           LHCVSR__00239]
+  //
+
+  // Pos 1 Warm Bellows DN100                   LHCVBU__0016
+  // Pos 1.1 Right Body 2 Ports with Support    LHCVBU__0014
+  //
+  // Tube 1
+  const Float_t kRB24VMABCRBT1Ri = 10.0/2.;
+  const Float_t kRB24VMABCRBT1Ro = 10.3/2.;
+  const Float_t kRB24VMABCRBT1L  = 11.5;   
+  const Float_t kRB24VMABCRBT1L2 = 8.;
+  const Float_t kRB24VMABCL      = 28.;
+
+  TGeoTube* shRB24VMABCRBT1 = new TGeoTube(kRB24VMABCRBT1Ri, kRB24VMABCRBT1Ro, kRB24VMABCRBT1L/2.);
+  shRB24VMABCRBT1->SetName("RB24VMABCRBT1");
+  TGeoTube* shRB24VMABCRBT1o = new TGeoTube(0., kRB24VMABCRBT1Ro,  kRB24VMABCRBT1L/2.);
+  shRB24VMABCRBT1o->SetName("RB24VMABCRBT1o");
+  TGeoTube* shRB24VMABCRBT1o2 = new TGeoTube(0., kRB24VMABCRBT1Ro + 0.3, kRB24VMABCRBT1L/2.);
+  shRB24VMABCRBT1o2->SetName("RB24VMABCRBT1o2");
+  // Lower inforcement 
+  TGeoVolume*  voRB24VMABCRBT12  = new TGeoVolume("RB24VMABCRBT12", 
+      new TGeoTubeSeg(kRB24VMABCRBT1Ro, kRB24VMABCRBT1Ro + 0.3, kRB24VMABCRBT1L2/2., 220., 320.)
+      , kMedSteelH);
+  //
+  // Tube 2
+  const Float_t kRB24VMABCRBT2Ri =   6.0/2.;
+  const Float_t kRB24VMABCRBT2Ro =   6.3/2.;
+  const Float_t kRB24VMABCRBF2Ro =  11.4/2.;
+  const Float_t kRB24VMABCRBT2L  =   5.95 + 2.; // 2. cm added for welding    
+  const Float_t kRB24VMABCRBF2L  =   1.75;
+  TGeoTube* shRB24VMABCRBT2 = new TGeoTube(kRB24VMABCRBT2Ri, kRB24VMABCRBT2Ro,  kRB24VMABCRBT2L/2.);
+  shRB24VMABCRBT2->SetName("RB24VMABCRBT2");
+  TGeoTube* shRB24VMABCRBT2i = new TGeoTube(0., kRB24VMABCRBT2Ri, kRB24VMABCRBT2L/2. + 2.);
+  shRB24VMABCRBT2i->SetName("RB24VMABCRBT2i");
+  TGeoCombiTrans* tRBT2 = new TGeoCombiTrans(-11.5 + kRB24VMABCRBT2L/2., 0., 7.2 - kRB24VMABCRBT1L/2.  , rotxz);
+  tRBT2->SetName("tRBT2");
+  tRBT2->RegisterYourself();
+  TGeoCompositeShape* shRB24VMABCRBT2c =  new TGeoCompositeShape("shRB24VMABCRBT2c","RB24VMABCRBT2:tRBT2-RB24VMABCRBT1o");
+  TGeoVolume* voRB24VMABCRBT2 = new TGeoVolume("shRB24VMABCRBT2", shRB24VMABCRBT2c, kMedSteelH);
+  // Flange
+  // Pos 1.4 Flange DN63                        LHCVBU__0008
+  TGeoVolume* voRB24VMABCRBF2 = new TGeoVolume("RB24VMABCRBF2", 
+      new TGeoTube(kRB24VMABCRBT2Ro, kRB24VMABCRBF2Ro, kRB24VMABCRBF2L/2.), kMedSteelH);
+  // DN63 Blank Flange (my best guess)
+  TGeoVolume* voRB24VMABCRBF2B = new TGeoVolume("RB24VMABCRBF2B", 
+      new TGeoTube(0., kRB24VMABCRBF2Ro, kRB24VMABCRBF2L/2.), kMedSteelH);
+  //
+  // Tube 3
+  const Float_t kRB24VMABCRBT3Ri =  3.5/2.;
+  const Float_t kRB24VMABCRBT3Ro =  3.8/2.;
+  const Float_t kRB24VMABCRBF3Ro =  7.0/2.;
+  const Float_t kRB24VMABCRBT3L  =  4.95 + 2.; // 2. cm added for welding    
+  const Float_t kRB24VMABCRBF3L  =  1.27;
+  TGeoTube* shRB24VMABCRBT3 = new TGeoTube(kRB24VMABCRBT3Ri, kRB24VMABCRBT3Ro,  kRB24VMABCRBT3L/2);
+  shRB24VMABCRBT3->SetName("RB24VMABCRBT3");
+  TGeoTube* shRB24VMABCRBT3i = new TGeoTube(0., kRB24VMABCRBT3Ri, kRB24VMABCRBT3L/2. + 2.);
+  shRB24VMABCRBT3i->SetName("RB24VMABCRBT3i");
+  TGeoCombiTrans* tRBT3 = new TGeoCombiTrans(0., 10.5 - kRB24VMABCRBT3L/2., 7.2 - kRB24VMABCRBT1L/2.  , rotyz);
+  tRBT3->SetName("tRBT3");
+  tRBT3->RegisterYourself();
+  TGeoCompositeShape* shRB24VMABCRBT3c =  new TGeoCompositeShape("shRB24VMABCRBT3c","RB24VMABCRBT3:tRBT3-RB24VMABCRBT1o");
+  TGeoVolume* voRB24VMABCRBT3 = new TGeoVolume("shRB24VMABCRBT3", shRB24VMABCRBT3c, kMedSteelH);
+  // Flange
+  // Pos 1.4 Flange DN35                        LHCVBU__0007
+  TGeoVolume* voRB24VMABCRBF3 = new TGeoVolume("RB24VMABCRBF3", 
+      new TGeoTube(kRB24VMABCRBT3Ro, kRB24VMABCRBF3Ro, kRB24VMABCRBF3L/2.), kMedSteelH);
+  //
+  // Tube 4
+  const Float_t kRB24VMABCRBT4Ri =  6.0/2.;
+  const Float_t kRB24VMABCRBT4Ro =  6.4/2.;
+  const Float_t kRB24VMABCRBT4L  =  6.6;    
+  TGeoTube* shRB24VMABCRBT4 = new TGeoTube(kRB24VMABCRBT4Ri, kRB24VMABCRBT4Ro,  kRB24VMABCRBT4L/2.);
+  shRB24VMABCRBT4->SetName("RB24VMABCRBT4");
+  TGeoCombiTrans* tRBT4 = new TGeoCombiTrans(0.,-11.+kRB24VMABCRBT4L/2., 7.2 - kRB24VMABCRBT1L/2.  , rotyz);
+  tRBT4->SetName("tRBT4");
+  tRBT4->RegisterYourself();
+  TGeoCompositeShape* shRB24VMABCRBT4c =  new TGeoCompositeShape("shRB24VMABCRBT4c","RB24VMABCRBT4:tRBT4-RB24VMABCRBT1o2");
+  TGeoVolume* voRB24VMABCRBT4 = new TGeoVolume("shRB24VMABCRBT4", shRB24VMABCRBT4c, kMedSteelH);
+  TGeoCompositeShape* shRB24VMABCRB = new TGeoCompositeShape("shRB24VMABCRB", "RB24VMABCRBT1-(RB24VMABCRBT2i:tRBT2+RB24VMABCRBT3i:tRBT3)");
+  TGeoVolume* voRB24VMABCRBI = new TGeoVolume("RB24VMABCRBI", shRB24VMABCRB, kMedSteelH);
+  //
+  // Plate
+  const Float_t kRB24VMABCRBBx = 16.0;
+  const Float_t kRB24VMABCRBBy =  1.5;
+  const Float_t kRB24VMABCRBBz = 15.0;
+
+  // Relative position of tubes
+  const Float_t  kRB24VMABCTz =   7.2;
+  // Relative position of plate
+  const Float_t  kRB24VMABCPz =   3.6;
+  const Float_t  kRB24VMABCPy = -12.5;
+
+  TGeoVolume* voRB24VMABCRBP = new TGeoVolume("RB24VMABCRBP", new TGeoBBox(kRB24VMABCRBBx/2., kRB24VMABCRBBy/2., kRB24VMABCRBBz/2.), kMedSteelH);
+  //
+  // Pirani Gauge (my best guess)
+  //
+  TGeoPcon* shRB24VMABCPirani = new TGeoPcon(0., 360., 15);
+  // DN35/16 Coupling
+  z = 0;
+  shRB24VMABCPirani->DefineSection( 0, z,  0.8 , kRB24VMABCRBF3Ro);
+  z += kRB24VMABCRBF3L; // 1.3
+  shRB24VMABCPirani->DefineSection( 1, z,  0.8 , kRB24VMABCRBF3Ro);
+  shRB24VMABCPirani->DefineSection( 2, z,  0.8 , 1.0);
+  // Pipe
+  z += 2.8;
+  shRB24VMABCPirani->DefineSection( 3, z,  0.8 , 1.0);
+  // Flange
+  shRB24VMABCPirani->DefineSection( 4, z,  0.8 , 1.75);
+  z += 1.6;
+  shRB24VMABCPirani->DefineSection( 5, z,  0.8 , 1.75);
+  shRB24VMABCPirani->DefineSection( 6, z,  0.8 , 1.0);
+  z += 5.2;
+  shRB24VMABCPirani->DefineSection( 7, z,  0.8 , 1.0);
+  shRB24VMABCPirani->DefineSection( 8, z,  0.8 , 2.5);    
+  z += 2.0;
+  shRB24VMABCPirani->DefineSection( 9, z,  0.80, 2.50);    
+  shRB24VMABCPirani->DefineSection(10, z,  1.55, 1.75);    
+  z += 5.7;
+  shRB24VMABCPirani->DefineSection(11, z,  1.55, 1.75);    
+  shRB24VMABCPirani->DefineSection(11, z,  0.00, 1.75);    
+  z += 0.2;
+  shRB24VMABCPirani->DefineSection(12, z,  0.00, 1.75);    
+  shRB24VMABCPirani->DefineSection(13, z,  0.00, 0.75);    
+  z += 0.5;
+  shRB24VMABCPirani->DefineSection(14, z,  0.00, 0.75);  
+  TGeoVolume* voRB24VMABCPirani = new TGeoVolume("RB24VMABCPirani", shRB24VMABCPirani, kMedSteelH);
+  //
+  //
+  // 
+
+
+  //
+  // Positioning of elements
+  TGeoVolumeAssembly* voRB24VMABCRB = new TGeoVolumeAssembly("RB24VMABCRB");
+  //
+  voRB24VMABCRB->AddNode(voRB24VMABCRBI,   1, gGeoIdentity);
+  // Plate
+  voRB24VMABCRB->AddNode(voRB24VMABCRBP,   1, new TGeoTranslation(0., kRB24VMABCPy +  kRB24VMABCRBBy /2., 
+        kRB24VMABCRBBz/2. - kRB24VMABCRBT1L/2. +  kRB24VMABCPz));
+  // Tube 2
+  voRB24VMABCRB->AddNode(voRB24VMABCRBT2,  1, gGeoIdentity);
+  // Flange Tube 2
+  voRB24VMABCRB->AddNode(voRB24VMABCRBF2,  1, new TGeoCombiTrans(kRB24VMABCPy + kRB24VMABCRBF2L/2., 0.,  kRB24VMABCTz - kRB24VMABCRBT1L/2., rotxz));
+  // Blank Flange Tube 2
+  voRB24VMABCRB->AddNode(voRB24VMABCRBF2B, 1, new TGeoCombiTrans(kRB24VMABCPy- kRB24VMABCRBF2L/2., 0.,  kRB24VMABCTz - kRB24VMABCRBT1L/2., rotxz));    
+  // Tube 3
+  voRB24VMABCRB->AddNode(voRB24VMABCRBT3,  1, gGeoIdentity);
+  // Flange Tube 3
+  voRB24VMABCRB->AddNode(voRB24VMABCRBF3,  1, new TGeoCombiTrans(0.,   11.2 - kRB24VMABCRBF3L/2.,  kRB24VMABCTz - kRB24VMABCRBT1L/2., rotyz));
+  // Pirani Gauge
+  voRB24VMABCRB->AddNode(voRB24VMABCPirani, 1, new  TGeoCombiTrans(0., 11.2,  kRB24VMABCTz - kRB24VMABCRBT1L/2., rotyz));
+  // Tube 4
+  voRB24VMABCRB->AddNode(voRB24VMABCRBT4,  1, gGeoIdentity);
+  // Inforcement 
+  voRB24VMABCRB->AddNode(voRB24VMABCRBT12, 1, new TGeoTranslation(0., 0., kRB24VMABCRBT1L2/2. - kRB24VMABCRBT1L/2. + 2.8));
+
+
+  // Pos 1.3 Bellows with end part              LHCVBU__0002
+  //
+  // Connection Tube    
+  // Connection tube inner r
+  const Float_t kRB24VMABBEConTubeRin        = 10.0/2.;
+  // Connection tube outer r
+  const Float_t kRB24VMABBEConTubeRou        = 10.3/2.;
+  // Connection tube length
+  const Float_t kRB24VMABBEConTubeL1         =  0.9;
+  const Float_t kRB24VMABBEConTubeL2         =  2.6;
+  //  const Float_t RB24VMABBEBellowL            =  kRB24VMABBEConTubeL1 + kRB24VMABBEConTubeL2 + kRB24B1BellowUndL;
+
+  // Mother volume
+  TGeoPcon* shRB24VMABBEBellowM = new TGeoPcon(0., 360., 6);
+  // Connection Tube and Flange
+  z = 0.;
+  shRB24VMABBEBellowM->DefineSection( 0, z, kRB24VMABBEConTubeRin,  kRB24VMABBEConTubeRou);
+  z += kRB24VMABBEConTubeL1;
+  shRB24VMABBEBellowM->DefineSection( 1, z, kRB24VMABBEConTubeRin, kRB24VMABBEConTubeRou);
+  shRB24VMABBEBellowM->DefineSection( 2, z, kRB24B1BellowRi,       kRB24B1BellowRo + kRB24B1ProtTubeThickness);
+  z += kRB24B1BellowUndL;
+  shRB24VMABBEBellowM->DefineSection( 3, z, kRB24B1BellowRi,       kRB24B1BellowRo + kRB24B1ProtTubeThickness);
+  shRB24VMABBEBellowM->DefineSection( 4, z, kRB24VMABBEConTubeRin,  kRB24VMABBEConTubeRou);
+  z += kRB24VMABBEConTubeL2;
+  shRB24VMABBEBellowM->DefineSection( 5, z, kRB24VMABBEConTubeRin,  kRB24VMABBEConTubeRou);
+  TGeoVolume* voRB24VMABBEBellowM = new TGeoVolume("RB24VMABBEBellowM", shRB24VMABBEBellowM, kMedVacH);
+  voRB24VMABBEBellowM->SetVisibility(0);
+
+  //  Connection tube left
+  TGeoVolume* voRB24VMABBECT1 = new TGeoVolume("RB24VMABBECT1", 
+      new TGeoTube(kRB24VMABBEConTubeRin, kRB24VMABBEConTubeRou,kRB24VMABBEConTubeL1/2.),
+      kMedSteelH);
+  //  Connection tube right
+  TGeoVolume* voRB24VMABBECT2 = new TGeoVolume("RB24VMABBECT2", 
+      new TGeoTube(kRB24VMABBEConTubeRin, kRB24VMABBEConTubeRou,kRB24VMABBEConTubeL2/2.),
+      kMedSteelH);
+  z = kRB24VMABBEConTubeL1/2.;
+  voRB24VMABBEBellowM->AddNode(voRB24VMABBECT1, 1, new TGeoTranslation(0., 0., z));
+  z += kRB24VMABBEConTubeL1/2.;
+  z += kRB24B1BellowUndL/2.;
+  voRB24VMABBEBellowM->AddNode(voRB24B1Bellow, 2, new TGeoTranslation(0., 0., z));
+  z += kRB24B1BellowUndL/2.;
+  z += kRB24VMABBEConTubeL2/2.;
+  voRB24VMABBEBellowM->AddNode(voRB24VMABBECT2, 1, new TGeoTranslation(0., 0., z));
+  z += kRB24VMABBEConTubeL2/2.;
+
+  voRB24VMABCRB->AddNode(voRB24VMABBEBellowM, 1, new TGeoTranslation(0., 0., kRB24VMABCRBT1L/2.));
+
+  // Pos 1.2 Rotable flange                     LHCVBU__0013[*]
+  // Front
+  voRB24VMABCRB->AddNode(voRB24B1RFlange,  3, new TGeoCombiTrans(0., 0., - kRB24VMABCRBT1L/2. + 0.86, rot180));
+  // End
+  z =  kRB24VMABCRBT1L/2. + kRB24B1BellowUndL +kRB24VMABBEConTubeL1 +  kRB24VMABBEConTubeL2;
+  voRB24VMABCRB->AddNode(voRB24B1RFlange,  4, new TGeoTranslation(0., 0., z - 0.86));
+
+
+  // Pos 2    Trans. Tube Flange       LHCVSR__0062
+  // Pos 2.1  Transition Tube          LHCVSR__0063
+  // Pos 2.2  Transition Flange        LHCVSR__0060
+  //
+  // Transition Tube with Flange
+  TGeoPcon* shRB24VMABCTT = new TGeoPcon(0., 360., 7);
+  z = 0.;
+  shRB24VMABCTT->DefineSection(0, z, 6.3/2., 11.16/2.);
+  z += 0.25;
+  shRB24VMABCTT->DefineSection(1, z, 6.3/2., 11.16/2.);
+  shRB24VMABCTT->DefineSection(2, z, 6.3/2.,  9.30/2.);
+  z += 0.25;
+  shRB24VMABCTT->DefineSection(3, z, 6.3/2.,  9.30/2.);
+  shRB24VMABCTT->DefineSection(4, z, 6.3/2.,  6.70/2.);
+  z += (20.35 - 0.63);
+  shRB24VMABCTT->DefineSection(5, z, 6.3/2.,  6.7/2.);
+  z += 0.63;
+  shRB24VMABCTT->DefineSection(6, z, 6.3/2.,  6.7/2.);
+  TGeoVolume* voRB24VMABCTT = new TGeoVolume("RB24VMABCTT", shRB24VMABCTT, kMedSteelH);
+  voRB24VMABCRB->AddNode(voRB24VMABCTT, 1, new TGeoTranslation(0., 0., - kRB24VMABCRBT1L/2.-1.));
+
+  // Pos 3   RF Contact   D63         LHCVSR__0057
+  // Pos 3.1 RF Contact Flange        LHCVSR__0017
+  //
+  TGeoPcon* shRB24VMABCCTFlange = new TGeoPcon(0., 360., 6);
+  const Float_t kRB24VMABCCTFlangeRin  = 6.36/2.;  // Inner radius
+  const Float_t kRB24VMABCCTFlangeL    = 1.30;     // Length
+
+  z = 0.;
+  shRB24VMABCCTFlange->DefineSection(0, z, kRB24VMABCCTFlangeRin,  6.5/2.);
+  z += 0.15;
+  shRB24VMABCCTFlange->DefineSection(1, z, kRB24VMABCCTFlangeRin,  6.5/2.);
+  shRB24VMABCCTFlange->DefineSection(2, z, kRB24VMABCCTFlangeRin,  6.9/2.);
+  z += 0.9;
+  shRB24VMABCCTFlange->DefineSection(3, z, kRB24VMABCCTFlangeRin,  6.9/2.);
+  shRB24VMABCCTFlange->DefineSection(4, z, kRB24VMABCCTFlangeRin, 11.16/2.);
+  z += 0.25;
+  shRB24VMABCCTFlange->DefineSection(5, z, kRB24VMABCCTFlangeRin, 11.16/2.);
+  TGeoVolume* voRB24VMABCCTFlange = new TGeoVolume("RB24VMABCCTFlange", shRB24VMABCCTFlange, kMedCuH);
+  //
+  // Pos 3.2 RF-Contact        LHCVSR__0056
+  //
+  TGeoPcon* shRB24VMABCCT = new TGeoPcon(0., 360., 4);
+  const Float_t kRB24VMABCCTRin  = 6.30/2.;        // Inner radius
+  const Float_t kRB24VMABCCTCRin = 7.29/2.;        // Max. inner radius conical section
+  const Float_t kRB24VMABCCTL    = 11.88;          // Length
+  const Float_t kRB24VMABCCTSL   = 10.48;          // Length of straight section
+  const Float_t kRB24VMABCCTd    =  0.03;          // Thickness
+  z = 0;
+  shRB24VMABCCT->DefineSection(0, z,  kRB24VMABCCTCRin,  kRB24VMABCCTCRin + kRB24VMABCCTd);
+  z =  kRB24VMABCCTL -  kRB24VMABCCTSL;
+  shRB24VMABCCT->DefineSection(1, z,  kRB24VMABCCTRin + 0.35,  kRB24VMABCCTRin + 0.35 + kRB24VMABCCTd);
+  z = kRB24VMABCCTL  -  kRB24VMABCCTFlangeL;
+  shRB24VMABCCT->DefineSection(2, z,  kRB24VMABCCTRin,  kRB24VMABCCTRin + kRB24VMABCCTd);
+  z = kRB24VMABCCTL;
+  shRB24VMABCCT->DefineSection(3, z,  kRB24VMABCCTRin,  kRB24VMABCCTRin + kRB24VMABCCTd);
+
+  TGeoVolume* voRB24VMABCCT = new TGeoVolume("RB24VMABCCT", shRB24VMABCCT, kMedCuH);
+
+  TGeoVolumeAssembly* voRB24VMABRFCT = new TGeoVolumeAssembly("RB24VMABRFCT");
+  voRB24VMABRFCT->AddNode(voRB24VMABCCT,        1, gGeoIdentity);
+  voRB24VMABRFCT->AddNode( voRB24VMABCCTFlange, 1, new TGeoTranslation(0., 0.,  kRB24VMABCCTL - kRB24VMABCCTFlangeL));
+
+  z =  kRB24VMABCRBT1L/2. + kRB24B1BellowUndL + kRB24VMABBEConTubeL1 +  kRB24VMABBEConTubeL2 - kRB24VMABCCTL + 1.;    
+  voRB24VMABCRB->AddNode(voRB24VMABRFCT, 1, new TGeoTranslation(0., 0., z));
+
+
+  //
+  // Assembling RB24/1
+  //    
+  TGeoVolumeAssembly* voRB24 = new TGeoVolumeAssembly("RB24");
+  // Cu Tube with two simplified flanges
+  voRB24->AddNode(voRB24CuTubeM, 1, gGeoIdentity);
+  if (!fBeamBackground) voRB24->AddNode(voRB24CuTubeA, 1, gGeoIdentity);
+  z = - kRB24CuTubeL/2 + kRB24CuTubeFL/2.;
+  voRB24->AddNode(voRB24CuTubeF, 1, new TGeoTranslation(0., 0., z));
+  z = + kRB24CuTubeL/2 - kRB24CuTubeFL/2.;
+  voRB24->AddNode(voRB24CuTubeF, 2, new TGeoTranslation(0., 0., z));
+  // VMABC close to compensator magnet
+  z = - kRB24CuTubeL/2. -  (kRB24VMABCL - kRB24VMABCRBT1L/2) + 1. + 14.5; // ECV FIX: +14.5 cm
+
+  voRB24->AddNode(voRB24VMABCRB, 2, new TGeoCombiTrans(0., 0., z, rot180)); // ECV FIX: 180°
+  // Bellow
+  z =  kRB24CuTubeL/2;
+  voRB24->AddNode(voRB24B1BellowM, 1, new TGeoTranslation(0., 0., z));
+  z +=  (kRB24B1L +  kRB24AIpML/2.);
+  // Annular ion pump
+  voRB24->AddNode(voRB24AIpM, 1, new TGeoCombiTrans(0., 0., z, rot180)); // ECV FIX: 180° rotation
+  z +=  (kRB24AIpML/2. +  kRB24ValveWz/2.);
+  // Valve
+  voRB24->AddNode(voRB24ValveMo, 1, new TGeoTranslation(0., 0., z));
+  z += (kRB24ValveWz/2.+ kRB24VMABCRBT1L/2. + 1.);
+  // VMABC close to forward detectors
+  voRB24->AddNode(voRB24VMABCRB, 3, new TGeoTranslation(0., 0., z));
+  //
+  //   RB24/2
+  //     
+  // Copper Tube RB24/2
+  //
+  // This is the part inside the compensator magnet
+  const Float_t  kRB242CuTubeL  = 350.0;
+
+  TGeoVolume* voRB242CuTubeM = new TGeoVolume("voRB242CuTubeM", 
+      new TGeoTube(0., kRB24CuTubeRo, kRB242CuTubeL/2.), kMedVacM);
+  voRB242CuTubeM->SetVisibility(0);
+  TGeoVolume* voRB242CuTube = new TGeoVolume("voRB242CuTube", 
+      new TGeoTube(kRB24CuTubeRi, kRB24CuTubeRo, kRB242CuTubeL/2.), kMedCuH);
+  voRB242CuTubeM->AddNode(voRB242CuTube, 1, gGeoIdentity);
+
+
+  // TGeoVolumeAssembly* voRB242 = new TGeoVolumeAssembly("RB242");
+  // voRB242->AddNode(voRB242CuTubeM, 1, gGeoIdentity);
+  // z = - kRB242CuTubeL/2 + kRB24CuTubeFL/2.;
+  // voRB242->AddNode(voRB24CuTubeF, 3, new TGeoTranslation(0., 0., z));
+  // z = + kRB242CuTubeL/2 - kRB24CuTubeFL/2.;
+  // voRB242->AddNode(voRB24CuTubeF, 4, new TGeoTranslation(0., 0., z));
+  // z = - kRB24CuTubeL/2 - kRB24VMABCL - kRB242CuTubeL/2.;
+  // voRB24->AddNode(voRB242, 1, new TGeoTranslation(0., 0., z));
+  //
+
+  TGeoVolume* voRB242 = CreatePipeOvalyzed(kMedCuH);
+  z = - kRB24CuTubeL/2 - kRB24VMABCL - kRB242CuTubeL/2.;
+  voRB24->AddNode(voRB242, 1, new TGeoTranslation(0., 0., z));
+
+  //
+  //   RB24/3
+  //     
+  // Copper Tube RB24/3
+  const Float_t  kRB243CuTubeL  = 294.42; 
+
+  TGeoVolume* voRB243CuTubeM = new TGeoVolume("voRB243CuTubeM", 
+      new TGeoTube(0., kRB24CuTubeRo, kRB243CuTubeL/2.), kMedVacH);
+  voRB24CuTubeM->SetVisibility(0);
+  TGeoVolume* voRB243CuTube = new TGeoVolume("voRB243CuTube", 
+      new TGeoTube(kRB24CuTubeRi, kRB24CuTubeRo, kRB243CuTubeL/2.), kMedCuH);
+  voRB243CuTubeM->AddNode(voRB243CuTube, 1, gGeoIdentity);
+
+
+  TGeoVolumeAssembly* voRB243  = new TGeoVolumeAssembly("RB243");
+  TGeoVolumeAssembly* voRB243A = new TGeoVolumeAssembly("RB243A");
+
+  voRB243A->AddNode(voRB243CuTubeM, 1, gGeoIdentity);
+  z = - kRB243CuTubeL/2 + kRB24CuTubeFL/2.;
+  voRB243A->AddNode(voRB24CuTubeF, 5, new TGeoTranslation(0., 0., z));
+  z = + kRB243CuTubeL/2 - kRB24CuTubeFL/2.;
+  voRB243A->AddNode(voRB24CuTubeF, 6, new TGeoTranslation(0., 0., z));
+  z = + kRB243CuTubeL/2;
+  voRB243A->AddNode(voRB24B1BellowM,  2, new TGeoTranslation(0., 0., z));    
+
+  z = - kRB243CuTubeL/2.  - kRB24B1L;
+  voRB243->AddNode(voRB243A, 1, new TGeoTranslation(0., 0., z));    
+  z = - (1.5 * kRB243CuTubeL + 2. * kRB24B1L);
+  voRB243->AddNode(voRB243A, 2, new TGeoTranslation(0., 0., z));    
+
+  z = - 2. * (kRB243CuTubeL + kRB24B1L) - (kRB24VMABCL - kRB24VMABCRBT1L/2) + 1.;
+  voRB243->AddNode(voRB24VMABCRB, 3, new TGeoTranslation(0., 0., z));    
+
+  z = - kRB24CuTubeL/2 - kRB24VMABCL - kRB242CuTubeL;
+  voRB24->AddNode(voRB243, 1, new TGeoTranslation(0., 0., z));
+
+
+  //
+  //
+  top->AddNode(voRB24, 1, new TGeoCombiTrans(0., 0., kRB24CuTubeL/2 + 88.5 + 400., rot180));
+
+
+  // 
+  ////////////////////////////////////////////////////////////////////////////////     
+  //                                                                            //
+  //                                  The Absorber Vacuum system                // 
+  //                                                                            //
+  ////////////////////////////////////////////////////////////////////////////////
+  //
+  //    Rotable Flange starts at:            82.00 cm from IP      
+  //    Length of rotable flange section:    10.68 cm             
+  //    Weld                                  0.08 cm                  
+  //    Length of straight section          207.21 cm
+  //    =======================================================================
+  //                                        299.97 cm  [0.03 cm missing ?]
+  //    Length of opening cone              252.09 cm
+  //    Weld                                  0.15 cm                
+  //    Length of compensator                30.54 cm
+  //    Weld                                  0.15 cm                
+  //    Length of fixed flange  2.13 - 0.97   1.16 cm
+  //    ======================================================================= 
+  //                                        584.06 cm [584.80 installed] [0.74 cm missing]
+  //    RB26/3
+  //    Length of split flange  2.13 - 1.2    0.93 cm
+  //    Weld                                  0.15 cm                
+  //    Length of fixed point section        16.07 cm               
+  //    Weld                                  0.15 cm                
+  //    Length of opening cone              629.20 cm
+  //    Weld                                  0.30 cm                
+  //    Kength of the compensator            41.70 cm
+  //    Weld                                  0.30 cm                
+  //    Length of fixed flange  2.99 - 1.72   1.27 cm
+  // =================================================
+  //    Length of RB26/3                    690.07 cm [689.20 installed] [0.87 cm too much] 
+  //
+  //    RB26/4-5
+  //    Length of split flange  2.13 - 1.2    0.93 cm
+  //    Weld                                  0.15 cm                
+  //    Length of fixed point section        16.07 cm               
+  //    Weld                                  0.15 cm                
+  //    Length of opening cone              629.20 cm
+  //    Weld                                  0.30 cm                
+  //    Length of closing cone
+  //    Weld
+  //    Lenth of straight section 
+  //    Kength of the compensator            41.70 cm
+  //    Weld                                  0.30 cm                
+  //    Length of fixed flange  2.99 - 1.72   1.27 cm
+  // =================================================
+  //    Length of RB26/3                    690.07 cm [689.20 installed] [0.87 cm too much] 
+
+  ///////////////////////////////////////////
+  //                                       //
+  //    RB26/1-2                           //  
+  //    Drawing LHCV2a_0050 [as installed] //
+  //    Drawing LHCV2a_0008                //
+  //    Drawing LHCV2a_0001                //
+  ///////////////////////////////////////////
+  //    Pos1 Vacuum Tubes   LHCVC2A__0010
+  //    Pos2 Compensator    LHCVC2A__0064
+  //    Pos3 Rotable Flange LHCVFX___0016
+  //    Pos4 Fixed Flange   LHCVFX___0006
+  //    Pos5 Bellow Tooling LHCVFX___0003
+  //
+  //             
+  //
+  ///////////////////////////////////
+  //    RB26/1-2 Vacuum Tubes      //
+  //    Drawing  LHCVC2a_0010      //
+  ///////////////////////////////////
+  const Float_t kRB26s12TubeL = 459.45; // 0.15 cm added for welding       
+  //
+  // Add 1 cm on outer diameter for insulation
+  //
+  TGeoPcon* shRB26s12Tube = new TGeoPcon(0., 360., 5);
+  // Section 1: straight section
+  shRB26s12Tube->DefineSection(0,   0.00,         5.84/2.,  6.00/2.);
+  shRB26s12Tube->DefineSection(1, 207.21,         5.84/2.,  6.00/2.);      
+  // Section 2: 0.72 deg opening cone
+  shRB26s12Tube->DefineSection(2, 207.21,         5.84/2.,  6.14/2.);      
+  shRB26s12Tube->DefineSection(3, 452.30,        12.00/2., 12.30/2.);      
+  shRB26s12Tube->DefineSection(4, kRB26s12TubeL, 12.00/2., 12.30/2.); 
+  TGeoVolume* voRB26s12Tube  = new TGeoVolume("RB26s12Tube", shRB26s12Tube, kMedSteelH);
+  // Add the insulation layer    
+  TGeoVolume* voRB26s12TubeIns = new TGeoVolume("RB26s12TubeIns", MakeInsulationFromTemplate(shRB26s12Tube), kMedInsuH); 
+  voRB26s12Tube->AddNode(voRB26s12TubeIns, 1, gGeoIdentity);
+
+
+  TGeoVolume* voRB26s12TubeM  = new TGeoVolume("RB26s12TubeM", MakeMotherFromTemplate(shRB26s12Tube), kMedVacH);
+  voRB26s12TubeM->AddNode(voRB26s12Tube, 1, gGeoIdentity);
+
+
+
+  ///////////////////////////////////
+  //    RB26/2   Axial Compensator //
+  //    Drawing  LHCVC2a_0064      //
+  ///////////////////////////////////
+  const Float_t kRB26s2CompL             = 30.65;    // Length of the compensator
+  const Float_t kRB26s2BellowRo          = 14.38/2.; // Bellow outer radius        [Pos 1]
+  const Float_t kRB26s2BellowRi          = 12.12/2.; // Bellow inner radius        [Pos 1] 
+  const Int_t   kRB26s2NumberOfPlies     = 14;       // Number of plies            [Pos 1] 
+  const Float_t kRB26s2BellowUndL        = 10.00;    // Length of undulated region [Pos 1]  [+10 mm installed including pretension ?] 
+  const Float_t kRB26s2PlieThickness     =  0.025;   // Plie thickness             [Pos 1]
+  const Float_t kRB26s2ConnectionPlieR   =  0.21;    // Connection plie radius     [Pos 1] 
+  //  Plie radius
+  const Float_t kRB26s2PlieR = 
+    (kRB26s2BellowUndL - 4. *  kRB26s2ConnectionPlieR + 
+     2. *  kRB26s2NumberOfPlies * kRB26s2PlieThickness) / (4. * kRB26s2NumberOfPlies);
+  const Float_t kRB26s2CompTubeInnerR    = 12.00/2.;  // Connection tubes inner radius     [Pos 2 + 3]
+  const Float_t kRB26s2CompTubeOuterR    = 12.30/2.;  // Connection tubes outer radius     [Pos 2 + 3]
+  const Float_t kRB26s2WeldingTubeLeftL  =  9.00/2.;  // Left connection tube half length  [Pos 2]
+  const Float_t kRB26s2WeldingTubeRightL = 11.65/2.;  // Right connection tube half length [Pos 3]  [+ 0.15 cm for welding]
+  const Float_t kRB26s2RingOuterR        = 18.10/2.;  // Ring inner radius                 [Pos 4]
+  const Float_t kRB26s2RingL             =  0.40/2.;  // Ring half length                  [Pos 4]
+  const Float_t kRB26s2RingZ             =  6.50   ;  // Ring z-position                   [Pos 4]
+  const Float_t kRB26s2ProtOuterR        = 18.20/2.;  // Protection tube outer radius      [Pos 5]
+  const Float_t kRB26s2ProtL             = 15.00/2.;  // Protection tube half length       [Pos 5]
+  const Float_t kRB26s2ProtZ             =  6.70   ;  // Protection tube z-position        [Pos 5]
+
+
+  // Mother volume
+  //
+  TGeoPcon* shRB26s2Compensator  = new TGeoPcon(0., 360., 6);
+  shRB26s2Compensator->DefineSection( 0,   0.0, 0., kRB26s2CompTubeOuterR);
+  shRB26s2Compensator->DefineSection( 1,   kRB26s2RingZ, 0., kRB26s2CompTubeOuterR);      
+  shRB26s2Compensator->DefineSection( 2,   kRB26s2RingZ, 0., kRB26s2ProtOuterR);      
+  shRB26s2Compensator->DefineSection( 3,   kRB26s2ProtZ + 2. * kRB26s2ProtL, 0., kRB26s2ProtOuterR);            
+  shRB26s2Compensator->DefineSection( 4,   kRB26s2ProtZ + 2. * kRB26s2ProtL, 0., kRB26s2CompTubeOuterR);
+  shRB26s2Compensator->DefineSection( 5,   kRB26s2CompL                    , 0., kRB26s2CompTubeOuterR);            
+  TGeoVolume* voRB26s2Compensator  = new TGeoVolume("RB26s2Compensator", shRB26s2Compensator, kMedVacH);
+
+  //
+  // [Pos 1] Bellow
+  //      
+  //
+  TGeoVolume* voRB26s2Bellow = new TGeoVolume("RB26s2Bellow", new TGeoTube(kRB26s2BellowRi, kRB26s2BellowRo, kRB26s2BellowUndL/2.), kMedVacH);
+  //      
+  //  Upper part of the undulation
+  //
+  TGeoTorus* shRB26s2PlieTorusU  =  new TGeoTorus(kRB26s2BellowRo - kRB26s2PlieR, kRB26s2PlieR - kRB26s2PlieThickness, kRB26s2PlieR);
+  shRB26s2PlieTorusU->SetName("RB26s2TorusU");
+  TGeoTube*  shRB26s2PlieTubeU   =  new TGeoTube (kRB26s2BellowRo - kRB26s2PlieR, kRB26s2BellowRo, kRB26s2PlieR);
+  shRB26s2PlieTubeU->SetName("RB26s2TubeU");
+  TGeoCompositeShape*  shRB26s2UpperPlie = new TGeoCompositeShape("RB26s2UpperPlie", "RB26s2TorusU*RB26s2TubeU");
+
+  TGeoVolume* voRB26s2WiggleU = new TGeoVolume("RB26s2UpperPlie", shRB26s2UpperPlie, kMedSteelH);
+  //
+  // Lower part of the undulation
+  TGeoTorus* shRB26s2PlieTorusL =  new TGeoTorus(kRB26s2BellowRi + kRB26s2PlieR, kRB26s2PlieR - kRB26s2PlieThickness, kRB26s2PlieR);
+  shRB26s2PlieTorusL->SetName("RB26s2TorusL");
+  TGeoTube*  shRB26s2PlieTubeL   =  new TGeoTube (kRB26s2BellowRi, kRB26s2BellowRi + kRB26s2PlieR, kRB26s2PlieR);
+  shRB26s2PlieTubeL->SetName("RB26s2TubeL");
+  TGeoCompositeShape*  shRB26s2LowerPlie = new TGeoCompositeShape("RB26s2LowerPlie", "RB26s2TorusL*RB26s2TubeL");
+
+  TGeoVolume* voRB26s2WiggleL = new TGeoVolume("RB26s2LowerPlie", shRB26s2LowerPlie, kMedSteelH); 
+
+  //
+  // Connection between upper and lower part of undulation
+  TGeoVolume* voRB26s2WiggleC1 = new TGeoVolume("RB26s2PlieConn1",  
+      new TGeoTube(kRB26s2BellowRi + kRB26s2PlieR, 
+        kRB26s2BellowRo - kRB26s2PlieR, kRB26s2PlieThickness / 2.), kMedSteelH);
+  //
+  // One wiggle
+  TGeoVolumeAssembly* voRB26s2Wiggle = new TGeoVolumeAssembly("RB26s2Wiggle");
+  z0 =  -  kRB26s2PlieThickness / 2.;
+  voRB26s2Wiggle->AddNode(voRB26s2WiggleC1,  1 , new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s2PlieR -  kRB26s2PlieThickness / 2.;
+  voRB26s2Wiggle->AddNode(voRB26s2WiggleU,   1 , new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s2PlieR -  kRB26s2PlieThickness / 2.;
+  voRB26s2Wiggle->AddNode(voRB26s2WiggleC1,  2 , new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s2PlieR -  kRB26s2PlieThickness;
+  voRB26s2Wiggle->AddNode(voRB26s2WiggleL ,  1 , new TGeoTranslation(0., 0., z0));
+  // Positioning of the volumes
+  z0   = - kRB26s2BellowUndL/2.+ kRB26s2ConnectionPlieR;
+  voRB26s2Bellow->AddNode(voRB26s2WiggleL, 1, new TGeoTranslation(0., 0., z0));
+  z0  +=  kRB26s2ConnectionPlieR;
+  zsh  = 4. *  kRB26s2PlieR -  2. * kRB26s2PlieThickness;
+  for (Int_t iw = 0; iw < kRB26s2NumberOfPlies; iw++) {
+    Float_t zpos =  z0 + iw * zsh;	
+    voRB26s2Bellow->AddNode(voRB26s2Wiggle,  iw + 1, new TGeoTranslation(0., 0., zpos -  kRB26s2PlieThickness));	
+  }
+
+  voRB26s2Compensator->AddNode(voRB26s2Bellow, 1,  new TGeoTranslation(0., 0., 2. * kRB26s2WeldingTubeLeftL + kRB26s2BellowUndL/2.));
+
+  //
+  // [Pos 2] Left Welding Tube
+  //      
+  TGeoTube* shRB26s2CompLeftTube = new TGeoTube(kRB26s2CompTubeInnerR, kRB26s2CompTubeOuterR, kRB26s2WeldingTubeLeftL);
+  TGeoVolume* voRB26s2CompLeftTube = new TGeoVolume("RB26s2CompLeftTube", shRB26s2CompLeftTube, kMedSteelH);
+  voRB26s2Compensator->AddNode(voRB26s2CompLeftTube, 1,  new TGeoTranslation(0., 0., kRB26s2WeldingTubeLeftL));
+  //
+  // [Pos 3] Right Welding Tube
+  //      
+  TGeoTube* shRB26s2CompRightTube = new TGeoTube(kRB26s2CompTubeInnerR, kRB26s2CompTubeOuterR, kRB26s2WeldingTubeRightL);
+  TGeoVolume* voRB26s2CompRightTube = new TGeoVolume("RB26s2CompRightTube", shRB26s2CompRightTube, kMedSteelH);
+  voRB26s2Compensator->AddNode(voRB26s2CompRightTube,  1, new TGeoTranslation(0., 0.,  kRB26s2CompL - kRB26s2WeldingTubeRightL));
+  //
+  // [Pos 4] Ring
+  //      
+  TGeoTube* shRB26s2CompRing = new TGeoTube(kRB26s2CompTubeOuterR, kRB26s2RingOuterR, kRB26s2RingL);
+  TGeoVolume* voRB26s2CompRing = new TGeoVolume("RB26s2CompRing", shRB26s2CompRing, kMedSteelH);
+  voRB26s2Compensator->AddNode(voRB26s2CompRing,  1, new TGeoTranslation(0., 0., kRB26s2RingZ + kRB26s2RingL));
+
+  //
+  // [Pos 5] Outer Protecting Tube
+  //      
+  TGeoTube* shRB26s2CompProtTube = new TGeoTube(kRB26s2RingOuterR, kRB26s2ProtOuterR, kRB26s2ProtL);
+  TGeoVolume* voRB26s2CompProtTube = new TGeoVolume("RB26s2CompProtTube", shRB26s2CompProtTube, kMedSteelH);
+  voRB26s2Compensator->AddNode(voRB26s2CompProtTube, 1,  new TGeoTranslation(0., 0., kRB26s2ProtZ + kRB26s2ProtL));
+
+  ///////////////////////////////////
+  //    Rotable Flange             //
+  //    Drawing  LHCVFX_0016       //
+  /////////////////////////////////// 
+  const Float_t kRB26s1RFlangeTubeRi    = 5.84/2. ;  // Tube inner radius
+  const Float_t kRB26s1RFlangeTubeRo    = 6.00/2. ;  // Tube outer radius
+
+  // Pos 1 Clamp Ring          LHCVFX__0015
+  const Float_t kRB26s1RFlangeCrL       = 1.40     ; // Lenth of the clamp ring
+  const Float_t kRB26s1RFlangeCrRi1     = 6.72/2.  ; // Ring inner radius section 1
+  const Float_t kRB26s1RFlangeCrRi2     = 6.06/2.  ; // Ring inner radius section 2
+  const Float_t kRB26s1RFlangeCrRo      = 8.60/2.  ; // Ring outer radius 
+  const Float_t kRB26s1RFlangeCrD       = 0.800    ; // Width section 1
+
+  TGeoPcon* shRB26s1RFlangeCr = new TGeoPcon(0., 360., 4);
+  z0 = 0.;
+  shRB26s1RFlangeCr->DefineSection(0, z0, kRB26s1RFlangeCrRi1, kRB26s1RFlangeCrRo);
+  z0 += kRB26s1RFlangeCrD;
+  shRB26s1RFlangeCr->DefineSection(1, z0, kRB26s1RFlangeCrRi1, kRB26s1RFlangeCrRo);
+  shRB26s1RFlangeCr->DefineSection(2, z0, kRB26s1RFlangeCrRi2, kRB26s1RFlangeCrRo);      
+  z0 = kRB26s1RFlangeCrL;
+  shRB26s1RFlangeCr->DefineSection(3, z0, kRB26s1RFlangeCrRi2, kRB26s1RFlangeCrRo);
+  TGeoVolume* voRB26s1RFlangeCr =  
+    new TGeoVolume("RB26s1RFlangeCr", shRB26s1RFlangeCr, kMedSteelH);
+
+  // Pos 2 Insert              LHCVFX__0015
+  const Float_t kRB26s1RFlangeIsL       = 4.88     ; // Lenth of the insert
+  const Float_t kRB26s1RFlangeIsR       = 6.70/2.  ; // Ring radius
+  const Float_t kRB26s1RFlangeIsD       = 0.80     ; // Ring Width
+
+  TGeoPcon* shRB26s1RFlangeIs = new TGeoPcon(0., 360., 4);
+  z0 = 0.;
+  shRB26s1RFlangeIs->DefineSection(0, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeIsR);
+  z0 += kRB26s1RFlangeIsD;
+  shRB26s1RFlangeIs->DefineSection(1, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeIsR);
+  shRB26s1RFlangeIs->DefineSection(2, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeTubeRo);      
+  z0 = kRB26s1RFlangeIsL;
+  shRB26s1RFlangeIs->DefineSection(3, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeTubeRo);
+  TGeoVolume* voRB26s1RFlangeIs =  
+    new TGeoVolume("RB26s1RFlangeIs", shRB26s1RFlangeIs, kMedSteelH);
+  // 4.88 + 3.7 = 8.58 (8.7 to avoid overlap)
+  // Pos 3 Fixed Point Section LHCVC2A_0021
+  const Float_t kRB26s1RFlangeFpL       = 5.88     ; // Length of the fixed point section (0.08 cm added for welding)
+  const Float_t kRB26s1RFlangeFpZ       = 3.82     ; // Position of the ring
+  const Float_t kRB26s1RFlangeFpD       = 0.59     ; // Width of the ring
+  const Float_t kRB26s1RFlangeFpR       = 7.00/2.  ; // Radius of the ring
+
+  TGeoPcon* shRB26s1RFlangeFp = new TGeoPcon(0., 360., 6);
+  z0 = 0.;
+  shRB26s1RFlangeFp->DefineSection(0, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeTubeRo);
+  z0 += kRB26s1RFlangeFpZ;
+  shRB26s1RFlangeFp->DefineSection(1, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeTubeRo);      
+  shRB26s1RFlangeFp->DefineSection(2, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeFpR);      	  
+  z0 += kRB26s1RFlangeFpD;
+  shRB26s1RFlangeFp->DefineSection(3, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeFpR);      	  
+  shRB26s1RFlangeFp->DefineSection(4, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeTubeRo);
+  z0 = kRB26s1RFlangeFpL;
+  shRB26s1RFlangeFp->DefineSection(5, z0, kRB26s1RFlangeTubeRi, kRB26s1RFlangeTubeRo);
+  TGeoVolume* voRB26s1RFlangeFp = new TGeoVolume("RB26s1RFlangeFp", shRB26s1RFlangeFp, kMedSteelH);
+
+  // Put everything in a mother volume
+  TGeoPcon* shRB26s1RFlange = new TGeoPcon(0., 360., 8);
+  z0 =  0.;
+  shRB26s1RFlange->DefineSection(0, z0, 0., kRB26s1RFlangeCrRo);
+  z0 += kRB26s1RFlangeCrL;
+  shRB26s1RFlange->DefineSection(1, z0, 0., kRB26s1RFlangeCrRo);
+  shRB26s1RFlange->DefineSection(2, z0, 0., kRB26s1RFlangeTubeRo);
+  z0 = kRB26s1RFlangeIsL + kRB26s1RFlangeFpZ;
+  shRB26s1RFlange->DefineSection(3, z0, 0., kRB26s1RFlangeTubeRo);      
+  shRB26s1RFlange->DefineSection(4, z0, 0., kRB26s1RFlangeFpR);
+  z0 += kRB26s1RFlangeFpD;
+  shRB26s1RFlange->DefineSection(5, z0, 0., kRB26s1RFlangeFpR);      	  
+  shRB26s1RFlange->DefineSection(6, z0, 0., kRB26s1RFlangeTubeRo);
+  z0 = kRB26s1RFlangeIsL + kRB26s1RFlangeFpL;
+  shRB26s1RFlange->DefineSection(7, z0, 0., kRB26s1RFlangeTubeRo);
+  TGeoVolume* voRB26s1RFlange = new TGeoVolume("RB26s1RFlange", shRB26s1RFlange, kMedVacH);
+
+  voRB26s1RFlange->AddNode(voRB26s1RFlangeIs, 1, gGeoIdentity);
+  voRB26s1RFlange->AddNode(voRB26s1RFlangeCr, 1, gGeoIdentity);
+  voRB26s1RFlange->AddNode(voRB26s1RFlangeFp, 1, new TGeoTranslation(0., 0., kRB26s1RFlangeIsL));
+
+  ///////////////////////////////////
+  //    Fixed Flange               //
+  //    Drawing  LHCVFX_0006       //
+  /////////////////////////////////// 
+  const Float_t kRB26s2FFlangeL      =  2.13;    // Length of the flange
+  const Float_t kRB26s2FFlangeD1     =  0.97;    // Length of section 1
+  const Float_t kRB26s2FFlangeD2     =  0.29;    // Length of section 2						     
+  const Float_t kRB26s2FFlangeD3     =  0.87;    // Length of section 3						           
+  const Float_t kRB26s2FFlangeRo     = 17.15/2.; // Flange outer radius 
+  const Float_t kRB26s2FFlangeRi1    = 12.30/2.; // Flange inner radius section 1
+  const Float_t kRB26s2FFlangeRi2    = 12.00/2.; // Flange inner radius section 2
+  const Float_t kRB26s2FFlangeRi3    = 12.30/2.; // Flange inner radius section 3
+  z0 = 0;
+  TGeoPcon* shRB26s2FFlange = new TGeoPcon(0., 360., 6);
+  z0 = 0.;
+  shRB26s2FFlange->DefineSection(0, z0, kRB26s2FFlangeRi1, kRB26s2FFlangeRo);
+  z0 += kRB26s2FFlangeD1;
+  shRB26s2FFlange->DefineSection(1, z0, kRB26s2FFlangeRi1, kRB26s2FFlangeRo);
+  shRB26s2FFlange->DefineSection(2, z0, kRB26s2FFlangeRi2, kRB26s2FFlangeRo);
+  z0 += kRB26s2FFlangeD2;
+  shRB26s2FFlange->DefineSection(3, z0, kRB26s2FFlangeRi2, kRB26s2FFlangeRo);
+  shRB26s2FFlange->DefineSection(4, z0, kRB26s2FFlangeRi3, kRB26s2FFlangeRo);
+  z0 += kRB26s2FFlangeD3;
+  shRB26s2FFlange->DefineSection(5, z0, kRB26s2FFlangeRi3, kRB26s2FFlangeRo);
+  TGeoVolume* voRB26s2FFlange = new TGeoVolume("RB26s2FFlange", shRB26s2FFlange, kMedSteelH);
+
+  TGeoVolume* voRB26s2FFlangeM = new TGeoVolume("RB26s2FFlangeM", MakeMotherFromTemplate(shRB26s2FFlange, 2, 5), kMedVacH);
+  voRB26s2FFlangeM->AddNode(voRB26s2FFlange, 1, gGeoIdentity);
+
+
+
+  ////////////////////////////////////////
+  //                                    //
+  //    RB26/3                          //  
+  //    Drawing LHCV2a_0048             //
+  //    Drawing LHCV2a_0002             //
+  ////////////////////////////////////////    
+  //
+  //    Pos 1 Vacuum Tubes      LHCVC2A__0003
+  //    Pos 2 Fixed Point       LHCVFX___0005
+  //    Pos 3 Split Flange      LHCVFX___0007
+  //    Pos 4 Fixed Flange      LHCVFX___0004
+  //    Pos 5 Axial Compensator LHCVC2A__0065
+  //
+  //
+  //
+  //
+  ///////////////////////////////////
+  //    Vacuum Tube                //
+  //    Drawing  LHCVC2A_0003      //
+  /////////////////////////////////// 
+  const Float_t kRB26s3TubeL  = 629.35 + 0.3; // 0.3 cm added for welding
+  const Float_t kRB26s3TubeR1 =  12./2.;
+  const Float_t kRB26s3TubeR2 =  kRB26s3TubeR1 + 215.8 * TMath::Tan(0.829 / 180. * TMath::Pi());
+
+
+  TGeoPcon* shRB26s3Tube = new TGeoPcon(0., 360., 7);
+  // Section 1: straight section
+  shRB26s3Tube->DefineSection(0,   0.00, kRB26s3TubeR1, kRB26s3TubeR1 + 0.15);
+  shRB26s3Tube->DefineSection(1,   2.00, kRB26s3TubeR1, kRB26s3TubeR1 + 0.15);      
+  // Section 2: 0.829 deg opening cone
+  shRB26s3Tube->DefineSection(2,   2.00, kRB26s3TubeR1, kRB26s3TubeR1 + 0.20);
+
+  shRB26s3Tube->DefineSection(3, 217.80, kRB26s3TubeR2, kRB26s3TubeR2 + 0.20);
+  shRB26s3Tube->DefineSection(4, 217.80, kRB26s3TubeR2, kRB26s3TubeR2 + 0.30);      
+
+  shRB26s3Tube->DefineSection(5, 622.20,       30.00/2., 30.60/2.);      
+  shRB26s3Tube->DefineSection(6, kRB26s3TubeL, 30.00/2., 30.60/2.); 
+
+  TGeoVolume* voRB26s3Tube = new TGeoVolume("RB26s3Tube", shRB26s3Tube, kMedSteelH);
+  //    Add the insulation layer
+  TGeoVolume* voRB26s3TubeIns = new TGeoVolume("RB26s3TubeIns", MakeInsulationFromTemplate(shRB26s3Tube), kMedInsuH); 
+  voRB26s3Tube->AddNode(voRB26s3TubeIns, 1, gGeoIdentity);
+
+  TGeoVolume* voRB26s3TubeM  = new TGeoVolume("RB26s3TubeM", MakeMotherFromTemplate(shRB26s3Tube), kMedVacH);
+  voRB26s3TubeM->AddNode(voRB26s3Tube, 1, gGeoIdentity);
+
+
+
+  ///////////////////////////////////
+  //    Fixed Point                //
+  //    Drawing  LHCVFX_0005       //
+  /////////////////////////////////// 
+  const Float_t kRB26s3FixedPointL       = 16.37     ; // Length of the fixed point section (0.3 cm added for welding)
+  const Float_t kRB26s3FixedPointZ       =  9.72     ; // Position of the ring (0.15 cm added for welding)
+  const Float_t kRB26s3FixedPointD       =  0.595    ; // Width of the ring
+  const Float_t kRB26s3FixedPointR       = 13.30/2.  ; // Radius of the ring
+  const Float_t kRB26s3FixedPointRi      = 12.00/2.  ; // Inner radius of the tube
+  const Float_t kRB26s3FixedPointRo1     = 12.30/2.  ; // Outer radius of the tube (in)
+  const Float_t kRB26s3FixedPointRo2     = 12.40/2.  ; // Outer radius of the tube (out)
+  const Float_t kRB26s3FixedPointDs      =  1.5      ; // Width of straight section behind ring
+  const Float_t kRB26s3FixedPointDc      =  3.15     ; // Width of conical  section behind ring (0.15 cm added for welding)      
+
+  TGeoPcon* shRB26s3FixedPoint = new TGeoPcon(0., 360., 8);
+  z0 = 0.;
+  shRB26s3FixedPoint->DefineSection(0, z0, kRB26s3FixedPointRi, kRB26s3FixedPointRo1);
+  z0 += kRB26s3FixedPointZ;
+  shRB26s3FixedPoint->DefineSection(1, z0, kRB26s3FixedPointRi, kRB26s3FixedPointRo1);      
+  shRB26s3FixedPoint->DefineSection(2, z0, kRB26s3FixedPointRi, kRB26s3FixedPointR);      	  
+  z0 += kRB26s3FixedPointD;
+  shRB26s3FixedPoint->DefineSection(3, z0, kRB26s3FixedPointRi, kRB26s3FixedPointR);      	  
+  shRB26s3FixedPoint->DefineSection(4, z0, kRB26s3FixedPointRi, kRB26s3FixedPointRo1);
+  z0 += kRB26s3FixedPointDs;
+  shRB26s3FixedPoint->DefineSection(5, z0, kRB26s3FixedPointRi, kRB26s3FixedPointRo1);
+  z0 += kRB26s3FixedPointDc;
+  shRB26s3FixedPoint->DefineSection(6, z0, kRB26s3FixedPointRi, kRB26s3FixedPointRo2);
+  z0 = kRB26s3FixedPointL;
+  shRB26s3FixedPoint->DefineSection(7, z0, kRB26s3FixedPointRi, kRB26s3FixedPointRo2);
+  TGeoVolume* voRB26s3FixedPoint = new TGeoVolume("RB26s3FixedPoint", shRB26s3FixedPoint, kMedSteelH);
+
+  TGeoVolume* voRB26s3FixedPointM = new TGeoVolume("RB26s3FixedPointM", MakeMotherFromTemplate(shRB26s3FixedPoint), kMedVacH);
+  voRB26s3FixedPointM->AddNode(voRB26s3FixedPoint, 1, gGeoIdentity);
+
+  ///////////////////////////////////
+  //    Split Flange               //
+  //    Drawing  LHCVFX_0005       //
+  /////////////////////////////////// 
+  const Float_t kRB26s3SFlangeL      =  2.13;        // Length of the flange
+  const Float_t kRB26s3SFlangeD1     =  0.57;        // Length of section 1
+  const Float_t kRB26s3SFlangeD2     =  0.36;        // Length of section 2						     
+  const Float_t kRB26s3SFlangeD3     =  0.50 + 0.70; // Length of section 3						           
+  const Float_t kRB26s3SFlangeRo     = 17.15/2.;     // Flange outer radius 
+  const Float_t kRB26s3SFlangeRi1    = 12.30/2.;     // Flange inner radius section 1
+  const Float_t kRB26s3SFlangeRi2    = 12.00/2.;     // Flange inner radius section 2
+  const Float_t kRB26s3SFlangeRi3    = 12.30/2.;     // Flange inner radius section 3
+  z0 = 0;
+  TGeoPcon* shRB26s3SFlange = new TGeoPcon(0., 360., 6);
+  z0 = 0.;
+  shRB26s3SFlange->DefineSection(0, z0, kRB26s3SFlangeRi1, kRB26s3SFlangeRo);
+  z0 += kRB26s3SFlangeD1;
+  shRB26s3SFlange->DefineSection(1, z0, kRB26s3SFlangeRi1, kRB26s3SFlangeRo);
+  shRB26s3SFlange->DefineSection(2, z0, kRB26s3SFlangeRi2, kRB26s3SFlangeRo);
+  z0 += kRB26s3SFlangeD2;
+  shRB26s3SFlange->DefineSection(3, z0, kRB26s3SFlangeRi2, kRB26s3SFlangeRo);
+  shRB26s3SFlange->DefineSection(4, z0, kRB26s3SFlangeRi3, kRB26s3SFlangeRo);
+  z0 += kRB26s3SFlangeD3;
+  shRB26s3SFlange->DefineSection(5, z0, kRB26s3SFlangeRi3, kRB26s3SFlangeRo);
+  TGeoVolume* voRB26s3SFlange = new TGeoVolume("RB26s3SFlange", shRB26s3SFlange, kMedSteelH);
+
+  TGeoVolume* voRB26s3SFlangeM = new TGeoVolume("RB26s3SFlangeM", MakeMotherFromTemplate(shRB26s3SFlange, 0, 3), kMedVacH);
+  voRB26s3SFlangeM->AddNode(voRB26s3SFlange, 1, gGeoIdentity);
+
+  ///////////////////////////////////
+  //    RB26/3   Fixed Flange      //
+  //    Drawing  LHCVFX___0004     //
+  /////////////////////////////////// 
+  const Float_t kRB26s3FFlangeL      =  2.99;    // Length of the flange
+  const Float_t kRB26s3FFlangeD1     =  1.72;    // Length of section 1
+  const Float_t kRB26s3FFlangeD2     =  0.30;    // Length of section 2						     
+  const Float_t kRB26s3FFlangeD3     =  0.97;    // Length of section 3						           
+  const Float_t kRB26s3FFlangeRo     = 36.20/2.; // Flange outer radius 
+  const Float_t kRB26s3FFlangeRi1    = 30.60/2.; // Flange inner radius section 1
+  const Float_t kRB26s3FFlangeRi2    = 30.00/2.; // Flange inner radius section 2
+  const Float_t kRB26s3FFlangeRi3    = 30.60/2.; // Flange inner radius section 3
+  z0 = 0;
+  TGeoPcon* shRB26s3FFlange = new TGeoPcon(0., 360., 6);
+  z0 = 0.;
+  shRB26s3FFlange->DefineSection(0, z0, kRB26s3FFlangeRi1, kRB26s3FFlangeRo);
+  z0 += kRB26s3FFlangeD1;
+  shRB26s3FFlange->DefineSection(1, z0, kRB26s3FFlangeRi1, kRB26s3FFlangeRo);
+  shRB26s3FFlange->DefineSection(2, z0, kRB26s3FFlangeRi2, kRB26s3FFlangeRo);
+  z0 += kRB26s3FFlangeD2;
+  shRB26s3FFlange->DefineSection(3, z0, kRB26s3FFlangeRi2, kRB26s3FFlangeRo);
+  shRB26s3FFlange->DefineSection(4, z0, kRB26s3FFlangeRi3, kRB26s3FFlangeRo);
+  z0 += kRB26s3FFlangeD3;
+  shRB26s3FFlange->DefineSection(5, z0, kRB26s3FFlangeRi3, kRB26s3FFlangeRo);
+  TGeoVolume* voRB26s3FFlange = new TGeoVolume("RB26s3FFlange", shRB26s3FFlange, kMedSteelH);
+
+  TGeoVolume* voRB26s3FFlangeM = new TGeoVolume("RB26s3FFlangeM", MakeMotherFromTemplate(shRB26s3FFlange, 2, 5), kMedVacH);
+  voRB26s3FFlangeM->AddNode(voRB26s3FFlange, 1, gGeoIdentity);
+
+
+
+  ///////////////////////////////////
+  //    RB26/3   Axial Compensator //
+  //    Drawing  LHCVC2a_0065      //
+  /////////////////////////////////// 
+  const Float_t kRB26s3CompL              = 42.0;     // Length of the compensator (0.3 cm added for welding)
+  const Float_t kRB26s3BellowRo           = 34.00/2.; // Bellow outer radius        [Pos 1]
+  const Float_t kRB26s3BellowRi           = 30.10/2.; // Bellow inner radius        [Pos 1] 
+  const Int_t   kRB26s3NumberOfPlies      = 13;       // Number of plies            [Pos 1] 
+  const Float_t kRB26s3BellowUndL         = 17.70;    // Length of undulated region [Pos 1] 
+  const Float_t kRB26s3PlieThickness      =  0.06;    // Plie thickness             [Pos 1]
+  const Float_t kRB26s3ConnectionPlieR    =  0.21;    // Connection plie radius     [Pos 1] 
+  //  Plie radius
+  const Float_t kRB26s3PlieR = 
+    (kRB26s3BellowUndL - 4. *  kRB26s3ConnectionPlieR + 
+     2. *  kRB26s3NumberOfPlies * kRB26s3PlieThickness) / (4. * kRB26s3NumberOfPlies);
+
+  //
+  // The welding tubes have 3 sections with different radii and 2 transition regions.
+  // Section 1: connection to the outside
+  // Section 2: commection to the bellow
+  // Section 3: between 1 and 2
+  const Float_t kRB26s3CompTubeInnerR1    = 30.0/2.;  // Outer Connection tubes inner radius     [Pos 4 + 3]
+  const Float_t kRB26s3CompTubeOuterR1    = 30.6/2.;  // Outer Connection tubes outer radius     [Pos 4 + 3]
+  const Float_t kRB26s3CompTubeInnerR2    = 29.4/2.;  // Connection tubes inner radius           [Pos 4 + 3]
+  const Float_t kRB26s3CompTubeOuterR2    = 30.0/2.;  // Connection tubes outer radius           [Pos 4 + 3]
+  const Float_t kRB26s3CompTubeInnerR3    = 30.6/2.;  // Connection tubes inner radius at bellow [Pos 4 + 3]
+  const Float_t kRB26s3CompTubeOuterR3    = 32.2/2.;  // Connection tubes outer radius at bellow [Pos 4 + 3]
+
+  const Float_t kRB26s3WeldingTubeLeftL1  =  2.0;     // Left connection tube length             [Pos 4]
+  const Float_t kRB26s3WeldingTubeLeftL2  =  3.4;     // Left connection tube length             [Pos 4]
+  const Float_t kRB26s3WeldingTubeLeftL   =  7.0;     // Left connection tube total length       [Pos 4]
+  const Float_t kRB26s3WeldingTubeRightL1 =  2.3;     // Right connection tube length            [Pos 3] (0.3 cm added for welding)
+  const Float_t kRB26s3WeldingTubeRightL2 = 13.4;     // Right connection tube length            [Pos 3]
+
+  const Float_t kRB26s3WeldingTubeT1      =  0.6;     // Length of first r-transition            [Pos 4 + 3]
+  const Float_t kRB26s3WeldingTubeT2      =  1.0;     // Length of 2nd   r-transition            [Pos 4 + 3]       
+
+
+
+  const Float_t kRB26s3RingOuterR         = 36.1/2.;  // Ring inner radius                       [Pos 4]
+  const Float_t kRB26s3RingL              =  0.8/2.;  // Ring half length                        [Pos 4]
+  const Float_t kRB26s3RingZ              =  3.7   ;  // Ring z-position                         [Pos 4]
+  const Float_t kRB26s3ProtOuterR         = 36.2/2.;  // Protection tube outer radius            [Pos 2]
+  const Float_t kRB26s3ProtL              = 27.0/2.;  // Protection tube half length             [Pos 2]
+  const Float_t kRB26s3ProtZ              =  4.0   ;  // Protection tube z-position              [Pos 2]
+
+
+  // Mother volume
+  //
+  TGeoPcon* shRB26s3Compensator  = new TGeoPcon(0., 360., 6);
+  shRB26s3Compensator->DefineSection( 0,   0.0, 0., kRB26s3CompTubeOuterR1);
+  shRB26s3Compensator->DefineSection( 1,   kRB26s3RingZ, 0., kRB26s3CompTubeOuterR1);      
+  shRB26s3Compensator->DefineSection( 2,   kRB26s3RingZ, 0., kRB26s3ProtOuterR);      
+  shRB26s3Compensator->DefineSection( 3,   kRB26s3ProtZ + 2. * kRB26s3ProtL, 0., kRB26s3ProtOuterR);            
+  shRB26s3Compensator->DefineSection( 4,   kRB26s3ProtZ + 2. * kRB26s3ProtL, 0., kRB26s3CompTubeOuterR1);
+  shRB26s3Compensator->DefineSection( 5,   kRB26s3CompL                    , 0., kRB26s3CompTubeOuterR1);            
+  TGeoVolume* voRB26s3Compensator  =  
+    new TGeoVolume("RB26s3Compensator", shRB26s3Compensator, kMedVacH);
+
+  //
+  // [Pos 1] Bellow
+  //      
+  //
+  TGeoVolume* voRB26s3Bellow = new TGeoVolume("RB26s3Bellow", 
+      new TGeoTube(kRB26s3BellowRi, kRB26s3BellowRo, kRB26s3BellowUndL/2.), kMedVacH);
+  //      
+  //  Upper part of the undulation
+  //
+  TGeoTorus* shRB26s3PlieTorusU  =  new TGeoTorus(kRB26s3BellowRo - kRB26s3PlieR, kRB26s3PlieR - kRB26s3PlieThickness, kRB26s3PlieR);
+  shRB26s3PlieTorusU->SetName("RB26s3TorusU");
+  TGeoTube*  shRB26s3PlieTubeU   =  new TGeoTube (kRB26s3BellowRo - kRB26s3PlieR, kRB26s3BellowRo, kRB26s3PlieR);
+  shRB26s3PlieTubeU->SetName("RB26s3TubeU");
+  TGeoCompositeShape*  shRB26s3UpperPlie = new TGeoCompositeShape("RB26s3UpperPlie", "RB26s3TorusU*RB26s3TubeU");
+
+  TGeoVolume* voRB26s3WiggleU = new TGeoVolume("RB26s3UpperPlie", shRB26s3UpperPlie, kMedSteelH);
+  //
+  // Lower part of the undulation
+  TGeoTorus* shRB26s3PlieTorusL =  new TGeoTorus(kRB26s3BellowRi + kRB26s3PlieR, kRB26s3PlieR - kRB26s3PlieThickness, kRB26s3PlieR);
+  shRB26s3PlieTorusL->SetName("RB26s3TorusL");
+  TGeoTube*  shRB26s3PlieTubeL   =  new TGeoTube (kRB26s3BellowRi, kRB26s3BellowRi + kRB26s3PlieR, kRB26s3PlieR);
+  shRB26s3PlieTubeL->SetName("RB26s3TubeL");
+  TGeoCompositeShape*  shRB26s3LowerPlie = new TGeoCompositeShape("RB26s3LowerPlie", "RB26s3TorusL*RB26s3TubeL");
+
+  TGeoVolume* voRB26s3WiggleL = new TGeoVolume("RB26s3LowerPlie", shRB26s3LowerPlie, kMedSteelH); 
+
+  //
+  // Connection between upper and lower part of undulation
+  TGeoVolume* voRB26s3WiggleC1 = new TGeoVolume("RB26s3PlieConn1",  
+      new TGeoTube(kRB26s3BellowRi + kRB26s3PlieR, 
+        kRB26s3BellowRo - kRB26s3PlieR, kRB26s3PlieThickness / 2.), kMedSteelH);
+  //
+  // One wiggle
+  TGeoVolumeAssembly* voRB26s3Wiggle = new TGeoVolumeAssembly("RB26s3Wiggle");
+  z0 =  -  kRB26s3PlieThickness / 2.;
+  voRB26s3Wiggle->AddNode(voRB26s3WiggleC1,  1 , new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s3PlieR -  kRB26s3PlieThickness / 2.;
+  voRB26s3Wiggle->AddNode(voRB26s3WiggleU,   1 , new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s3PlieR -  kRB26s3PlieThickness / 2.;
+  voRB26s3Wiggle->AddNode(voRB26s3WiggleC1,  2 , new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s3PlieR -  kRB26s3PlieThickness;
+  voRB26s3Wiggle->AddNode(voRB26s3WiggleL,  1 , new TGeoTranslation(0., 0., z0));
+  // Positioning of the volumes
+  z0   = - kRB26s3BellowUndL/2.+ kRB26s3PlieR;
+  voRB26s3Bellow->AddNode(voRB26s3WiggleL, 1, new TGeoTranslation(0., 0., z0));
+  z0  +=  kRB26s3PlieR;
+  zsh  = 4. *  kRB26s3PlieR -  2. * kRB26s3PlieThickness;
+  for (Int_t iw = 0; iw < kRB26s3NumberOfPlies; iw++) {
+    Float_t zpos =  z0 + iw * zsh;	
+    voRB26s3Bellow->AddNode(voRB26s3Wiggle,  iw + 1, new TGeoTranslation(0., 0., zpos -  kRB26s3PlieThickness));	
+  }
+
+  voRB26s3Compensator->AddNode(voRB26s3Bellow, 1,  new TGeoTranslation(0., 0., kRB26s3WeldingTubeLeftL + kRB26s3BellowUndL/2.));
+
+
+  //
+  // [Pos 2] Outer Protecting Tube
+  //      
+  TGeoTube* shRB26s3CompProtTube = new TGeoTube(kRB26s3RingOuterR, kRB26s3ProtOuterR, kRB26s3ProtL);
+  TGeoVolume* voRB26s3CompProtTube =  
+    new TGeoVolume("RB26s3CompProtTube", shRB26s3CompProtTube, kMedSteelH);
+  voRB26s3Compensator->AddNode(voRB26s3CompProtTube, 1,  new TGeoTranslation(0., 0., kRB26s3ProtZ + kRB26s3ProtL));
+
+
+  //
+  // [Pos 3] Right Welding Tube
+  //      
+  TGeoPcon* shRB26s3CompRightTube = new TGeoPcon(0., 360., 5);
+  z0 = 0.;
+  shRB26s3CompRightTube->DefineSection(0, z0,  kRB26s3CompTubeInnerR3, kRB26s3CompTubeOuterR3);
+  z0 += kRB26s3WeldingTubeT2;
+  shRB26s3CompRightTube->DefineSection(1, z0,  kRB26s3CompTubeInnerR2, kRB26s3CompTubeOuterR2);
+  z0 += kRB26s3WeldingTubeRightL2;
+  shRB26s3CompRightTube->DefineSection(2, z0,  kRB26s3CompTubeInnerR2, kRB26s3CompTubeOuterR2);
+  z0 += kRB26s3WeldingTubeT1;
+  shRB26s3CompRightTube->DefineSection(3, z0,  kRB26s3CompTubeInnerR1, kRB26s3CompTubeOuterR1);
+  z0 += kRB26s3WeldingTubeRightL1;
+  shRB26s3CompRightTube->DefineSection(4, z0,  kRB26s3CompTubeInnerR1, kRB26s3CompTubeOuterR1);
+
+  TGeoVolume* voRB26s3CompRightTube =  
+    new TGeoVolume("RB26s3CompRightTube", shRB26s3CompRightTube, kMedSteelH);
+  voRB26s3Compensator->AddNode(voRB26s3CompRightTube,  1, new TGeoTranslation(0., 0.,  kRB26s3CompL - z0));
+
+  //
+  // [Pos 4] Left Welding Tube
+  //      
+  TGeoPcon* shRB26s3CompLeftTube = new TGeoPcon(0., 360., 5);
+  z0 = 0.;
+  shRB26s3CompLeftTube->DefineSection(0, z0,  kRB26s3CompTubeInnerR1, kRB26s3CompTubeOuterR1);
+  z0 += kRB26s3WeldingTubeLeftL1;
+  shRB26s3CompLeftTube->DefineSection(1, z0,  kRB26s3CompTubeInnerR1, kRB26s3CompTubeOuterR1);
+  z0 += kRB26s3WeldingTubeT1;
+  shRB26s3CompLeftTube->DefineSection(2, z0,  kRB26s3CompTubeInnerR2, kRB26s3CompTubeOuterR2);
+  z0 += kRB26s3WeldingTubeLeftL2;
+  shRB26s3CompLeftTube->DefineSection(3, z0,  kRB26s3CompTubeInnerR2, kRB26s3CompTubeOuterR2);
+  z0 += kRB26s3WeldingTubeT2;
+  shRB26s3CompLeftTube->DefineSection(4, z0,  kRB26s3CompTubeInnerR3, kRB26s3CompTubeOuterR3);
+
+  TGeoVolume* voRB26s3CompLeftTube =  
+    new TGeoVolume("RB26s3CompLeftTube", shRB26s3CompLeftTube, kMedSteelH);
+  voRB26s3Compensator->AddNode(voRB26s3CompLeftTube, 1,  gGeoIdentity);
+  //
+  // [Pos 5] Ring
+  //      
+  TGeoTube* shRB26s3CompRing = new TGeoTube(kRB26s3CompTubeOuterR2, kRB26s3RingOuterR, kRB26s3RingL);
+  TGeoVolume* voRB26s3CompRing =  
+    new TGeoVolume("RB26s3CompRing", shRB26s3CompRing, kMedSteelH);
+  voRB26s3Compensator->AddNode(voRB26s3CompRing,  1, new TGeoTranslation(0., 0., kRB26s3RingZ + kRB26s3RingL));
+
+
+
+  ///////////////////////////////////////////
+  //                                       //
+  //    RB26/4-5                           //  
+  //    Drawing LHCV2a_0012 [as installed] //
+  ////////////////////////////////////////////
+  //    Pos1 Vacuum Tubes        LHCVC2A__0014
+  //    Pos2 Compensator         LHCVC2A__0066
+  //    Pos3 Fixed Point Section LHCVC2A__0016
+  //    Pos4 Split Flange        LHCVFX___0005
+  //    Pos5 RotableFlange       LHCVFX___0009
+  ////////////////////////////////////////////
+
+  ///////////////////////////////////
+  //    RB26/4-5 Vacuum Tubes      //
+  //    Drawing  LHCVC2a_0014      //
+  /////////////////////////////////// 
+  const Float_t kRB26s45TubeL = 593.12 + 0.3; // 0.3 cm added for welding
+
+  TGeoPcon* shRB26s45Tube = new TGeoPcon(0., 360., 11);
+  // Section 1: straight section
+  shRB26s45Tube->DefineSection( 0,   0.00, 30.00/2., 30.60/2.);
+  shRB26s45Tube->DefineSection( 1,   1.20, 30.00/2., 30.60/2.);
+  shRB26s45Tube->DefineSection( 2,   1.20, 30.00/2., 30.80/2.);
+  shRB26s45Tube->DefineSection( 3,  25.10, 30.00/2., 30.80/2.);      
+  // Section 2: 0.932 deg opening cone
+  shRB26s45Tube->DefineSection( 4, 486.10, 45.00/2., 45.80/2.);      
+  // Section 3: straight section 4 mm 
+  shRB26s45Tube->DefineSection( 5, 512.10, 45.00/2., 45.80/2.);
+  // Section 4: straight section 3 mm
+  shRB26s45Tube->DefineSection( 6, 512.10, 45.00/2., 45.60/2.);
+  shRB26s45Tube->DefineSection( 7, 527.70, 45.00/2., 45.60/2.);
+  // Section 4: closing cone 
+  shRB26s45Tube->DefineSection( 8, 591.30, 10.00/2., 10.60/2.);      
+  shRB26s45Tube->DefineSection( 9, 591.89, 10.00/2., 10.30/2.);      
+
+  shRB26s45Tube->DefineSection(10, kRB26s45TubeL, 10.00/2., 10.30/2.);      
+  TGeoVolume* voRB26s45Tube  =  
+    new TGeoVolume("RB26s45Tube", shRB26s45Tube, kMedSteelH);
+
+  TGeoVolume* voRB26s45TubeM  = new TGeoVolume("RB26s45TubeM", MakeMotherFromTemplate(shRB26s45Tube), kMedVacH);
+  voRB26s45TubeM->AddNode(voRB26s45Tube, 1, gGeoIdentity);
+
+
+
+  ///////////////////////////////////
+  //    RB26/5   Axial Compensator //
+  //    Drawing  LHCVC2a_0066      //
+  /////////////////////////////////// 
+  const Float_t kRB26s5CompL             = 27.60;    // Length of the compensator (0.30 cm added for welding)
+  const Float_t kRB26s5BellowRo          = 12.48/2.; // Bellow outer radius        [Pos 1]
+  const Float_t kRB26s5BellowRi          = 10.32/2.; // Bellow inner radius        [Pos 1] 
+  const Int_t   kRB26s5NumberOfPlies     = 15;       // Number of plies            [Pos 1] 
+  const Float_t kRB26s5BellowUndL        = 10.50;    // Length of undulated region [Pos 1] 
+  const Float_t kRB26s5PlieThickness     =  0.025;   // Plie thickness             [Pos 1]
+  const Float_t kRB26s5ConnectionPlieR   =  0.21;    // Connection plie radius     [Pos 1] 
+  const Float_t kRB26s5ConnectionR       = 11.2/2.;  // Bellow connection radius   [Pos 1] 
+  //  Plie radius
+  const Float_t kRB26s5PlieR = 
+    (kRB26s5BellowUndL - 4. *  kRB26s5ConnectionPlieR + 
+     2. *  kRB26s5NumberOfPlies * kRB26s5PlieThickness) / (4. * kRB26s5NumberOfPlies);
+  const Float_t kRB26s5CompTubeInnerR    = 10.00/2.;  // Connection tubes inner radius     [Pos 2 + 3]
+  const Float_t kRB26s5CompTubeOuterR    = 10.30/2.;  // Connection tubes outer radius     [Pos 2 + 3]
+  const Float_t kRB26s5WeldingTubeLeftL  =  3.70/2.;  // Left connection tube half length  [Pos 2]
+  const Float_t kRB26s5WeldingTubeRightL = 13.40/2.;  // Right connection tube half length [Pos 3]   (0.3 cm added for welding)
+  const Float_t kRB26s5RingInnerR        = 11.2/2.;   // Ring inner radius                 [Pos 4]
+  const Float_t kRB26s5RingOuterR        = 16.0/2.;   // Ring inner radius                 [Pos 4]
+  const Float_t kRB26s5RingL             =  0.4/2.;   // Ring half length                  [Pos 4]
+  const Float_t kRB26s5RingZ             = 14.97;     // Ring z-position                   [Pos 4]
+  const Float_t kRB26s5ProtOuterR        = 16.2/2.;   // Protection tube outer radius      [Pos 5]
+  const Float_t kRB26s5ProtL             = 13.0/2.;   // Protection tube half length       [Pos 5]
+  const Float_t kRB26s5ProtZ             =  2.17;     // Protection tube z-position        [Pos 5]
+  const Float_t kRB26s5DetailZR          = 11.3/2.;   // Detail Z max radius
+
+
+  // Mother volume
+  //
+  TGeoPcon* shRB26s5Compensator  = new TGeoPcon(0., 360., 8);
+  shRB26s5Compensator->DefineSection( 0,   0.0,                                                  0., kRB26s5CompTubeOuterR);
+  shRB26s5Compensator->DefineSection( 1,   kRB26s5ProtZ,                                         0., kRB26s5CompTubeOuterR);      
+  shRB26s5Compensator->DefineSection( 2,   kRB26s5ProtZ,                                         0., kRB26s5ProtOuterR);
+  shRB26s5Compensator->DefineSection( 3,   kRB26s5ProtZ + 2. * kRB26s5ProtL + 2. * kRB26s5RingL, 0., kRB26s5ProtOuterR);      
+  shRB26s5Compensator->DefineSection( 4,   kRB26s5ProtZ + 2. * kRB26s5ProtL + 2. * kRB26s5RingL, 0., kRB26s5DetailZR);
+  shRB26s5Compensator->DefineSection( 5,   kRB26s5CompL - 8.,                                    0., kRB26s5DetailZR);
+  shRB26s5Compensator->DefineSection( 6,   kRB26s5CompL - 8.,                                    0., kRB26s5CompTubeOuterR);            
+  shRB26s5Compensator->DefineSection( 7,   kRB26s5CompL,                                         0., kRB26s5CompTubeOuterR);            
+  TGeoVolume* voRB26s5Compensator  = new TGeoVolume("RB26s5Compensator", shRB26s5Compensator, kMedVacH);
+
+  //
+  // [Pos 1] Bellow
+  //      
+  //
+  TGeoVolume* voRB26s5Bellow = new TGeoVolume("RB26s5Bellow", 
+      new TGeoTube(kRB26s5BellowRi, kRB26s5BellowRo, kRB26s5BellowUndL/2.), kMedVacH);
+  //      
+  //  Upper part of the undulation
+  //
+  TGeoTorus* shRB26s5PlieTorusU  =  new TGeoTorus(kRB26s5BellowRo - kRB26s5PlieR, kRB26s5PlieR - kRB26s5PlieThickness, kRB26s5PlieR);
+  shRB26s5PlieTorusU->SetName("RB26s5TorusU");
+  TGeoTube*  shRB26s5PlieTubeU   =  new TGeoTube (kRB26s5BellowRo - kRB26s5PlieR, kRB26s5BellowRo, kRB26s5PlieR);
+  shRB26s5PlieTubeU->SetName("RB26s5TubeU");
+  TGeoCompositeShape*  shRB26s5UpperPlie = new TGeoCompositeShape("RB26s5UpperPlie", "RB26s5TorusU*RB26s5TubeU");
+
+  TGeoVolume* voRB26s5WiggleU = new TGeoVolume("RB26s5UpperPlie", shRB26s5UpperPlie, kMedSteelH);
+  //
+  // Lower part of the undulation
+  TGeoTorus* shRB26s5PlieTorusL =  new TGeoTorus(kRB26s5BellowRi + kRB26s5PlieR, kRB26s5PlieR - kRB26s5PlieThickness, kRB26s5PlieR);
+  shRB26s5PlieTorusL->SetName("RB26s5TorusL");
+  TGeoTube*  shRB26s5PlieTubeL   =  new TGeoTube (kRB26s5BellowRi, kRB26s5BellowRi + kRB26s5PlieR, kRB26s5PlieR);
+  shRB26s5PlieTubeL->SetName("RB26s5TubeL");
+  TGeoCompositeShape*  shRB26s5LowerPlie = new TGeoCompositeShape("RB26s5LowerPlie", "RB26s5TorusL*RB26s5TubeL");
+
+  TGeoVolume* voRB26s5WiggleL = new TGeoVolume("RB26s5LowerPlie", shRB26s5LowerPlie, kMedSteelH); 
+
+  //
+  // Connection between upper and lower part of undulation
+  TGeoVolume* voRB26s5WiggleC1 = new TGeoVolume("RB26s5PlieConn1",  
+      new TGeoTube(kRB26s5BellowRi + kRB26s5PlieR, 
+        kRB26s5BellowRo - kRB26s5PlieR, kRB26s5PlieThickness / 2.), kMedSteelH);
+  //
+  // One wiggle
+  TGeoVolumeAssembly* voRB26s5Wiggle = new TGeoVolumeAssembly("RB26s5Wiggle");
+  z0 =  -  kRB26s5PlieThickness / 2.;
+  voRB26s5Wiggle->AddNode(voRB26s5WiggleC1,  1 , new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s5PlieR -  kRB26s5PlieThickness / 2.;
+  voRB26s5Wiggle->AddNode(voRB26s5WiggleU,   1 , new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s5PlieR -  kRB26s5PlieThickness / 2.;
+  voRB26s5Wiggle->AddNode(voRB26s5WiggleC1,  2 , new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s5PlieR -  kRB26s5PlieThickness;
+  voRB26s5Wiggle->AddNode(voRB26s5WiggleL ,  1 , new TGeoTranslation(0., 0., z0));
+  // Positioning of the volumes
+  z0   = - kRB26s5BellowUndL/2.+ kRB26s5ConnectionPlieR;
+  voRB26s5Bellow->AddNode(voRB26s5WiggleL, 1, new TGeoTranslation(0., 0., z0));
+  z0  +=  kRB26s5ConnectionPlieR;
+  zsh  = 4. *  kRB26s5PlieR -  2. * kRB26s5PlieThickness;
+  for (Int_t iw = 0; iw < kRB26s5NumberOfPlies; iw++) {
+    Float_t zpos =  z0 + iw * zsh;	
+    voRB26s5Bellow->AddNode(voRB26s5Wiggle,  iw + 1, new TGeoTranslation(0., 0., zpos -  kRB26s5PlieThickness));	
+  }
+
+  voRB26s5Compensator->AddNode(voRB26s5Bellow, 1,  new TGeoTranslation(0., 0., 2. * kRB26s5WeldingTubeLeftL + kRB26s5BellowUndL/2.));
+
+  //
+  // [Pos 2] Left Welding Tube
+  //      
+  TGeoPcon* shRB26s5CompLeftTube = new TGeoPcon(0., 360., 3);
+  z0 = 0;
+  shRB26s5CompLeftTube->DefineSection(0, z0, kRB26s5CompTubeInnerR, kRB26s5CompTubeOuterR);
+  z0 += 2 * kRB26s5WeldingTubeLeftL - ( kRB26s5ConnectionR - kRB26s5CompTubeOuterR);
+  shRB26s5CompLeftTube->DefineSection(1, z0, kRB26s5CompTubeInnerR, kRB26s5CompTubeOuterR);
+  z0 += ( kRB26s5ConnectionR - kRB26s5CompTubeOuterR);
+  shRB26s5CompLeftTube->DefineSection(2, z0, kRB26s5ConnectionR - 0.15, kRB26s5ConnectionR);
+  TGeoVolume* voRB26s5CompLeftTube = new TGeoVolume("RB26s5CompLeftTube", shRB26s5CompLeftTube, kMedSteelH);
+  voRB26s5Compensator->AddNode(voRB26s5CompLeftTube, 1,  gGeoIdentity);
+  //
+  // [Pos 3] Right Welding Tube
+  //      
+  TGeoPcon* shRB26s5CompRightTube = new TGeoPcon(0., 360., 11);
+  // Detail Z
+  shRB26s5CompRightTube->DefineSection( 0, 0.  , kRB26s5CompTubeInnerR + 0.22, 11.2/2.);
+  shRB26s5CompRightTube->DefineSection( 1, 0.05, kRB26s5CompTubeInnerR + 0.18, 11.2/2.);
+  shRB26s5CompRightTube->DefineSection( 2, 0.22, kRB26s5CompTubeInnerR       , 11.2/2. - 0.22);
+  shRB26s5CompRightTube->DefineSection( 3, 0.44, kRB26s5CompTubeInnerR       , 11.2/2.);
+  shRB26s5CompRightTube->DefineSection( 4, 1.70, kRB26s5CompTubeInnerR       , 11.2/2.);
+  shRB26s5CompRightTube->DefineSection( 5, 2.10, kRB26s5CompTubeInnerR       , kRB26s5CompTubeOuterR);
+  shRB26s5CompRightTube->DefineSection( 6, 2.80, kRB26s5CompTubeInnerR       , kRB26s5CompTubeOuterR);
+  shRB26s5CompRightTube->DefineSection( 7, 2.80, kRB26s5CompTubeInnerR       , 11.3/2.);
+  shRB26s5CompRightTube->DefineSection( 8, 3.40, kRB26s5CompTubeInnerR       , 11.3/2.);
+  // Normal pipe
+  shRB26s5CompRightTube->DefineSection( 9, 3.50, kRB26s5CompTubeInnerR       , kRB26s5CompTubeOuterR);
+  shRB26s5CompRightTube->DefineSection(10, 2. * kRB26s5WeldingTubeRightL, kRB26s5CompTubeInnerR, kRB26s5CompTubeOuterR);
+
+  TGeoVolume* voRB26s5CompRightTube =  
+    new TGeoVolume("RB26s5CompRightTube", shRB26s5CompRightTube, kMedSteelH);
+  voRB26s5Compensator->AddNode(voRB26s5CompRightTube,  1, 
+      new TGeoTranslation(0., 0.,  kRB26s5CompL - 2. * kRB26s5WeldingTubeRightL));
+  //
+  // [Pos 4] Ring
+  //      
+  TGeoTube* shRB26s5CompRing = new TGeoTube(kRB26s5RingInnerR, kRB26s5RingOuterR, kRB26s5RingL);
+  TGeoVolume* voRB26s5CompRing =  
+    new TGeoVolume("RB26s5CompRing", shRB26s5CompRing, kMedSteelH);
+  voRB26s5Compensator->AddNode(voRB26s5CompRing,  1, new TGeoTranslation(0., 0., kRB26s5RingZ + kRB26s5RingL));
+
+  //
+  // [Pos 5] Outer Protecting Tube
+  //      
+  TGeoTube* shRB26s5CompProtTube = new TGeoTube(kRB26s5RingOuterR, kRB26s5ProtOuterR, kRB26s5ProtL);
+  TGeoVolume* voRB26s5CompProtTube =  
+    new TGeoVolume("RB26s5CompProtTube", shRB26s5CompProtTube, kMedSteelH);
+  voRB26s5Compensator->AddNode(voRB26s5CompProtTube, 1,  new TGeoTranslation(0., 0., kRB26s5ProtZ + kRB26s5ProtL));
+
+  ///////////////////////////////////////
+  //    RB26/4   Fixed Point Section   //
+  //    Drawing  LHCVC2a_0016          //
+  /////////////////////////////////////// 
+  const Float_t kRB26s4TubeRi            =  30.30/2. ; // Tube inner radius  (0.3 cm added for welding)
+  const Float_t kRB26s4TubeRo            =  30.60/2. ; // Tube outer radius      
+  const Float_t kRB26s4FixedPointL       =  12.63    ; // Length of the fixed point section
+  const Float_t kRB26s4FixedPointZ       =  10.53    ; // Position of the ring (0.15 added for welding)
+  const Float_t kRB26s4FixedPointD       =   0.595   ; // Width of the ring
+  const Float_t kRB26s4FixedPointR       =  31.60/2. ; // Radius of the ring
+
+  TGeoPcon* shRB26s4FixedPoint = new TGeoPcon(0., 360., 6);
+  z0 = 0.;
+  shRB26s4FixedPoint->DefineSection(0, z0, kRB26s4TubeRi, kRB26s4TubeRo);
+  z0 += kRB26s4FixedPointZ;
+  shRB26s4FixedPoint->DefineSection(1, z0, kRB26s4TubeRi, kRB26s4TubeRo);      
+  shRB26s4FixedPoint->DefineSection(2, z0, kRB26s4TubeRi, kRB26s4FixedPointR);      	  
+  z0 += kRB26s4FixedPointD;
+  shRB26s4FixedPoint->DefineSection(3, z0, kRB26s4TubeRi, kRB26s4FixedPointR);      	  
+  shRB26s4FixedPoint->DefineSection(4, z0, kRB26s4TubeRi, kRB26s4TubeRo);
+  z0 = kRB26s4FixedPointL;
+  shRB26s4FixedPoint->DefineSection(5, z0, kRB26s4TubeRi, kRB26s4TubeRo);
+  TGeoVolume* voRB26s4FixedPoint = new TGeoVolume("RB26s4FixedPoint", shRB26s4FixedPoint, kMedSteelH);
+
+  TGeoVolume* voRB26s4FixedPointM = new TGeoVolume("RB26s4FixedPointM", MakeMotherFromTemplate(shRB26s4FixedPoint), kMedVacH);
+  voRB26s4FixedPointM->AddNode(voRB26s4FixedPoint, 1, gGeoIdentity);
+
+
+  ///////////////////////////////////////
+  //    RB26/4   Split Flange          //
+  //    Drawing  LHCVFX__0005          //
+  /////////////////////////////////////// 
+  const Float_t kRB26s4SFlangeL      =  2.99;        // Length of the flange
+  const Float_t kRB26s4SFlangeD1     =  0.85;        // Length of section 1
+  const Float_t kRB26s4SFlangeD2     =  0.36;        // Length of section 2						     
+  const Float_t kRB26s4SFlangeD3     =  0.73 + 1.05; // Length of section 3						           
+  const Float_t kRB26s4SFlangeRo     = 36.20/2.;     // Flange outer radius 
+  const Float_t kRB26s4SFlangeRi1    = 30.60/2.;     // Flange inner radius section 1
+  const Float_t kRB26s4SFlangeRi2    = 30.00/2.;     // Flange inner radius section 2
+  const Float_t kRB26s4SFlangeRi3    = 30.60/2.;     // Flange inner radius section 3
+  z0 = 0;
+  TGeoPcon* shRB26s4SFlange = new TGeoPcon(0., 360., 6);
+  z0 = 0.;
+  shRB26s4SFlange->DefineSection(0, z0, kRB26s4SFlangeRi1, kRB26s4SFlangeRo);
+  z0 += kRB26s4SFlangeD1;
+  shRB26s4SFlange->DefineSection(1, z0, kRB26s4SFlangeRi1, kRB26s4SFlangeRo);
+  shRB26s4SFlange->DefineSection(2, z0, kRB26s4SFlangeRi2, kRB26s4SFlangeRo);
+  z0 += kRB26s4SFlangeD2;
+  shRB26s4SFlange->DefineSection(3, z0, kRB26s4SFlangeRi2, kRB26s4SFlangeRo);
+  shRB26s4SFlange->DefineSection(4, z0, kRB26s4SFlangeRi3, kRB26s4SFlangeRo);
+  z0 += kRB26s4SFlangeD3;
+  shRB26s4SFlange->DefineSection(5, z0, kRB26s4SFlangeRi3, kRB26s4SFlangeRo);
+  TGeoVolume* voRB26s4SFlange = new TGeoVolume("RB26s4SFlange", shRB26s4SFlange, kMedSteelH);
+
+  TGeoVolume* voRB26s4SFlangeM = new TGeoVolume("RB26s4SFlangeM", MakeMotherFromTemplate(shRB26s4SFlange, 0, 3), kMedVacH);
+  voRB26s4SFlangeM->AddNode(voRB26s4SFlange, 1, gGeoIdentity);
+
+  ///////////////////////////////////////
+  //    RB26/5   Rotable Flange        //
+  //    Drawing  LHCVFX__0009          //
+  /////////////////////////////////////// 
+  const Float_t kRB26s5RFlangeL      =  1.86;    // Length of the flange
+  const Float_t kRB26s5RFlangeD1     =  0.61;    // Length of section 1
+  const Float_t kRB26s5RFlangeD2     =  0.15;    // Length of section 2						     
+  const Float_t kRB26s5RFlangeD3     =  0.60;    // Length of section 3						           
+  const Float_t kRB26s5RFlangeD4     =  0.50;    // Length of section 4						           
+  const Float_t kRB26s5RFlangeRo     = 15.20/2.; // Flange outer radius 
+  const Float_t kRB26s5RFlangeRi1    = 10.30/2.; // Flange inner radius section 1
+  const Float_t kRB26s5RFlangeRi2    = 10.00/2.; // Flange inner radius section 2
+  const Float_t kRB26s5RFlangeRi3    = 10.30/2.; // Flange inner radius section 3
+  const Float_t kRB26s5RFlangeRi4    = 10.50/2.; // Flange inner radius section 4
+
+  z0 = 0;
+  TGeoPcon* shRB26s5RFlange = new TGeoPcon(0., 360., 8);
+  z0 = 0.;
+  shRB26s5RFlange->DefineSection(0, z0, kRB26s5RFlangeRi4, kRB26s5RFlangeRo);
+  z0 += kRB26s5RFlangeD4;
+  shRB26s5RFlange->DefineSection(1, z0, kRB26s5RFlangeRi4, kRB26s5RFlangeRo);
+  shRB26s5RFlange->DefineSection(2, z0, kRB26s5RFlangeRi3, kRB26s5RFlangeRo);
+  z0 += kRB26s5RFlangeD3;
+  shRB26s5RFlange->DefineSection(3, z0, kRB26s5RFlangeRi3, kRB26s5RFlangeRo);
+  shRB26s5RFlange->DefineSection(4, z0, kRB26s5RFlangeRi2, kRB26s5RFlangeRo);
+  z0 += kRB26s5RFlangeD2;
+  shRB26s5RFlange->DefineSection(5, z0, kRB26s5RFlangeRi2, kRB26s5RFlangeRo);
+  shRB26s5RFlange->DefineSection(6, z0, kRB26s5RFlangeRi1, kRB26s5RFlangeRo);
+  z0 += kRB26s5RFlangeD1;
+  shRB26s5RFlange->DefineSection(7, z0, kRB26s5RFlangeRi1, kRB26s5RFlangeRo);
+  TGeoVolume* voRB26s5RFlange = new TGeoVolume("RB26s5RFlange", shRB26s5RFlange, kMedSteelH);
+
+  TGeoVolume* voRB26s5RFlangeM = new TGeoVolume("RB26s5RFlangeM", MakeMotherFromTemplate(shRB26s5RFlange, 4, 7), kMedVacH);
+  voRB26s5RFlangeM->AddNode(voRB26s5RFlange, 1, gGeoIdentity);
+
+  //      
+  // Assemble RB26/1-2
+  //
+  TGeoVolumeAssembly* asRB26s12 = new TGeoVolumeAssembly("RB26s12"); 
+  z0 = 0.;
+  asRB26s12->AddNode(voRB26s1RFlange,       1, gGeoIdentity);
+  z0 += kRB26s1RFlangeIsL + kRB26s1RFlangeFpL;
+  asRB26s12->AddNode(voRB26s12TubeM,         1, new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s12TubeL;
+  asRB26s12->AddNode(voRB26s2Compensator,   1, new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s2CompL;
+  z0 -= kRB26s2FFlangeD1;
+  asRB26s12->AddNode(voRB26s2FFlangeM,       1, new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s2FFlangeL;
+  const Float_t kRB26s12L = z0;
+
+  //
+  // Assemble RB26/3
+  //
+  TGeoVolumeAssembly* asRB26s3 = new TGeoVolumeAssembly("RB26s3"); 
+  z0 = 0.;
+  asRB26s3->AddNode(voRB26s3SFlangeM,      1, gGeoIdentity);
+  z0 +=  kRB26s3SFlangeL;
+  z0 -=  kRB26s3SFlangeD3;
+  asRB26s3->AddNode(voRB26s3FixedPointM,   1, new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s3FixedPointL;
+  asRB26s3->AddNode(voRB26s3TubeM,         1, new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s3TubeL;
+  asRB26s3->AddNode(voRB26s3Compensator,   1, new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s3CompL;
+  z0 -= kRB26s3FFlangeD1;
+  asRB26s3->AddNode(voRB26s3FFlangeM,      1, new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s3FFlangeL;
+  const Float_t kRB26s3L = z0;
+
+
+  //
+  // Assemble RB26/4-5
+  //
+  TGeoVolumeAssembly* asRB26s45 = new TGeoVolumeAssembly("RB26s45"); 
+  z0 = 0.;
+  asRB26s45->AddNode(voRB26s4SFlangeM,       1, gGeoIdentity);
+  z0 +=  kRB26s4SFlangeL;
+  z0 -=  kRB26s4SFlangeD3;
+  asRB26s45->AddNode(voRB26s4FixedPointM,    1, new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s4FixedPointL;
+  asRB26s45->AddNode(voRB26s45TubeM,         1, new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s45TubeL;
+  asRB26s45->AddNode(voRB26s5Compensator,    1, new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s5CompL;
+  z0 -= kRB26s5RFlangeD3;
+  z0 -= kRB26s5RFlangeD4;
+  asRB26s45->AddNode(voRB26s5RFlangeM,       1, new TGeoTranslation(0., 0., z0));
+  z0 += kRB26s5RFlangeL;
+  const Float_t kRB26s45L = z0;
+
+  //
+  // Assemble RB26
+  //
+  TGeoVolumeAssembly* asRB26Pipe = new TGeoVolumeAssembly("RB26Pipe"); 
+  z0 = 0.;
+  asRB26Pipe->AddNode(asRB26s12,       1, new TGeoTranslation(0., 0., z0));
+  z0 +=  kRB26s12L;
+  asRB26Pipe->AddNode(asRB26s3,        1, new TGeoTranslation(0., 0., z0));
+  z0 +=  kRB26s3L;
+  asRB26Pipe->AddNode(asRB26s45,       1, new TGeoTranslation(0., 0., z0));
+  z0 +=  kRB26s45L;
+  top->AddNode(asRB26Pipe, 1, new TGeoCombiTrans(0., 0., -82., rot180));
 }
 
 
@@ -2818,21 +2825,21 @@ void AliPIPEv3::CreateMaterials()
   // Anticorodal 
   AliMixture(24, "ANTICORODAL1", aaco, zaco, 2.66, 3, waco);
   AliMixture(44, "ANTICORODAL2", aaco, zaco, 2.66, 3, waco);
-  
+
   //
   //     Insulation powder 
-   AliMixture(14, "INSULATION0$", ains, zins, 0.41, 4, wins);
-   AliMixture(34, "INSULATION1$", ains, zins, 0.41, 4, wins);
-   AliMixture(54, "INSULATION2$", ains, zins, 0.41, 4, wins);
+  AliMixture(14, "INSULATION0$", ains, zins, 0.41, 4, wins);
+  AliMixture(34, "INSULATION1$", ains, zins, 0.41, 4, wins);
+  AliMixture(54, "INSULATION2$", ains, zins, 0.41, 4, wins);
 
-   //    NEG
-   AliMixture(25, "NEG COATING1", aNEG, zNEG, dNEG, -3, wNEG);
-   AliMixture(45, "NEG COATING2", aNEG, zNEG, dNEG, -3, wNEG);
-   
-   
-   // **************** 
-   //     Defines tracking media parameters. 
-   //
+  //    NEG
+  AliMixture(25, "NEG COATING1", aNEG, zNEG, dNEG, -3, wNEG);
+  AliMixture(45, "NEG COATING2", aNEG, zNEG, dNEG, -3, wNEG);
+
+
+  // **************** 
+  //     Defines tracking media parameters. 
+  //
   Float_t epsil  = .001;    // Tracking precision, 
   Float_t stemax = -0.01;   // Maximum displacement for multiple scat 
   Float_t tmaxfd = -20.;    // Maximum angle due to field deflection 
@@ -2841,7 +2848,7 @@ void AliPIPEv3::CreateMaterials()
   // *************** 
   //
   //    Beryllium 
-  
+
   AliMedium(12, "BE1",       12, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
   AliMedium(32, "BE2",       32, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
 
@@ -2903,126 +2910,126 @@ void AliPIPEv3::CreateMaterials()
 
 TGeoPcon* AliPIPEv3::MakeMotherFromTemplate(const TGeoPcon* shape, Int_t imin, Int_t imax, Float_t r0, Int_t nz)
 {
-//
-//  Create a mother shape from a template setting some min radii to 0
-//
-    Int_t nz0 = shape->GetNz();
-    // if nz > -1 the number of planes is given by nz
-    if (nz != -1) nz0 = nz;
-    TGeoPcon* mother = new TGeoPcon(0., 360., nz0);
+  //
+  //  Create a mother shape from a template setting some min radii to 0
+  //
+  Int_t nz0 = shape->GetNz();
+  // if nz > -1 the number of planes is given by nz
+  if (nz != -1) nz0 = nz;
+  TGeoPcon* mother = new TGeoPcon(0., 360., nz0);
 
-    if (imin == -1 || imax == -1) {
-	imin = 0;
-	imax = shape->GetNz();
-    } else if (imax >= nz0) {
-	imax = nz0 - 1;
-	printf("Warning: imax reset to nz-1 %5d %5d %5d %5d\n", imin, imax, nz, nz0);
-    }
-    
+  if (imin == -1 || imax == -1) {
+    imin = 0;
+    imax = shape->GetNz();
+  } else if (imax >= nz0) {
+    imax = nz0 - 1;
+    printf("Warning: imax reset to nz-1 %5d %5d %5d %5d\n", imin, imax, nz, nz0);
+  }
 
-    
-    for (Int_t i = 0;  i < shape->GetNz(); i++) {
-	Double_t rmin = shape->GetRmin(i);
-	if ((i >= imin) && (i <= imax) ) rmin = r0;
-	Double_t rmax = shape->GetRmax(i);
-	Double_t    z = shape->GetZ(i);
-	mother->DefineSection(i, z, rmin, rmax);
-    }
-    return mother;
-    
+
+
+  for (Int_t i = 0;  i < shape->GetNz(); i++) {
+    Double_t rmin = shape->GetRmin(i);
+    if ((i >= imin) && (i <= imax) ) rmin = r0;
+    Double_t rmax = shape->GetRmax(i);
+    Double_t    z = shape->GetZ(i);
+    mother->DefineSection(i, z, rmin, rmax);
+  }
+  return mother;
+
 }
 
 TGeoPcon* AliPIPEv3::MakeInsulationFromTemplate(TGeoPcon* shape)
 {
-//
-//  Create an beam pipe insulation layer shape from a template
-//
-    Int_t nz = shape->GetNz();
-    TGeoPcon* insu = new TGeoPcon(0., 360., nz);
-    
-    for (Int_t i = 0;  i < nz; i++) {
-	Double_t    z = shape->GetZ(i);
-	Double_t rmin = shape->GetRmin(i);
-	Double_t rmax = shape->GetRmax(i);
-	rmax += 0.5;
-	shape->DefineSection(i, z, rmin, rmax);	
-	rmin  = rmax - 0.5;
-	insu->DefineSection(i, z, rmin, rmax);	
-    }
-    return insu;
-    
+  //
+  //  Create an beam pipe insulation layer shape from a template
+  //
+  Int_t nz = shape->GetNz();
+  TGeoPcon* insu = new TGeoPcon(0., 360., nz);
+
+  for (Int_t i = 0;  i < nz; i++) {
+    Double_t    z = shape->GetZ(i);
+    Double_t rmin = shape->GetRmin(i);
+    Double_t rmax = shape->GetRmax(i);
+    rmax += 0.5;
+    shape->DefineSection(i, z, rmin, rmax);	
+    rmin  = rmax - 0.5;
+    insu->DefineSection(i, z, rmin, rmax);	
+  }
+  return insu;
+
 }
 
 
 TGeoVolume* AliPIPEv3::MakeBellow(const char* ext, Int_t nc, Float_t rMin, Float_t rMax, Float_t dU, Float_t rPlie, Float_t dPlie)
 {
-    // nc     Number of convolution
-    // rMin   Inner radius of the bellow
-    // rMax   Outer radius of the bellow
-    // dU     Undulation length
-    // rPlie  Plie radius
-    // dPlie  Plie thickness
-    const TGeoMedium* kMedVac    =  gGeoManager->GetMedium("PIPE_VACUUM2");    
-    const TGeoMedium* kMedSteel  =  gGeoManager->GetMedium("PIPE_INOX2");   
+  // nc     Number of convolution
+  // rMin   Inner radius of the bellow
+  // rMax   Outer radius of the bellow
+  // dU     Undulation length
+  // rPlie  Plie radius
+  // dPlie  Plie thickness
+  const TGeoMedium* kMedVac    =  gGeoManager->GetMedium("PIPE_VACUUM2");    
+  const TGeoMedium* kMedSteel  =  gGeoManager->GetMedium("PIPE_INOX2");   
 
-    char name[64], nameA[64], nameB[64], bools[64];
-    snprintf(name, 64, "%sBellowUS", ext);
-    TGeoVolume* voBellow = new TGeoVolume(name, new TGeoTube(rMin, rMax, dU/2.), kMedVac);
-//      
-//  Upper part of the undulation
-//
-    TGeoTorus* shPlieTorusU  =  new TGeoTorus(rMax - rPlie, rPlie - dPlie, rPlie);
-    snprintf(nameA, 64, "%sTorusU", ext);
-    shPlieTorusU->SetName(nameA);
-    TGeoTube*  shPlieTubeU   =  new TGeoTube (rMax - rPlie, rMax, rPlie);
-    snprintf(nameB, 64, "%sTubeU", ext);
-    shPlieTubeU->SetName(nameB);
-    snprintf(name,  64, "%sUpperPlie", ext);
-    snprintf(bools, 64, "%s*%s", nameA, nameB);
-    TGeoCompositeShape*  shUpperPlie = new TGeoCompositeShape(name, bools);
-    
-    TGeoVolume* voWiggleU = new TGeoVolume(name, shUpperPlie, kMedSteel);
-//
-// Lower part of the undulation
-    TGeoTorus* shPlieTorusL =  new TGeoTorus(rMin + rPlie, rPlie - dPlie, rPlie);
-    snprintf(nameA, 64, "%sTorusL", ext);
-    shPlieTorusL->SetName(nameA);
-    TGeoTube*  shPlieTubeL  =  new TGeoTube (rMin, rMin + rPlie, rPlie);
-    snprintf(nameB, 64, "%sTubeL", ext);
-    shPlieTubeL->SetName(nameB);
-    snprintf(name,  64, "%sLowerPlie", ext);
-    snprintf(bools, 64, "%s*%s", nameA, nameB);
-    TGeoCompositeShape*  shLowerPlie = new TGeoCompositeShape(name, bools);
-    
-    TGeoVolume* voWiggleL = new TGeoVolume(name, shLowerPlie, kMedSteel); 
-    
-//
-// Connection between upper and lower part of undulation
-    snprintf(name, 64, "%sPlieConn1", ext);
-    TGeoVolume* voWiggleC1 = new TGeoVolume(name, new TGeoTube(rMin + rPlie, rMax - rPlie, dPlie/2.), kMedSteel);
-//
-// One wiggle
-    Float_t dz = rPlie -  dPlie / 2.;
-    Float_t z0 = -  dPlie / 2.;
-    snprintf(name, 64, "%sWiggle", ext);
-    TGeoVolumeAssembly* asWiggle = new TGeoVolumeAssembly(name);
-    asWiggle->AddNode(voWiggleC1,  1 , new TGeoTranslation(0., 0., z0));
-    z0 += dz;
-    asWiggle->AddNode(voWiggleU,   1 , new TGeoTranslation(0., 0., z0));
-    z0 += dz;
-    asWiggle->AddNode(voWiggleC1,  2 , new TGeoTranslation(0., 0., z0));
-    z0 += dz;
-    asWiggle->AddNode(voWiggleL ,  1 , new TGeoTranslation(0., 0., z0));
-// Positioning of the volumes
-    z0   = - dU / 2.+ rPlie;
-    voBellow->AddNode(voWiggleL, 2, new TGeoTranslation(0., 0., z0));
-    z0  +=  rPlie;
-    Float_t zsh  = 4. *  rPlie -  2. * dPlie;
-    for (Int_t iw = 0; iw < nc; iw++) {
-	Float_t zpos =  z0 + iw * zsh;	
-	voBellow->AddNode(asWiggle,  iw + 1, new TGeoTranslation(0., 0., zpos - dPlie));	
-    }
-    return voBellow;
+  char name[64], nameA[64], nameB[64], bools[64];
+  snprintf(name, 64, "%sBellowUS", ext);
+  TGeoVolume* voBellow = new TGeoVolume(name, new TGeoTube(rMin, rMax, dU/2.), kMedVac);
+  //      
+  //  Upper part of the undulation
+  //
+  TGeoTorus* shPlieTorusU  =  new TGeoTorus(rMax - rPlie, rPlie - dPlie, rPlie);
+  snprintf(nameA, 64, "%sTorusU", ext);
+  shPlieTorusU->SetName(nameA);
+  TGeoTube*  shPlieTubeU   =  new TGeoTube (rMax - rPlie, rMax, rPlie);
+  snprintf(nameB, 64, "%sTubeU", ext);
+  shPlieTubeU->SetName(nameB);
+  snprintf(name,  64, "%sUpperPlie", ext);
+  snprintf(bools, 64, "%s*%s", nameA, nameB);
+  TGeoCompositeShape*  shUpperPlie = new TGeoCompositeShape(name, bools);
+
+  TGeoVolume* voWiggleU = new TGeoVolume(name, shUpperPlie, kMedSteel);
+  //
+  // Lower part of the undulation
+  TGeoTorus* shPlieTorusL =  new TGeoTorus(rMin + rPlie, rPlie - dPlie, rPlie);
+  snprintf(nameA, 64, "%sTorusL", ext);
+  shPlieTorusL->SetName(nameA);
+  TGeoTube*  shPlieTubeL  =  new TGeoTube (rMin, rMin + rPlie, rPlie);
+  snprintf(nameB, 64, "%sTubeL", ext);
+  shPlieTubeL->SetName(nameB);
+  snprintf(name,  64, "%sLowerPlie", ext);
+  snprintf(bools, 64, "%s*%s", nameA, nameB);
+  TGeoCompositeShape*  shLowerPlie = new TGeoCompositeShape(name, bools);
+
+  TGeoVolume* voWiggleL = new TGeoVolume(name, shLowerPlie, kMedSteel); 
+
+  //
+  // Connection between upper and lower part of undulation
+  snprintf(name, 64, "%sPlieConn1", ext);
+  TGeoVolume* voWiggleC1 = new TGeoVolume(name, new TGeoTube(rMin + rPlie, rMax - rPlie, dPlie/2.), kMedSteel);
+  //
+  // One wiggle
+  Float_t dz = rPlie -  dPlie / 2.;
+  Float_t z0 = -  dPlie / 2.;
+  snprintf(name, 64, "%sWiggle", ext);
+  TGeoVolumeAssembly* asWiggle = new TGeoVolumeAssembly(name);
+  asWiggle->AddNode(voWiggleC1,  1 , new TGeoTranslation(0., 0., z0));
+  z0 += dz;
+  asWiggle->AddNode(voWiggleU,   1 , new TGeoTranslation(0., 0., z0));
+  z0 += dz;
+  asWiggle->AddNode(voWiggleC1,  2 , new TGeoTranslation(0., 0., z0));
+  z0 += dz;
+  asWiggle->AddNode(voWiggleL ,  1 , new TGeoTranslation(0., 0., z0));
+  // Positioning of the volumes
+  z0   = - dU / 2.+ rPlie;
+  voBellow->AddNode(voWiggleL, 2, new TGeoTranslation(0., 0., z0));
+  z0  +=  rPlie;
+  Float_t zsh  = 4. *  rPlie -  2. * dPlie;
+  for (Int_t iw = 0; iw < nc; iw++) {
+    Float_t zpos =  z0 + iw * zsh;	
+    voBellow->AddNode(asWiggle,  iw + 1, new TGeoTranslation(0., 0., zpos - dPlie));	
+  }
+  return voBellow;
 }
 
 //_______________________________________________________________________
@@ -3040,16 +3047,112 @@ void AliPIPEv3::AddAlignableVolumes() const
   TString volpath("/ALIC_1/CP_1/Cp1_1");
   if(!gGeoManager->SetAlignableEntry(symname.Data(),volpath.Data()))
     AliFatal(Form("Alignable entry %s not created. Volume path %s not valid",
-		  symname.Data(),volpath.Data()));
+          symname.Data(),volpath.Data()));
 
   TString symname2("CP3");
   TString volpath2("/ALIC_1/CP_1/Cp3_1");
   if(!gGeoManager->SetAlignableEntry(symname2.Data(),volpath2.Data()))
     AliFatal(Form("Alignable entry %s not created. Volume path %s not valid",
-		  symname2.Data(),volpath2.Data()));
+          symname2.Data(),volpath2.Data()));
 }
 
+//_______________________________________________________________________
+TGeoVolume * AliPIPEv3::CreatePipeOvalyzed(const TGeoMedium * mat)
+{
+  TGeoVolumeAssembly * voPipeOvalyzed = new TGeoVolumeAssembly("voRB242Pipe");
+  TGeoRotation * Ry180;
+  Ry180 = new TGeoRotation("Ry180", 180., 180.,   0.) ; 
+
+  // Create Central Part
+
+  // TODO: ***OVERLAP***
+  // const Double_t dx        =   6.75/2.0; // <-- According to https://edms.cern.ch/ui/file/909866/0/lhcvc2u_0036-v0.pdf
+  const Double_t ax        =   6.00/2.0; // According to LHCVC2U_0008 ( there is a 0.75 cm discrepancy)
+  const Double_t by        =   9.50/2.0;
+  const Double_t dL        = 270.00/2.0;
+  const Double_t thickness =   0.20/1.0;
+  TGeoMedium* vac     =  gGeoManager->GetMedium("PIPE_VACUUM1");    
+
+  TGeoEltu * shPipeOvalyzedOuter = new TGeoEltu("shPipeOvalyzedOuter" , ax           , by           , dL          ); 
+  TGeoEltu * shPipeOvalyzedInner = new TGeoEltu("shPipeOvalyzedInner" , ax-thickness , by-thickness , dL+thickness); 
+  TGeoEltu * shPipeOvalyzedVac   = new TGeoEltu("shPipeOvalyzedVac"   , ax-thickness , by-thickness , dL          ); 
+  TGeoCompositeShape * shPipeOvalyzedCentral = new TGeoCompositeShape("shPipeOvalyzedCentral", "shPipeOvalyzedOuter-shPipeOvalyzedInner");
+  TGeoVolume * voPipeOvalyzedCentral    = new TGeoVolume("voPipeOvalyzedCentral"   , shPipeOvalyzedCentral, mat);
+  TGeoVolume * voPipeOvalyzedCentralVac = new TGeoVolume("voPipeOvalyzedCentralVac", shPipeOvalyzedVac    , vac);
+
+  // Create Transition Elliptic->Circular: 
 
 
+  // Formula: y(z) = a + (r-a)*(z/L)
+  TGeoVolumeAssembly * voPipeTransition = new TGeoVolumeAssembly("voPipeTransition");
 
+  const Double_t       Fdz =                   2.0/1.0 ;  // z-lenght of the Beam-Pipe Flange
+  const Double_t        FR =                  15.2/2.0 ;  // Outher Radius of Beam-Pipe Flange
+  const Double_t         R =                   8.4/2.0 ;  // Outher Radius of Beam-Pipe
+  const Double_t         L =                  20.0/1.0 ;  // length of elliptical -> circular transition in cm
+  const Int_t      nslices =                 100       ; 
+  const Double_t        dz = L / Double_t(nslices)     ; 
+  const Double_t         a = ax;
+  const Double_t         b = by;
+
+  for (Int_t iplane=0; iplane<nslices; iplane++) 
+  {
+    Double_t zslice = dz * Double_t(iplane);
+
+    Double_t y = b + (R-b)*(zslice/L);
+    Double_t x = a + (R-a)*(zslice/L);
+    voPipeTransition->AddNode(MakeEllipticalSlice(x, y, dz, thickness, iplane, mat), 1, new TGeoTranslation(0., 0., zslice+dz/2.0));
+  }
+
+  // Make PIPE Ends
+  new TGeoTube("shEndTube"  , R-thickness,  R,   L/2.0);
+  new TGeoTube("shEndFlange", R-thickness, FR, Fdz/2.0);
+  (new TGeoTranslation("trEndF", 0., 0., L/2.0-Fdz/2.0))->RegisterYourself();
+
+  TGeoVolume * voRB242PipeEnd = new TGeoVolume("voRB242PipeEnd", new TGeoCompositeShape("shRB242PipeEnd", "shEndTube+shEndFlange:trEndF"), mat);
+  voRB242PipeEnd -> SetLineColor(kSpring-8);
+
+  TGeoVolume * voRB242PipeEndVac = gGeoManager->MakeTube("voRB242PipeEndVac", vac, 0.0,  R-thickness,   L/2.0);
+
+  voPipeOvalyzedCentral    -> SetLineColor(kSpring+5);
+  voPipeOvalyzedCentralVac -> SetLineColor(kCyan-10);
+  voRB242PipeEndVac        -> SetLineColor(kCyan-10);
+  // voPipeOvalyzedCentralVac -> SetTransparency(16);
+
+  voPipeOvalyzed->AddNode(voPipeOvalyzedCentral    , 1 , new TGeoTranslation(0. , 0. ,   0.                   )); 
+  voPipeOvalyzed->AddNode(voPipeOvalyzedCentralVac , 1 , new TGeoTranslation(0. , 0. ,   0.                   )); 
+  voPipeOvalyzed->AddNode(voPipeTransition         , 1 , new TGeoTranslation(0. , 0. ,   dL                   )); 
+  voPipeOvalyzed->AddNode(voPipeTransition         , 2 , new TGeoCombiTrans (0. , 0. , -(dL )         , Ry180 )); 
+  voPipeOvalyzed->AddNode(voRB242PipeEnd           , 1 , new TGeoTranslation(0. , 0. , + dL + (1.5*L)         )); 
+  voPipeOvalyzed->AddNode(voRB242PipeEnd           , 2 , new TGeoCombiTrans (0. , 0. , - dL - (1.5*L) , Ry180 )); 
+  voPipeOvalyzed->AddNode(voRB242PipeEndVac        , 1 , new TGeoTranslation(0. , 0. , + dL + (1.5*L)         )); 
+  voPipeOvalyzed->AddNode(voRB242PipeEndVac        , 2 , new TGeoCombiTrans (0. , 0. , - dL - (1.5*L) , Ry180 )); 
+  return (TGeoVolume*) voPipeOvalyzed;
+}
+
+//_______________________________________________________________________
+TGeoVolume * AliPIPEv3::MakeEllipticalSlice(Double_t x, Double_t y, Double_t dz, Double_t thk, Int_t iplane, const TGeoMedium * mat)
+{
+  const TGeoMedium* vac     =  gGeoManager->GetMedium("PIPE_VACUUM1");    
+  TString siplane   = TString::Format("%03d", iplane);
+  TString volname   = "voTubeSliceElliptical_"; volname   += siplane;
+  TString shapename = "shTubeSliceElliptical_"; shapename += siplane;
+  TString shapestr  = TString::Format("shTubeSliceEltuO_%s-shTubeSliceEltuI_%s", siplane.Data(), siplane.Data()); 
+
+  TGeoEltu * shTubeSliceOuter = new TGeoEltu(Form("shTubeSliceEltuO_%s" , siplane.Data()) , x     , y     , dz/2.);
+  TGeoEltu * shTubeSliceInner = new TGeoEltu(Form("shTubeSliceEltuI_%s" , siplane.Data()) , x-thk , y-thk , dz/1.);
+  TGeoEltu * shTubeSliceVac   = new TGeoEltu(Form("shTubeSliceEltuV_%s" , siplane.Data()) , x-thk , y-thk , dz/2.);
+
+  TGeoCompositeShape * shTubeSlice = new TGeoCompositeShape(shapename.Data() , shapestr.Data());
+  TGeoVolume * volmat = new TGeoVolume((volname+ "_mat").Data() , shTubeSlice      , mat ); 
+  TGeoVolume * volvac = new TGeoVolume((volname+ "_vac").Data() , shTubeSliceVac   , vac ); 
+
+  volmat -> SetLineColor(kViolet+1+(iplane%2));
+  volvac -> SetLineColor(kCyan-10);
+
+  TGeoVolumeAssembly * vol = new TGeoVolumeAssembly(volname.Data());
+  vol->AddNode(volmat, 1);
+  vol->AddNode(volvac, 1);
+  return (TGeoVolume*) vol;
+}
 

--- a/STRUCT/AliPIPEv3.h
+++ b/STRUCT/AliPIPEv3.h
@@ -16,6 +16,9 @@
 #include "AliPIPE.h"
 class TGeoPcon;
 class TGeoVolume;
+class TGeoMedium; 
+class TGeoVolumeAssembly; 
+class TGeoRotation; 
 
 
 class AliPIPEv3 : public AliPIPE {
@@ -34,12 +37,16 @@ class AliPIPEv3 : public AliPIPE {
   virtual void   AddAlignableVolumes() const;
 	  
  private:
+  // ECV 
+  // TGeoRotation * Ry180;
+  virtual TGeoVolume * CreatePipeOvalyzed(const TGeoMedium * mat);
+  virtual TGeoVolume * MakeEllipticalSlice(Double_t x, Double_t y, Double_t dz, Double_t thk, Int_t iplane, const TGeoMedium * mat);
   virtual TGeoPcon*   MakeMotherFromTemplate(const TGeoPcon* shape, Int_t imin = -1, Int_t imax = -1, Float_t r0 = 0., Int_t nz =-1);
   virtual TGeoPcon*   MakeInsulationFromTemplate(TGeoPcon* shape);
   virtual TGeoVolume* MakeBellow(const char* ext, Int_t nc, Float_t rMin, Float_t rMax, Float_t dU, Float_t rPlie, Float_t dPlie);
   Bool_t  fBeamBackground; // Flag for beam background simulations
   
-  ClassDef(AliPIPEv3, 2)  //Class for PIPE version using TGeo
+  ClassDef(AliPIPEv3, 3)  //Class for PIPE version using TGeo
 };
  
 #endif


### PR DESCRIPTION
 * Corrected Dipole geometry for ADA (2017)
 * Ovalized Beam Pipe (RB242) inside Dipole
 * A-Side: Shielding for PM's, I-Beam and other beam-pipe supports, OldAD, BLM's, support for Warm Module
 * C-Side: Grid of U-Profiles near the wall that separates CAVERN from LHC tunnel

supercedes #234.