### PR TITLE
ATO-402- Add: class AliElasticSearchRoot 

### DIFF
--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -28,7 +28,7 @@
 ///    * performance reports -  with styles as a parameter
 ///    * QA reports
 ///    * AliTreePlayer, and TStatToolkit
-/// \author marian  Ivanov marian.ivanov@cen.ch
+/// \author marian  Ivanov marian.ivanov@cern.ch
 ///
 ///  ## Example usage
 ///

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -18,7 +18,7 @@
 ///    * performance reports -  with styles as a parameter
 ///    * QA reports
 ///    * AliTreePlayer, and TStatToolkit
-/// \author marian  Ivanov marian.ivanov@cen.ch
+/// \author marian  Ivanov marian.ivanov@cern.ch
 
 
 #include "TObject.h"

--- a/STAT/AliElasticSearchRoot.cxx
+++ b/STAT/AliElasticSearchRoot.cxx
@@ -1,0 +1,296 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: The ALICE Off-line Project.                                    *
+ * Contributors are mentioned in the code where appropriate.              *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+/// ### Example usage (expecting acces to Elastic server with alice indexes)
+///  - see also $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.c
+///  - to create indeces needed $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.c:testExportBinary() can be used
+/// \code
+///  hostName="localhost:9200";            // local elastic
+///  // or remote ElastichostName="https://localhost:9206";    //  connect to remote via tunnel e.g ssh mivanov@lxplus.cern.ch -f -N -L 9206:es-alice.cern.ch:9203
+///  //
+///  AliElasticSearchRoot elastic(hostName,kFALSE,1);
+///  elastic.SetCertificate();           // default certification="--insecure --cacert CERNRootCertificationAuthority2.crt --netrc-file $HOME/.globus/.elastic/.netrc"
+///  elastic.ls();                       // list all indeces
+///  elastic.ls("alice");                // list incdeces containing alice
+///  elastic.ls(".alice_mc");             // list indeces containing alice_mc
+///  elastic.Print();
+///  // GetIndexLayeout
+///  elastic.GetIndexLayout("/alice/logbook_test0/")->Print();
+///  elastic.GetIndexLayout("/alice_mc/passguess/")->Print();
+///  // make a Tree like query
+///  TString select="";
+///  select=  elastic.select("/alice/qatpc_test0/","run:meanMIP:meanTPCncl","run>240000&&run<246844&&meanMIP>50",0,1000,"jqEQueryStat,jqEQueryHeader")
+///  select=  elastic.select("/alice/logbook_test0/","run:totalSubEvents:ctpDuration","run>140000",0,10000,"jqEQueryStat,jqEQueryHeader")
+///  select=  elastic.select("/alice_mc/passguess/","*","1",0,1000,"jqEQueryStat,jqEQueryHeader,jqEQueryArrayNamed");  // get list of all runs output in query.json
+///  //
+///  select=  elastic.select("/alice/qatpc_test0/","*","run>240000&&run<246844&&meanMIP>50",0,1000,0)
+///
+/// To do  - json- formatted cvs conversion to enable root like queries
+/// \endcode
+/// \author marian  Ivanov marian.ivanov@cern.ch
+
+#include <iostream>
+#include "TSystem.h"
+#include "TString.h"
+#include "TError.h"
+#include "TObjArray.h"
+#include "TObjString.h"
+#include "AliElasticSearchRoot.h"
+
+/// jg filters
+std::map<std::string,std::string> AliElasticSearchRoot::fJQFilters;
+
+/// default constructor
+AliElasticSearchRoot::AliElasticSearchRoot():
+        TObject(),
+        fNode(""),
+        fReadOnly(0),
+        fVerbose(15),
+        fCertificate("")
+{
+}
+
+/// named cosntructor
+/// \param node           - node description
+/// \param readOnly       - not used yet
+/// \param verbose        - verbosity
+/// \param certification  - certification argument - will be prepended to  in curl queries
+AliElasticSearchRoot::AliElasticSearchRoot(const std::string node, bool readOnly, Int_t verbose, std::string certification){
+  //
+  //
+  fNode=node;
+  fReadOnly=readOnly;
+  fVerbose=verbose;
+  fCertificate=certification;
+    AliElasticSearchRoot::RegisterDefaultJQFilters();
+}
+
+/// print JQ filters selected by regular expression
+void AliElasticSearchRoot::PrintJQFilters(TPRegexp reg) {
+    typedef std::map<std::string,std::string>::const_iterator it_type;
+    for(it_type iterator = fJQFilters.begin(); iterator != fJQFilters.end(); ++iterator) {
+      if (reg.Match(iterator->first)==0) continue;
+      std::cout << iterator->first << " " << iterator->second << "\n";
+    }
+    return;
+}
+
+/// Register default JQ filters - jq is like sed for JSON data
+/// See jq filters:  https://stedolan.github.io/jq/
+/// Example usage
+/// \code
+/// // Example usage of filters
+/// index="alice_mc", type="passguess"
+/// query=TString::Format("curl -s -XGET 'localhost:9200/%s/%s/_mapping' | %s",index,type,  TString::Format(AliElasticSearchRoot::fJQFilters["jqELayoutType"].data(),index,type,"text").Data());
+/// result=gSystem->GetFromPipe(query);
+/// \endcode
+void AliElasticSearchRoot::RegisterDefaultJQFilters(){
+    fJQFilters["jqELayoutJSON"] ="jq '.%s.mappings.%s.properties'"; // colored  filter to process elastic layout
+    fJQFilters["jqELayoutType"] ="jq '.%s.mappings.%s.properties |. as $in| keys[]  | select($in[.].type==\"%s\")'"; // colored  filter to process elastic layout
+    fJQFilters["jqELayoutTable"]="jq '.%s.mappings.%s.properties | keys[] as $k | \"\\\($k), \\\(.[$k] |.type)\"'";
+    // Query filters
+    fJQFilters["jqEQueryStat"]="jq '. | {hits_total:.hits.total, hits_max_score:.hits.max_score, _shards, timed_out, took}'";  // query stats  - extract stat
+    fJQFilters["jqEQueryHeader"]="jq  -r '.hits|.hits|[.[]._source]|(map(keys) | add | unique) as $cols| $cols'";              // query layout - return array of variables
+    fJQFilters["jqEQueryArrayNamed"]="jq  -r '.hits|.hits|[.[]._source][]'";            // query layout - return array of variables
+    fJQFilters["jqEQueryArrayFlat"]="jq  -r '.hits|.hits|[.[]._source][][]'";           // query layout - return array of variables flat
+}
+
+void AliElasticSearchRoot::SetCertificate(std::string certification){
+  fCertificate=certification;
+}
+
+///
+/// \param option  - not used
+void AliElasticSearchRoot::Print(Option_t* /*option*/) const{
+  ::Info("AliElasticSearch::Print","Host:%s\tCertificate:%s\tReadOnly:%d",fNode.data(),fCertificate.data(),fReadOnly);
+}
+
+/// Bulk export to Elastic server
+/// \param indexName    - index to export
+/// \param jsonFile     - input bulk json file (e.g create by AliTreePlayer::select ...)
+/// \return
+Int_t AliElasticSearchRoot::ExportBinary(std::string indexName, std::string jsonFile, std::string /*option*/){
+  //
+  //
+  //
+  TString query=TString::Format("curl  -s  %s -XPOST '%s%s_bulk?pretty' --data-binary \"@%s\"",fCertificate.data(), fNode.data(),indexName.data(),jsonFile.data());
+  if (fVerbose>0){
+    ::Info("AliElasticSearchRoot:ExportBinary","%s%s %s",fNode.data(),indexName.data(),jsonFile.data());
+  }
+  ::Info("AliElasticSearchRoot:ExportBinary","%s",query.Data());
+  return (gSystem->GetFromPipe(query.Data())).Length();
+}
+
+/// List indices in the Elastic server
+void AliElasticSearchRoot::ls(Option_t *option) const {
+  //
+  // make indices list on server
+  TString query=TString::Format("curl -s %s %s/_cat/indices?v | grep \"%s\"",fCertificate.data(), fNode.data(),option);
+  if (fVerbose>0){
+    ::Info("AliElasticSearchRoot::ls","%s",query.Data());
+  }
+  TString returnValue = gSystem->Exec(query.Data());
+  ::Info("AliElasticSearchRoot::ls","%s",fNode.data());
+  printf("%s\n",returnValue.Data());
+}
+
+/// GetIndexLayout projections for given data types
+///  \param index     - elastic index name
+///  \param type      - elastic index type
+///  \param dataType  - data types to print - in case of NULL pointer print all
+///  \param toScreen  - in case specified use nice printing to stdout (default only export to TString)
+TString  AliElasticSearchRoot::GetIndexLayout(const char *index, const char *type, const char *dataType, Bool_t toScreen){
+    TString query="";
+    if (dataType){
+        query=TString::Format("curl -s %s -XGET '%s/%s/%s/_mapping' | %s", fCertificate.data(), fNode.data(), index,type,  TString::Format(AliElasticSearchRoot::fJQFilters["jqELayoutType"].data(),index,type,dataType).Data());
+    }else{
+        query=TString::Format("curl -s %s -XGET '%s/%s/%s/_mapping' | %s", fCertificate.data(), fNode.data(), index,type,  TString::Format(AliElasticSearchRoot::fJQFilters["jqELayoutTable"].data(),index,type).Data());
+    }
+    if (fVerbose>0) {
+        ::Info("AliElasticSearchRoot::GetIndexLayout()","%s",query.Data());
+    }
+    if (toScreen){
+        gSystem->Exec(query);
+    }
+    return gSystem->GetFromPipe(query);
+}
+/// GetIndexLayeout - assuming flat structure (to be replace by jq implementation soon)
+/// \param indexName  - old version
+/// \return           - array of parameters
+TObjArray *  AliElasticSearchRoot::GetIndexLayout(const char *indexName){
+  //
+  // simplified version of parser - working only for flat structure
+  //
+  TString query=TString::Format("curl -s -XGET '%s%s_mapping'",fNode.data(),indexName);
+  if (fVerbose>0){
+    ::Info("AliElasticSearchRoot::GetIndexLayout","%s",query.Data());
+  }
+  TString mapping  = gSystem->GetFromPipe(query.Data());
+  //
+  TObjArray * mappingArray = mapping.Tokenize("{},:\"");  
+  Int_t nDesc=mappingArray->GetEntries();
+  TObjArray *layoutArray = new TObjArray(nDesc/3);
+  Int_t nFields=0;
+  for (Int_t iEntry=0; iEntry<nDesc-1; iEntry++){
+    if (TString(mappingArray->At(iEntry)->GetName()).EqualTo("type")){
+      layoutArray->AddLast(new TNamed(mappingArray->At(iEntry-1)->GetName(), mappingArray->At(iEntry+1)->GetName()));
+      iEntry+=1;
+    }
+  }
+  return layoutArray;
+}
+
+
+/// select query  with similar interace to the TTree::Draw query
+///   more options to be added soon -> Elastic json-> TTree,   GetVal())
+/// \param indexName
+/// \param fields          - fields to export  "*" select all fields
+/// \param query           - elastic query in format as in TTree - internaly converted to painless script
+/// \param first           - first entry to select
+/// \param size            -
+/// \param filterArray     - in verbose mode - provide list of jq filters
+/// \return                - result of query is written to temporary query.json file
+/// Example queries : see $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.c:testSelect()
+
+///\code
+///   select=  pelastic->select("/alice/qatpc_test0/","*","run>240000&&run<246844&&meanMIP>50",0,1000,"jqEQueryStat,jqEQueryHeader");
+///    select=  pelastic->select("/alice/qatpc_test0/","*","run>240000&&run<246844&&meanMIP>50",0,1000,"jqEQueryArrayNamed,jqEQueryStat,jqEQueryHeader");
+///\endcode
+
+ TString AliElasticSearchRoot::select(const char *indexName, TString fields, TString query, Int_t first, Int_t size, TString filterArray){
+  //
+  /*
+    const char *indexName="/alice/logbook_test0/"
+    TString fields="run:totalSubEvents";
+    TString query="run>240000&&run<246844"
+    verbose=7;
+    first=0; size=1000;
+  */
+  
+  AliElasticSearchRoot * el=this;                     //AliElasticSearchRoot * el=&elastic
+  TObjArray * layout = el->GetIndexLayout(indexName);
+  TString where=query;
+  TObjArray *queryFields=where.Tokenize("><&|+=()! ");
+  if (fVerbose&0x2) queryFields->Print();
+  //
+  {
+    Int_t currentIndex=-1;
+    for (Int_t ifield=0; ifield<queryFields->GetEntriesFast(); ifield++){
+      currentIndex= where.Index(queryFields->At(ifield)->GetName(),currentIndex);
+      //printf("%d\t%s\n",currentIndex, queryFields->At(ifield)->GetName());
+      TObjString * field=(TObjString*)layout->FindObject(queryFields->At(ifield)->GetName());
+      if (field!=NULL){
+        if (fVerbose&0x1){
+            printf("%d\t%s\t%s\n",ifield,field->GetName(), where.Data());
+        }
+        TString insertString=TString::Format("doc[\\u0027%s\\u0027].value",field->GetName()).Data();
+        where.Replace(currentIndex,field->String().Length(),"");
+        where.Insert(currentIndex,insertString);
+      }
+    } 
+  }
+  //
+  where=TString::Format("\"query\":\n{\"bool\":{\n\"must\":{\n\"script\":{\n\"script\":{\n\"inline\": \"%s\",\n\"lang\":\"painless\"\n}\n}\n}\n}\n}",where.Data());
+  //where=TString::Format("\"query\":\n{\"bool\":{\n\"must\":{\n\"script\":{\n\"script\":{\n\"inline\": \"%s\",\n\"lang\":\"groovy\"\n}\n}\n}\n}\n}",where.Data());
+  if (fVerbose&0x4) printf("%s\n",where.Data());
+  //
+  TObjArray *fieldsArray = fields.Tokenize(":|");
+  TString what =TString::Format("\"_source\" :[");
+  for (Int_t iField=0; iField<fieldsArray->GetEntriesFast(); iField++){
+    what+="\"";
+    what+=fieldsArray->At(iField)->GetName();
+    if (iField<fieldsArray->GetEntriesFast()-1)  {
+      what+="\",";
+    }else{
+      what+="\"]";
+    }
+  }
+  TString elQuery="";
+  {
+    elQuery=TString::Format("curl -s -XPOST \"%s%s_search?pretty\" -d\'\n{",el->fNode.data(), indexName);
+    elQuery+=TString::Format("\"from\": %d,\n",first);
+    elQuery+=TString::Format("\"size\": %d,\n",size);
+    elQuery+=what;
+    elQuery+=",\n";
+    elQuery+=where;
+    elQuery+="\n}\n'>query.json\n";
+  }
+  if ((fVerbose&0x1)>0)  ::Info("selectFromWhere\n","%s",elQuery.Data());
+  TString result= gSystem->GetFromPipe(elQuery.Data());
+    if (filterArray.Length()>0) {
+        TObjArray * fArray = filterArray.Tokenize(",");
+        Int_t fentries = fArray->GetEntries();
+        for (Int_t ientry=0; ientry<fentries; ientry++){
+            std::string filter=fJQFilters[fArray->At(ientry)->GetName()];
+            if (filter.size()>0) {
+                gSystem->Exec(TString::Format("cat query.json | %s", filter.data()).Data());
+            }else{
+
+            }
+        }
+    }
+
+  return result;
+  
+}
+
+
+/*
+void jsontocsv(){
+  //
+  https://csvkit.readthedocs.io/en/0.9.1/install.html
+  sudo apt-get install jq
+}
+*/

--- a/STAT/AliElasticSearchRoot.h
+++ b/STAT/AliElasticSearchRoot.h
@@ -1,0 +1,71 @@
+#ifndef ALIELASTICSEARCHROOT_H
+#define ALIELASTICSEARCHROOT__H
+
+/// \ingroup STAT
+/// \class AliElasticSearchRoot
+/// \brief AliDrawStyle - AliElasticSearchRoot - C++ interace to the Elastic --> root tree like-   using gSystem->GetFromPipe, Exec, Elastic, painlsees scripting,  curl,  jq
+///      - Originally planned usage of  higher level C++ inteface not possible for a moment
+///      -- C++11 or better C++14 and ROOT6 needed (e.g https://github.com/QHedgeTech/cpp-elasticsearch/tree/master/src )
+///      - Using older  C++  and Root 5 to represent heirarchiacal structure root trees to be used
+///      - Query language similar to TTree::Draw  - suing elastic painless scriptin langaug (see query expamples)
+/// ### Example usage (expecting acces to Elastic server with alice indexes)
+///  - see also $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.c
+///  - to create indeces needed $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.c:testExportBinary() can be used
+/// \code
+///  hostName="localhost:9200";            // local elastic
+///   // or remote ElastichostName="https://localhost:9206";    //  connect to remote via tunnel e.g ssh mivanov@lxplus.cern.ch -f -N -L 9206:es-alice.cern.ch:9203
+///  //
+///  AliElasticSearchRoot elastic(hostName,kFALSE,1);
+///  elastic.SetCertificate();           // default certification="--insecure --cacert CERNRootCertificationAuthority2.crt --netrc-file $HOME/.globus/.elastic/.netrc"
+///  elastic.ls();                       // list all indeces
+///  elastic.ls("alice");                // list incdeces containing alice
+///  elastic.ls(".alice_mc");             // list indeces containing alice_mc
+///  elastic.Print();
+///  // GetIndexLayeout
+///  elastic.GetIndexLayout("/alice/logbook_test0/")->Print();
+///  elastic.GetIndexLayout("/alice_mc/passguess/")->Print();
+///  // make a Tree like query
+///  TString select="";
+///  select=  elastic.select("/alice/qatpc_test0/","run:meanMIP:meanTPCncl","run>240000&&run<246844&&meanMIP>50",0,1000,"jqEQueryStat,jqEQueryHeader")
+///  select=  elastic.select("/alice/logbook_test0/","run:totalSubEvents:ctpDuration","run>140000",0,10000,"jqEQueryStat,jqEQueryHeader")
+///  select=  elastic.select("/alice_mc/passguess/","*","1",0,1000,"jqEQueryStat,jqEQueryHeader,jqEQueryArrayNamed");  // get list of all runs output in query.json
+///  //
+///  select=  elastic.select("/alice/qatpc_test0/","*","run>240000&&run<246844&&meanMIP>50",0,1000,0)
+///
+/// To do  - json- formatted cvs conversion to enable root like queries
+/// \endcode
+/// \author marian  Ivanov marian.ivanov@cern.ch
+
+#include "TObject.h"
+#include <map>
+#include <string>
+#include "TPRegexp.h"
+
+
+class AliElasticSearchRoot : public TObject{
+
+public:
+    AliElasticSearchRoot();
+    AliElasticSearchRoot(const std::string node, bool readOnly, Int_t fVerbose, std::string certification="");
+    void SetCertificate(std::string certification="--cacert $HOME/.globus/CERNGridCertificationAuthority.crt --netrc-file $HOME/.globus/.elastic/.netrc");
+    void Print(Option_t* option = "") const;
+    virtual void ls(Option_t *option="") const;
+    // queries
+    Int_t        ExportBinary(std::string indexName, std::string jsonFile, std::string option);
+    TObjArray *  GetIndexLayout(const char *indexName);
+    TString      GetIndexLayout(const char *index, const char *type, const char *dataType, Bool_t display=kFALSE);
+    TString select(const char *indexName, TString fields, TString query, Int_t first, Int_t size, TString filterArray="");
+    // JQ filters
+    static void RegisterDefaultJQFilters();
+    static void PrintJQFilters(TPRegexp reg);
+public:
+    std::string fNode;
+    Bool_t  fReadOnly;
+    Int_t   fVerbose;
+    std::string  fCertificate;  // certificates description - not tested yet
+    static std::map<std::string,std::string> fJQFilters;
+private:
+    ClassDef(AliElasticSearchRoot,1);
+};
+
+#endif

--- a/STAT/AliElasticSearchRoot.h
+++ b/STAT/AliElasticSearchRoot.h
@@ -3,7 +3,7 @@
 
 /// \ingroup STAT
 /// \class AliElasticSearchRoot
-/// \brief AliDrawStyle - AliElasticSearchRoot - C++ interace to the Elastic --> root tree like-   using gSystem->GetFromPipe, Exec, Elastic, painlsees scripting,  curl,  jq
+/// \brief AliElasticSearchRoot - C++ interace to the Elastic --> root tree like-   using gSystem->GetFromPipe, Exec, Elastic, painlsees scripting,  curl,  jq
 ///      - Originally planned usage of  higher level C++ inteface not possible for a moment
 ///      -- C++11 or better C++14 and ROOT6 needed (e.g https://github.com/QHedgeTech/cpp-elasticsearch/tree/master/src )
 ///      - Using older  C++  and Root 5 to represent heirarchiacal structure root trees to be used

--- a/STAT/CMakeLists.txt
+++ b/STAT/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SRCS
     AliTreeTrending.cxx
     AliNDFormulaBrowser.cxx
     AliDrawStyle.cxx
+        AliElasticSearchRoot.cxx
   )
 
 # Headers from sources

--- a/STAT/Macros/AliElasticSearchRootTest.c
+++ b/STAT/Macros/AliElasticSearchRootTest.c
@@ -1,0 +1,96 @@
+///  ### test of AliEleasticSearchRoot - C++ interace to the Elastic using gSystem->GetFromPipe,Exec, curl and jq
+///      Origignally planned usage of  higher level C++ inteface not possible for a moment
+///           - C++11 or better C++14 and ROOT6 needed (e.g https://github.com/QHedgeTech/cpp-elasticsearch/tree/master/src )
+///  \author marian  Ivanov marian.ivanov@cern.ch
+
+///          In order to run the test Elastic server has to be running = default location hostName="localhost:9200"  - but it can pbe specified as test argument
+/////  to run tests one by one
+/////  \code
+//      .L $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.c
+//    InitElastic();
+//    testExportBinary();
+//    testGetIndexLayout();
+//    testSelect();
+///// \endcode
+//
+///// To run full test
+/////  \code
+// aliroot -b -q $AliRoot_SRC/STAT/AliElasticSearchRoot.cxx+  $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.c >AliElasticSearchRootTest.log
+//    Parse output
+//    cat AliElasticSearchRootTest.log | grep "I-AliElasticSearchRoot.*Key"
+//I-AliElasticSearchRoot::AliElasticSearchRootTest: KeyValue-Begin
+//I-AliElasticSearchRoot::ExportBinary: KeyValue-Begin
+//I-AliElasticSearchRoot::ExportBinary: KeyValue-End
+//I-AliElasticSearchRoot::GetIndexLayout: KeyValue-Begin
+//I-AliElasticSearchRoot::GetIndexLayout: KeyValue-End
+//I-AliElasticSearchRoot::select: KeyValue-Begin
+//I-AliElasticSearchRoot::select: KeyValue-End
+//I-AliElasticSearchRoot::AliElasticSearchRootTest: KeyValue-End
+///// \endcode
+
+
+
+
+char *hostName="localhost:9200";
+AliElasticSearchRoot *pelastic=NULL;
+
+void InitElastic();
+void testExportBinary();
+void testGetIndexLayout();
+void testSelect();
+
+
+void AliElasticSearchRootTest(char *phostName=0){
+    if (phostName) hostName=phostName;
+    ::Info("AliElasticSearchRoot::AliElasticSearchRootTest","KeyValue-Begin");
+    InitElastic();
+    testExportBinary();
+    testGetIndexLayout();
+    testSelect();
+    ::Info("AliElasticSearchRoot::AliElasticSearchRootTest","KeyValue-EndOK");
+}
+
+void InitElastic(){
+    pelastic=new AliElasticSearchRoot(hostName,kFALSE,1);
+    pelastic->SetCertificate();           // default certification="--insecure --cacert CERNRootCertificationAuthority2.crt --netrc-file $HOME/.globus/.elastic/.netrc"
+    pelastic->ls();
+    pelastic->Print();
+}
+
+///  testExportBinary() AliElasticSearchRoot::ExportBinary
+///  Get production tree and export al branches to the elastic key /alice_mc/passguess/
+void testExportBinary(){
+  // Example export MC production table
+  ::Info("AliElasticSearchRoot::ExportBinary","KeyValue-Begin");
+  AliExternalInfo info;
+  TTree * tree = info.GetTreeMCPassGuess();
+  TString exportInfo="%IprodName:";
+  Int_t nBranches = tree->GetListOfBranches()->GetEntries();
+  for (Int_t iBranch=0; iBranch<nBranches; iBranch++){
+    exportInfo+= tree->GetListOfBranches()->At(iBranch)->GetName();
+    if (iBranch<nBranches) exportInfo+=":";
+  }
+  Int_t entries = AliTreePlayer::selectWhatWhereOrderBy(tree,exportInfo.Data(),"1", "", 0,100000, "elastic","mctableAnchor.json");
+  pelastic->ExportBinary("/alice_mc/passguess/","mctableAnchor.json","xxx");
+  ::Info("AliElasticSearchRoot::ExportBinary","KeyValue-EndOK");
+}
+
+
+void testGetIndexLayout(){
+    //
+    // elastic.GetInde xLayout("/alice/logbook_test0/")->Print();
+    ::Info("AliElasticSearchRoot::GetIndexLayout","KeyValue-Begin");
+    pelastic->GetIndexLayout("alice_mc","passguess","text").Tokenize("\n")->Print();
+    pelastic->GetIndexLayout("alice_mc","passguess",0,kTRUE).Tokenize("\n")->Print();
+    pelastic->GetIndexLayout("alice","qatpc_test0","float").Tokenize("\n")->Print();
+    pelastic->GetIndexLayout("alice","qatpc_test0",0,kTRUE).Tokenize("\n")->Print();
+    ::Info("AliElasticSearchRoot::GetIndexLayout","KeyValue-EndOK");
+}
+
+void testSelect(){
+    ::Info("AliElasticSearchRoot::select","KeyValue-Begin");
+    TString select="";
+    select=  pelastic->select("/alice/qatpc_test0/","*","run>240000&&run<246844&&meanMIP>50",0,1000,"jqEQueryStat,jqEQueryHeader");
+    select=  pelastic->select("/alice/qatpc_test0/","*","run>240000&&run<246844&&meanMIP>50",0,1000,"jqEQueryArrayNamed,jqEQueryStat,jqEQueryHeader");
+    ::Info("AliElasticSearchRoot::select","KeyValue-EndOK");
+}

--- a/STAT/STATLinkDef.h
+++ b/STAT/STATLinkDef.h
@@ -24,7 +24,8 @@
 #pragma link C++ class AliTreeTrending+;
 #pragma link C++ class AliNDFormulaBrowser+; 
 #pragma link C++ class AliDrawStyle+;
- 
+#pragma link C++ class AliElasticSearchRoot++;
+
 #pragma link C++ namespace AliFFTsmoother+;
 
 #pragma link C++ namespace TStatToolkit;
@@ -52,6 +53,7 @@
 #pragma link C++ class std::map<std::string,TVectorD*>+;
 #pragma link C++ class std::map<UInt_t,THn*>+;
 #pragma link C++ class std::map<Int_t,TClonesArray*>+;
+#pragma link C++ class std::map<std::string,std::string>+;
 
 /*
 // RS At the moment is not recognized by the CINT...


### PR DESCRIPTION
## ATO-402- Add: class AliElasticSearchRoot

* AliElasticSearchRoot - C++ interface to the Elastic --> root tree like-   using gSystem->GetFromPipe, Exec, Elastic, painless scripting,  curl,  jq
* Originally planned usage of  higher level C++ interface not possible for a moment
  * C++11 or better C++14 and ROOT6 needed (e.g https://github.com/QHedgeTech/cpp-elasticsearch/tree/master/src )
  * Using older  C++  and Root 5 to represent hierarchical structure root trees to be used
  * Query language similar to TTree::Draw  - suing elastic painless scripting language (see query examples)

### Example usage
```c++
hostName="localhost:9200";            // local elastic
 // or remote ElastichostName="https://localhost:9206";    //  connect to remote via tunnel e.g ssh mivanov@lxplus.cern.ch -f -N -L 9206:es-alice.cern.ch:9203
 //
 AliElasticSearchRoot elastic(hostName,kFALSE,1);
 elastic.SetCertificate();           // default certification="--insecure --cacert CERNRootCertificationAuthority2.crt --netrc-file $HOME/.globus/.elastic/.netrc"
 elastic.ls();                       // list all indeces
 elastic.ls("alice");                // list incdeces containing alice
 elastic.ls(".alice_mc");             // list indeces containing alice_mc
 elastic.Print();
 // GetIndexLayeout
 elastic.GetIndexLayout("/alice/logbook_test0/")->Print();
 elastic.GetIndexLayout("/alice_mc/passguess/")->Print();
 // make a Tree like query
 TString select="";
 select=  elastic.select("/alice/qatpc_test0/","run:meanMIP:meanTPCncl","run>240000&&run<246844&&meanMIP>50",0,1000,"jqEQueryStat,jqEQueryHeader")
 select=  elastic.select("/alice/logbook_test0/","run:totalSubEvents:ctpDuration","run>140000",0,10000,"jqEQueryStat,jqEQueryHeader")
 select=  elastic.select("/alice_mc/passguess/","*","1",0,1000,"jqEQueryStat,jqEQueryHeader,jqEQueryArrayNamed");  // get list of all runs output in query.json
 //
 select=  elastic.select("/alice/qatpc_test0/","*","run>240000&&run<246844&&meanMIP>50",0,1000,0)
```