### PR TITLE
EVE: char* -> const char* fix in header

### DIFF
--- a/EVE/EveBase/AliEveSaveViews.cxx
+++ b/EVE/EveBase/AliEveSaveViews.cxx
@@ -274,7 +274,7 @@ void AliEveSaveViews::SaveForAmore()
     if (++fCurrentFileNumber >= fMaxFiles) fCurrentFileNumber = 0;
 }
 
-void AliEveSaveViews::Save(bool withDialog,char* filename)
+void AliEveSaveViews::Save(bool withDialog,const char* filename)
 {
     TEnv settings;
     AliEveInit::GetConfig(&settings);

--- a/EVE/EveBase/AliEveSaveViews.h
+++ b/EVE/EveBase/AliEveSaveViews.h
@@ -24,7 +24,7 @@ public:
     ~AliEveSaveViews();
     
     void SaveForAmore();
-    void Save(bool withDialog=true,char* filename="");
+    void Save(bool withDialog=true,const char* filename="");
     int SendToAmore();
 private:
     void ChangeRun();


### PR DESCRIPTION
Fixes char* -> const char* for string literal in header which otherwise gives plenty of warning messages.  Can you comment @jniedzie ?