### PR TITLE
include charged kaons in AliDecayerPythia long lived decays

### DIFF
--- a/PYTHIA6/AliPythia6/AliDecayerPythia.cxx
+++ b/PYTHIA6/AliPythia6/AliDecayerPythia.cxx
@@ -126,7 +126,8 @@ void AliDecayerPythia::Init()
 
     Int_t isw = 0;
     if (fLongLived) isw = 1;
-    
+
+    fPythia->SetMDCY(fPythia->Pycomp(321) ,1, isw);
     fPythia->SetMDCY(fPythia->Pycomp(310) ,1, isw);
     fPythia->SetMDCY(fPythia->Pycomp(3122),1, isw);
     fPythia->SetMDCY(fPythia->Pycomp(3112),1, isw);


### PR DESCRIPTION
in order to let them decay using the Pythia6 decayer (like e.g. K0 long)