### PR TITLE
Updated RemoveGraphDuplicates so that always first and last points are kept

### DIFF
--- a/STEER/CDB/AliDCSSensorArray.cxx
+++ b/STEER/CDB/AliDCSSensorArray.cxx
@@ -477,8 +477,11 @@ void AliDCSSensorArray::RemoveGraphDuplicates(Double_t tolerance){
     Double_t x=-999.,y=-999., x0=-999.,y0=-999.;
     if (graph) {
       Int_t npoints=graph->GetN();
-      if (npoints>1) {
-        for (Int_t i=npoints-1;i>0;i--) {
+
+// Keep first and last point anyway ( i.e. npoints-2 ...)
+
+      if (npoints>2) {
+        for (Int_t i=npoints-2;i>0;i--) {
 	   graph->GetPoint(i,x,y);
 	   graph->GetPoint(i-1,x0,y0);
 	   if ( TMath::Abs(y-y0) < TMath::Abs(tolerance*y0) ) graph->RemovePoint(i);


### PR DESCRIPTION
On request from Jens Wiechula, the removal of duplicate points (or rather points falling within a tolerance interval) is changed so that the first and last point are always kept. This just required modifications to the loop control statement (and the initial protection test) -- no other change to the logic.