### PR TITLE
Set special flag in AliStack in case of MC embedding

### DIFF
--- a/STEER/STEERBase/AliMCEvent.cxx
+++ b/STEER/STEERBase/AliMCEvent.cxx
@@ -664,6 +664,7 @@ void AliMCEvent::AddSubsidiaryEvent(AliMCEvent* event)
     }
     
     fSubsidiaryEvents->Add(event);
+    if (fStack) fStack->SetMCEmbeddingFlag(kTRUE);
 }
 
 AliGenEventHeader *AliMCEvent::FindHeader(Int_t ipart) {

--- a/STEER/STEERBase/AliStack.cxx
+++ b/STEER/STEERBase/AliStack.cxx
@@ -55,7 +55,8 @@ AliStack::AliStack():
   fCurrentPrimary(-1),
   fHgwmk(0),
   fLoadPoint(0),
-  fTrackLabelMap(0)
+  fTrackLabelMap(0),
+  fMCEmbeddingFlag(kFALSE)
 {
   //
   // Default constructor
@@ -77,7 +78,8 @@ AliStack::AliStack(Int_t size, const char* /*evfoldname*/):
   fCurrentPrimary(-1),
   fHgwmk(0),
   fLoadPoint(0),
-  fTrackLabelMap(0)
+  fTrackLabelMap(0),
+  fMCEmbeddingFlag(kFALSE)
 {
   //
   //  Constructor
@@ -100,7 +102,8 @@ AliStack::AliStack(const AliStack& st):
     fCurrentPrimary(-1),
     fHgwmk(0),
     fLoadPoint(0),
-    fTrackLabelMap(0)
+    fTrackLabelMap(0),
+    fMCEmbeddingFlag(kFALSE)
 {
     // Copy constructor
 }

--- a/STEER/STEERBase/AliStack.h
+++ b/STEER/STEERBase/AliStack.h
@@ -86,6 +86,9 @@ class AliStack : public TVirtualMCStack
     Int_t       TrackLabel(Int_t label) const {return fTrackLabelMap[label];}
     Int_t*      TrackLabelMap() {return fTrackLabelMap.GetArray();}
     const TObjArray*  Particles() const;
+
+    void        SetMCEmbeddingFlag(Bool_t v=kTRUE)        {fMCEmbeddingFlag = v;}
+    Bool_t      GetMCEmbeddingFlag()                const {return fMCEmbeddingFlag;}
     
   protected:
     // methods
@@ -113,6 +116,7 @@ class AliStack : public TVirtualMCStack
     Int_t          fHgwmk;             //! Last track purified
     Int_t          fLoadPoint;         //! Next free position in the particle buffer
     TArrayI        fTrackLabelMap;     //! Map of track labels
+    Bool_t         fMCEmbeddingFlag;   //! Flag that this is a top stack of embedded MC
     ClassDef(AliStack,6) //Particles stack
 };
 


### PR DESCRIPTION
The MCEvent::AddSubsidiaryEvent will also
set the flag AliStack::fMCEmbeddingFlag, it can be checked from Stak::Particle etc. via GetMCEmbeddingFlag.