### PR TITLE
Make option to switch on long-lived decayse in PYTHIA8

### DIFF
--- a/PYTHIA8/AliPythia8/AliPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliPythia8.cxx
@@ -67,7 +67,7 @@ AliPythia8::AliPythia8():
     fPtScale(0.),
     fNJetMin(0),
     fNJetMax(0),
-	fDecayLonglived(kFALSE)
+    fDecayLonglived(kFALSE)
 {
 // Default Constructor
 //
@@ -91,7 +91,7 @@ AliPythia8::AliPythia8(const AliPythia8& pythia):
     fPtScale(0.),
     fNJetMin(0),
     fNJetMax(0),
-	fDecayLonglived(kFALSE)
+    fDecayLonglived(kFALSE)
 {
     // Copy Constructor
     pythia.Copy(*this);

--- a/PYTHIA8/AliPythia8/AliPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliPythia8.cxx
@@ -66,7 +66,8 @@ AliPythia8::AliPythia8():
     fYScale(0.),
     fPtScale(0.),
     fNJetMin(0),
-    fNJetMax(0)
+    fNJetMax(0),
+	fDecayLonglived(kFALSE)
 {
 // Default Constructor
 //
@@ -89,7 +90,8 @@ AliPythia8::AliPythia8(const AliPythia8& pythia):
     fYScale(0.),
     fPtScale(0.),
     fNJetMin(0),
-    fNJetMax(0)
+    fNJetMax(0),
+	fDecayLonglived(kFALSE)
 {
     // Copy Constructor
     pythia.Copy(*this);
@@ -106,13 +108,15 @@ void AliPythia8::ProcInit(Process_t process, Float_t energy, StrucFunc_t strucfu
     fStrucFunc = strucfunc;
     ReadString("111:mayDecay  = on");
 //...Switch off decay of K0L, Lambda, Sigma+-, Xi0-, Omega-.
-    ReadString("310:mayDecay  = off");
-    ReadString("3122:mayDecay = off");
-    ReadString("3112:mayDecay = off");
-    ReadString("3222:mayDecay = off");
-    ReadString("3312:mayDecay = off");
-    ReadString("3322:mayDecay = off");
-    ReadString("3334:mayDecay = off");
+    if(!fDecayLonglived){
+        ReadString("310:mayDecay  = off");
+        ReadString("3122:mayDecay = off");
+        ReadString("3112:mayDecay = off");
+        ReadString("3222:mayDecay = off");
+        ReadString("3312:mayDecay = off");
+        ReadString("3322:mayDecay = off");
+        ReadString("3334:mayDecay = off");
+    }
     // Select structure function 
     //          ReadString("PDF:useLHAPDF = on");
     //	  ReadString(Form("PDF:LHAPDFset = %s", AliStructFuncType::PDFsetName(fStrucFunc).Data()));

--- a/PYTHIA8/AliPythia8/AliPythia8.h
+++ b/PYTHIA8/AliPythia8/AliPythia8.h
@@ -55,7 +55,21 @@ class AliPythia8 :public AliTPythia8, public AliPythiaBase
 			       Int_t ngmax = 30);
     virtual void SwitchHadronisationOff();
     virtual void SwitchHadronisationOn();
+
+    /**
+     * @brief Switching on decays of long-lived particles which are normally suppressed by AliPythia8
+     *
+     * Particles for which the decays are enabled by this switch
+     * - K0short
+     * - Lambda
+     * - Sigma
+     * - Omega
+     * - Xi
+     *
+     * @param doDecay If true the particles listed here are decayed
+     */
     void SetDecayLonglived(Bool_t doDecay = kTRUE) { fDecayLonglived = doDecay; }
+
     //
     // Common Getters
     virtual void    GetXandQ(Float_t& x1, Float_t& x2, Float_t& q);
@@ -63,6 +77,15 @@ class AliPythia8 :public AliTPythia8, public AliPythiaBase
     virtual Float_t GetPtHard();
     virtual Int_t GetNMPI() { return fLastNMPI; }
     virtual Int_t GetNSuperpositions() { return fLastNSuperposition; }
+
+    /**
+     * @brief Get status of the decayer for long-lived particles
+     *
+     * See @ref SetDecayLonglived for the list of supported particles
+     *
+     * @return Decayer status (if true then long-lived particles are decayed)
+     */
+    Bool_t IsDecayLonglived() const { return fDecayLonglived; }
 
     //
     //
@@ -105,7 +128,7 @@ class AliPythia8 :public AliTPythia8, public AliPythiaBase
     Float_t               fPtScale;           //  ! cut-off joining scale
     Int_t                 fNJetMin;           //  ! min. number of jets
     Int_t                 fNJetMax;           //  ! max. number of jets
-    Bool_t                fDecayLonglived;	  //    Decay long-lived particles
+    Bool_t                fDecayLonglived;	  ///<    Decay long-lived particles (see @ref SetDecayLonglived for list of supported particles)
     static AliPythia8*    fgAliPythia8;       //    Pointer to single instance
 
     ClassDef(AliPythia8, 1) //ALICE UI to PYTHIA8

--- a/PYTHIA8/AliPythia8/AliPythia8.h
+++ b/PYTHIA8/AliPythia8/AliPythia8.h
@@ -105,7 +105,7 @@ class AliPythia8 :public AliTPythia8, public AliPythiaBase
     Float_t               fPtScale;           //  ! cut-off joining scale
     Int_t                 fNJetMin;           //  ! min. number of jets
     Int_t                 fNJetMax;           //  ! max. number of jets
-    Bool_t				  fDecayLonglived;	  //    Decay long-lived particles
+    Bool_t                fDecayLonglived;	  //    Decay long-lived particles
     static AliPythia8*    fgAliPythia8;       //    Pointer to single instance
 
     ClassDef(AliPythia8, 1) //ALICE UI to PYTHIA8

--- a/PYTHIA8/AliPythia8/AliPythia8.h
+++ b/PYTHIA8/AliPythia8/AliPythia8.h
@@ -55,6 +55,7 @@ class AliPythia8 :public AliTPythia8, public AliPythiaBase
 			       Int_t ngmax = 30);
     virtual void SwitchHadronisationOff();
     virtual void SwitchHadronisationOn();
+    void SetDecayLonglived(Bool_t doDecay = kTRUE) { fDecayLonglived = doDecay; }
     //
     // Common Getters
     virtual void    GetXandQ(Float_t& x1, Float_t& x2, Float_t& q);
@@ -104,6 +105,7 @@ class AliPythia8 :public AliTPythia8, public AliPythiaBase
     Float_t               fPtScale;           //  ! cut-off joining scale
     Int_t                 fNJetMin;           //  ! min. number of jets
     Int_t                 fNJetMax;           //  ! max. number of jets
+    Bool_t				  fDecayLonglived;	  //    Decay long-lived particles
     static AliPythia8*    fgAliPythia8;       //    Pointer to single instance
 
     ClassDef(AliPythia8, 1) //ALICE UI to PYTHIA8


### PR DESCRIPTION
Decays of long-lived particles (K0short, lambda) are currently
disabled in a hard coded way in the AliPythia8 wrapper. While
this is OK for normal MC productions, on the MC_gen lego train
this might not always be the desired behaviour. The patch allows
for an optional switch on of the decayer for long lived particles
(default: off)