### PR TITLE
Protection against Short_t overflow when filling correction maps

### DIFF
--- a/ITS/ITSbase/AliITSCorrMap1DSDD.cxx
+++ b/ITS/ITSbase/AliITSCorrMap1DSDD.cxx
@@ -72,3 +72,13 @@ void AliITSCorrMap1DSDD::Set1DMap(TH1F* hmap){
   }
 }
 
+void AliITSCorrMap1DSDD::SetCellContent(Int_t /*iAn*/, Int_t iTb, Float_t devMicron)
+{
+    double val = devMicron*10.+0.5;
+    // check for short overflow
+    if (TMath::Abs(val)>=SHRT_MAX) {
+      printf("Truncating channel %d to avoid sign flip: %e -> %e\n",iTb,val,TMath::Sign(double(SHRT_MAX),val));
+      val=TMath::Sign(double(SHRT_MAX),val);
+    }
+    if(CheckDriftBounds(iTb)) fCorrMap[iTb]=(Short_t)(val);
+}

--- a/ITS/ITSbase/AliITSCorrMap1DSDD.h
+++ b/ITS/ITSbase/AliITSCorrMap1DSDD.h
@@ -13,7 +13,7 @@
 //                                                               //
 ///////////////////////////////////////////////////////////////////
 
-
+#include <limits.h>
 #include<TNamed.h>
 
 class TH1F;
@@ -29,10 +29,7 @@ class AliITSCorrMap1DSDD : public AliITSCorrMapSDD {
 
   virtual void ResetMap();
   virtual void Set1DMap(TH1F* hmap);
-  virtual void SetCellContent(Int_t /*iAn*/, Int_t iTb, Float_t devMicron){
-    if(CheckDriftBounds(iTb)) fCorrMap[iTb]=(Short_t)(devMicron*10.+0.5);
-  }
-
+  virtual void SetCellContent(Int_t /*iAn*/, Int_t iTb, Float_t devMicron);
   virtual Float_t GetCellContent(Int_t /*iAn*/, Int_t iTb) const {
     if(CheckDriftBounds(iTb)) return (Float_t)fCorrMap[iTb]/10.;
     else return 0.;


### PR DESCRIPTION
@fprino : this is to protect correction maps from the sign flip due to the Short_t (used internally to store the map) overflow, which happens in very rare cases of "nonuniformiry" exceeding ~3.2mm (mostly artifact of modules with only fraction of the drift distance having calibration data)