### PR TITLE
Protect against missing information - such as ESD tracks or AliMultip…

### DIFF
--- a/ANALYSIS/ANALYSISalice/AliESDtrackCuts.cxx
+++ b/ANALYSIS/ANALYSISalice/AliESDtrackCuts.cxx
@@ -2905,6 +2905,7 @@ Int_t AliESDtrackCuts::GetReferenceMultiplicity(const AliESDEvent* esd, MultEstT
   if (trackType == kTracklets)
   {
     const AliMultiplicity* spdmult = esd->GetMultiplicity();    // spd multiplicity object
+    if (!spdmult) return 0;
     for (Int_t i=0; i<spdmult->GetNumberOfTracklets(); ++i)
     {
       if (TMath::Abs(spdmult->GetEta(i)-etaCent) > etaRange)
@@ -2951,6 +2952,7 @@ Int_t AliESDtrackCuts::GetReferenceMultiplicity(const AliESDEvent* esd, MultEstT
   const Int_t kSecBit = BIT(16); // set this bit in global tracks if it is secondary according to a cut
 
   for(Int_t itracks=0; itracks < nESDTracks; itracks++) {
+    if (!esd->GetTrack(itracks)) continue;
     esd->GetTrack(itracks)->ResetBit(kSecBit|kRejBit); //reset bits used for flagging secondaries and rejected tracks in case they were changed before this analysis
   }
   const Int_t maxid = nESDTracks; // used to define bool array for check multiple associations of tracklets to one track. array starts at 0.
@@ -2968,7 +2970,8 @@ Int_t AliESDtrackCuts::GetReferenceMultiplicity(const AliESDEvent* esd, MultEstT
   // get multiplicity from global tracks
   for(Int_t itracks = 0; itracks < nESDTracks; itracks++) { // flag the tracks
     AliESDtrack* track = esd->GetTrack(itracks);
-
+    if (!track) continue;
+    
     // if track is a secondary from a V0, flag as a secondary
     if (track->IsOn(AliESDtrack::kMultInV0)) {
       track->SetBit(kSecBit);
@@ -3024,6 +3027,7 @@ Int_t AliESDtrackCuts::GetReferenceMultiplicity(const AliESDEvent* esd, MultEstT
   //*******************************************************************************************************
   // get multiplicity from ITS tracklets to complement TPC+ITS, and ITSpureSA
   const AliMultiplicity* spdmult = esd->GetMultiplicity();    // spd multiplicity object
+  if (spdmult) {
   for (Int_t i=0; i<spdmult->GetNumberOfTracklets(); ++i) {
     if (TMath::Abs(spdmult->GetEta(i)-etaCent) > etaRange) continue; // eta selection for tracklets
 
@@ -3073,6 +3077,7 @@ Int_t AliESDtrackCuts::GetReferenceMultiplicity(const AliESDEvent* esd, MultEstT
 
 	    if ( bUsedInPureITS < 0 ) ++trackletsITSSA_complementary; //no associated track, just count the tracklet
     }
+  }
   }
 
   //*******************************************************************************************************

--- a/ANALYSIS/ANALYSISalice/AliESDtrackCuts.cxx
+++ b/ANALYSIS/ANALYSISalice/AliESDtrackCuts.cxx
@@ -3028,56 +3028,56 @@ Int_t AliESDtrackCuts::GetReferenceMultiplicity(const AliESDEvent* esd, MultEstT
   // get multiplicity from ITS tracklets to complement TPC+ITS, and ITSpureSA
   const AliMultiplicity* spdmult = esd->GetMultiplicity();    // spd multiplicity object
   if (spdmult) {
-  for (Int_t i=0; i<spdmult->GetNumberOfTracklets(); ++i) {
-    if (TMath::Abs(spdmult->GetEta(i)-etaCent) > etaRange) continue; // eta selection for tracklets
+    for (Int_t i=0; i<spdmult->GetNumberOfTracklets(); ++i) {
+      if (TMath::Abs(spdmult->GetEta(i)-etaCent) > etaRange) continue; // eta selection for tracklets
 
-    // if counting tracks+tracklets, check if clusters were already used in tracks
-    Int_t id1, id2, id3, id4;
-    spdmult->GetTrackletTrackIDs ( i, 0, id1, id2 ); // references for eventual Global/ITS_SA tracks
-    spdmult->GetTrackletTrackIDs ( i, 1, id3, id4 ); // references for eventual ITS_SA_pure tracks
+      // if counting tracks+tracklets, check if clusters were already used in tracks
+      Int_t id1, id2, id3, id4;
+      spdmult->GetTrackletTrackIDs ( i, 0, id1, id2 ); // references for eventual Global/ITS_SA tracks
+      spdmult->GetTrackletTrackIDs ( i, 1, id3, id4 ); // references for eventual ITS_SA_pure tracks
 
-    // are both clusters from the same tracks? If not, skip the tracklet (shouldn't change things much)
-    if ( ( id1 != id2 && id1 >= 0 && id2 >= 0 ) || ( id3 != id4 && id3 >= 0 && id4 >= 0 ) ) continue;
+      // are both clusters from the same tracks? If not, skip the tracklet (shouldn't change things much)
+      if ( ( id1 != id2 && id1 >= 0 && id2 >= 0 ) || ( id3 != id4 && id3 >= 0 && id4 >= 0 ) ) continue;
 
-    //referenced track
-    //at this point we either have id1 = id2 (id3 = id4) or only one of the ids pair is -1
-    // id1>=0, id2>=0, id1=id2	: tracklet has associated track
-    // id1>=0, id2 = -1		: 1st layer cluster has associated track
-    // id1=-1, id2>=0		: 2nd layer cluster has associated track
-    // id1=-1, id2=-1		: tracklet has no associated track
-    //
-    Int_t bUsedInGlobal(-1);
-    if ( id1 != -1 ) bUsedInGlobal = globalBits.TestBitNumber(id1) ? id1 : -1;
-    else if ( id2 != -1) bUsedInGlobal = globalBits.TestBitNumber(id2) ? id2 : -1;
-    Int_t bUsedInPureITS(-1);
-    if ( id3 != -1 ) bUsedInPureITS = pureITSBits.TestBitNumber(id3) ? id3 : -1;
-    else if ( id4 != -1) bUsedInPureITS = pureITSBits.TestBitNumber(id4) ? id4 : -1;
-    //
-    AliESDtrack* tr_global = bUsedInGlobal >= 0 ? esd->GetTrack ( bUsedInGlobal ) : 0;
-    AliESDtrack* tr_itssa = bUsedInPureITS >= 0 ? esd->GetTrack ( bUsedInPureITS ) : 0;
-    //
-    // has associated pure ITS track been associated to a previous tracklet?
-    //*******************************************************************************************************
-    if (trackType == kTrackletsITSTPC) {
-	    //*******************************************************************************************************
-	    // count tracklets towards global+complimentary tracks
-	    if ( ( tr_global && !tr_global->TestBit ( kSecBit ) ) && ( tr_global &&  tr_global->TestBit ( kRejBit ) ) ) {  // count tracklet as bad quality track
-		    globalBits.SetBitNumber( bUsedInGlobal ); // mark global track linked to this tracklet as used
-		    ++trackletsITSTPC_complementary;
-	    }
+      //referenced track
+      //at this point we either have id1 = id2 (id3 = id4) or only one of the ids pair is -1
+      // id1>=0, id2>=0, id1=id2	: tracklet has associated track
+      // id1>=0, id2 = -1		: 1st layer cluster has associated track
+      // id1=-1, id2>=0		: 2nd layer cluster has associated track
+      // id1=-1, id2=-1		: tracklet has no associated track
+      //
+      Int_t bUsedInGlobal(-1);
+      if ( id1 != -1 ) bUsedInGlobal = globalBits.TestBitNumber(id1) ? id1 : -1;
+      else if ( id2 != -1) bUsedInGlobal = globalBits.TestBitNumber(id2) ? id2 : -1;
+      Int_t bUsedInPureITS(-1);
+      if ( id3 != -1 ) bUsedInPureITS = pureITSBits.TestBitNumber(id3) ? id3 : -1;
+      else if ( id4 != -1) bUsedInPureITS = pureITSBits.TestBitNumber(id4) ? id4 : -1;
+      //
+      AliESDtrack* tr_global = bUsedInGlobal >= 0 ? esd->GetTrack ( bUsedInGlobal ) : 0;
+      AliESDtrack* tr_itssa = bUsedInPureITS >= 0 ? esd->GetTrack ( bUsedInPureITS ) : 0;
+      //
+      // has associated pure ITS track been associated to a previous tracklet?
+      //*******************************************************************************************************
+      if (trackType == kTrackletsITSTPC) {
+	//*******************************************************************************************************
+	// count tracklets towards global+complimentary tracks
+	if ( ( tr_global && !tr_global->TestBit ( kSecBit ) ) && ( tr_global &&  tr_global->TestBit ( kRejBit ) ) ) {  // count tracklet as bad quality track
+	  globalBits.SetBitNumber( bUsedInGlobal ); // mark global track linked to this tracklet as used
+	  ++trackletsITSTPC_complementary;
+	}
 
-	    if ( bUsedInGlobal < 0 ) ++trackletsITSTPC_complementary; //no associated track, just count the tracklet
-    } else {
-	    //*******************************************************************************************************
-	    // count tracklets towards ITS_SA_pure tracks
-	    if ( ( tr_itssa && !tr_itssa->TestBit ( kSecBit ) ) && ( tr_itssa &&  tr_itssa->TestBit ( kRejBit ) ) ) {  // count tracklet as bad quality track
-		    pureITSBits.SetBitNumber( bUsedInPureITS ); // mark ITS pure SA track linked to this tracklet as used
-		    ++trackletsITSSA_complementary;
-	    }
+	if ( bUsedInGlobal < 0 ) ++trackletsITSTPC_complementary; //no associated track, just count the tracklet
+      } else {
+	//*******************************************************************************************************
+	// count tracklets towards ITS_SA_pure tracks
+	if ( ( tr_itssa && !tr_itssa->TestBit ( kSecBit ) ) && ( tr_itssa &&  tr_itssa->TestBit ( kRejBit ) ) ) {  // count tracklet as bad quality track
+	  pureITSBits.SetBitNumber( bUsedInPureITS ); // mark ITS pure SA track linked to this tracklet as used
+	  ++trackletsITSSA_complementary;
+	}
 
-	    if ( bUsedInPureITS < 0 ) ++trackletsITSSA_complementary; //no associated track, just count the tracklet
+	if ( bUsedInPureITS < 0 ) ++trackletsITSSA_complementary; //no associated track, just count the tracklet
+      }
     }
-  }
   }
 
   //*******************************************************************************************************


### PR DESCRIPTION
This patch will protect against segmentation violations if an AliESDtrackCuts object is used on an 
event that for example, does not have tracks or the SPD multiplicity object. 