### PR TITLE
Recognize root_archive*.zip as Zip archives.  This is useful if one h…

### DIFF
--- a/STEER/ESD/AliESDInputHandlerRP.cxx
+++ b/STEER/ESD/AliESDInputHandlerRP.cxx
@@ -99,7 +99,8 @@ Bool_t AliESDInputHandlerRP::Init(Option_t* opt)
     {
       TString rppath;
       if (det->TestBit(kReadFromArchiveBIT)) {
-	if (fPathName->EndsWith("root_archive.zip"))
+	// if (fPathName->EndsWith("root_archive.zip"))
+	if (fPathName->Contains("root_archive"))
 	  rppath.Form("%s#%s.RecPoints.root", fPathName->Data(), det->GetName());
 	else
 	  rppath.Form("%sroot_archive.zip#%s.RecPoints.root", fPathName->Data(), det->GetName());

--- a/STEER/ESD/AliESDInputHandlerRP.cxx
+++ b/STEER/ESD/AliESDInputHandlerRP.cxx
@@ -99,8 +99,9 @@ Bool_t AliESDInputHandlerRP::Init(Option_t* opt)
     {
       TString rppath;
       if (det->TestBit(kReadFromArchiveBIT)) {
-	// if (fPathName->EndsWith("root_archive.zip"))
-	if (fPathName->Contains("root_archive"))
+	if (fPathName->Contains("root_archive", TString::kIgnoreCase) &&
+	    fPathName->Contains(".zip", TString::kIgnoreCase))
+	    
 	  rppath.Form("%s#%s.RecPoints.root", fPathName->Data(), det->GetName());
 	else
 	  rppath.Form("%sroot_archive.zip#%s.RecPoints.root", fPathName->Data(), det->GetName());


### PR DESCRIPTION
This patch will allow the input handler to recognise ZIP archives that has names like 
root_archive_X.zip (where X may be a sequence number - for example).  This allows users 
 to store local mirrors of data in a single directory. 