### PR TITLE
Include DIM header as <dim/dim.hxx> since the header is always

### DIFF
--- a/HLT/createGRP/lib/AliHLTCreateGRP.cxx
+++ b/HLT/createGRP/lib/AliHLTCreateGRP.cxx
@@ -16,7 +16,7 @@
 //***************************************************************************
 
 #include "AliHLTCreateGRP.h"
-#include <dic.hxx>
+#include <dim/dic.hxx>
 #include <stdio.h>
 #include <ctime>
 #include <iostream>


### PR DESCRIPTION
Include the DIM header as <dim/dic.hxx> as it is always in a sub-directory named dim. 