### PR TITLE
Just run 1 event by default in vmctest/gun

### DIFF
--- a/test/vmctest/gun/runtest.sh
+++ b/test/vmctest/gun/runtest.sh
@@ -8,7 +8,7 @@ if [ ! -f gen/galice.root ]; then
   ./rungen.sh
 fi
 
-NEVENTS=5
+NEVENTS=1
 G3CONFIG="$ALICE_ROOT/test/vmctest/gun/g3Config.C" 
 G4CONFIG="$ALICE_ROOT/test/vmctest/gun/g4Config.C" 
 


### PR DESCRIPTION
 * Setting the number to 1 since this test should run as a simple
   automatized regression test