### PR TITLE
[ALIROOT-7344]: Removing access to a dereferenced nullptr

### DIFF
--- a/EMCAL/EMCALsim/AliEMCALTriggerElectronics.cxx
+++ b/EMCAL/EMCALsim/AliEMCALTriggerElectronics.cxx
@@ -100,7 +100,9 @@ fGeometry(0)
       fSTUDCAL = new AliEMCALTriggerSTU(stuConf, rSize);
       AliDebug(999,"Manually setting DCAL STU fW object to 0xd000.");
       // Manually setting DCAL STU DCS fW version to 0xd000
-      stuConfDCal->SetFw(0xd000);
+
+      // Sandro Wenzel: THIS LINE IS INCORRECT AND NEEDS TO BE REPLACED WITH SOMETHING CORRECT
+      // stuConfDCal->SetFw(0xd000);
     }
   } else fSTUDCAL = 0;
 


### PR DESCRIPTION
 * Urgent fix removing a wrong statement
 * Reenables the vmctest/gun to run correctly
 * The original authors should cross-check and eventually provide the
   correct behaviour