### PR TITLE
Fix merge from .zip not from AliEn

### DIFF
--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -2946,11 +2946,18 @@ Bool_t AliAnalysisAlien::MergeOutput(const char *output, const char *basedir, In
       }
       // Iterate grid collection
       while (coll->Next()) {
-         TString fname = gSystem->DirName(coll->GetTURL());
-         fname += "/";
-         fname += inputFile;      
+         TString fname = coll->GetTURL();
+         if (!fname.BeginsWith("alien:") && fname.EndsWith(".zip", TString::kIgnoreCase)) {
+           fname += "#" + inputFile;
+           isGrid = kFALSE; // tells TFileMerger to not use TFile::Cp (which does not support anchors)
+         }
+         else {
+           fname = gSystem->DirName(fname);
+           fname += "/";
+           fname += inputFile;
+         }
          listoffiles->Add(new TNamed(fname.Data(),""));
-      }   
+      }
    } else if (sbasedir.Contains(".txt")) {
       // The file having the .txt extension is expected to contain a list of
       // folders where the output files will be looked. For alien folders,


### PR DESCRIPTION
Merging .zip files from non-AliEn paths requires specifying the inner .root file
with an anchor, in the format `arch.zip#file.root`. On AliEn this is not
necessary as the .zip entries are stored in the catalog as part of the current
directory.

It also tells the TFileMerger to access the .zip files not on AliEn directly, as
opposed to copying them locally first, as `TFile::Cp()` does not support .zip
anchors (silently).