### PR TITLE
test AOD filtering must use reference OCDB

### DIFF
--- a/test/PbPbbench/aod.C
+++ b/test/PbPbbench/aod.C
@@ -15,5 +15,5 @@ void aod(){
 
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/PbPbbench/recraw/aod.C
+++ b/test/PbPbbench/recraw/aod.C
@@ -15,5 +15,5 @@ void aod(){
 
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAODs.root\",\"local://$ALICE_ROOT/OCDB\",\"local://..\",kFALSE)");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAODs.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://..\",kFALSE)");
 }

--- a/test/QA/rawqa.C
+++ b/test/QA/rawqa.C
@@ -26,7 +26,7 @@ TString ClassName() { return "rawqa" ; }
 void rawqa(const Int_t runNumber, Int_t maxFiles = 10, const char* year = "08") 
 {	
 //	char * kDefaultOCDBStorage = Form("alien://folder=/alice/data/20%s/LHC%sd/OCDB/", year, year) ; 
-	char * kDefaultOCDBStorage = Form("local://$ALICE_ROOT/OCDB") ; 
+	char * kDefaultOCDBStorage = Form("local://$ALIROOT_OCDB_ROOT/OCDB") ; 
 	//AliQA::SetQARefStorage(Form("%s%s/", AliQA::GetQARefDefaultStorage(), year)) ;  
 	AliQA::SetQARefStorage("local://$ALICE_ROOT/QAref") ;
 	

--- a/test/generators/TUHKMgen/aod.C
+++ b/test/generators/TUHKMgen/aod.C
@@ -9,5 +9,5 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/generators/herwig/aod.C
+++ b/test/generators/herwig/aod.C
@@ -9,5 +9,5 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/generators/phojet/aod.C
+++ b/test/generators/phojet/aod.C
@@ -9,5 +9,5 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/generators/therminator/aod.C
+++ b/test/generators/therminator/aod.C
@@ -9,5 +9,5 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/genkine/sim/aod.C
+++ b/test/genkine/sim/aod.C
@@ -15,5 +15,5 @@ void aod(){
 
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/genkine/simG4/aod.C
+++ b/test/genkine/simG4/aod.C
@@ -15,5 +15,5 @@ void aod(){
 
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/gun/aod.C
+++ b/test/gun/aod.C
@@ -15,5 +15,5 @@ void aod(){
 
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/gun/recraw/aod.C
+++ b/test/gun/recraw/aod.C
@@ -15,5 +15,5 @@ void aod(){
 
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAODs.root\",\"local://$ALICE_ROOT/OCDB\",\"local://..\",kFALSE)");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAODs.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://..\",kFALSE)");
 }

--- a/test/merge/backgr/aod.C
+++ b/test/merge/backgr/aod.C
@@ -9,5 +9,5 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/merge/signal/aod.C
+++ b/test/merge/signal/aod.C
@@ -9,5 +9,5 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/pileup/aod.C
+++ b/test/pileup/aod.C
@@ -15,5 +15,5 @@ void aod(){
   gSystem->Load("libTender");
   gSystem->Load("libPWGPP");
 
-  gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAODs.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+  gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAODs.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/ppbench/aod.C
+++ b/test/ppbench/aod.C
@@ -15,5 +15,5 @@ void aod(){
 
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/ppbench/recraw/aod.C
+++ b/test/ppbench/recraw/aod.C
@@ -15,5 +15,5 @@ void aod(){
 
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAODs.root\",\"local://$ALICE_ROOT/OCDB\",\"local://..\",kFALSE)");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAODs.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://..\",kFALSE)");
 }

--- a/test/pploadlibs/aod.C
+++ b/test/pploadlibs/aod.C
@@ -9,5 +9,5 @@ void aod(){
   gSystem->Load("libTender");
   gSystem->Load("libPWGPP");
   
-  gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+  gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/vmctest/ppbench/aod.C
+++ b/test/vmctest/ppbench/aod.C
@@ -15,5 +15,5 @@ void aod(){
 
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
-    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALICE_ROOT/OCDB\",\"local://.\")");
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }


### PR DESCRIPTION
AOD filtering in test directories should use the OCDB described in
http://alisw.github.io/git-advanced/#use-the-reference-ocdb