### PR TITLE
ATO-46 - Add: MonALISA.RCT index remapping

### DIFF
--- a/STAT/Macros/AliExternalInfo.cfg
+++ b/STAT/Macros/AliExternalInfo.cfg
@@ -136,3 +136,5 @@ MonALISA.RCT.location https://alimonitor.cern.ch/configuration/index.jsp?partiti
 MonALISA.RCT.timeout 86400
 MonALISA.RCT.filename RCT.root
 MonALISA.RCT.treename RCT
+MonALISA.RCT.indexname run
+MonALISA.RCT.oldindexname raw_run

--- a/TPC/TPCcalib/AliTPCDistortionFit.h
+++ b/TPC/TPCcalib/AliTPCDistortionFit.h
@@ -15,7 +15,7 @@ public:
   static TString   LoadDistortionTree(const char *chinput);
   static void  SetMetadata(TTree * tree, TString friendName,Int_t run);
   static void  PrintMap(TPRegexp *filter=NULL);
-  static void MakeFitExample1(Int_t run, const char * chinput);
+  static void MakeFitExample1(Int_t run, const char * chinput, const char * ocdbPath);
   //
   static void   RegisterMap(TString mapName,  AliTPCChebCorr *map);
   static Int_t  GetNameHash(string name){  return fgkMapNameHash[name];}


### PR DESCRIPTION
ATO-336 - Update - OCDB path as an argument
￼ATO-46, PWGPP-342 - providing index remapping for RCT table