### PR TITLE
Fix PYTHIA6 and PYTHIA8 (ALIROOT-7308)

### DIFF
--- a/PYTHIA6/AliPythia6/AliGenPythia.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythia.cxx
@@ -1028,8 +1028,7 @@ Int_t  AliGenPythia::GenerateMB()
 
     Int_t* pParent = new Int_t[np];
     for (i=0; i< np; i++) pParent[i] = -1;
-    if ((fProcess == kPyJets || fProcess == kPyDirectGamma || fProcess == kPyBeautyJets || fProcess == kPyBeautyppMNRwmi || fProcess == kPyJetsPWHG || fProcess == kPyCharmPWHG || fProcess == kPyBeautyPWHG)
-	&& fEtMinJet > 0.) {
+    if ((fProcess == kPyJets || fProcess == kPyDirectGamma || fProcess == kPyBeautyJets || fProcess == kPyBeautyppMNRwmi || fProcess == kPyJetsPWHG || fProcess == kPyCharmPWHG || fProcess == kPyBeautyPWHG)) {
  	TParticle* jet1 = (TParticle *) fParticles.At(6);
 	TParticle* jet2 = (TParticle *) fParticles.At(7);
 	

--- a/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
@@ -860,8 +860,9 @@ Int_t  AliGenPythiaPlus::GenerateMB()
     for (i=0; i< np; i++) pParent[i] = -1;
     if (fProcess == kPyJets || fProcess == kPyDirectGamma || fProcess == kPyJetsPWHG || 
         fProcess == kPyCharmPWHG || fProcess == kPyBeautyPWHG ) {
-	TParticle* jet1 = (TParticle *) fParticles.At(6);
-	TParticle* jet2 = (TParticle *) fParticles.At(7);
+       // 6,7 particles in PYTHIA6
+       TParticle* jet1 = (TParticle *) fParticles.At(4);
+       TParticle* jet2 = (TParticle *) fParticles.At(5);
 	if (!CheckTrigger(jet1, jet2)) {
 	  delete [] pParent;
 	  return 0;


### PR DESCRIPTION
6 - Do not depend on value of min Et jet cut to select the direct photon acceptance
8 - Outgoing partons are in positions 4-5, needed to select direct gamma acceptance