### PR TITLE
Fixes to the FMD pedestal DA

### DIFF
--- a/FMD/FMDutil/AliFMDBaseDA.cxx
+++ b/FMD/FMDutil/AliFMDBaseDA.cxx
@@ -228,6 +228,17 @@ AliFMDBaseDA::OpenFiles(Bool_t appendRun)
 }
 
 //_____________________________________________________________________
+void
+AliFMDBaseDA::CloseFiles()
+{
+  // If we have an output file, close it  
+  if(!fOutputFile.is_open()) return;
+
+  fOutputFile.write("# EOF\n",6);
+  fOutputFile.close();
+}
+
+//_____________________________________________________________________
 Bool_t AliFMDBaseDA::HaveEnough(Int_t nEvents) const
 {
   // if (!fAll) return nEvents > GetRequiredEvents();
@@ -391,12 +402,8 @@ AliFMDBaseDA::Run(AliRawReader* reader, Bool_t appendRun, Bool_t isBase)
       std::cout << "done" << std::endl;
     }
   }
-  
-  // If we have an output file, close it  
-  if(fOutputFile.is_open()) {
-    fOutputFile.write("# EOF\n",6);
-    fOutputFile.close();
-  }
+  // Close output files
+  CloseFiles();
   
   // Do final stuff on the diagnostics file 
   Terminate(diagFile);

--- a/FMD/FMDutil/AliFMDBaseDA.h
+++ b/FMD/FMDutil/AliFMDBaseDA.h
@@ -193,6 +193,11 @@ protected:
    */
   virtual Bool_t OpenFiles(Bool_t appendRun=false);
   /** 
+   * Close output files
+   * 
+   */
+  virtual void CloseFiles();
+  /** 
    * Initialize 
    */  
   virtual void Init()  {};

--- a/FMD/FMDutil/AliFMDPedestalDA.h
+++ b/FMD/FMDutil/AliFMDPedestalDA.h
@@ -72,6 +72,11 @@ public:
    */
   Bool_t OpenFiles(Bool_t appendRun=false);
   /** 
+   * Close output files
+   * 
+   */
+  void CloseFiles();
+  /** 
    * Initialiser
    * 
    */  
@@ -176,7 +181,10 @@ private:
    */
   Int_t HWIndex(UShort_t ddl, UShort_t board, UShort_t altro, 
 		UShort_t chan) const;
-  void FillinTimebins(std::ofstream& out, UShort_t ddl);
+  /**
+   * Move ddl files into place 
+   */
+  void InstallFile(Int_t d);
   /** Current strip */ 
   Int_t fCurrentChannel;                           //The current channel
   /** Pedestal summary */ 


### PR DESCRIPTION
- Do not open the ddl-files (the content of which is
  uploaded to the front-ends) until we really need
  to.

- Also, write to a temporary file name - the
  ddl-file name with ".tmp" appended - so
  we can postpone the rotation of old files until
  we know we have good data.

- Do not rotate the old files until we're sure
  all is OK.

- Made the member function AliFMDBaseDA::CloseFiles
  which is overloaded in AliFMDPedestalDA.

- Removed some obsolete code