### PR TITLE
Possibility to add offset in R,Z per particle

### DIFF
--- a/EVGEN/AliGenBox.h
+++ b/EVGEN/AliGenBox.h
@@ -27,12 +27,19 @@ class AliGenBox : public AliGenerator
   virtual void SetPart(Int_t part) {fIpart=part;}
   virtual void SetParticleType(Int_t part) {SetPart(part);}
   virtual void SetSeed(UInt_t /*seed*/) {;}
+
+  void SetRandomOffset(float rmin, float rmax, float zmin,float zmax);
 protected:
 
   Int_t fIpart; // Particle type
   Float_t fEtaMin;  // Minimum eta 
   Float_t fEtaMax;  // Maximum eta
-  ClassDef(AliGenBox,2) // Square box random generator
+  Bool_t fRandomOffset; // add random offset to origin per track
+  Float_t fRMinOffset;   // min R of the offset
+  Float_t fRMaxOffset;   // max R of the offset
+  Float_t fZMinOffset;   // max Z of the offset
+  Float_t fZMaxOffset;   // max Z of the offset
+  ClassDef(AliGenBox,3) // Square box random generator
 };
 
 #endif


### PR DESCRIPTION
By calling AliGenBox::SetRandomOffset(rmin,rmax,zmin,zmax) each generated track will be forced to
have random offset within requested range (radial shift along phi of momentum). Needed for injection
of loopers in the TPC