### PR TITLE
Conversion moved to NextEvent() since NextParticle() can be called several times

### DIFF
--- a/EVGEN/AliGenReaderHepMC.cxx
+++ b/EVGEN/AliGenReaderHepMC.cxx
@@ -89,6 +89,20 @@ Int_t AliGenReaderHepMC::NextEvent()
       if (!weights.empty())
         fGenEventHeader->SetEventWeight(weights.front());
       AliDebug(1, Form("Parsed event %d with %d particles, weight = %e", fGenEvent->event_number(), fGenEvent->particles_size(), fGenEventHeader->EventWeight()));
+   //
+   // convert time from [cm/c] to [s] 
+      const Double_t conv = 0.01 / 2.99792458e8; 
+
+      Int_t npart = fGenEvent->particles_size();
+      for (Int_t i = 0; i < npart; i++) {
+	   TParticle * particle = (TParticle*)fParticleIterator->Next();
+	   particle->SetProductionVertex(particle->Vx(), particle->Vy(), particle->Vz(),
+					 particle->T() * conv);
+	   
+      }
+      fParticleIterator->Reset();
+      //
+      //
       return fGenEvent->particles_size();
    }
    AliError("No more events in the file.");
@@ -103,11 +117,6 @@ TParticle* AliGenReaderHepMC::NextParticle()
    if (particle && particle->GetStatusCode()==1) {
       particle->SetBit(kTransportBit);
    }
-   //
-   // convert time from [cm/c] to [s] 
-   const Double_t conv = 0.01 / 2.99792458e8; 
-   particle->SetProductionVertex(particle->Vx(), particle->Vy(), particle->Vz(),
-				 particle->T() * conv);
    //
    return particle;
 }


### PR DESCRIPTION
Conversion moved to NextEvent() since NextParticle() can be called several times

for the same particle, which leads to multiple application of the conversion factor.
Related to 
https://alice.its.cern.ch/jira/browse/PWGMM-21
Difference in tracking efficinecy in LHC17a2a (EPOSLHC) and LHC17a2b