### PR TITLE
PWGPP-350-Add:AliXRDPROOFtoolkit::TestFile(fileIn,keyList)

### DIFF
--- a/TPC/TPCbase/AliXRDPROOFtoolkit.h
+++ b/TPC/TPCbase/AliXRDPROOFtoolkit.h
@@ -27,6 +27,7 @@ class AliXRDPROOFtoolkit : public TObject
   static void JoinTreesIndex(const char * outputFile, const char * outputTree, const char *indexName, const char *inputTrees, Int_t debugLevel);
   static void   MakeTreeFromList(const char *fout, const char * treeOut, const char * treeIn, const char * flist, Bool_t debug);
   static void CacheFileList(const char * fileIn, const char* cachePrefix);
+  static Int_t  TestFile(const char*fileName,const char*keyNames);
  private:
   Int_t         fVerbose;          ///< verbso mode  - print command
   TString       fUserName;         ///< user name


### PR DESCRIPTION
* test status of selected keys (array of regular expressions) in file

### Tests:
* read  object
* write object
* delete object
  * +CopyTree in case of trees

### Usage:
* prefilter of file lists before merging
* prepare list of corrpted files together with diagnostic
  * see  examples in  https://alice.its.cern.ch/jira/browse/PWGPP-350

### Example usage from command line
```
echo 'TGrid::Connect("alien"); AliXRDPROOFtoolkit::TestFile("alien:///alice/cern.ch/user/p/pwg_pp/ESDFilteringWithPlugin/sub1/output/000246153/408/AnalysisResults.root", "highPt")' | aliroot -l 2&> testHighPt.log
```