### PR TITLE
Integrated fast L3 magnet param to AliMagF

### DIFF
--- a/STEER/STEERBase/AliMagF.h
+++ b/STEER/STEERBase/AliMagF.h
@@ -13,6 +13,8 @@
 
 //#include <TGeoGlobalMagField.h>
 #include <TVirtualMagField.h>
+
+class AliMagFast;
 class AliMagWrapCheb;
 
 class AliMagF : public TVirtualMagField
@@ -38,6 +40,8 @@ class AliMagF : public TVirtualMagField
   void       GetTPCRatIntCyl(const Double_t *rphiz, Double_t *b) const;
   Double_t   GetBz(const Double_t *xyz)                          const;
   //
+  void        AllowFastField(Bool_t v=kTRUE);
+  AliMagFast* GetFastField()                                    const {return fFastField;}
   AliMagWrapCheb* GetMeasuredMap()                              const {return fMeasuredMap;}
   //
   // former AliMagF methods or their aliases
@@ -82,6 +86,7 @@ class AliMagF : public TVirtualMagField
   //
  protected:
   AliMagWrapCheb*  fMeasuredMap;     //! Measured part of the field map
+  AliMagFast*      fFastField;       //! optional fast param
   BMap_t           fMapType;         // field map type
   Double_t         fSolenoid;        // Solenoid field setting
   BeamType_t       fBeamType;        // Beam type: A-A (fBeamType=0) or p-p (fBeamType=1)
@@ -93,6 +98,7 @@ class AliMagF : public TVirtualMagField
   Double_t         fFactorDip;       // Multiplicative factor for dipole
   Double_t         fMax;             // Max Field as indicated in Geant
   Bool_t           fDipoleOFF;       // Dipole ON/OFF flag
+  Bool_t           fAllowFastField;  // allow optional fast field param
   //
   Double_t         fQuadGradient;    // Gradient field for inner triplet quadrupoles
   Double_t         fDipoleField;     // Field value for D1 and D2 dipoles

--- a/STEER/STEERBase/AliMagFast.h
+++ b/STEER/STEERBase/AliMagFast.h
@@ -23,14 +23,24 @@ class AliMagFast : public TObject
   typedef SolParam SolParam_t;
 
   AliMagFast(const char* inpFName=0);
+  AliMagFast(Float_t factor, Int_t nomField = 5, const char* inpFmt="$(ALICE_ROOT)/data/maps/sol%dk.txt");
+  AliMagFast(const AliMagFast& src);
+  AliMagFast& operator=(const AliMagFast& src);
+  
   Bool_t LoadData(const char* inpFName);
   virtual ~AliMagFast() {}
 
   Bool_t Field(const double xyz[3], double bxyz[3]) const;
-  Bool_t GetBz(const double xyz[3], double& bz) const;
+  Bool_t GetBz(const double xyz[3], double& bz)     const;
+  Bool_t Field(const float  xyz[3], float bxyz[3])  const;
+  Bool_t GetBz(const float  xyz[3], float& bz)      const;
+
+  void    SetFactorSol(float v=1.f)                       {fFactorSol = v;}
+  Float_t GetFactorSol()                            const {return fFactorSol;}
   
  protected:
-  
+
+  Bool_t GetSegment(const float xyz[3], int& zSeg,int &rSeg, int &quadrant) const;  
   static const float fgkSolR2Max[kNSolRRanges];       // Rmax2 of each range
   static const float fgkSolZMax;                      // max |Z| for solenoid parametrization
 
@@ -42,7 +52,8 @@ class AliMagFast : public TObject
   }
   
   float CalcPol(const float* cf, float x,float y, float z) const;
-  
+
+  Float_t fFactorSol; // scaling factor
   SolParam_t fSolPar[kNSolRRanges][kNSolZRanges][kNQuadrants];
   
   ClassDef(AliMagFast,1)


### PR DESCRIPTION
By calling AliMagF::AllowFastField() one invokes field query in |z|<260 cm via fast polynomial
parametrization (factor ~10 faster than AliMagWrapCheb calculation)