### PR TITLE
Create on demand extra tree with vector of NTPC clusters per MC track

### DIFF
--- a/TPC/TPCrec/AliTPCReconstructor.cxx
+++ b/TPC/TPCrec/AliTPCReconstructor.cxx
@@ -73,6 +73,7 @@ TVectorD *  AliTPCReconstructor::fgPrimaryDCACut=0;
 Double_t    AliTPCReconstructor::fgPrimaryZ2XCut = 0;
 Double_t    AliTPCReconstructor::fgZOutSectorCut = 0;
 Bool_t      AliTPCReconstructor::fgCompactClusters = kFALSE;
+Bool_t      AliTPCReconstructor::fgCountMCTrackClusters = kFALSE;
 
 AliTPCReconstructor::AliTPCReconstructor():
 AliReconstructor(),

--- a/TPC/TPCrec/AliTPCReconstructor.h
+++ b/TPC/TPCrec/AliTPCReconstructor.h
@@ -65,6 +65,9 @@ public:
   static  void SetZOutSectorCut( double v )                { fgZOutSectorCut=v; }
   static  void SetCompactClusters(Bool_t v)                { fgCompactClusters=v;}
 
+  static Bool_t GetCountMCTrackClusters()                  {return fgCountMCTrackClusters;}
+  static void   SetCountMCTrackClusters(Bool_t v=kTRUE)    {fgCountMCTrackClusters = v;}
+  
 private:
   AliTPCReconstructor(const AliTPCReconstructor&); //Not implemented
   AliTPCReconstructor& operator=(const AliTPCReconstructor&); //Not implemented
@@ -83,6 +86,7 @@ private:
   static Double_t              fgPrimaryZ2XCut;       // cut on Z2X for fast primaries reco 
   static Double_t              fgZOutSectorCut;       // cut on Z going on other side of CE 
   static Bool_t                fgCompactClusters;     // if true, cluster coordinates will be set to 0 in clusterizer
+  static Bool_t                fgCountMCTrackClusters; // create tree with Ncl per MC track
   TObjArray *fArrSplines;                  // array of pid splines
 
   void SetSplinesFromOADB(const char* tmplt, AliESDpid *esdPID);

--- a/TPC/TPCrec/AliTPCtracker.h
+++ b/TPC/TPCrec/AliTPCtracker.h
@@ -294,6 +294,7 @@ private:
    Bool_t fClStatShared[kMaxRow];       //! cached info on shared clusters of the seed   
    //
    Int_t fAccountDistortions;           //! flag to account for distortions. RS: to set!
+   TTree* fMCtrackNClTree;              //! optional tree with N clusters per MC track
    //
    ClassDef(AliTPCtracker,5) 
 };

--- a/TPC/TPCrec/TPCrecLinkDef.h
+++ b/TPC/TPCrec/TPCrecLinkDef.h
@@ -8,6 +8,8 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
+#pragma link C++ class vector<short>+;
+
 #pragma link C++ class AliTPCclusterer+;      // The TPC clusterer
 
 #pragma link C++ class AliTPCtrack+;          // Derived from AliTrack base class for TPC tracks


### PR DESCRIPTION
With AliTPCReconstructor::SetCountMCTrackClusters(kTRUE) static call
from rec.C a nclTPCperMCtrack.root file will be created with
srd::vector<short> containing number of TPC clusters per MC track. The full
content is:
nclPerMCtrack->Print()
...
*Br    0 :nMCTracks : nMCTracks/I                                            *
*Br    1 :nclTot    : nclTot/I                                               *
*Br    2 :nclOrphan : nclOrphan/I                                            *
*Br    3 :nclPerTrack : vector<short>                                        *
Since the same clusters may mention up to 3 MC tracks, the sum of Ncl per MC
track will normally exceed the total number of clusters.
nclOrphan gives number of clusters not originated by any track (noise)