### PR TITLE
ATO-426 0 Enabling CTest for subset of the STAT classes

### DIFF
--- a/STAT/AliTreePlayer.cxx
+++ b/STAT/AliTreePlayer.cxx
@@ -826,13 +826,25 @@ void  AliTreePlayer::AddStatInfo(TTree* treeLeft,  TTree * treeRight , const TSt
                         statValue=TMath::MaxElement(index1-index0, dvalues.GetMatrixArray());
                     } else if(statType==kLTM){
                         TVectorD params(7);
-                        TStatToolkit::LTMUnbinned(index1-index0, dvalues.GetMatrixArray()
-                                ,params,frac);
+                        try {
+                            TStatToolkit::LTMUnbinned(index1 - index0, dvalues.GetMatrixArray(), params, frac);
+                        }
+                        catch (int e)
+                        {
+                            cout << "TStatToolkit::LTMUnbinned. Catch Exception Nr. " << e << '\n';
+                            continue;
+                        }
                         statValue = params[1];
                     } else if(statType==kLTMRMS){
                         TVectorD params(7);
-                        TStatToolkit::LTMUnbinned(index1-index0, dvalues.GetMatrixArray()
-                                ,params,frac);
+                        try {
+                            TStatToolkit::LTMUnbinned(index1 - index0, dvalues.GetMatrixArray(), params, frac);
+                        }
+                        catch (int e)
+                        {
+                            cout << "TStatToolkit::LTMUnbinned. Catch Exception Nr. " << e << '\n';
+                            continue;
+                        }
                         statValue = params[2];
                     } else{
                         ::Error("AddStatInfo()","String %s StatType %d not implemented",stat.Data(),statType);

--- a/STAT/AliTreePlayer.cxx
+++ b/STAT/AliTreePlayer.cxx
@@ -678,17 +678,6 @@ Int_t  AliTreePlayer::selectWhatWhereOrderBy(TTree * tree, TString what, TString
     return selected;
 }
 
-
-
-
-
-
-
-
-
-
-
-
 // Get the enumeration type from a string
 Int_t AliTreePlayer::GetStatType(const TString &stat){
 
@@ -701,7 +690,11 @@ Int_t AliTreePlayer::GetStatType(const TString &stat){
   } else if(!stat.CompareTo("RMS",TString::kIgnoreCase)){
     return kRMS;
   } else if(!stat.CompareTo("Mean",TString::kIgnoreCase)){
-    return kMean;
+      return kMean;
+  }else if(!stat.CompareTo("Max",TString::kIgnoreCase)){
+      return kMax;
+  }else if(!stat.CompareTo("Min",TString::kIgnoreCase)){
+      return kMin;
   } else if(stat.BeginsWith("LTMRMS",TString::kIgnoreCase)){ // Least trimmed RMS, argument is LTMRMS0.95 or similar
     return kLTMRMS;
   } else if(stat.BeginsWith("LTM",TString::kIgnoreCase)){ // Least trimmed mean, argument is LTM0.95 or similar
@@ -719,142 +712,140 @@ Int_t AliTreePlayer::GetStatType(const TString &stat){
 }
 //__________________________________________________________
 void  AliTreePlayer::AddStatInfo(TTree* treeLeft,  TTree * treeRight , const TString refQuery, Double_t deltaT,
-		 const TString statString,
-		 Int_t maxEntries){  
- 
-  
-  //
-  // 1.) Get variables from the right tree, sort them according to the coordinate
-  //
-  treeRight->SetEstimate(treeRight->GetEntries()*540);
-  Int_t entries  = treeRight->Draw(refQuery.Data(),"","goffpara",maxEntries);
-  if(entries<1){
-    ::Error("AddStatInfo","No matching entries for query");
-    return;
-  }
-  Int_t * indexArr = new Int_t[entries];
-  TMath::Sort(entries, treeRight->GetV1(), indexArr,kFALSE);
-  Double_t * coordArray  = new Double_t[entries];
-  for (Int_t icoord=0; icoord<entries; icoord++) coordArray[icoord]=treeRight->GetV1()[indexArr[icoord]];
+                                 const TString statString,
+                                 Int_t maxEntries){
 
+    //
+    // 1.) Get variables from the right tree, sort them according to the coordinate
+    //
+    Int_t entries  = treeRight->Draw(refQuery.Data(),"","goffpara",maxEntries);
+    if(entries<1){
+        ::Error("AddStatInfo","No matching entries for query");
+        return;
+    }else if (entries>treeRight->GetEstimate()){
+        treeRight->SetEstimate(entries*2);
+        entries  = treeRight->Draw(refQuery.Data(),"","goffpara",maxEntries);
+    }
+    Int_t * indexArr = new Int_t[entries];
+    TMath::Sort(entries, treeRight->GetV1(), indexArr,kFALSE);
+    Double_t * coordArray  = new Double_t[entries];
+    for (Int_t icoord=0; icoord<entries; icoord++) coordArray[icoord]=treeRight->GetV1()[indexArr[icoord]];
+    //
+    // 2.) Attach the median,.. of the variables to the left tree
+    //
+    // The first token is the coordinate
+    TString var;
+    Ssiz_t from=0;
+    if(!refQuery.Tokenize(var,from,":")){
+        ::Error("AddStatInfo","Cannot tokenize query \'%s\'. Use colon separated list"
+                ,refQuery.Data());
+        delete[]indexArr;indexArr=0;
+        delete[]coordArray;coordArray=0;
+        return;
+    }
+    Int_t entriesCoord =  treeLeft->GetEntries();
+    TBranch * br = treeLeft->GetBranch(var.Data());
+    Int_t coordValue;
+    br->SetAddress(&coordValue);
+    //TLeaf *coordLeaf = (TLeaf*)(br->GetListOfLeaves()->At(0));
 
-  //
-  // 2.) Attach the median,.. of the variables to the left tree
-  //
-  // The first token is the coordinate
-  TString var;
-  Ssiz_t from=0;
-  if(!refQuery.Tokenize(var,from,":")){
-    ::Error("AddStatInfo","Cannot tokenize query \'%s\'. Use colon separated list"
-	    ,refQuery.Data());
+    while(refQuery.Tokenize(var,from,":")){
+        //   var="valueAnodeRaw.fElements[0]";
+        TString stat;
+        Ssiz_t fromStat=0;
+        while(statString.Tokenize(stat,fromStat,":")){
+            // stat = "median"; stat="medianLeft"; stat="medianRight";
+            //      Int_t statType=TStatToolkit::GetStatType(stat);
+            Int_t statType=GetStatType(stat);
+            if(statType==kUndef)continue;
+            //printf("\n\n\n--- StatType %d ---\n\n\n\n",statType);
+
+            // In case of LMS or LMR determine the fraction
+            Float_t frac=0.;
+            if(statType==kLTM || statType==kLTMRMS){ // stat="LTM0.95" or "LTMRMS0.95" similar
+                TString tmp= stat;
+                tmp.ReplaceAll("LTMRMS","");
+                tmp.ReplaceAll("LTM","");
+                frac = tmp.Atof(); // atof returns 0.0 on error
+                if(frac>1)frac/=100.; // allows "LTM95" for 95%
+            }
+
+            // Determine the offset in coordinate to the left and right
+            Double_t leftOffset=-1e99,rightOffset=-1e99;
+            if(statType==kMedian||statType==kRMS || statType==kMean
+               || statType==kLTM || statType==kLTMRMS || statType==kMin || statType==kMax ){ // symmetric
+                leftOffset=-deltaT;rightOffset=deltaT;
+            } else if(statType==kMedianLeft){ //left
+                leftOffset=-2.*deltaT;rightOffset=0.;
+            } else if(statType==kMedianRight){ //right
+                leftOffset=0.;rightOffset=2.*deltaT;
+            }
+
+            TString brName=Form("%s_%s",var.Data(),stat.Data());
+            brName.ReplaceAll("[","_");
+            brName.ReplaceAll("]","_");
+            brName.ReplaceAll(".","_");
+            Double_t statValue=0;
+            if (treeLeft->GetDirectory()) treeLeft->GetDirectory()->cd();
+            TBranch *brToFill = treeLeft->Branch(brName.Data(),&statValue, (brName+"/D").Data());
+            TVectorD dvalues(entries);
+
+            for (Int_t icoord=0; icoord<entriesCoord; icoord++){
+                // Int_t icoord=0
+                br->GetEntry(icoord);
+                Double_t startCoord=coordValue+leftOffset;
+                Double_t endCoord       =coordValue+rightOffset;
+                //Double_t startCoord=coordLeaf->GetValue()+leftOffset;
+                //Double_t endCoord	=coordLeaf->GetValue()+rightOffset;
+
+                // Binary search finds last element smaller or equal
+                Int_t index0=BinarySearchSmaller(entries, coordArray, startCoord)+1;
+                Int_t index1=TMath::BinarySearch(entries, coordArray, endCoord) +1;
+                statValue=0;
+                if (index1>=0 && index0>=0){
+                    //if (values.capacity()<index1-index0)  values.reserve(1.5*(index1-index0));     //resize of needed
+                    if (index1-index0<=0){
+                        index0--;
+                        index1++;
+                        if (index0<0) index0=0;
+                        if (index1>=entries) index1=entries-1;
+                    }
+                    for (Int_t i=0; i<index1-index0; i++){
+                        dvalues[i]=treeRight->GetV2()[indexArr[i+index0]];
+                    }
+                    // Calculate
+                    if(statType==kMedian||statType==kMedianLeft||statType==kMedianRight){
+                        statValue=TMath::Median(index1-index0, dvalues.GetMatrixArray());
+                    } else if(statType==kRMS){
+                        statValue=TMath::RMS(index1-index0, dvalues.GetMatrixArray());
+                    } else if(statType==kMean){
+                        statValue=TMath::Mean(index1-index0, dvalues.GetMatrixArray());
+                    }else if(statType==kMin){
+                        statValue=TMath::MinElement(index1-index0, dvalues.GetMatrixArray());
+                    }else if(statType==kMax){
+                        statValue=TMath::MaxElement(index1-index0, dvalues.GetMatrixArray());
+                    } else if(statType==kLTM){
+                        TVectorD params(7);
+                        TStatToolkit::LTMUnbinned(index1-index0, dvalues.GetMatrixArray()
+                                ,params,frac);
+                        statValue = params[1];
+                    } else if(statType==kLTMRMS){
+                        TVectorD params(7);
+                        TStatToolkit::LTMUnbinned(index1-index0, dvalues.GetMatrixArray()
+                                ,params,frac);
+                        statValue = params[2];
+                    } else{
+                        ::Error("AddStatInfo()","String %s StatType %d not implemented",stat.Data(),statType);
+                    }
+                }
+                brToFill->Fill();
+            } // Loop over cordinates
+            brToFill->FlushBaskets();
+        } // Loop over stat types
+    } // Loop over variables
+    treeLeft->Write();
     delete[]indexArr;indexArr=0;
     delete[]coordArray;coordArray=0;
-    return;
-  }
-  Int_t entriesCoord =  treeLeft->GetEntries();
-  TBranch * br = treeLeft->GetBranch(var.Data());
-  Int_t coordValue;
-  br->SetAddress(&coordValue);
-  //TLeaf *coordLeaf = (TLeaf*)(br->GetListOfLeaves()->At(0));
-
-  while(refQuery.Tokenize(var,from,":")){
-    //   var="valueAnodeRaw.fElements[0]";
-    TString stat;
-    Ssiz_t fromStat=0;
-    while(statString.Tokenize(stat,fromStat,":")){
-      // stat = "median"; stat="medianLeft"; stat="medianRight";
-      //      Int_t statType=TStatToolkit::GetStatType(stat);
-      Int_t statType=GetStatType(stat);
-      if(statType==kUndef)continue;
-      //printf("\n\n\n--- StatType %d ---\n\n\n\n",statType);
-
-      // In case of LMS or LMR determine the fraction
-      Float_t frac=0.;
-      if(statType==kLTM || statType==kLTMRMS){ // stat="LTM0.95" or "LTMRMS0.95" similar
-	TString tmp= stat;
-	tmp.ReplaceAll("LTMRMS","");
-	tmp.ReplaceAll("LTM","");
-	frac = tmp.Atof(); // atof returns 0.0 on error
-	if(frac>1)frac/=100.; // allows "LTM95" for 95%
-      }
-      
-      // Determine the offset in coordinate to the left and right
-      Double_t leftOffset=-1e99,rightOffset=-1e99;
-      if(statType==kMedian||statType==kRMS || statType==kMean
-	 || statType==kLTM || statType==kLTMRMS){ // symmetric
-	leftOffset=-deltaT;rightOffset=deltaT;
-      } else if(statType==kMedianLeft){ //left
-	leftOffset=-2.*deltaT;rightOffset=0.;
-      } else if(statType==kMedianRight){ //right
-	leftOffset=0.;rightOffset=2.*deltaT;
-      }
-      
-      TString brName=Form("%s_%s",var.Data(),stat.Data());
-      brName.ReplaceAll("[","_");
-      brName.ReplaceAll("]","_");
-      brName.ReplaceAll(".","_");
-      Double_t statValue=0;
-      TBranch *brToFill = treeLeft->Branch(brName.Data(),&statValue, (brName+"/D").Data());
-      TVectorD dvalues(entries/10+1);
-				 
-      for (Int_t icoord=0; icoord<entriesCoord; icoord++){
-	// Int_t icoord=0
-	br->GetEntry(icoord);
-	Double_t startCoord=coordValue+leftOffset;
-	Double_t endCoord       =coordValue+rightOffset;
-	//Double_t startCoord=coordLeaf->GetValue()+leftOffset;
-	//Double_t endCoord	=coordLeaf->GetValue()+rightOffset;
- 
-	// Binary search finds last element smaller or equal
-	Int_t index0=BinarySearchSmaller(entries, coordArray, startCoord)+1;
-	Int_t index1=TMath::BinarySearch(entries, coordArray, endCoord) +1;
-	statValue=0;
-	if (index1>=0 && index0>=0){
-	  //if (values.capacity()<index1-index0)  values.reserve(1.5*(index1-index0));     //resize of needed
-	  for (Int_t i=0; i<index1-index0; i++){
-	    dvalues[i]=treeRight->GetV2()[indexArr[i+index0]];
-	  }
-
-	  // Calculate 
-	  if(statType==kMedian||statType==kMedianLeft||statType==kMedianRight){
-	    statValue=TMath::Median(index1-index0, dvalues.GetMatrixArray());
-	  } else if(statType==kRMS){
-	    statValue=TMath::RMS(index1-index0, dvalues.GetMatrixArray());
-	  } else if(statType==kMean){
-	    statValue=TMath::Mean(index1-index0, dvalues.GetMatrixArray());
-	  } else if(statType==kLTM){
-	    TVectorD params(7);
-	    TStatToolkit::LTMUnbinned(index1-index0, dvalues.GetMatrixArray()
-				      ,params,frac);
-	    statValue = params[1];
-	  } else if(statType==kLTMRMS){
-	    TVectorD params(7);
-	    TStatToolkit::LTMUnbinned(index1-index0, dvalues.GetMatrixArray()
-				      ,params,frac);
-	    statValue = params[2];
-	  } else{
-	    ::Error("AddStatInfo()","String %s StatType %d not implemented",stat.Data(),statType);
-	  }
-
-	  // // debug
-	  // printf("startCoord=%.3e, endCoord=%.3e, median=%.3e, index0=%d, index1=%d "
-	  // 	 ,startCoord,endCoord,statValue,index0,index1);
-	  // for(Int_t i=0;i<index1-index0;i++){
-	  //   printf("dvalues[%d]=%.3e "
-	  // 	   ,i,dvalues[i]);
-	  // }
-	  // printf("\n");
-	    
-
-	}
-	brToFill->Fill();
-      } // Loop over cordinates
-      brToFill->FlushBaskets();
-    } // Loop over stat types
-  } // Loop over variables
-  treeLeft->Write();
-  delete[]indexArr;indexArr=0;
-  delete[]coordArray;coordArray=0;
 
 }
 

--- a/STAT/AliTreePlayer.h
+++ b/STAT/AliTreePlayer.h
@@ -42,10 +42,10 @@ public:
   static void MakeCacheTree(TTree * tree, TString varList, TString outFile, TString outTree, TCut selection);
 
   template <typename T> static Long64_t BinarySearchSmaller(Long64_t n, const T *array, T value);
-  enum TStatType {kUndef=-1,kEntries, kSum, kMean, kRMS, kMedian, kLTM, kLTMRMS, kMedianLeft,kMedianRight}; 
+  enum TStatType {kUndef=-1,kEntries, kSum, kMean, kRMS, kMedian, kLTM, kLTMRMS, kMedianLeft,kMedianRight,kMax,kMin};
   static Int_t GetStatType(const TString &stat);
   static void AddStatInfo(TTree* treeLeft,  TTree * treeRight , const TString refQuery, Double_t deltaT,
-		   const TString statString="median:medianLeft:medianRight:RMS:Mean:LTM0.60:LTMRMS0.60",
+		   const TString statString="median:medianLeft:medianRight:RMS:Mean:LTM0.60:LTMRMS0.60:Max:Min",
 		   Int_t maxEntries=100000000); 
 protected:
   

--- a/STAT/CMakeLists.txt
+++ b/STAT/CMakeLists.txt
@@ -12,6 +12,7 @@
 # * about the suitability of this software for any purpose. It is          *
 # * provided "as is" without express or implied warranty.                  *
 # **************************************************************************
+add_subdirectory(test)
 
 # Module
 set(MODULE STAT)

--- a/STAT/CMakeLists.txt
+++ b/STAT/CMakeLists.txt
@@ -12,11 +12,12 @@
 # * about the suitability of this software for any purpose. It is          *
 # * provided "as is" without express or implied warranty.                  *
 # **************************************************************************
-add_subdirectory(test)
 
 # Module
 set(MODULE STAT)
 add_definitions(-D_MODULE_="${MODULE}")
+
+add_subdirectory(test)
 
 # Module include folders
 include_directories(${AliRoot_SOURCE_DIR}/${MODULE})

--- a/STAT/TStatToolkit.cxx
+++ b/STAT/TStatToolkit.cxx
@@ -1038,11 +1038,11 @@ TGraphErrors * TStatToolkit::MakeGraphErrors(TTree * tree, const char * expr, co
   if (msize>0) graph->SetMarkerSize(msize);
   for(Int_t i=0;i<graph->GetN();i++) graph->GetX()[i]+=offset;
   //
-  if (tree->GetVar(1)->IsInteger()){
+  if (tree->GetVar(1)->IsString()){ // use string for axis description
     TAxis * axis = tree->GetHistogram()->GetXaxis();
     axis->Copy(*(graph->GetXaxis()));
   }
-  if (tree->GetVar(0)->IsInteger()){
+  if (tree->GetVar(0)->IsString()){
     TAxis * axis = tree->GetHistogram()->GetYaxis();
     axis->Copy(*(graph->GetYaxis()));
   }

--- a/STAT/TStatToolkit.h
+++ b/STAT/TStatToolkit.h
@@ -686,6 +686,12 @@ Int_t* TStatToolkit::LTMUnbinned(int np, const T *arr, TVectorT<T> &params , Flo
   }
   //
   if (!params[0]) return 0;
+  if (params[2]<0) {
+    ::Error("TStatToolkit::LTMUnbinned","rounding error in RMS<0");
+    // current fast algorithm N  -  Sometimes rounding errors can lead to negative RMS
+    // more precise algorithm N2
+    throw 1;
+  }
   params[2] = TMath::Sqrt(params[2]);
   params[3] = params[2]/TMath::Sqrt(params[0]); // error on mean
   params[4] = params[3]/TMath::Sqrt(2.0); // error on RMS

--- a/STAT/test/AliTMinuitToolkitTestLinear.C
+++ b/STAT/test/AliTMinuitToolkitTestLinear.C
@@ -1,10 +1,8 @@
-/*
-   Test AliTMinuitToolkit fit option
-   For the moment: Test only code doe not crachs
-   .L $AliRoot_SRC/STAT/test/AliTMinuitToolkitTestLinear.C+
-   AliTMinuitToolkitTestLinear(2000,3);
-
-*/
+// Test AliTMinuitToolkit fit option
+// For the moment: we only test that the code does not crash
+// Usage: from the ROOT prompt:
+//     .L <AliRoot_source>/STAT/test/AliTMinuitToolkitTestLinear.C+
+//     AliTMinuitToolkitTestLinear(2000, 3)
 
 #include "AliTMinuitToolkit.h"
 #include "TVectorD.h"
@@ -32,17 +30,17 @@ void AliTMinuitToolkitTestLinear(Int_t nIter, Int_t nDraw){
   //      5.) Bootstrap with 20 iteration
   //      6.) Bootstrap with 100 iteration
   //      7.) MISAC     with 200 iteration
-  // 
+  //
   //   Input data: pol1 gausian nosie with tails
-  //      pol1+ ((rmdm>x) ? rndmG :10*rndmG)   
-  // 
+  //      pol1+ ((rmdm>x) ? rndmG :10*rndmG)
+  //
   // nIter=1000; nDraw=4;
   AliTMinuitToolkit::RegisterDefaultFitters();
   AliTMinuitToolkit::GetPredefinedFitter("pol1R")->SetStreamer("AliTMinuitToolkit_Pol1Rstreamer.root");
   ((TFormula*)AliTMinuitToolkit::GetPredefinedFitter("pol1R")->GetLogLikelihoodFunction())->SetParameter(0,0.7);
 
   //
-  //  
+  //
   TMatrixD &pInit = *((AliTMinuitToolkit::GetPredefinedFitter("pol1R")->GetInitialParam()));
   TMatrixD &pInitH = *((AliTMinuitToolkit::GetPredefinedFitter("pol1H")->GetInitialParam()));
   pInit(0,0)=0; pInit(0,1)=10;
@@ -85,9 +83,9 @@ void AliTMinuitToolkitTestLinear(Int_t nIter, Int_t nDraw){
     f1->GetParameters(fit1.GetMatrixArray());
     //
     AliTMinuitToolkit*fitter2 = AliTMinuitToolkit::Fit(gr,"pol1","default", "", "funOption(1,3,1)");  // standard minuit
-    fit2=*(fitter2->GetParameters());     mfit2=*(fitter2->GetCovarianceMatrix());    
+    fit2=*(fitter2->GetParameters());     mfit2=*(fitter2->GetCovarianceMatrix());
     AliTMinuitToolkit*fitter3 = AliTMinuitToolkit::Fit(gr,"pol1R","iter1", "", "funOption(2,3,1)"); // logLike:gaus+cauchy
-    fit3=*(fitter3->GetParameters());     mfit3=*(fitter3->GetCovarianceMatrix());    
+    fit3=*(fitter3->GetParameters());     mfit3=*(fitter3->GetCovarianceMatrix());
     AliTMinuitToolkit*fitter4 = AliTMinuitToolkit::Fit(gr,"pol1H","", "", "funOption(2,3,2)"); // logLike: huber
     fit4=*(fitter4->GetParameters());     mfit4=*(fitter3->GetCovarianceMatrix());
     AliTMinuitToolkit*fitter5 = AliTMinuitToolkit::Fit(gr,"pol1R","bootstrap20", "","funOption(6,3,4)");  // bootstrap20
@@ -95,7 +93,7 @@ void AliTMinuitToolkitTestLinear(Int_t nIter, Int_t nDraw){
     AliTMinuitToolkit*fitter6 = AliTMinuitToolkit::Fit(gr,"pol1R","bootstrap50", "", "funOption(3,3,5)" ); // bootstrap50
     fit6=*(fitter6->GetParameters());     rms6=*(fitter6->GetRMSEstimator());
     AliTMinuitToolkit*fitter7 = AliTMinuitToolkit::Fit(gr,"pol1R","misac(4,20)","","funOption(3,3,6)");    // misac 20
-    fit7=*(fitter7->GetParameters()); rms7=*(fitter7->GetRMSEstimator());    
+    fit7=*(fitter7->GetParameters()); rms7=*(fitter7->GetRMSEstimator());
     AliTMinuitToolkit*fitter8 = AliTMinuitToolkit::Fit(gr,"pol1R","misac(4,50)","","funOption(3,3,6)");    // misac 50
     TMatrixD *misacEstimator=(TMatrixD*)(fitter8->GetMISACEstimators());
     fit8=*(fitter8->GetParameters()); rms8=*(fitter8->GetRMSEstimator());
@@ -133,8 +131,8 @@ void AliTMinuitToolkitTestLinear(Int_t nIter, Int_t nDraw){
       "mfit3.="<<&mfit3<<
       "mfit4.="<<&mfit4<<
       //
-      "misacE.="<<misacEstimator<<       
-      "\n";      
+      "misacE.="<<misacEstimator<<
+      "\n";
   }
   canvasTestLinearFit->SaveAs("AliTMinuiToolkit.TestLinearFitExample.png");
   canvasTestLinearFit->SaveAs("AliTMinuiToolkit.TestLinearFitExample.pdf");
@@ -155,7 +153,7 @@ void AliTMinuitToolkitTestLinear(Int_t nIter, Int_t nDraw){
     canvasStatComparison->cd(iFit+1)->SetLogy();
     treeOut->Draw(TString::Format("fit%d.fElements[1]-p1>>hisDelta0_%d(100,-20,20)",iFit,iFit));
     treeOut->GetHistogram()->SetTitle(fnames[iFit]);
-    treeOut->GetHistogram()->GetXaxis()->SetTitle("p_{1fit}-p_{1in}"); 
+    treeOut->GetHistogram()->GetXaxis()->SetTitle("p_{1fit}-p_{1in}");
     treeOut->GetHistogram()->Fit("gaus");
     ::Info("AliTMinuitToolkitTestLinear", Form("Fit%s",fnames[iFit]));
   }
@@ -166,6 +164,6 @@ void AliTMinuitToolkitTestLinear(Int_t nIter, Int_t nDraw){
   TTree * treeBootstrap = ((*(AliTMinuitToolkit::GetPredefinedFitter("pol1R")->GetStreamer()))<<"bootstrap").GetTree();
   TTree * treeTwoFold = ((*(AliTMinuitToolkit::GetPredefinedFitter("pol1R")->GetStreamer()))<<"crossValidation").GetTree();
   TTree * treeMISAC = ((*(AliTMinuitToolkit::GetPredefinedFitter("pol1R")->GetStreamer()))<<"misac").GetTree();
-  
+
 
 }

--- a/STAT/test/AliTMinuitToolkitTestLinear.C
+++ b/STAT/test/AliTMinuitToolkitTestLinear.C
@@ -1,4 +1,6 @@
 /*
+   Test AliTMinuitToolkit fit option
+   For the moment: Test only code doe not crachs
    .L $AliRoot_SRC/STAT/test/AliTMinuitToolkitTestLinear.C+
    AliTMinuitToolkitTestLinear(2000,3);
 
@@ -154,7 +156,8 @@ void AliTMinuitToolkitTestLinear(Int_t nIter, Int_t nDraw){
     treeOut->Draw(TString::Format("fit%d.fElements[1]-p1>>hisDelta0_%d(100,-20,20)",iFit,iFit));
     treeOut->GetHistogram()->SetTitle(fnames[iFit]);
     treeOut->GetHistogram()->GetXaxis()->SetTitle("p_{1fit}-p_{1in}"); 
-    treeOut->GetHistogram()->Fit("gaus"); 
+    treeOut->GetHistogram()->Fit("gaus");
+    ::Info("AliTMinuitToolkitTestLinear", Form("Fit%s",fnames[iFit]));
   }
   canvasStatComparison->SaveAs("AliTMinuiToolkit.TestLinearFitStatExample.png");
   canvasStatComparison->SaveAs("AliTMinuiToolkit.TestLinearFitStatExample.pdf");

--- a/STAT/test/AliTMinuitToolkitTestLinear.C
+++ b/STAT/test/AliTMinuitToolkitTestLinear.C
@@ -1,8 +1,10 @@
-// Test AliTMinuitToolkit fit option
-// For the moment: we only test that the code does not crash
-// Usage: from the ROOT prompt:
-//     .L <AliRoot_source>/STAT/test/AliTMinuitToolkitTestLinear.C+
-//     AliTMinuitToolkitTestLinear(2000, 3)
+/*
+   Test AliTMinuitToolkit fit option
+   For the moment: Test only code doe not crachs
+   .L $AliRoot_SRC/STAT/test/AliTMinuitToolkitTestLinear.C+
+   AliTMinuitToolkitTestLinear(2000,3);
+
+*/
 
 #include "AliTMinuitToolkit.h"
 #include "TVectorD.h"

--- a/STAT/test/AliTreePlayerTest.C
+++ b/STAT/test/AliTreePlayerTest.C
@@ -1,7 +1,6 @@
 /*
   Test suit for the AliTreePlayer:
 
-  aliroot -b -q   $AliRoot_SRC/STAT/test/AliTreePlayerTest.C+ |tee AliTreePlayerTest.log
   cat AliTreePlayerTest.log | grep "AliTreePlayerTest\."
 
   Test should be integrated to AliRoot test suit (not cmake test as it need access to the external files)
@@ -17,12 +16,7 @@
      .L  $ALICE_ROOT/../src/STAT/test/AliTreePlayerTest.C+
      AliTreePlayerTest();
 
-  Tests: see desciption in idnividual test
-  void testSelectMetadata();
-  void testselectTreeInfo();
-  //void testselectWhatWhereOrderBy();
-  void testConvertTree();
-  in case
+  Tests: see description in individual test
 
 
 
@@ -61,7 +55,7 @@ void AliTreePlayerTest(){
   // 
   AliExternalInfo info;
   TTree * treeLogbook = info.GetTree("Logbook","LHC15o","cpass1_pass1","QA.TPC;QA.TRD;QA.TOF;");
-  TTree * treeTPC = info.GetTree("QA.TPC","LHC15o","cpass1_pass1","QA.TRD;QA.TPC;QA.TOC;QA.TOF;Logbook");
+  TTree * treeTPC = info.GetTree("QA.TPC","LHC15o","cpass1_pass1","QA.TRD;QA.TPC;QA.TOF;QA.TOF;Logbook");
   TTree * treeTRD = info.GetTree("QA.TRD","LHC15o","cpass1_pass1","QA.TPC;QA.TRD;QA.TOF;Logbook;");
   //
   testTree=treeLogbook;
@@ -155,6 +149,10 @@ void testselectWhatWhereOrderByForTRD(){
 }
 
 void testConvertTree() {
+  // test root->csv conversion
+  //    test proper match of indexes
+  //    In case of corruption of the indices  test was failing
+  //
   AliExternalInfo info;
   TTree *treeTPC = info.GetTree("QA.TPC", "LHC15o", "cpass1_pass1");
   TTree *treeTRD = info.GetTree("QA.TRD", "LHC15o", "cpass1_pass1");

--- a/STAT/test/AliTreePlayerTest.C
+++ b/STAT/test/AliTreePlayerTest.C
@@ -1,27 +1,33 @@
-// Test suite for AliTreePlayer.
-//
-// cat AliTreePlayerTest.log | grep "AliTreePlayerTest\."
-//
-// Test should be integrated to AliRoot test suite (not cmake test as it needs
-// to access the external files).
-//
-// Output should be that "Test OK" on all lines, e.g.:
-//
-// I-AliTreePlayerTest.testSelectMetadata AND invariant: Test OK: N(Logbook&&(Stat))=N(Logbook&&(Stat&&Base))+N(Logbook&&(Stat&&(!Base)))   7=2+5
-// I-AliTreePlayerTest.testSelectMetadata Negatioation test: Test OK:   N(!(A||B))=N((!A)&&(!B)) 73==73
-// I-AliTreePlayerTest.testselectTreeInfo: Test OK:   N(A))==N(A&&B)&&N(A&&!B)) 46=6+40
-// I-AliTreePlayerTest.testConvertTree: Test OK
-//
-// To run test interacivally, or test subsets:
-//     .L  $ALICE_ROOT/../src/STAT/test/AliTreePlayerTest.C+
-//     AliTreePlayerTest()
-//
-// Tests: see description in individual tests.
-
-// AliTreePlayer::selectMetadata(treeLogbook, "[class==\"Logbook&&Time\"]",0)->Print();
-// AliTreePlayer::selectWhatWhereOrderBy(treeTPC,"run:Logbook.run:QA.TPC.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"html","qatpc.html");
-// AliTreePlayer::selectWhatWhereOrderBy(treeTRD,"run:Logbook.run:QA.TRD.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"json","qatpc.json");
-// AliTreePlayer::selectWhatWhereOrderBy(treeTRD,"run:Logbook.run:QA.TRD.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"csv","qatpc.csv");
+/// \ingroup STAT/test
+/// \brief  test of AliTreePlayer class
+/*!
+  # Test suit for the AliTreePlayer: Integrated into CTEST
+  To run standalone:
+  \code
+  aliroot -b -q $AliRoot_SRC/STAT/test/AliTreePlayerTest.C+ | tee AliTreePlayerTest.log
+  cat AliTreePlayerTest.log | grep "AliTreePlayerTest\."
+  \endcode
+  Output should be all test OK:
+  \code
+  I-AliTreePlayerTest.testSelectMetadata AND invariant: Test OK: N(Logbook&&(Stat))=N(Logbook&&(Stat&&Base))+N(Logbook&&(Stat&&(!Base)))   7=2+5
+  I-AliTreePlayerTest.testSelectMetadata Negatioation test: Test OK:   N(!(A||B))=N((!A)&&(!B)) 73==73
+  I-AliTreePlayerTest.testselectTreeInfo: Test OK:   N(A))==N(A&&B)&&N(A&&!B)) 46=6+40
+  I-AliTreePlayerTest.testConvertTree: Test OK
+  \endcode
+  To run test interactivally, or test subsets (in debugger,valgrind/callgrind):
+  \code
+     .L  $AliRoot_SRC/STAT/test/AliTreePlayerTest.C+
+     AliTreePlayerTest();
+  \endcode
+  Tests: see description in individual test
+  \code
+  AliTreePlayer::selectMetadata(treeLogbook, "[class==\"Logbook&&Time\"]",0)->Print();
+  AliTreePlayer::selectWhatWhereOrderBy(treeTPC,"run:Logbook.run:QA.TPC.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"html","qatpc.html");
+  AliTreePlayer::selectWhatWhereOrderBy(treeTRD,"run:Logbook.run:QA.TRD.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"json","qatpc.json");
+  AliTreePlayer::selectWhatWhereOrderBy(treeTRD,"run:Logbook.run:QA.TRD.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"csv","qatpc.csv");
+  \endcode
+ */
+/// \author marian  Ivanov marian.ivanov@cern.ch
 
 #include "TStatToolkit.h"
 #include "Riostream.h"

--- a/STAT/test/AliTreePlayerTest.C
+++ b/STAT/test/AliTreePlayerTest.C
@@ -1,31 +1,27 @@
-/*
-  Test suit for the AliTreePlayer:
+// Test suite for AliTreePlayer.
+//
+// cat AliTreePlayerTest.log | grep "AliTreePlayerTest\."
+//
+// Test should be integrated to AliRoot test suite (not cmake test as it needs
+// to access the external files).
+//
+// Output should be that "Test OK" on all lines, e.g.:
+//
+// I-AliTreePlayerTest.testSelectMetadata AND invariant: Test OK: N(Logbook&&(Stat))=N(Logbook&&(Stat&&Base))+N(Logbook&&(Stat&&(!Base)))   7=2+5
+// I-AliTreePlayerTest.testSelectMetadata Negatioation test: Test OK:   N(!(A||B))=N((!A)&&(!B)) 73==73
+// I-AliTreePlayerTest.testselectTreeInfo: Test OK:   N(A))==N(A&&B)&&N(A&&!B)) 46=6+40
+// I-AliTreePlayerTest.testConvertTree: Test OK
+//
+// To run test interacivally, or test subsets:
+//     .L  $ALICE_ROOT/../src/STAT/test/AliTreePlayerTest.C+
+//     AliTreePlayerTest()
+//
+// Tests: see description in individual tests.
 
-  cat AliTreePlayerTest.log | grep "AliTreePlayerTest\."
-
-  Test should be integrated to AliRoot test suit (not cmake test as it need access to the external files)
-
-  Output should be all test OK:
-  I-AliTreePlayerTest.testSelectMetadata AND invariant: Test OK: N(Logbook&&(Stat))=N(Logbook&&(Stat&&Base))+N(Logbook&&(Stat&&(!Base)))   7=2+5
-  I-AliTreePlayerTest.testSelectMetadata Negatioation test: Test OK:   N(!(A||B))=N((!A)&&(!B)) 73==73
-  I-AliTreePlayerTest.testselectTreeInfo: Test OK:   N(A))==N(A&&B)&&N(A&&!B)) 46=6+40
-  I-AliTreePlayerTest.testConvertTree: Test OK
-
-
-  To run test interacivally, or test subsets:
-     .L  $ALICE_ROOT/../src/STAT/test/AliTreePlayerTest.C+
-     AliTreePlayerTest();
-
-  Tests: see description in individual test
-
-
-
-
-  AliTreePlayer::selectMetadata(treeLogbook, "[class==\"Logbook&&Time\"]",0)->Print();
-  AliTreePlayer::selectWhatWhereOrderBy(treeTPC,"run:Logbook.run:QA.TPC.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"html","qatpc.html");
-  AliTreePlayer::selectWhatWhereOrderBy(treeTRD,"run:Logbook.run:QA.TRD.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"json","qatpc.json");  
-  AliTreePlayer::selectWhatWhereOrderBy(treeTRD,"run:Logbook.run:QA.TRD.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"csv","qatpc.csv");  
-*/
+// AliTreePlayer::selectMetadata(treeLogbook, "[class==\"Logbook&&Time\"]",0)->Print();
+// AliTreePlayer::selectWhatWhereOrderBy(treeTPC,"run:Logbook.run:QA.TPC.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"html","qatpc.html");
+// AliTreePlayer::selectWhatWhereOrderBy(treeTRD,"run:Logbook.run:QA.TRD.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"json","qatpc.json");
+// AliTreePlayer::selectWhatWhereOrderBy(treeTRD,"run:Logbook.run:QA.TRD.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"csv","qatpc.csv");
 
 #include "TStatToolkit.h"
 #include "Riostream.h"
@@ -41,29 +37,22 @@
 #include "TTreeFormulaManager.h"
 #include "AliTreePlayer.h"
 
+TTree *testTree = 0x0;
 
-TTree * testTree=0;
 void testSelectMetadata();
 void testselectTreeInfo();
 //void testselectWhatWhereOrderBy();
 void testConvertTree();
 
-
-void AliTreePlayerTest(){
-  // test all  
-  // Input data are provided by AliExternalInfo 
-  // 
+void AliTreePlayerTest() {
   AliExternalInfo info;
-  TTree * treeLogbook = info.GetTree("Logbook","LHC15o","cpass1_pass1","QA.TPC;QA.TRD;QA.TOF;");
-  TTree * treeTPC = info.GetTree("QA.TPC","LHC15o","cpass1_pass1","QA.TRD;QA.TPC;QA.TOF;QA.TOF;Logbook");
-  TTree * treeTRD = info.GetTree("QA.TRD","LHC15o","cpass1_pass1","QA.TPC;QA.TRD;QA.TOF;Logbook;");
-  //
-  testTree=treeLogbook;
-  testSelectMetadata();  // run test
-  //
-  testTree=treeTPC;
+  TTree *treeLogbook = info.GetTree("Logbook","LHC15o","cpass1_pass1","QA.TPC;QA.TRD;QA.TOF;");
+  TTree *treeTPC = info.GetTree("QA.TPC","LHC15o","cpass1_pass1","QA.TRD;QA.TPC;QA.TOF;QA.TOF;Logbook");
+  TTree *treeTRD = info.GetTree("QA.TRD","LHC15o","cpass1_pass1","QA.TPC;QA.TRD;QA.TOF;Logbook;");
+  testTree = treeLogbook;
+  testSelectMetadata();
+  testTree = treeTPC;
   testselectTreeInfo();
-  //
   testConvertTree();
 }
 
@@ -164,10 +153,10 @@ void testConvertTree() {
   treeTRD->AddFriend(treeTPC,"QA.TPC");
 
   AliTreePlayer::selectWhatWhereOrderBy(treeTRD,"run:QA.TRD.run:QA.TPC.run","1", "", 0,1000,"csv","sparsetest.csv");
-  // test that the 1 and 2 columns are the same - count different collumns 
+  // test that the 1 and 2 columns are the same - count different collumns
   //      cat sparsetest.csv | grep -v "run" | gawk  '{ sum+=($1!=$2) } END {print sum} '
   Int_t mismatch0 = (gSystem->GetFromPipe(" cat sparsetest.csv | grep -v \"run\" | gawk  '{ sum+=($1!=$2) } END {print sum} '")).Atoi(); // should be 0 count run mismatch
-  //  cat sparsetest.csv | grep -v "run" | gawk  '{sum+=($1==prev); prev=$1;} END {print sum} '  
+  //  cat sparsetest.csv | grep -v "run" | gawk  '{sum+=($1==prev); prev=$1;} END {print sum} '
   Int_t mismatch1=(gSystem->GetFromPipe("cat sparsetest.csv | grep -v \"run\" | gawk  '{sum+=($1==prev); prev=$1;} END {print sum} '")).Atoi();
   if (mismatch0>0||mismatch1){
     ::Error("AliTreePlayerTest.testConvertTree","Test ERROR Run mismatch for sparse trees");

--- a/STAT/test/CMakeLists.txt
+++ b/STAT/test/CMakeLists.txt
@@ -1,15 +1,5 @@
-#
-# test $Ali_Physics/PWGPP/scripts/utilities.sh
-#
 enable_testing()
-
-# AliTreePlayer test
-add_test( "testAliTreePlayer"
-           bash -c "( export AliRoot_SRC=${PROJECT_SOURCE_DIR}; source $AliRoot_SRC/STEER/Utilities/alilog4bash.sh; source $AliRoot_SRC/STAT/test/statTest.sh; testAliTreePlayer)")
-# command to be executed can be tested from command line
-#  ctest -R testAliTreePlayer --verbose
-# AliTMinuitToolkitTest
-add_test( "testAliTMinuitToolkitTest"
-           bash -c "( export AliRoot_SRC=${PROJECT_SOURCE_DIR}; source $AliRoot_SRC/STEER/Utilities/alilog4bash.sh; source $AliRoot_SRC/STAT/test/statTest.sh; testAliTMinutiToolkitTestLinear )")
-# command to be executed can be tested from command line
-#  ctest -R  testAliTMinuitToolkitTest --verbose
+add_test("func_STAT_AliTreePlayer"
+         bash -c "ALIROOT_SOURCE=${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/STAT/test/statTest.sh testAliTreePlayer")
+add_test("func_STAT_AliTMinuitToolkitTest"
+         bash -c "ALIROOT_SOURCE=${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/STAT/test/statTest.sh testAliTMinutiToolkitTestLinear")

--- a/STAT/test/CMakeLists.txt
+++ b/STAT/test/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# test $Ali_Physics/PWGPP/scripts/utilities.sh
+#
+enable_testing()
+
+# AliTreePlayer test
+add_test( "testAliTreePlayer"
+           bash -c "( export AliRoot_SRC=${PROJECT_SOURCE_DIR}; source $AliRoot_SRC/STEER/Utilities/alilog4bash.sh; source $AliRoot_SRC/STAT/test/statTest.sh; testAliTreePlayer)")
+# command to be executed can be tested from command line
+#  ctest -R testAliTreePlayer --verbose
+# AliTMinuitToolkitTest
+add_test( "testAliTMinuitToolkitTest"
+           bash -c "( export AliRoot_SRC=${PROJECT_SOURCE_DIR}; source $AliRoot_SRC/STEER/Utilities/alilog4bash.sh; source $AliRoot_SRC/STAT/test/statTest.sh; testAliTMinutiToolkitTestLinear )")
+# command to be executed can be tested from command line
+#  ctest -R  testAliTMinuitToolkitTest --verbose

--- a/STAT/test/statTest.sh
+++ b/STAT/test/statTest.sh
@@ -7,7 +7,8 @@
 #   alienv enter AliRoot/latest  # load AliRoot environment
 #   cd <AliRoot_Build_Directory>
 #   ctest --output-on-failure -R func_STAT_*
-#
+#   or extra verbose
+#   ctest --extra-verbose -R func_STAT_*
 # Tests output will be printed only in case of failures.
 
 source $ALICE_ROOT/libexec/alilog4bash.sh
@@ -17,15 +18,16 @@ if [[ ! $ALIROOT_SOURCE ]]; then
 fi
 
 testAliTreePlayer() {
-  TMPDIR=$(mktemp -d)
-  cd $TMPDIR
+  # MI comment: Keep log file for later log archiving and log parsing
+  # TMPDIR=$(mktemp -d)
+  # cd $TMPDIR
   cp $ALIROOT_SOURCE/STAT/test/AliTreePlayerTest.C .
-  root -b -l <<\EOF &> test.log
+  root -b -l <<\EOF &> testAliTreePlayer.log
     gSystem->AddIncludePath("-I$ALICE_ROOT/include");
     .x ./AliTreePlayerTest.C+
 EOF
-  N_GOOD=$(grep -cE 'AliTreePlayerTest\..*Test.*OK' test.log)
-  N_BAD=$(grep -c "E-" test.log)
+  N_GOOD=$(grep -cE 'AliTreePlayerTest\..*Test.*OK' testAliTreePlayer.log)
+  N_BAD=$(grep -c "E-" testAliTreePlayer.log)
   TEST_STATUS=0
   if [[ $N_GOOD != 4 ]]; then
     alilog_error "statTest.testAliTreePlayer: Invariant test failed"
@@ -39,18 +41,19 @@ EOF
     alilog_success "statTest.testAliTreePlayer: All OK"
   else
     alilog_success "statTest.testAliTreePlayer: FAILED (code $TEST_STATUS): full log follows"
-    cat test.log
+    cat testAliTreePlayer.log
   fi
-  cd /
-  rm -rf $TMPDIR
+  # cd /
+  # rm -rf $TMPDIR
   exit $TEST_STATUS
 }
 
 testAliTMinutiToolkitTestLinear() {
-  TMPDIR=$(mktemp -d)
-  cd $TMPDIR
+  #MI comment: Keep log file for later log archiving and log parsing
+  #TMPDIR=$(mktemp -d)
+  #cd $TMPDIR
   cp $ALIROOT_SOURCE/STAT/test/AliTMinuitToolkitTestLinear.C .
-  root -b -l <<\EOF &> test.log
+  root -b -l <<\EOF &> testAliTMinutiToolkitTestLinear
     gSystem->AddIncludePath("-I$ALICE_ROOT/include");
     cout << gSystem->GetIncludePath() << "e che cz" << endl;
     .x ./AliTMinuitToolkitTestLinear.C+(50,3)
@@ -61,11 +64,11 @@ EOF
     exit 0
   else
     alilog_error "statTest.testAliTMinutiToolkitTestLinear: FAILED: full log follows"
-    cat test.log
+    cat testAliTMinutiToolkitTestLinear
     exit 1
   fi
-  cd /
-  rm -rf $TMPDIR
+  #cd /
+  #rm -rf $TMPDIR
 }
 
 [[ $1 ]] && $1

--- a/STAT/test/statTest.sh
+++ b/STAT/test/statTest.sh
@@ -7,8 +7,11 @@
 #   alienv enter AliRoot/latest  # load AliRoot environment
 #   cd <AliRoot_Build_Directory>
 #   ctest --output-on-failure -R func_STAT_*
-#   or extra verbose
+#
+# Or extra verbose:
+#
 #   ctest --extra-verbose -R func_STAT_*
+#
 # Tests output will be printed only in case of failures.
 
 source $ALICE_ROOT/libexec/alilog4bash.sh
@@ -17,12 +20,11 @@ if [[ ! $ALIROOT_SOURCE ]]; then
   exit 1
 fi
 
+export ROOT_HIST=0
+
 testAliTreePlayer() {
-  # MI comment: Keep log file for later log archiving and log parsing
-  # TMPDIR=$(mktemp -d)
-  # cd $TMPDIR
   cp $ALIROOT_SOURCE/STAT/test/AliTreePlayerTest.C .
-  root -b -l <<\EOF &> testAliTreePlayer.log
+  root -n -b -l <<\EOF 2>&1 | tee testAliTreePlayer.log
     gSystem->AddIncludePath("-I$ALICE_ROOT/include");
     .x ./AliTreePlayerTest.C+
 EOF
@@ -40,22 +42,15 @@ EOF
   if [[ $TEST_STATUS == 0 ]]; then
     alilog_success "statTest.testAliTreePlayer: All OK"
   else
-    alilog_success "statTest.testAliTreePlayer: FAILED (code $TEST_STATUS): full log follows"
-    cat testAliTreePlayer.log
+    alilog_error "statTest.testAliTreePlayer: FAILED (code $TEST_STATUS)"
   fi
-  # cd /
-  # rm -rf $TMPDIR
   exit $TEST_STATUS
 }
 
 testAliTMinutiToolkitTestLinear() {
-  #MI comment: Keep log file for later log archiving and log parsing
-  #TMPDIR=$(mktemp -d)
-  #cd $TMPDIR
   cp $ALIROOT_SOURCE/STAT/test/AliTMinuitToolkitTestLinear.C .
-  root -b -l <<\EOF &> testAliTMinutiToolkitTestLinear
+  root -n -b -l <<\EOF 2>&1 | tee testAliTMinutiToolkitTestLinear.log
     gSystem->AddIncludePath("-I$ALICE_ROOT/include");
-    cout << gSystem->GetIncludePath() << "e che cz" << endl;
     .x ./AliTMinuitToolkitTestLinear.C+(50,3)
 EOF
   NPDF=$(ls -1 *.pdf | grep -c '\.pdf')
@@ -63,12 +58,9 @@ EOF
     alilog_success "statTest.testAliTMinutiToolkitTestLinear: All OK"
     exit 0
   else
-    alilog_error "statTest.testAliTMinutiToolkitTestLinear: FAILED: full log follows"
-    cat testAliTMinutiToolkitTestLinear
+    alilog_error "statTest.testAliTMinutiToolkitTestLinear: FAILED"
     exit 1
   fi
-  #cd /
-  #rm -rf $TMPDIR
 }
 
 [[ $1 ]] && $1

--- a/STAT/test/statTest.sh
+++ b/STAT/test/statTest.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Test tp be used in CTEST of make test of aliroot
+#      see CMakeList.txt
+# To execute test standalone:
+#     ctest -R testAliTreePlayer --verbose
+#     or
+#     ( source $AliRoot_SRC/STEER/Utilities/alilog4bash.sh; source $AliRoot_SRC/STAT/test/statTest.sh; testAliTreePlayer )
+#     ( source $AliRoot_SRC/STEER/Utilities/alilog4bash.sh; source $AliRoot_SRC/STAT/test/statTest.sh; testAliTMinutiToolkitTestLinear )
+# assuming AliRoot_SRC variable is set
+
+testAliTreePlayer(){
+    #
+    # see AliTreePlayerTest.C source code for the list of tests
+    #     AliTreePlayerTest.log for details about test
+    aliroot -b -q   $AliRoot_SRC/STAT/test/AliTreePlayerTest.C+ |tee AliTreePlayerTest.log
+    cat AliTreePlayerTest.log | grep "AliTreePlayerTest\."
+    nGOOD=`cat AliTreePlayerTest.log | grep "AliTreePlayerTest\." | grep  -c -i -e "TEST.*OK"`;
+    nErr=`cat AliTreePlayerTest.log | grep -c "E-"`
+    testStatus=0;
+    if [ $nGOOD != 4 ] ; then
+        alilog_error "statTest.testAliTreePlayer: Invariant test  failed. See log files AliTreePlayerTest.log"
+        ((testStatus++))
+    fi;
+    if [ $nErr != 0 ] ; then
+        alilog_error "statTest.testAliTreePlayer: Invariant test  failed. See log files AliTreePlayerTest.log"
+        ((testStatus+=2))
+    fi
+    if [ $testStatus == 0 ] ; then
+        alilog_success "statTest.testAliTreePlayer: All OK"
+    else
+        alilog_success "statTest.testAliTreePlayer: FAILED code %"
+    fi;
+    #exit 1; #
+    exit $testStatus; # exist status tested in ctest
+}
+
+testAliTMinutiToolkitTestLinear(){
+    aliroot -b -q  $AliRoot_SRC/STAT/test/AliTMinuitToolkitTestLinear.C+\(50,3\) |tee AliTMinuitToolkitTestLinear.log
+    # for the moment test only that code did not fail
+    # dead band on fit values to be checked in regression test (Elast search DB)?
+    npdf=`ls *.pdf | grep -c pdf`
+    if [ $npdf == 2 ] ;then
+        alilog_success "statTest.testAliTMinutiToolkitTestLinear: All OK"
+        exit 0;
+    else
+        alilog_error "statTest.testAliTMinutiToolkitTestLinear: FAILED"
+        exit 1;
+    fi
+}

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -760,6 +760,7 @@ WARN_LOGFILE           =
 
 INPUT                  = @CMAKE_SOURCE_DIR@/doxygen \
                          @CMAKE_SOURCE_DIR@/STAT \
+                         @CMAKE_SOURCE_DIR@/STAT/test \
                          @CMAKE_SOURCE_DIR@/TPC \
                          @CMAKE_SOURCE_DIR@/TPC/Attic \
                          @CMAKE_SOURCE_DIR@/TPC/Base/test \


### PR DESCRIPTION
### Modifications
*  testAliTreePlayer
```
ctest -R testAliTreePlayer --verbose
95: I-AliTreePlayerTest.testConvertTree: Test OK
95: Processing /u/miranov/alicesw/sw/SOURCES/AliRoot/alicesw/0/STAT/test/AliTreePlayerTest.C+...
95: I-AliTreePlayerTest.testSelectMetadata AND invariant: Test OK: N(Logbook&&(Stat))=N(Logbook&&(Stat&&Base))+N(Logbook&&(Stat&&(!Base)))       7=2+5
95: I-AliTreePlayerTest.testSelectMetadata Negatioation test: Test OK:   N(!(A||B))=N((!A)&&(!B)) 73==73
95: I-AliTreePlayerTest.testselectTreeInfo: Test OK:   N(A))==N(A&&B)&&N(A&&!B)) 46=6+40
95: I-AliTreePlayerTest.testConvertTree: Test OK
95: [2017-07-12 15:26:50 CEST] [lxbk0198] [SUCCESS] statTest.testAliTreePlayer: All OK 
1/1 Test #95: testAliTreePlayer ................   Passed    1.82 sec

The following tests passed:
        testAliTreePlayer

100% tests passed, 0 tests failed out of 1
```
*  testAliTMinutiToolkitTestLinear
```
ctest -R  testAliTMinuitToolkitTest --verbose
...
96: I-AliTMinuitToolkitTestLinear: FitLogLike:Gaus(80%)Cauchy(20%)- MISAC(50)
96: I-TCanvas::Print: png file AliTMinuiToolkit.TestLinearFitStatExample.png has been created
96: I-TCanvas::Print: pdf file AliTMinuiToolkit.TestLinearFitStatExample.pdf has been created
96: [2017-07-12 15:15:49 CEST] [lxbk0198] [SUCCESS] statTest.testAliTMinutiToolkitTestLinear: All OK 
1/1 Test #96: testAliTMinuitToolkitTest ........   Passed    7.63 sec
The following tests passed:
        testAliTMinuitToolkitTest
100% tests passed, 0 tests failed out of 1
```
### Tests
* Ubuntu system (laptop) 
  * root 5 - OK
  * root 6 - OK
* Debian (GSI batch farm)
  * root 5

### HTTP access to QA server needed 
* test on server to be done
  * According discussion with Peter test server should have an access
