### PR TITLE
Introduce SetXYZcascade for testing purposes

### DIFF
--- a/STEER/ESD/AliESDcascade.cxx
+++ b/STEER/ESD/AliESDcascade.cxx
@@ -368,6 +368,15 @@ void AliESDcascade::GetXYZcascade(Double_t &x, Double_t &y, Double_t &z) const {
   z=fPosXi[2];
 }
 
+void AliESDcascade::SetXYZcascade(Double_t x, Double_t y, Double_t z) {
+    //--------------------------------------------------------------------
+    // This function sets cascade position (global)
+    //--------------------------------------------------------------------
+    fPosXi[0]=x;
+    fPosXi[1]=y;
+    fPosXi[2]=z;
+}
+
 Double_t AliESDcascade::GetDcascade(Double_t x0, Double_t y0, Double_t z0) const {
   //--------------------------------------------------------------------
   // This function returns the cascade impact parameter

--- a/STEER/ESD/AliESDcascade.h
+++ b/STEER/ESD/AliESDcascade.h
@@ -73,6 +73,7 @@ public:
   Double_t GetChi2Xi()  const {return fChi2Xi;}
   void     GetPxPyPz(Double_t &px, Double_t &py, Double_t &pz) const;
   void     GetXYZcascade(Double_t &x, Double_t &y, Double_t &z) const;
+  void     SetXYZcascade(Double_t x, Double_t y, Double_t z); //for testing purposes
   Double_t GetDcascade(Double_t x0, Double_t y0, Double_t z0) const;
 
   void     GetBPxPyPz(Double_t &px, Double_t &py, Double_t &pz) const {
@@ -104,7 +105,7 @@ protected:
 private:
 
 
-  ClassDef(AliESDcascade,5) // reconstructed cascade vertex
+  ClassDef(AliESDcascade,6) // reconstructed cascade vertex
 };
 
 inline


### PR DESCRIPTION
This commit introduces a way to change the decay position estimate for AliESDcascades, as discussed with the class author, @iouribelikov . 

At the moment, this decay position is calculated in the standard AliESDcascade constructor via a simple 50/50 average of the points of closest approach of bachelor and V0. This is different wrt to what is done in V0s, in which the decay position is estimated using a weighted (with errors) average of the DCA points of negative and positive tracks, and we are currently exploring the possibility of using a similar approach for cascades. In offline checks, such an approach has been shown to result in an improvement in CosPA resolution of up to 15%, and the purpose of having a SetXYZcascade function is for us to be able to cross-check these offline checks in full-fledged grid analysis before moving to a more definite change of the AliESDcascade constructor. 