### PR TITLE
Basic documentation of the interface of the calo trigger object

### DIFF
--- a/STEER/AOD/AliAODCaloTrigger.cxx
+++ b/STEER/AOD/AliAODCaloTrigger.cxx
@@ -28,7 +28,9 @@ Author: R. GUERNANE LPSC Grenoble CNRS/IN2P3
 #include "Riostream.h"
 #include <cstdlib>
 
+/// \cond CLASSIMP
 ClassImp(AliAODCaloTrigger)
+/// \endcond
 
 //_______________
 AliAODCaloTrigger::AliAODCaloTrigger() : AliVCaloTrigger(),

--- a/STEER/AOD/AliAODCaloTrigger.h
+++ b/STEER/AOD/AliAODCaloTrigger.h
@@ -1,20 +1,18 @@
 #ifndef ALIAODCALOTRIGGER_H
 #define ALIAODCALOTRIGGER_H
-
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */
-
-/*
- 
-
-
-Author: R. GUERNANE LPSC Grenoble CNRS/IN2P3
-*/
 
 #include "AliVCaloTrigger.h"
 
 class TArrayI;
 
+/**
+ * @class AliAODCaloTrigger
+ * @brief Container with calorimeter trigger information in the AOD event
+ *
+ * @author  R. Guernane, LPSC Grenoble CNRS/IN2P3
+ */
 class AliAODCaloTrigger : public AliVCaloTrigger 
 {
 public:
@@ -54,16 +52,64 @@ public:
 	void    SetTriggerBitWord(Int_t w) {fTriggerBitWord = w;}
 	void    SetMedian(Int_t i, Int_t m) {fMedian[i] = m;}
 
+	/**
+	 * @brief Access to position of the current fastor channel
+	 * @param[out] col Column of the current fastor in the detector plane
+	 * @param[out] row Row of the current fastor in the detector plane
+	 */
 	void    GetPosition(     Int_t& col, Int_t& row           ) const;
+
+	/**
+	 * @brief Access to L0-amplitude of the current fastor channel
+	 * @param[out] amp L0-amplitude for the given fastor channel
+	 */
 	void    GetAmplitude(    Float_t& amp                     ) const;
 	void    GetTime(         Float_t& time                    ) const;
 	
+	/**
+	 * @brief Get the trigger bits for a given fastor position
+	 *
+	 * Trigger bits define the starting position of online patches.
+	 * They are defined in AliEMCALTriggerTypes.h. Note that for
+	 * reconstructed patches an offset (MC offset) has to be taken
+	 * into account
+	 *
+	 * @param[out] bits Trigger bits connected to a given position
+	 */
 	void    GetTriggerBits(  Int_t& bits                      ) const;
+
+	/**
+	 * @brief Get the number of L0 times for the current patch
+	 *
+	 * Level0 times are handled per L0 patch. Indexing is different
+	 * with respect to the fastor indexing.
+	 *
+	 * @param[out] ntimes Number of level0
+	 */
 	void    GetNL0Times(     Int_t& ntimes                    ) const;
+
+	/**
+	 * @brief Get level0 times for the current L0 patch
+	 * @param times L0 times for the current L0 patch
+	 */
 	void    GetL0Times(      Int_t  times[]                   ) const;
+
+	/**
+	 * @brief Get the number of entries in the trigger data
+	 * @return Number of entries
+	 */
 	Int_t   GetEntries(                                       ) const {return fNEntries;}
 
+    /**
+     * @brief Get the L1 time sums (L1 ADC values) for the current fastor
+     * @param[out] timesum L1 timesums for the current fastor
+     */
         void    GetL1TimeSum(    Int_t& timesum                   ) const;
+
+     /**
+      * @brief Get the L1 time sums (L1 ADC values) for the current fastor
+      * @return L1 timesums for the current fastor
+      */
         Int_t   GetL1TimeSum(                                     ) const;
 
         void    GetL1SubRegion(  Int_t& subreg                    ) const;
@@ -83,6 +129,10 @@ public:
         Int_t   GetTriggerBitWord(                                ) const {return fTriggerBitWord;}
         void    GetTriggerBitWord( Int_t& bw                      ) const {bw = fTriggerBitWord;}
 
+    /**
+     * @brief Forward to next trigger entry (fastor / L0 patch)
+     * @return True if successful (next entry existing), false otherwise (was already at the end of the buffer)
+     */
 	virtual Bool_t Next();
 
 	virtual void Copy(TObject& obj) const;
@@ -91,30 +141,51 @@ public:
 	
 private:
 
-        Int_t    fNEntries;
-        Int_t    fCurrent;
+        Int_t    fNEntries;					///< Number of entries in the trigger object (usually mapped to fastor channels)
+        Int_t    fCurrent;					///< Index of the current entry
 
+    	/** Array of col positions for a trigger entry, one entry corresponds to a certain fastor channel */
 	Int_t*   fColumn;             // [fNEntries]
+
+	/** Array of row positions for a trigger entry, one entry corresponds to a certain fastor channel */
 	Int_t*   fRow;                // [fNEntries]
+
+	/** Array with L0 amplitudes for a trigger entry, one entry corresponds to a certain fastor channel */
 	Float_t* fAmplitude;          // [fNEntries]
+
+	/** Array of trigger times, one entry corresponds to a certain fastor channel */
 	Float_t* fTime;               // [fNEntries]
+
+	/** Array of the number of Level0 times, one entry corresponds to a certain L0 patch */
 	Int_t*   fNL0Times;           // [fNEntries]
+
+	/** Array of Level0 times, one entry corresponds to a certain L0 patch */
 	TArrayI* fL0Times;            //
+
+	/** Array of the L1 time sums (L1 ADC values), one entry corresponds to a certain fastor channel */
 	Int_t*   fL1TimeSum;          // [fNEntries]
+
+	/** Array of trigger bits: Each bit position corresponds to a certain trigger (L0/L1) fired. Note
+	 * that there is a MC offset to be taken into account. Reconsturcted triggers start from the position
+	 * of the MC offset. Trigger bits are defined in AliEMCALTriggerTypes.h. One entry correspons to a
+	 * certain fastor position.
+	 */
 	Int_t*   fTriggerBits;        // [fNEntries]
 	
-	Int_t    fL1Threshold[4];     // L1 thresholds from raw data
-	Int_t    fL1V0[2];            // L1 threshold components
-	Int_t    fL1FrameMask;        // Validation flag for L1 data
+	Int_t    fL1Threshold[4];     ///< L1 thresholds from raw data
+	Int_t    fL1V0[2];            ///< L1 threshold components
+	Int_t    fL1FrameMask;        ///< Validation flag for L1 data
 	
-        Int_t    fL1DCALThreshold[4]; // L1 thresholds from raw data
+        Int_t    fL1DCALThreshold[4]; ///< L1 thresholds from raw data
         Int_t*   fL1SubRegion;        // [fNEntries]
-        Int_t    fL1DCALFrameMask;    // Validation flag for L1 data
-        Int_t    fMedian[2];          // Background median
-        Int_t    fTriggerBitWord;     // Trigger bit word
-        Int_t    fL1DCALV0[2];        // L1 threshold components
+        Int_t    fL1DCALFrameMask;    ///< Validation flag for L1 data
+        Int_t    fMedian[2];          ///< Background median
+        Int_t    fTriggerBitWord;     ///< Trigger bit word
+        Int_t    fL1DCALV0[2];        ///< L1 threshold components
 
+    /// \cond CLASSIMP
 	ClassDef(AliAODCaloTrigger, 5)
+    /// \endcond
 };
 #endif
 

--- a/STEER/ESD/AliESDCaloTrigger.h
+++ b/STEER/ESD/AliESDCaloTrigger.h
@@ -4,17 +4,16 @@
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */
 
-/*
- 
-
-
-Author: R. GUERNANE LPSC Grenoble CNRS/IN2P3
-*/
-
 #include "AliVCaloTrigger.h"
 
 class TArrayI;
 
+/**
+ * @class AliESDCaloTrigger
+ * @brief Container with calorimeter trigger information in the ESD event
+ *
+ * @author  R. Guernane, LPSC Grenoble CNRS/IN2P3
+ */
 class AliESDCaloTrigger : public AliVCaloTrigger 
 {
 public:
@@ -48,16 +47,65 @@ public:
 	void    SetTriggerBitWord(Int_t w) {fTriggerBitWord = w;}
 	void    SetMedian(Int_t i, Int_t m) {fMedian[i] = m;}
 
+	/**
+	 * @brief Access to position of the current fastor channel
+	 * @param[out] col Column of the current fastor in the detector plane
+	 * @param[out] row Row of the current fastor in the detector plane
+	 */
 	void    GetPosition(       Int_t& col, Int_t& row           ) const;
+
+	/**
+	 * @brief Access to L0-amplitude of the current fastor channel
+	 * @param[out] amp L0-amplitude for the given fastor channel
+	 */
 	void    GetAmplitude(      Float_t& amp                     ) const;
+
 	void    GetTime(           Float_t& time                    ) const;
 	
+	/**
+	 * @brief Get the trigger bits for a given fastor position
+	 *
+	 * Trigger bits define the starting position of online patches.
+	 * They are defined in AliEMCALTriggerTypes.h. Note that for
+	 * reconstructed patches an offset (MC offset) has to be taken
+	 * into account
+	 *
+	 * @param[out] bits Trigger bits connected to a given position
+	 */
 	void    GetTriggerBits(    Int_t& bits                      ) const;
+
+	/**
+	 * @brief Get the number of L0 times for the current patch
+	 *
+	 * Level0 times are handled per L0 patch. Indexing is different
+	 * with respect to the fastor indexing.
+	 *
+	 * @param[out] ntimes Number of level0
+	 */
 	void    GetNL0Times(       Int_t& ntimes                    ) const;
+
+	/**
+	 * @brief Get level0 times for the current L0 patch
+	 * @param times L0 times for the current L0 patch
+	 */
 	void    GetL0Times(        Int_t  times[]                   ) const;
+
+	/**
+	 * @brief Get the number of entries in the trigger data
+	 * @return Number of entries
+	 */
 	Int_t   GetEntries(                                         ) const {return fNEntries;}
 
+    /**
+     * @brief Get the L1 time sums (L1 ADC values) for the current fastor
+     * @param[out] timesum L1 timesums for the current fastor
+     */
         void    GetL1TimeSum(      Int_t& timesum                   ) const;
+
+        /**
+         * @brief Get the L1 time sums (L1 ADC values) for the current fastor
+         * @return L1 timesums for the current fastor
+         */
         Int_t   GetL1TimeSum(                                       ) const;
   
         void    GetL1SubRegion(    Int_t& subreg                    ) const;
@@ -76,7 +124,11 @@ public:
   
         Int_t   GetTriggerBitWord(                                  ) const {return fTriggerBitWord;}
         void    GetTriggerBitWord( Int_t& bw                        ) const {bw = fTriggerBitWord;}
-        
+
+    /**
+     * @brief Forward to next trigger entry (fastor / L0 patch)
+     * @return True if successful (next entry existing), false otherwise (was already at the end of the buffer)
+     */
 	virtual Bool_t Next();
 
 	virtual void Copy(TObject& obj) const;
@@ -85,30 +137,51 @@ public:
 	
 private:
 
-        Int_t    fNEntries;
-        Int_t    fCurrent;
+        Int_t    fNEntries;		///< Number of entries in the trigger object (usually mapped to fastor channels)
+        Int_t    fCurrent;		///< Index of the current entry
 
+    	/** Array of col positions for a trigger entry, one entry corresponds to a certain fastor channel */
 	Int_t*   fColumn;             // [fNEntries]
+
+	/** Array of row positions for a trigger entry, one entry corresponds to a certain fastor channel */
 	Int_t*   fRow;                // [fNEntries]
+
+	/** Array with L0 amplitudes for a trigger entry, one entry corresponds to a certain fastor channel */
 	Float_t* fAmplitude;          // [fNEntries]
+
+	/** Array of trigger times, one entry corresponds to a certain fastor channel */
 	Float_t* fTime;               // [fNEntries]
+
+	/** Array of the number of Level0 times, one entry corresponds to a certain L0 patch */
 	Int_t*   fNL0Times;           // [fNEntries]
+
+	/** Array of Level0 times, one entry corresponds to a certain L0 patch */
 	TArrayI* fL0Times;            //
+
+	/** Array of the L1 time sums (L1 ADC values), one entry corresponds to a certain fastor channel */
 	Int_t*   fL1TimeSum;          // [fNEntries]
+
+	/** Array of trigger bits: Each bit position corresponds to a certain trigger (L0/L1) fired. Note
+	 * that there is a MC offset to be taken into account. Reconsturcted triggers start from the position
+	 * of the MC offset. Trigger bits are defined in AliEMCALTriggerTypes.h. One entry correspons to a
+	 * certain fastor position.
+	 */
 	Int_t*   fTriggerBits;        // [fNEntries]
 	
-	Int_t    fL1Threshold[4];     // L1 thresholds from raw data
-	Int_t    fL1V0[2];            // L1 threshold components
-	Int_t    fL1FrameMask;        // Validation flag for L1 data
+	Int_t    fL1Threshold[4];     ///< L1 thresholds from raw data
+	Int_t    fL1V0[2];            ///< L1 threshold components
+	Int_t    fL1FrameMask;        ///< Validation flag for L1 data
   
-        Int_t    fL1DCALThreshold[4]; // L1 thresholds from raw data
+        Int_t    fL1DCALThreshold[4]; ///< L1 thresholds from raw data
         Int_t*   fL1SubRegion;        // [fNEntries]
-        Int_t    fL1DCALFrameMask;    // Validation flag for L1 data
-        Int_t    fMedian[2];          // Background median
-        Int_t    fTriggerBitWord;     // Trigger bit word
-        Int_t    fL1DCALV0[2];        // L1 threshold components
+        Int_t    fL1DCALFrameMask;    ///< Validation flag for L1 data
+        Int_t    fMedian[2];          ///< Background median
+        Int_t    fTriggerBitWord;     ///< Trigger bit word
+        Int_t    fL1DCALV0[2];        ///< L1 threshold components
 	
+    /// \cond CLASSIMP
 	ClassDef(AliESDCaloTrigger, 8)
+    /// \endcond
 };
 #endif
 

--- a/STEER/STEERBase/AliVCaloTrigger.cxx
+++ b/STEER/STEERBase/AliVCaloTrigger.cxx
@@ -12,25 +12,17 @@
  * about the suitability of this software for any purpose. It is          *
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
-
-//-----------------------------------------------------------------
-//
-//   Virtual class to access calorimeter 
-//   (EMCAL, PHOS, PMD, FMD) trigger data
-//   Author: Salvatore Aiola
-//
-//-----------------------------------------------------------------
-
 #include "AliVCaloTrigger.h"
 
+/// \cond CLASSIMP
 ClassImp(AliVCaloTrigger)
+/// \endcond
   
   AliVCaloTrigger::AliVCaloTrigger(const AliVCaloTrigger& vtrg) :
-    TNamed(vtrg) { ; } // Copy constructor
+    TNamed(vtrg) { ; }
 
 AliVCaloTrigger& AliVCaloTrigger::operator=(const AliVCaloTrigger& vtrg)
 { 
-  //Assignment operator
   if (this!=&vtrg) { 
     TObject::operator=(vtrg); 
   }

--- a/STEER/STEERBase/AliVCaloTrigger.h
+++ b/STEER/STEERBase/AliVCaloTrigger.h
@@ -3,16 +3,13 @@
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */
 
-//-------------------------------------------------------------------------
-//
-//   Virtual class to access calorimeter 
-//   (EMCAL, PHOS, PMD, FMD) trigger data
-//   Author: Salvatore Aiola
-//
-//-------------------------------------------------------------------------
-
 #include <TNamed.h>
 
+/**
+ * @class AliVCaloTrigger
+ * @brief  Virtual class to access calorimeter  (EMCAL, PHOS, PMD, FMD) trigger data
+ * @author Salvatore Aiola
+ */
 class AliVCaloTrigger : public TNamed 
 {
 public:
@@ -48,16 +45,64 @@ public:
   virtual void         SetL1FrameMask(Int_t /*m*/)                           = 0;
   virtual void         SetL1FrameMask(Int_t /*i*/, Int_t /*m*/)              = 0;
 
+  /**
+   * @brief Access to position of the current fastor channel
+   * @param[out] col Column of the current fastor in the detector plane
+   * @param[out] row Row of the current fastor in the detector plane
+   */
   virtual void         GetPosition(Int_t& /*col*/, Int_t& /*row*/)    const  = 0;
+
+  /**
+   * @brief Access to L0-amplitude of the current fastor channel
+   * @param[out] amp L0-amplitude for the given fastor channel
+   */
   virtual void         GetAmplitude(Float_t& /*amp*/)                 const  = 0;
   virtual void         GetTime(Float_t& /*time*/)                     const  = 0;
   
+  /**
+   * @brief Get the trigger bits for a given fastor position
+   *
+   * Trigger bits define the starting position of online patches.
+   * They are defined in AliEMCALTriggerTypes.h. Note that for
+   * reconstructed patches an offset (MC offset) has to be taken
+   * into account
+   *
+   * @param[out] bits Trigger bits connected to a given position
+   */
   virtual void         GetTriggerBits(Int_t& /*bits*/)                const  = 0;
+
+  /**
+   * @brief Get the number of L0 times for the current patch
+   *
+   * Level0 times are handled per L0 patch. Indexing is different
+   * with respect to the fastor indexing.
+   *
+   * @param[out] ntimes Number of level0
+   */
   virtual void         GetNL0Times(Int_t& /*ntimes*/)                 const  = 0;
+
+  /**
+   * @brief Get level0 times for the current L0 patch
+   * @param times L0 times for the current L0 patch
+   */
   virtual void         GetL0Times(Int_t* /*times*/)                   const  = 0;
+
+  /**
+   * @brief Get the number of entries in the trigger data
+   * @return Number of entries
+   */
   virtual Int_t        GetEntries()                                   const  = 0;
 
+  /**
+   * @brief Get the L1 time sums (L1 ADC values) for the current fastor
+   * @param[out] timesum L1 timesums for the current fastor
+   */
   virtual void         GetL1TimeSum(Int_t& /*timesum*/)               const  = 0;
+
+  /**
+   * @brief Get the L1 time sums (L1 ADC values) for the current fastor
+   * @return L1 timesums for the current fastor
+   */
   virtual Int_t        GetL1TimeSum()                                 const  = 0;
   
   virtual void         GetL1SubRegion(  Int_t& /*subreg*/)            const  = 0;
@@ -77,6 +122,10 @@ public:
   virtual Int_t        GetTriggerBitWord()                            const  = 0;
   virtual void         GetTriggerBitWord(Int_t& /*bw*/ )              const  = 0;
 
+  /**
+   * @brief Forward to next trigger entry (fastor / L0 patch)
+   * @return True if successful (next entry existing), false otherwise (was already at the end of the buffer)
+   */
   virtual Bool_t       Next()                                                = 0;
   virtual void         Copy(TObject& obj)                             const     ;
 
@@ -84,7 +133,9 @@ public:
   
 private:
 
+  /// \cond CLASSIMP
   ClassDef(AliVCaloTrigger, 0)
+  /// \endcond
 };
 #endif //ALIVCALOTRIGGER_H
 


### PR DESCRIPTION
Where available information of the scope (per patch, per fastor)
added, plus some basic information about the return types. Not
yet complete, more information to be added.