### PR TITLE
Changes to do with primary particle definition as implemented in AliStack::IsPhysicalPrimary

### DIFF
--- a/STEER/STEERBase/AliStack.cxx
+++ b/STEER/STEERBase/AliStack.cxx
@@ -983,6 +983,80 @@ Bool_t AliStack::GetEvent()
     ResetArrays(size);
     return kTRUE;
 }
+
+// Some utilities used 
+namespace {
+    /** 
+   * Check the heaviest flavour of a particle.  Note, the original
+   * implementation is
+   *
+   *@f$f =  \left\lfloor\frac{c}{10^{\lfloor\log_{10}c\rfloor}}\right\rfloor@f$
+   * 
+   * since it will return 1 for @f$\Upsilon(2\mathrm{S})@f$ (@f$ c=100553@f$). 
+   * 
+   * The coding convention for PDG numbers is 
+   *
+   * @f$ n n_r n_L n_{q1} n_{q2} n_{q3} n_J@f$ 
+   *
+   * which means to guage the quark content we need only the 4
+   * right-most digits.  The most optimal way to extract these is to
+   * format the modulo of the passed number to @f$10\,000@f$, format
+   * that remainder as a string and then take the first character and
+   * convert that to a number by subtracting off the character @c '0'.
+   * 
+   * @param pdg 
+   * 
+   * @return 
+   */
+  Int_t HeaviestFlavour(Int_t pdg)
+  {
+    Int_t apdg = TMath::Abs(pdg);
+    // Special codes for bosons and leptons 
+    if (apdg < 100 && apdg > 6) return 0;
+    // Special codes for nuclei
+    // Ion/nucleus with format 10LZZZAAAI - take the 10L part modulo
+    // 10 to get the L part.  Hyper nucleons with np protons, nn
+    // neutrons, and nl Lambdas have
+    //
+    //    AAA = np+nn
+    //    ZZZ = np
+    //    L   = nl
+    //    I   = isomer level
+    //
+    // Deutron: 1000010020
+    // U(235):  1000922350
+    // 
+    if (apdg > 1000000000) return ((apdg/10000000) % 10) != 0 ? kStrange : kUp;
+    // Take lower 4 digits 
+    Int_t mpdg = apdg % 10000;
+    // Special case for K0L
+    if (mpdg == kK0Long) return kStrange;
+    // If a baryon (>999) then the 4th digit, other wise the 3rd 
+    return mpdg > 999 ? mpdg/1000 : mpdg / 100;
+  }
+  /** 
+   * Check if a particle is heavy flavoured 
+   * 
+   * @param pdg Particle identification code 
+   * 
+   * @return True if the heaviest quark is a charm, bottom, or top
+   */
+  Bool_t IsHeavyFlavour(Int_t pdg)
+  {
+    return HeaviestFlavour(pdg) >= kCharm;
+  }
+  /** 
+   * Check if particle is strange 
+   * 
+   * @param pdg Particle identification code 
+   * 
+   * @return true if heaviest quark is a strange 
+   */
+  Bool_t IsStrange(Int_t pdg)
+  {
+    return HeaviestFlavour(pdg) == kStrange;
+  }
+}
 //_____________________________________________________________________________
 
 Bool_t AliStack::IsStable(Int_t pdg) const
@@ -990,49 +1064,39 @@ Bool_t AliStack::IsStable(Int_t pdg) const
   //
   // Decide whether particle (pdg) is stable
   //
-  
-  
+  Int_t apdg = TMath::Abs(pdg);
+    		    
   // All ions/nucleons are considered as stable
   // Nuclear code is 10LZZZAAAI
-  if(pdg>1000000000)return kTRUE;
+  if(apdg>1000000000)return kTRUE;
 
-  const Int_t kNstable = 18;
-  Int_t i;
-  
-  Int_t pdgStable[kNstable] = {
-    kGamma,             // Photon
-    kElectron,          // Electron
-    kMuonPlus,          // Muon 
-    kPiPlus,            // Pion
-    kKPlus,             // Kaon
-    kK0Short,           // K0s
-    kK0Long,            // K0l
-    kProton,            // Proton 
-    kNeutron,           // Neutron
-    kLambda0,           // Lambda_0
-    kSigmaMinus,        // Sigma Minus
-    kSigmaPlus,         // Sigma Plus
-    3312,               // Xsi Minus 
-    3322,               // Xsi 
-    3334,               // Omega
-    kNuE,               // Electron Neutrino 
-    kNuMu,              // Muon Neutrino
-    kNuTau              // Tau Neutrino
-  };
-    
-  Bool_t isStable = kFALSE;
-  for (i = 0; i < kNstable; i++) {
-    if (pdg == TMath::Abs(pdgStable[i])) {
-      isStable = kTRUE;
-      break;
-    }
+  switch (apdg) {
+  case kGamma:             // 22   Photon
+  case kElectron:          // 11   Electron
+  case kMuonMinus:         // 13   Muon 
+  case kPiPlus:            // 211  Pion
+  case kKPlus:             // 321  Kaon
+  case kK0Short:           // 310  K0s
+  case kK0Long:            // 130  K0l
+  case kProton:            // 2212 Proton 
+  case kNeutron:           // 2112 Neutron
+  case kLambda0:           // 3122 Lambda_0
+  case kSigmaMinus:        // 3112 Sigma Minus
+  case kSigmaPlus:         // 3222 Sigma Plus
+  case kXiMinus:           // 3312 Xi Minus 
+  case 3322:               //      Xi 0 
+  case kOmegaMinus:        // 3334 Omega
+  case kNuE:               // 12   Electron Neutrino 
+  case kNuMu:              // 14   Muon Neutrino
+  case kNuTau:             // 16   Tau Neutrino
+    return true;
   }
-  
-  return isStable;
+  return false;
 }
 
+
 //_____________________________________________________________________________
-Bool_t AliStack::IsPhysicalPrimary(Int_t index, Bool_t useInEmbedding)
+Bool_t AliStack::IsPhysicalPrimaryOld(Int_t index, Bool_t useInEmbedding)
 {
     //
     // Test if a particle is a physical primary according to the following definition:
@@ -1044,7 +1108,10 @@ Bool_t AliStack::IsPhysicalPrimary(Int_t index, Bool_t useInEmbedding)
     Int_t ist = p->GetStatusCode();
     
     //
-    // Initial state particle
+    // Initial state particle - note, this is tricky - it depends on
+    // what the EG defines as final state (status=1) particles.  Could
+    // be very late in the game if particles are allowed to decay late
+    // in the EG.
     if (ist > 1) return kFALSE;
     
     Int_t pdg = TMath::Abs(p->GetPdgCode());
@@ -1071,10 +1138,10 @@ Bool_t AliStack::IsPhysicalPrimary(Int_t index, Bool_t useInEmbedding)
 	if ((mpdg == kPi0) && (imo < GetNprimary()))   return kTRUE; 
 
 // Check if this is a heavy flavor decay product
-	Int_t mfl  = Int_t (mpdg / TMath::Power(10, Int_t(TMath::Log10(mpdg))));
+	Int_t mfl  =  HeaviestFlavour(mpdg);
 	//
 	// Light hadron
-	if (mfl < 4) return kFALSE;
+	if (mfl < kCharm) return kFALSE;
 	
 	//
 	// Heavy flavor hadron produced by generator
@@ -1089,9 +1156,9 @@ Bool_t AliStack::IsPhysicalPrimary(Int_t index, Bool_t useInEmbedding)
 	    pm  =  Particle(imo,useInEmbedding);
 	}
 	mpdg = TMath::Abs(pm->GetPdgCode());
-	mfl  = Int_t (mpdg / TMath::Power(10, Int_t(TMath::Log10(mpdg))));
+	mfl  = HeaviestFlavour(mpdg);
 
-	if (mfl < 4) {
+	if (mfl < kCharm) {
 	    return kFALSE;
 	} else {
 	    return kTRUE;
@@ -1099,6 +1166,82 @@ Bool_t AliStack::IsPhysicalPrimary(Int_t index, Bool_t useInEmbedding)
     } // produced by generator ?
 } 
 
+//_____________________________________________________________________________
+Bool_t AliStack::IsPhysicalPrimaryNew(Int_t index, Bool_t useInEmbedding)
+{
+  // Check wether a given particle is a primary according to the
+  // definition adopted by ALICE:
+  //
+  //   A primary particle is a particle with a mean proper lifetime
+  //   tau than 1cm/c, which is either a) produced directly in the
+  //   interaction, or b) from decays of particles with tau smaller
+  //   than 1cm/c, restricted to decay chains leading to the interaction.
+  //
+  // See also ALICE-PUBLIC-2017-005 at
+  //
+  //   https://cds.cern.ch/record/2270008
+  //
+  // for more on this
+  TParticle* p = Particle(index,useInEmbedding);
+
+  // Check if we should ignore this particle - i.e., all particles
+  // that the EG has flagged as intermiddent particles.
+  Int_t ist = p->GetStatusCode();
+  if (ist == 0 || (ist >= 11 && ist <= 200)) return false;
+  
+  // Check if this particle has tau >= 1cm/c 
+  if (!IsStable(p->GetPdgCode())) return false;
+
+  // Check if this comes from a primary process (i.e., decay or the
+  // generator)
+  switch (p->GetUniqueID()) {
+  case kPDecay:
+  case kPNoProcess:
+  case kPNull:
+  case kPPrimary:
+    break;
+  default:
+    return false;
+  }
+
+  // Loop back over all mothers
+  TParticle* m  = p;
+  Int_t      mi = 0;
+  while ((mi = m->GetFirstMother()) >= 0) {
+    // Get (grand)mother 
+    m = Particle(mi,useInEmbedding);
+    // Check if (grand)mother is beam particle.  Note, Pythia6 does
+    // not follow HepMC standard and uses status code 3 for initial
+    // state - sigh!
+    Int_t mist = m->GetStatusCode();
+    if (mist == 3 || mist == 4) return true;
+    
+    
+    // If (grand)mother has tau >= 1cm/c, then this (p) isn't a
+    // primary
+    if (IsStable(m->GetPdgCode())) return false;
+    
+    // Check that the (grand)mother comes from a primary process e.g.,
+    // decay or from the generator
+    switch (m->GetUniqueID()) {
+    case kPDecay:
+    case kPNoProcess:
+    case kPNull:
+    case kPPrimary:
+      break;
+    default:
+      return false;
+    }
+  }
+  return true;
+}
+//_____________________________________________________________________________
+Bool_t AliStack::IsPhysicalPrimary(Int_t index, Bool_t useInEmbedding)
+{
+  return IsPhysicalPrimaryNew(index, useInEmbedding);
+}
+
+//_____________________________________________________________________________
 Bool_t AliStack::IsSecondaryFromWeakDecay(Int_t index, Bool_t useInEmbedding) {
 
   // If a particle is not a physical primary, check if it comes from weak decay
@@ -1115,16 +1258,11 @@ Bool_t AliStack::IsSecondaryFromWeakDecay(Int_t index, Bool_t useInEmbedding) {
   // mass of the flavour
   Int_t mfl = 0;
   // Protect the "rootino" case when codemoth is 0
-  if (TMath::Abs(codemoth)>0) mfl = Int_t (codemoth / TMath::Power(10, Int_t(TMath::Log10(codemoth))));
+  if (TMath::Abs(codemoth)>0) mfl = HeaviestFlavour(codemoth);
   
-  if(mfl == 3 && uniqueID == kPDecay) return kTRUE;// The first mother is strange and it's a decay
-  if(codemoth == 211 && uniqueID == kPDecay) return kTRUE;// pion+- decay products
-  if(codemoth == 13 && uniqueID == kPDecay) return kTRUE;// muon decay products
-
-  /// Hypernuclei case
-  if (TMath::Abs(moth->GetPdgCode()) > 1000000000 && uniqueID == kPDecay) {
-    if ((moth->GetPdgCode() / 10000000) % 10 != 0) return kTRUE; /// Number of lambdas in the hypernucleus != 0
-  }
+  if(mfl == kStrange && uniqueID == kPDecay) return kTRUE;// The first mother is strange and it's a decay
+  if(codemoth == kPiPlus && uniqueID == kPDecay) return kTRUE;// pion+- decay products
+  if(codemoth == kMuonMinus && uniqueID == kPDecay) return kTRUE;// muon decay products
 
   return kFALSE;
   

--- a/STEER/STEERBase/AliStack.h
+++ b/STEER/STEERBase/AliStack.h
@@ -82,6 +82,8 @@ class AliStack : public TVirtualMCStack
     TParticle*  ParticleFromTreeK(Int_t id, Bool_t useInEmbedding=kFALSE) const;
     Int_t       TreeKEntry(Int_t id, Bool_t useInEmbedding=kFALSE) const;
     Bool_t      IsPhysicalPrimary(Int_t i, Bool_t useInEmbedding=kFALSE);
+    Bool_t      IsPhysicalPrimaryNew(Int_t i, Bool_t useInEmbedding=kFALSE);
+    Bool_t      IsPhysicalPrimaryOld(Int_t i, Bool_t useInEmbedding=kFALSE);
     Bool_t      IsSecondaryFromWeakDecay(Int_t index, Bool_t useInEmbedding=kFALSE);
     Bool_t      IsSecondaryFromMaterial (Int_t index, Bool_t useInEmbedding=kFALSE);
     Int_t       TrackLabel(Int_t label) const {return fTrackLabelMap[label];}


### PR DESCRIPTION
- The code of `AliStack::IsPhysicalPrimary` was changed to conform with
  the definition adopted by ALICE in a recent public note:

    A primary particle is a particle with a mean proper lifetime
    tau larger than 1cm/c, which is either a) produced directly in the
    interaction, or b) from decays of particles with tau smaller
    than 1cm/c, restricted to decay chains leading to the interaction.

  See also ALICE-PUBLIC-2017-005 at

     https://cds.cern.ch/record/2270008

  Please note, that the definition is approved by the Physics Board

  - This is the modified implementation which stops the search for long-lived mothers 
    when encountering beam particles (status code 3 or 4).  It also ignores particles flagged
    by the EG as intermittent. 

- The old implementation of `AliStack::IsPhysicalPrimary` is still
  available as `AliStack::IsPhysicalPrimaryOld` to allow testing etc.

- Various bugs in the old implementation (now `AliStack::IsPhysicalPrimaryOld`)
  and in `AliStack::IsSecondaryFromWeakDecay` were corrected.  Specifically
  these bugs had to do with extracting the heaviest flavour or a
  particle (to see if a particle was heavy flavour or strange)

  To get the heaviest flavour of a particle with PID pdg the old code
  tried to extract the heaviest flavour quark by doing

    `f = floor(|pdg| / 10^{floor(log10(|pdg|)})`

  Value of f corresponds to the heaviest quark in the particle
  (1: d, 2: u, 3: s, 4: c, 5: b, 6; t) For most particles
  this is fine, e.g.,

  - pi+:   pdg=211  -> f=2
  - K+:    pdg=311  -> f=3
  - K0(S): pdg=310  -> f=3
  - K0(L): pdg=130  -> f=1(!)
  - p      pdg=2212 -> f=2
  - B+:    pdg=521  -> f=5
  - D+:    pdg=411  -> f=4

  while for others it will give the wrong result

  - D(0)*      pdg=10421   -> f=1 (should be 4)
  - K(1)+      pdg=10323   -> f=1 (should be 3)
  - f(0)(500)  pdg=9000221 -> f=9(!) (should be 2)

  and the leptons are really messed up

  - e-   pdg=11 -> f=1
  - mu-  pdg=13 -> f=1
  - tau- pdg=15 -> f=1

  The definition of the PDG code conventions state that each
  PDG code is formatted as

    `n nr nL nq1 nq2 nq3 nJ`

  where `nq1`, `nq2`, and `nq3` encode the quark content.
  For mesons `nq1=0`.  So a better way to extract the heaviest
  flavour is to take the absolute value of the PDG code, modulo
  10,000 and then, depending on whether the value is larger than
  999 (baryons) extract the 4th or 3rd digit

```
    if (|pdg|<100 && |pdg|>6) return 0; // No quark content
    m = |pdg| % 10000; // get nq1 nq2 nq3 nJ
    if (m == K(0)L) return 3; // special for K0L
    return (m > 999) ? m / 1000 : m/100;
```

  Note, for nuclei the convention is to encode as

    `10LZZZAAAI`

  where `L` is the number of Lambda's in the nucleus.  So we
  should check if this number is non-zero and in that case
  get 3 (strange), otherwise 2 (up).  I.e., the full
  pseudo-code is

    ```
    if (|pdg|>1000000000)
      f = (|pdg|/10000000) % 10) != 0 ? 3 : 2;
    else if (|pdg|<100 && |pdg|>6)
      f = 0; // No quark content
    else
      m = |pdg| % 10000; // get nq1 nq2 nq3 nJ
      if (m == K(0)L) return 3; // special for K0L
      f = (m > 999) ? m / 1000 : m/100;
```

  This algorithm is implemented in the service function
  `HeaviestFlavour` in the scope of **AliStack.cxx**

- Other small efficiency fixes.