### PR TITLE
Store/autodetect MC embedding + misc methods

### DIFF
--- a/STEER/STEER/AliSimulation.cxx
+++ b/STEER/STEER/AliSimulation.cxx
@@ -178,7 +178,6 @@ AliSimulation *AliSimulation::fgInstance = 0;
 
 const Char_t* AliSimulation::fgkRunHLTAuto = "auto";
 const Char_t* AliSimulation::fgkHLTDefConf = "default";
-
 //_____________________________________________________________________________
 AliSimulation::AliSimulation(const char* configFileName,
 			     const char* name, const char* title) :
@@ -626,7 +625,7 @@ void AliSimulation::MergeWith(const char* fileName, Int_t nSignalPerBkgrd)
 
 void AliSimulation::EmbedInto(const char* fileName, Int_t nSignalPerBkgrd)
 {
-// add a file with background events for embeddin
+// add a file with background events for embedding
   MergeWith(fileName, nSignalPerBkgrd);
   fEmbeddingFlag = kTRUE;
 }
@@ -821,7 +820,7 @@ Bool_t AliSimulation::Run(Int_t nEvents)
 
   AliSysInfo::AddStamp("RunQA");
   //
-  StoreUsedCDBMaps();
+  StoreUsedCDBMapsAndEmbPaths();
   //  
   TString snapshotFileOut("");
   if(TString(gSystem->Getenv("OCDB_SNAPSHOT_CREATE")) == TString("kTRUE")){ 
@@ -2772,7 +2771,7 @@ time_t AliSimulation::GenerateTimeStamp() const
 }
 
 //_____________________________________________________________________________
-void AliSimulation::StoreUsedCDBMaps() const
+void AliSimulation::StoreUsedCDBMapsAndEmbPaths() const
 {
   // write in galice.root maps with used CDB paths
   //
@@ -2792,7 +2791,13 @@ void AliSimulation::StoreUsedCDBMaps() const
   //
   AliRunLoader::Instance()->CdGAFile();
   gDirectory->WriteObject(cdbMapCopy,"cdbMap","kSingleKey");
-  gDirectory->WriteObject(cdbListCopy,"cdbList","kSingleKey");  
+  gDirectory->WriteObject(cdbListCopy,"cdbList","kSingleKey");
+
+  // store embedding info
+  if (fBkgrdFileNames) {
+    gDirectory->WriteObject(fBkgrdFileNames,AliStack::GetEmbeddingBKGPathsKey(),"kSingleKey");
+  }
+  
   delete runLoader;
   //
   AliInfo(Form("Stored used OCDB entries as TMap %s and TList %s in %s",

--- a/STEER/STEER/AliSimulation.h
+++ b/STEER/STEER/AliSimulation.h
@@ -125,7 +125,7 @@ public:
   AliLego* Lego() const {return fLego;}
   virtual  void  FinishRun();
   //
-  void StoreUsedCDBMaps() const; 
+  void StoreUsedCDBMapsAndEmbPaths() const; 
 
   //Quality Assurance
   Int_t       GetDetIndex(const char * detector);
@@ -151,7 +151,8 @@ public:
   Bool_t          GetUseDetectorsFromGRP()               const {return fUseDetectorsFromGRP;}
   void            SetUseDetectorsFromGRP(Bool_t v=kTRUE)       {fUseDetectorsFromGRP = v;}
   //
-private:
+
+ private:
 
   AliSimulation(const AliSimulation&); // Not implemented
   AliSimulation& operator = (const AliSimulation&); // Not implemented
@@ -236,7 +237,6 @@ private:
 
   static const Char_t *fgkRunHLTAuto;         // flag for automatic HLT mode detection
   static const Char_t *fgkHLTDefConf;         // default configuration to run HLT
-
   ClassDef(AliSimulation, 15)  // class for running generation, simulation and digitization
 };
 

--- a/STEER/STEERBase/AliHeader.h
+++ b/STEER/STEERBase/AliHeader.h
@@ -66,7 +66,8 @@ public:
 
   Int_t    GetSgPerBgEmbedded()      const {return fSgPerBgEmbedded;}
   void     SetSgPerBgEmbedded(int i)       {fSgPerBgEmbedded = i;}
-
+  Int_t    GetBgReuseID()            const {return fSgPerBgEmbedded ? (fEventNrInRun%fSgPerBgEmbedded) : 0;}
+  
   AliHeader& operator=(const AliHeader& head) 
     {head.Copy(*this); return *this;}
   

--- a/STEER/STEERBase/AliMCEvent.h
+++ b/STEER/STEERBase/AliMCEvent.h
@@ -38,7 +38,7 @@ class AliMCEvent : public AliVEvent {
 public:
 
     AliMCEvent();
-    virtual ~AliMCEvent() {;} 
+    virtual ~AliMCEvent();
     AliMCEvent(const AliMCEvent& mcEvnt); 
     AliMCEvent& operator=(const AliMCEvent& mcEvnt);
     //
@@ -164,6 +164,7 @@ public:
   virtual Int_t     FindIndexAndEvent(Int_t oldidx, AliMCEvent*& event) const; //RS
 
   Bool_t HasSubsidiaries() const {return fSubsidiaryEvents!=0;}
+  Bool_t IsFromSubsidiaryEvent(int id) const;
   
 private:
     virtual void      ReorderAndExpandTreeTR();

--- a/STEER/STEERBase/AliMCEventHandler.cxx
+++ b/STEER/STEERBase/AliMCEventHandler.cxx
@@ -139,7 +139,37 @@ Bool_t AliMCEventHandler::Init(Option_t* opt)
       fInitOk = kFALSE;
       return kFALSE;
     }
-    
+
+    // check if AliRun refers to some background file of embedding
+    TObjArray* embBKGPaths = 0;
+    fFileE->GetObject(AliStack::GetEmbeddingBKGPathsKey(),embBKGPaths);
+    if (embBKGPaths) {
+      AliInfo("galice.root contains paths of background for embedding");
+      embBKGPaths->Print();
+      for (int ib=0;ib<embBKGPaths->GetEntriesFast();ib++) {
+	if (!fSubsidiaryHandlers || fSubsidiaryHandlers->GetEntries()<ib) AddSubsidiaryHandler(new AliMCEventHandler());
+	// if needed, add subsidiary handlers
+	AliMCEventHandler* hs = (AliMCEventHandler*)fSubsidiaryHandlers->At(ib);
+	TString pth = embBKGPaths->At(ib)->GetName();
+	// check if the path is relative
+	if ( !pth.BeginsWith("/") && !pth.BeginsWith("alien://")) {
+	  TString pths = fPathName->Data();
+	  if (pths.EndsWith("#")) { // archive is used
+	    int indSl = pths.Last('/')+1;
+	    if (!pth.EndsWith("/")) pth += "/";
+	    pths.Insert(indSl,pth);
+	  }
+	  else {
+	    pths += pth; // pths ends by "/"
+	  }
+	  pth = pths;	      
+	}
+	hs->SetInputPath(pth.Data());
+	hs->SetReadTR(fReadTR);
+	AliInfoF("Set subsidiary event#%d path to %s",ib,hs->GetInputPath()->Data());
+      }
+      delete embBKGPaths;
+    }
     //
     // Tree E
     fFileE->GetObject("TE", fTreeE);
@@ -574,7 +604,14 @@ void AliMCEventHandler::SetInputPath(const char* fname)
 {
     // Set the input path name
     delete fPathName;
-    fPathName = new TString(fname);
+    TString tmps = fname;
+    if (tmps.IsNull()) {
+      tmps = "./";
+    }
+    else if (!tmps.EndsWith("#")) { // not archive ?
+      if (!tmps.EndsWith("/")) tmps += "/";
+    }
+    fPathName = new TString(tmps);
 }
 
 void AliMCEventHandler::AddSubsidiaryHandler(AliMCEventHandler* handler)

--- a/STEER/STEERBase/AliStack.cxx
+++ b/STEER/STEERBase/AliStack.cxx
@@ -42,7 +42,8 @@
 ClassImp(AliStack)
 
 
-TParticle AliStack::fgDummyParticle(21,999,-1,-1,-1,-1,0,0,-999,999,0,0,0,0);
+TParticle AliStack::fgDummyParticle(21,999,-1,-1,-1,-1,1,1,999,999,0,0,0,0);
+const Char_t* AliStack::fgkEmbedPathsKey = "embeddingBKGPaths";
 
 //_______________________________________________________________________
 AliStack::AliStack():

--- a/STEER/STEERBase/AliStack.h
+++ b/STEER/STEERBase/AliStack.h
@@ -90,7 +90,8 @@ class AliStack : public TVirtualMCStack
 
     void        SetMCEmbeddingFlag(Bool_t v=kTRUE)        {fMCEmbeddingFlag = v;}
     Bool_t      GetMCEmbeddingFlag()                const {return fMCEmbeddingFlag;}
-    
+    static const char*   GetEmbeddingBKGPathsKey() {return fgkEmbedPathsKey;}
+
   protected:
     // methods
     void  CleanParents();
@@ -120,7 +121,8 @@ class AliStack : public TVirtualMCStack
     Bool_t         fMCEmbeddingFlag;   //! Flag that this is a top stack of embedded MC
 
     static TParticle fgDummyParticle; // dummy particle returned in Stack::Particle call in embedding mode
-    
+    static const Char_t *fgkEmbedPathsKey;       // keyword for embedding paths
+
     ClassDef(AliStack,6) //Particles stack
 };
 


### PR DESCRIPTION
In the embedding mode the galice.root will store the paths of underlying events during simulation.
When reading via AliMCEventHandler the paths will be automatically connected: no need to set the
subsudiary MCEventHandlers from the user side (if set, the error will happen).

Additional methods in ESD mode:
1) one can use method AliMCEvent::IsFromSubsidiaryEvent(id) to query if the particle id comes
from underlying bg event.
2) once can use AliHeader::GetBgReuseID() to query the get the instance (copy) of the underlying
bg. event used for given event /MCEvent->Header()->GetBgReuseID()/