### PR TITLE
Sync. macros whith version used to produce current recoparam

### DIFF
--- a/TPC/macros/MakeTPCRecoParam_Run2Dist.C
+++ b/TPC/macros/MakeTPCRecoParam_Run2Dist.C
@@ -58,6 +58,7 @@ void MakeTPCRecoParam_Run2Dist(const char* storage="local://OCDB", AliRecoParam:
     // scaling
     tpcRecoParam->SetUseLumiType(AliLumiTools::kLumiCTP);
     tpcRecoParam->SetCorrMapTimeDepMethod(AliTPCRecoParam::kCorrMapGlobalScalingLumi);
+    tpcRecoParam->SetUseMapLumiInfoCOG(kTRUE); // use lumi correction from the map if available
     // add difference to reference distortions as syst. error
     tpcRecoParam->SetUseDistortionFractionAsErrorY(-1);
     tpcRecoParam->SetUseDistortionFractionAsErrorZ(-1);
@@ -121,6 +122,7 @@ void MakeTPCRecoParam_Run2Dist(const char* storage="local://OCDB", AliRecoParam:
     // scaling
     tpcRecoParam->SetUseLumiType(AliLumiTools::kLumiCTP);
     tpcRecoParam->SetCorrMapTimeDepMethod(AliTPCRecoParam::kCorrMapGlobalScalingLumi);
+    tpcRecoParam->SetUseMapLumiInfoCOG(kTRUE); // use lumi correction from the map if available
     // add difference to reference distortions as syst. error
     tpcRecoParam->SetUseDistortionFractionAsErrorY(-1);
     tpcRecoParam->SetUseDistortionFractionAsErrorZ(-1);

--- a/TPC/macros/MakeTPCRecoParam_Run2DistMC.C
+++ b/TPC/macros/MakeTPCRecoParam_Run2DistMC.C
@@ -58,6 +58,7 @@ void MakeTPCRecoParam_Run2DistMC(const char* storage="local://OCDB", AliRecoPara
     // scaling
     tpcRecoParam->SetUseLumiType(AliLumiTools::kLumiCTP);
     tpcRecoParam->SetCorrMapTimeDepMethod(AliTPCRecoParam::kCorrMapGlobalScalingLumi);
+    tpcRecoParam->SetUseMapLumiInfoCOG(kTRUE); // use lumi correction from the map if available
     // add difference to reference distortions as syst. error
     tpcRecoParam->SetUseDistortionFractionAsErrorY(-1);
     tpcRecoParam->SetUseDistortionFractionAsErrorZ(-1);
@@ -121,6 +122,7 @@ void MakeTPCRecoParam_Run2DistMC(const char* storage="local://OCDB", AliRecoPara
     // scaling
     tpcRecoParam->SetUseLumiType(AliLumiTools::kLumiCTP);
     tpcRecoParam->SetCorrMapTimeDepMethod(AliTPCRecoParam::kCorrMapGlobalScalingLumi);
+    tpcRecoParam->SetUseMapLumiInfoCOG(kTRUE); // use lumi correction from the map if available
     // add difference to reference distortions as syst. error
     tpcRecoParam->SetUseDistortionFractionAsErrorY(-1);
     tpcRecoParam->SetUseDistortionFractionAsErrorZ(-1);
@@ -247,7 +249,7 @@ void MakeTPCRecoParam_Run2DistMC(const char* storage="local://OCDB", AliRecoPara
   md->SetComment("Reconstruction parameters TPC, as used for Run2 data with distortions");
   md->SetAliRootVersion(gSystem->Getenv("ARVERSION"));
   md->SetBeamPeriod(0);
-  AliCDBId id("TPC/Calib/RecoParam",0,AliCDBRunRange::Infinity());
+  AliCDBId id("TPC/Calib/RecoParam",227735,AliCDBRunRange::Infinity());
   cdb->GetDefaultStorage()->Put(recoParamArray,id, md);
   return;
 }


### PR DESCRIPTION
The TPC/Calib/RecoParams of 2017 have setting to use the Lumi info from the SP 
correction map (if available), synced macros producing recoparams to reflect current status