### PR TITLE
 Check for duplicates, fill muliple labels, use all tracks in case of embedding

### DIFF
--- a/ITS/ITSbase/AliITSClusterFinder.cxx
+++ b/ITS/ITSbase/AliITSClusterFinder.cxx
@@ -321,14 +321,14 @@ void AliITSClusterFinder::CheckLabels2(Int_t lab[10])
   //------------------------------------------------------------
   const AliMCEvent* mcEv = AliReconstructor::GetMCEvent();
   int ntracks = 0;
-  if (!mcEv) {
+  if (!mcEv) { // we need to filter out labels from bg event in absence of full MCevent info
     AliRunLoader *rl = AliRunLoader::Instance();
     if(!rl) return;
     TTree *trK=(TTree*)rl->TreeK();
     if (!trK) return;
   }
-  else { // we need to filter out labels from bg event in absence of full MCevent info
-    ntracks = gAlice->GetMCApp()->GetNtrack();
+  else { 
+    ntracks = mcEv->GetNumberOfTracks(); //gAlice->GetMCApp()->GetNtrack();
   }
   //
   int labS[10];

--- a/TPC/TPCrec/AliTPCtracker.h
+++ b/TPC/TPCrec/AliTPCtracker.h
@@ -189,6 +189,8 @@ public:
    static Int_t GetTrackSector(double alpha);
 
 private:
+
+  int GetAdjustedLabels(const AliTPCclusterMI* cl, int *lbReal);
   Bool_t IsFindable(AliTPCseed & t);
   AliTPCtracker(const AliTPCtracker& r);           //dummy copy constructor
   AliTPCtracker &operator=(const AliTPCtracker& r);//dummy assignment operator


### PR DESCRIPTION
1) when filling nCl-per-track tree check for duplicate labels in the same cluster 
2) fill additional array nclMPerTrack for every MC label, accumulating there total non-negative labels count for clusters contributed by this label. I.e. if all N clusters related to given label were made of this label only, the nclMPerTrack[label] will be equal to N, if all clusters had exactly 2 non-negative labels contributing, it would be 2N etc. Therefore, statistically each nclPerTrack[i] should have a weight float(nclPerTrack[i])/nclMPerTrack[i]<1 to add up to nclTot-nclOrphan