### PR TITLE
Removed superfluous return statement in AliESD.h

### DIFF
--- a/STEER/ESD/AliESD.h
+++ b/STEER/ESD/AliESD.h
@@ -158,7 +158,7 @@ public:
   Float_t GetSigma2DiamondX() const {return fDiamondCovXY[0];}
   Float_t GetSigma2DiamondY() const {return fDiamondCovXY[2];}
   void GetDiamondCovXY(Float_t cov[3]) const {
-    for(Int_t i=0;i<3;i++) cov[i]=fDiamondCovXY[i]; return;
+    for(Int_t i=0;i<3;i++) cov[i]=fDiamondCovXY[i];
   }
 
   Int_t  GetEventNumberInFile() const {return fEventNumberInFile;}


### PR DESCRIPTION
Removed the superfluous return statement in AliESD::GetDiamondCovXY() which produces a warning with gcc 6.2, see https://github.com/alisw/AliPhysics/issues/2193

warning by @mfasDa 
```c++
/home/markus/alice/sw/ubuntu1404_x86-64/AliRoot/ali-work-1/include/AliESD.h: In member function 'void AliESD::GetDiamondCovXY(Float_t*) const':
/home/markus/alice/sw/ubuntu1404_x86-64/AliRoot/ali-work-1/include/AliESD.h:161:5: error: this 'for' clause does not guard... [-Werror=misleading-indentation]
for(Int_t i=0;i<3;i++) cov[i]=fDiamondCovXY[i]; return;
^~~
/home/markus/alice/sw/ubuntu1404_x86-64/AliRoot/ali-work-1/include/AliESD.h:161:53: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'for'
for(Int_t i=0;i<3;i++) cov[i]=fDiamondCovXY[i]; return;
```