### PR TITLE
Restore the functionality of some tests

### DIFF
--- a/STEER/macros/CheckESD.C
+++ b/STEER/macros/CheckESD.C
@@ -191,7 +191,7 @@ Bool_t CheckESD(const char* gAliceFileName = "galice.root",
 
   //set correct BB parameters. Assume the ones from the ALIROOT OCDB were used for simulation
   AliCDBManager *man=AliCDBManager::Instance();
-  man->SetDefaultStorage("local://$ALICE_ROOT/OCDB");
+  man->SetDefaultStorage("local://$ALIROOT_OCDB_ROOT/OCDB");
   man->SetRun(0);
   const AliCDBEntry *eParam   = man->Get("TPC/Calib/Parameters");
   AliTPCParam *params   = (AliTPCParam*)eParam->GetObject();

--- a/STEER/macros/CreateAODfromESD.C
+++ b/STEER/macros/CreateAODfromESD.C
@@ -26,7 +26,7 @@ void CreateAODfromESD(const char *inFileName = "AliESDs.root",
     AliESDInputHandler* inpHandler = new AliESDInputHandler();
     inpHandler->SetReadFriends(kFALSE);
     inpHandler->SetReadTags();
-    inpHandler->NeedField();
+    inpHandler->SetNeedField();
     mgr->SetInputEventHandler  (inpHandler);
     // Output
     AliAODHandler* aodHandler   = new AliAODHandler();

--- a/test/PbPbbench/aod.C
+++ b/test/PbPbbench/aod.C
@@ -13,6 +13,7 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
+    AliGeomManager::LoadGeometry("geometry.root");
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");

--- a/test/PbPbbench/recraw/aod.C
+++ b/test/PbPbbench/recraw/aod.C
@@ -13,6 +13,7 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
+    AliGeomManager::LoadGeometry("../geometry.root");
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAODs.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://..\",kFALSE)");

--- a/test/generators/TUHKMgen/aod.C
+++ b/test/generators/TUHKMgen/aod.C
@@ -2,12 +2,19 @@ void aod(){
 
     gSystem->Load("libANALYSIS");
     gSystem->Load("libANALYSISalice");
-    gSystem->Load("libCORRFW");
+
+    if( gSystem->Load("libCORRFW") <0) {
+      cerr << "Error: AliPhysics is not installed, no AOD test is possible!" << endl;
+      return;
+    }
     gSystem->Load("libPWGHFbase");
     gSystem->Load("libPWGmuon");
     gSystem->Load("libESDfilter");
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
+
+    AliGeomManager::LoadGeometry("geometry.root");
+    AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/generators/herwig/aod.C
+++ b/test/generators/herwig/aod.C
@@ -2,12 +2,19 @@ void aod(){
 
     gSystem->Load("libANALYSIS");
     gSystem->Load("libANALYSISalice");
-    gSystem->Load("libCORRFW");
+
+    if( gSystem->Load("libCORRFW") <0) {
+      cerr << "Error: AliPhysics is not installed, no AOD test is possible!" << endl;
+      return;
+    }
     gSystem->Load("libPWGHFbase");
     gSystem->Load("libPWGmuon");
     gSystem->Load("libESDfilter");
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
+
+    AliGeomManager::LoadGeometry("geometry.root");
+    AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/generators/phojet/aod.C
+++ b/test/generators/phojet/aod.C
@@ -2,12 +2,19 @@ void aod(){
 
     gSystem->Load("libANALYSIS");
     gSystem->Load("libANALYSISalice");
-    gSystem->Load("libCORRFW");
+
+    if( gSystem->Load("libCORRFW") <0) {
+      cerr << "Error: AliPhysics is not installed, no AOD test is possible!" << endl;
+      return;
+    }
     gSystem->Load("libPWGHFbase");
     gSystem->Load("libPWGmuon");
     gSystem->Load("libESDfilter");
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
+
+    AliGeomManager::LoadGeometry("geometry.root");
+    AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/generators/therminator/aod.C
+++ b/test/generators/therminator/aod.C
@@ -2,12 +2,19 @@ void aod(){
 
     gSystem->Load("libANALYSIS");
     gSystem->Load("libANALYSISalice");
-    gSystem->Load("libCORRFW");
+
+    if( gSystem->Load("libCORRFW") <0) {
+      cerr << "Error: AliPhysics is not installed, no AOD test is possible!" << endl;
+      return;
+    }
     gSystem->Load("libPWGHFbase");
     gSystem->Load("libPWGmuon");
     gSystem->Load("libESDfilter");
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
+
+    AliGeomManager::LoadGeometry("geometry.root");
+    AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/genkine/sim/aod.C
+++ b/test/genkine/sim/aod.C
@@ -13,6 +13,7 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
+    AliGeomManager::LoadGeometry("geometry.root");
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");

--- a/test/genkine/simG4/aod.C
+++ b/test/genkine/simG4/aod.C
@@ -13,6 +13,7 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
+    AliGeomManager::LoadGeometry("geometry.root");
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");

--- a/test/gun/aod.C
+++ b/test/gun/aod.C
@@ -13,6 +13,7 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
+    AliGeomManager::LoadGeometry("geometry.root");
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");

--- a/test/gun/recraw/aod.C
+++ b/test/gun/recraw/aod.C
@@ -13,6 +13,7 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
+    AliGeomManager::LoadGeometry("../geometry.root");
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAODs.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://..\",kFALSE)");

--- a/test/merge/backgr/aod.C
+++ b/test/merge/backgr/aod.C
@@ -2,12 +2,19 @@ void aod(){
 
     gSystem->Load("libANALYSIS");
     gSystem->Load("libANALYSISalice");
-    gSystem->Load("libCORRFW");
+
+    if( gSystem->Load("libCORRFW") <0) {
+      cerr << "Error: AliPhysics is not installed, no AOD test is possible!" << endl;
+      return;
+    }
     gSystem->Load("libPWGHFbase");
     gSystem->Load("libPWGmuon");
     gSystem->Load("libESDfilter");
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
+
+    AliGeomManager::LoadGeometry("geometry.root");
+    AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/merge/signal/aod.C
+++ b/test/merge/signal/aod.C
@@ -2,12 +2,19 @@ void aod(){
 
     gSystem->Load("libANALYSIS");
     gSystem->Load("libANALYSISalice");
-    gSystem->Load("libCORRFW");
+
+    if( gSystem->Load("libCORRFW") <0) {
+      cerr << "Error: AliPhysics is not installed, no AOD test is possible!" << endl;
+      return;
+    }
     gSystem->Load("libPWGHFbase");
     gSystem->Load("libPWGmuon");
     gSystem->Load("libESDfilter");
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
+
+    AliGeomManager::LoadGeometry("geometry.root");
+    AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/pileup/aod.C
+++ b/test/pileup/aod.C
@@ -1,19 +1,20 @@
 void aod(){
-  gSystem->Load("liblhapdf");      // Parton density functions
-  gSystem->Load("libEGPythia6");   // TGenerator interface
-  gSystem->Load("libpythia6");     // Pythia
-  gSystem->Load("libAliPythia6");  // ALICE specific implementations
-  gSystem->Load("libDPMJET");
-  gSystem->Load("libTDPMjet");
- 
-  gSystem->Load("libANALYSIS");
-  gSystem->Load("libANALYSISalice");
-  gSystem->Load("libCORRFW");
-  gSystem->Load("libPWGHFbase");
-  gSystem->Load("libPWGmuon");
-  gSystem->Load("libESDfilter");
-  gSystem->Load("libTender");
-  gSystem->Load("libPWGPP");
 
-  gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAODs.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
+    gSystem->Load("libANALYSIS");
+    gSystem->Load("libANALYSISalice");
+
+    if( gSystem->Load("libCORRFW") <0) {
+      cerr << "Error: AliPhysics is not installed, no AOD test is possible!" << endl;
+      return;
+    }
+    gSystem->Load("libPWGHFbase");
+    gSystem->Load("libPWGmuon");
+    gSystem->Load("libESDfilter");
+    gSystem->Load("libTender");
+    gSystem->Load("libPWGPP");
+
+    AliGeomManager::LoadGeometry("geometry.root");
+    AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
+
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/ppbench/aod.C
+++ b/test/ppbench/aod.C
@@ -1,5 +1,6 @@
 void aod(){
 
+    gSystem->Load("libpythia6.so");
     gSystem->Load("libANALYSIS");
     gSystem->Load("libANALYSISalice");
 
@@ -13,6 +14,7 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
+    AliGeomManager::LoadGeometry("geometry.root");
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");

--- a/test/ppbench/rec.C
+++ b/test/ppbench/rec.C
@@ -1,4 +1,5 @@
 void rec() {
+  gSystem->Load("libpythia6.so");
   AliReconstruction reco;
 
   reco.SetWriteESDfriend();

--- a/test/ppbench/recraw/aod.C
+++ b/test/ppbench/recraw/aod.C
@@ -13,6 +13,7 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
+    AliGeomManager::LoadGeometry("../geometry.root");
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAODs.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://..\",kFALSE)");

--- a/test/pploadlibs/aod.C
+++ b/test/pploadlibs/aod.C
@@ -1,13 +1,20 @@
 void aod(){
 
-  gSystem->Load("libANALYSIS");
-  gSystem->Load("libANALYSISalice");
-  gSystem->Load("libCORRFW");
-  gSystem->Load("libPWGHFbase");
-  gSystem->Load("libPWGmuon");
-  gSystem->Load("libESDfilter");
-  gSystem->Load("libTender");
-  gSystem->Load("libPWGPP");
-  
-  gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
+    gSystem->Load("libANALYSIS");
+    gSystem->Load("libANALYSISalice");
+
+    if( gSystem->Load("libCORRFW") <0) {
+      cerr << "Error: AliPhysics is not installed, no AOD test is possible!" << endl;
+      return;
+    }
+    gSystem->Load("libPWGHFbase");
+    gSystem->Load("libPWGmuon");
+    gSystem->Load("libESDfilter");
+    gSystem->Load("libTender");
+    gSystem->Load("libPWGPP");
+
+    AliGeomManager::LoadGeometry("geometry.root");
+    AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
+
+    gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");
 }

--- a/test/vmctest/lego/sim.C
+++ b/test/vmctest/lego/sim.C
@@ -17,6 +17,9 @@ void sim(Int_t nev, const char * config, const char * det)  {
   gROOT->LoadMacro("$ALICE_ROOT/test/vmctest/lego/commonConfig.C");
 
   AliSimulation simulator(config);
+  simulator.SetDefaultStorage("local://$ALIROOT_OCDB_ROOT/OCDB");
+  simulator.SetSpecificStorage("GRP/GRP/Data",
+			       Form("local://%s",gSystem->pwd()));
   TString configFunction("Config(\"");
   configFunction.Append(det);
   configFunction.Append(TString("\");"));

--- a/test/vmctest/lego/simG4.C
+++ b/test/vmctest/lego/simG4.C
@@ -17,6 +17,9 @@ void simG4(Int_t nev, const char * config, const char * det)  {
   gROOT->LoadMacro("$ALICE_ROOT/test/vmctest/lego/commonConfig.C");
 
   AliSimulation simulator(config);
+  simulator.SetDefaultStorage("local://$ALIROOT_OCDB_ROOT/OCDB");
+  simulator.SetSpecificStorage("GRP/GRP/Data",
+			       Form("local://%s",gSystem->pwd()));
   TString configFunction("Config(\"");
   configFunction.Append(det);
   configFunction.Append(TString("\");"));

--- a/test/vmctest/ppbench/aod.C
+++ b/test/vmctest/ppbench/aod.C
@@ -13,6 +13,7 @@ void aod(){
     gSystem->Load("libTender");
     gSystem->Load("libPWGPP");
 
+    AliGeomManager::LoadGeometry("geometry.root");
     AliEMCALGeometry::GetInstance("EMCAL_COMPLETEV1");
 
     gROOT->Macro("${ALICE_ROOT}/STEER/macros/CreateAODfromESD.C(\"AliESDs.root\",\"AliAOD.root\",\"local://$ALIROOT_OCDB_ROOT/OCDB\",\"local://.\")");


### PR DESCRIPTION
Use ALIROOT_OCDB_ROOT to find the default OCDB. Fix the loading of the magnetic field. Load libpythia to avoid crashes when the header is stored in galice.root.