### PR TITLE
fixing include path for Pythia8 headers

### DIFF
--- a/PYTHIA8/AliPythia8/AliPythia8.h
+++ b/PYTHIA8/AliPythia8/AliPythia8.h
@@ -5,7 +5,7 @@
 
 /* $Id: AliPythia.h,v 1.22 2007/10/09 08:43:24 morsch Exp $ */
 
-#include "Analysis.h"
+#include "Pythia8/Analysis.h"
 #include "AliPythiaBase.h"
 #include "AliTPythia8.h"
 

--- a/PYTHIA8/AliPythia8/AliTPythia8.h
+++ b/PYTHIA8/AliPythia8/AliTPythia8.h
@@ -60,7 +60,7 @@
 */
 
 #include "TGenerator.h"
-#include "Pythia.h"
+#include "Pythia8/Pythia.h"
 
 
 class TClonesArray;


### PR DESCRIPTION
Following the discussion on the alice-analysis-operations@cern.ch mailing list here is the fix to use Pythia8 in aliroot without having to add the Pythia8 folder to ROOT's include path 