### PR TITLE
Fix unused variable warning AliVEvent.h

### DIFF
--- a/STEER/STEERBase/AliVEvent.h
+++ b/STEER/STEERBase/AliVEvent.h
@@ -261,7 +261,7 @@ public:
   const char* Whoami();
   virtual ULong64_t  GetSize()  const {return 0;}
 
-  virtual void AdjustMCLabels(const AliVEvent *mctruth) {return;}
+  virtual void AdjustMCLabels(const AliVEvent */*mctruth*/) {return;}
   
   ClassDef(AliVEvent, 3)  // base class for AliEvent data
 };


### PR DESCRIPTION
Warning is issued when running local analysis (with root6).

```c++
/Users/hbeck/alice/alibuild/sw/osx_x86-64/AliRoot/0_ROOT6-1/include/AliVEvent.h:264:48: warning: unused
      parameter 'mctruth' [-Wunused-parameter]
  virtual void AdjustMCLabels(const AliVEvent *mctruth) {return;}
                                               ^
1 warning generated.
```