### PR TITLE
Prefix vector with std:: in AliFITv7

### DIFF
--- a/FIT/FITsim/AliFITv7.cxx
+++ b/FIT/FITsim/AliFITv7.cxx
@@ -184,7 +184,7 @@ void AliFITv7::CreateGeometry()
     gridpoints[i] = crad*TMath::Sin((1 - 1/(2*TMath::Abs(grdin[i])))*grdin[i]*btta);
   } 
 
-  vector<Double_t> xi,yi;
+  std::vector<Double_t> xi,yi;
     
   for(Int_t j = 5; j >= 0; j--){
       for(Int_t i = 0; i < 6; i++){


### PR DESCRIPTION
Does not compile with root6 otherwise

Dear @AllaMaevskaya,

The recent update in AliFITv7 breaks compilation of AliRoot with root6. The error is below.

Cheers,
Hans

```c++

/Users/hbeck/alice/alibuild/sw/SOURCES/AliRoot/0_ROOT6/0/FIT/FITsim/AliFITv7.cxx:187:3: error: no template named
      'vector'; did you mean 'std::vector'?
  vector<Double_t> xi,yi;
  ^~~~~~
  std::vector
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/vector:458:29: note: 
      'std::vector' declared here
class _LIBCPP_TYPE_VIS_ONLY vector
                            ^

```