### PR TITLE
Fix mismatched new[] delete AliMFTAnalysisTools

### DIFF
--- a/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx
+++ b/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx
@@ -170,7 +170,7 @@ Bool_t AliMFTAnalysisTools::ExtrapAODMuonToXY(AliAODTrack *muon, Double_t xy[2],
   else if (r[0]<r[1] && r[1]>r[2]) {
     printf("E-AliMFTAnalysisTools::ExtrapAODMuonToXY: Point of closest approach cannot be found (no minima)\n");
     delete param;
-    delete points;
+    delete[] points;
     return kFALSE;
   }
   
@@ -189,7 +189,7 @@ Bool_t AliMFTAnalysisTools::ExtrapAODMuonToXY(AliAODTrack *muon, Double_t xy[2],
     if (TMath::Abs(z[0])>900.) {
       printf("E-AliMFTAnalysisTools::ExtrapAODMuonToXY: Point of closest approach cannot be found (no minima in the fiducial region)\n");
       delete param;
-      delete points;
+      delete[] points;
       return kFALSE;
     }
     
@@ -430,7 +430,7 @@ Bool_t AliMFTAnalysisTools::CalculatePCA(TObjArray *muons, Double_t *pca, Double
   else if (r[0]<r[1] && r[1]>r[2]) {
     printf("E-AliMFTAnalysisTools::CalculatePCA: Point of closest approach cannot be found for dimuon (no minima)\n");
     for (Int_t iMu=0;iMu<nMuons;iMu++) delete param[iMu];
-    delete points;
+    delete[] points;
     return kFALSE;
   }	
   
@@ -449,7 +449,7 @@ Bool_t AliMFTAnalysisTools::CalculatePCA(TObjArray *muons, Double_t *pca, Double
     if (TMath::Abs(z[0])>900.) {
       printf("E-AliMFTAnalysisTools::CalculatePCA: Point of closest approach cannot be found for dimuon (no minima in the fiducial region)\n");
       for (Int_t iMu=0;iMu<nMuons;iMu++) delete param[iMu];
-      delete points;
+      delete[] points;
       return kFALSE;
     }
     
@@ -535,7 +535,7 @@ Bool_t AliMFTAnalysisTools::CalculatePCA(TObjArray *muons, Double_t *pca, Double
     Double_t wOffset = 0;
     if (!GetAODMuonWeightedOffset(muon[iMu],fXPointOfClosestApproach, fYPointOfClosestApproach, fZPointOfClosestApproach, wOffset)) {
       for(Int_t jMu=0;jMu<nMuons;jMu++) delete param[jMu];
-      delete points;
+      delete[] points;
       return kFALSE;
     }
     Double_t f = TMath::Exp(-0.5 * wOffset);
@@ -546,7 +546,7 @@ Bool_t AliMFTAnalysisTools::CalculatePCA(TObjArray *muons, Double_t *pca, Double
   else pcaQuality = 0.;
   
   for(Int_t iMu=0;iMu<nMuons;iMu++) delete param[iMu];
-  delete points;
+  delete[] points;
   return kTRUE;
   
 }


### PR DESCRIPTION
points is created with new[] and thus has to be erased with delete[]
Spotted by compiler.

```c++
/Users/hbeck/alice/alibuild/sw/SOURCES/AliRoot/0_ROOT6/0/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx:173:5: warning: 'delete' applied to a pointer
      that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
    delete points;
    ^
          []
/Users/hbeck/alice/alibuild/sw/SOURCES/AliRoot/0_ROOT6/0/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx:156:23: note: allocated with 'new[]' here
  TVector3 **points = new TVector3*[2];     // points[0] for the muon, points[1] for the direction parallel to the z-axis defined by the given (x,y)
                      ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliRoot/0_ROOT6/0/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx:192:7: warning: 'delete' applied to a pointer
      that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
      delete points;
      ^
            []
/Users/hbeck/alice/alibuild/sw/SOURCES/AliRoot/0_ROOT6/0/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx:156:23: note: allocated with 'new[]' here
  TVector3 **points = new TVector3*[2];     // points[0] for the muon, points[1] for the direction parallel to the z-axis defined by the given (x,y)
                      ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliRoot/0_ROOT6/0/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx:433:5: warning: 'delete' applied to a pointer
      that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
    delete points;
    ^
          []
/Users/hbeck/alice/alibuild/sw/SOURCES/AliRoot/0_ROOT6/0/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx:411:23: note: allocated with 'new[]' here
  TVector3 **points = new TVector3*[AliMFTConstants::fNMaxMuonsForPCA];
                      ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliRoot/0_ROOT6/0/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx:452:7: warning: 'delete' applied to a pointer
      that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
      delete points;
      ^
            []
/Users/hbeck/alice/alibuild/sw/SOURCES/AliRoot/0_ROOT6/0/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx:411:23: note: allocated with 'new[]' here
  TVector3 **points = new TVector3*[AliMFTConstants::fNMaxMuonsForPCA];
                      ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliRoot/0_ROOT6/0/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx:538:7: warning: 'delete' applied to a pointer
      that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
      delete points;
      ^
            []
/Users/hbeck/alice/alibuild/sw/SOURCES/AliRoot/0_ROOT6/0/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx:411:23: note: allocated with 'new[]' here
  TVector3 **points = new TVector3*[AliMFTConstants::fNMaxMuonsForPCA];
                      ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliRoot/0_ROOT6/0/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx:549:3: warning: 'delete' applied to a pointer
      that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
  delete points;
  ^
        []
/Users/hbeck/alice/alibuild/sw/SOURCES/AliRoot/0_ROOT6/0/ITSMFT/MFT/MFTbase/AliMFTAnalysisTools.cxx:411:23: note: allocated with 'new[]' here
  TVector3 **points = new TVector3*[AliMFTConstants::fNMaxMuonsForPCA];
                      ^
```