### PR TITLE
Fix printout statement AliPIDResponse

### DIFF
--- a/STEER/STEERBase/AliPIDResponse.cxx
+++ b/STEER/STEERBase/AliPIDResponse.cxx
@@ -1955,7 +1955,7 @@ void AliPIDResponse::SetTRDCentralityMaps()
 
     if (fIsMC) fUseTRDCentralityCorrection = kFALSE;
     if (fUseTRDCentralityCorrection == kFALSE) {
-	AliInfo("Request to disable TRD eta correction -> Centrality correction has been disabled");
+	AliInfo("Request to disable TRD centrality correction -> Centrality correction has been disabled");
         return;
     }
     TH2D* centralityMap[1];


### PR DESCRIPTION
SetTRDCentralityMaps printed a statement about an eta correction while in fact the centrality correction was meant.

Printout is visible when running local analysis
```bash
I-AliESDpid::SetTRDEtaMaps: Request to disable TRD eta correction -> Eta correction has been disabled
I-AliESDpid::SetTRDClusterMaps: Request to disable TRD cluster correction -> Cluster correction has been disabled
I-AliESDpid::SetTRDCentralityMaps: Request to disable TRD eta correction -> Centrality correction has been disabled
```