### PR TITLE
Include ROOT headers as -isystem

### DIFF
--- a/HLT/BASE/CMakeLists.txt
+++ b/HLT/BASE/CMakeLists.txt
@@ -28,13 +28,11 @@ endif()
 set(MODULE HLTbase)
 
 # Module include folder
-include_directories(${ROOT_INCLUDE_DIR}
-                              ${AliRoot_SOURCE_DIR}/HLT/BASE
-                   )
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE/HOMER
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE/HOMER
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatabase
                     ${AliRoot_SOURCE_DIR}/STEER/STEERBase
                    )

--- a/HLT/BASE/HOMER/CMakeLists.txt
+++ b/HLT/BASE/HOMER/CMakeLists.txt
@@ -20,8 +20,7 @@ set(MODULE AliHLTHOMER)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE/HOMER)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                   )
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
 
 # Sources in alphabetical order
 set(SRCS

--- a/HLT/BASE/interface/CMakeLists.txt
+++ b/HLT/BASE/interface/CMakeLists.txt
@@ -21,8 +21,8 @@ include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE/interface
                    )
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                    )
 
 # Sources in alphabetical order

--- a/HLT/BASE/util/CMakeLists.txt
+++ b/HLT/BASE/util/CMakeLists.txt
@@ -21,8 +21,8 @@ include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE/util
                    )
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/ANALYSIS/ANALYSISalice
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/ANALYSIS/ANALYSISalice
                     ${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatabase
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatarec

--- a/HLT/EVE/CMakeLists.txt
+++ b/HLT/EVE/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE AliHLTEve)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/EVE)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/EMCAL/EMCALUtils
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/EMCAL/EMCALUtils
                     ${AliRoot_SOURCE_DIR}/EVE/EveBase
                     ${AliRoot_SOURCE_DIR}/EVE/EveDet
                     ${AliRoot_SOURCE_DIR}/EVE/EveHLT

--- a/HLT/FMD/CMakeLists.txt
+++ b/HLT/FMD/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE AliHLTFMD)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/FMD)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/FMD/FMDbase
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/FMD/FMDbase
                     ${AliRoot_SOURCE_DIR}/FMD/FMDrec
                     ${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatabase

--- a/HLT/ITS/CMakeLists.txt
+++ b/HLT/ITS/CMakeLists.txt
@@ -25,8 +25,8 @@ include_directories(${AliRoot_SOURCE_DIR}/HLT/ITS
                    )
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/HLT/BASE/util
                     ${AliRoot_SOURCE_DIR}/ITS/ITSbase
                     ${AliRoot_SOURCE_DIR}/ITS/ITSrec

--- a/HLT/MUON/CMakeLists.txt
+++ b/HLT/MUON/CMakeLists.txt
@@ -23,8 +23,8 @@ include_directories(${AliRoot_SOURCE_DIR}/HLT/MUON
                    )
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/MUON/MUONbase
                     ${AliRoot_SOURCE_DIR}/MUON/MUONcalib
                     ${AliRoot_SOURCE_DIR}/MUON/MUONcore

--- a/HLT/PHOS/CMakeLists.txt
+++ b/HLT/PHOS/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE AliHLTPHOS)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/PHOS)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/EMCAL/EMCALraw
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/EMCAL/EMCALraw
                     ${AliRoot_SOURCE_DIR}/EMCAL/EMCALUtils
                     ${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/HLT/BASE/util

--- a/HLT/QA/CMakeLists.txt
+++ b/HLT/QA/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE HLTqadm)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/QA)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/STEER/ESD
                     ${AliRoot_SOURCE_DIR}/STEER/STEER
                     ${AliRoot_SOURCE_DIR}/STEER/STEERBase

--- a/HLT/RCU/CMakeLists.txt
+++ b/HLT/RCU/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE AliHLTRCU)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/RCU)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatabase
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatarec
                     ${AliRoot_SOURCE_DIR}/STEER/ESD

--- a/HLT/SampleLib/CMakeLists.txt
+++ b/HLT/SampleLib/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE AliHLTSample)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/SampleLib)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatabase
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatarec
                     ${AliRoot_SOURCE_DIR}/STEER/CDB

--- a/HLT/TPCLib/CMakeLists.txt
+++ b/HLT/TPCLib/CMakeLists.txt
@@ -43,8 +43,8 @@ include_directories(${AliRoot_SOURCE_DIR}/HLT/TPCLib
 )
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/ANALYSIS/ANALYSISalice
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/ANALYSIS/ANALYSISalice
                     ${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/HLT/BASE/util
                     ${AliRoot_SOURCE_DIR}/HLT/RCU

--- a/HLT/TPCLib/EVE/CMakeLists.txt
+++ b/HLT/TPCLib/EVE/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE AliHLTTPCEVE)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/TPCLib/EVE)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/HLT/TPCLib
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatabase
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatarec

--- a/HLT/TPCLib/tracking-ca/cagpu/cuda/CMakeLists.txt
+++ b/HLT/TPCLib/tracking-ca/cagpu/cuda/CMakeLists.txt
@@ -42,8 +42,8 @@ include_directories(${AliRoot_SOURCE_DIR}/HLT/TPCLib/tracking-ca/cagpu/cuda
                    )
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                    )
 
 #nvcc fails with std=c++11, remove it temporarily

--- a/HLT/TPCLib/tracking-ca/cagpu/opencl/CMakeLists.txt
+++ b/HLT/TPCLib/tracking-ca/cagpu/opencl/CMakeLists.txt
@@ -80,8 +80,8 @@ include_directories(${AliRoot_SOURCE_DIR}/HLT/TPCLib/tracking-ca/cagpu/opencl
                    )
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AMDAPPSDKROOT}/include
                    )
 

--- a/HLT/TRD/CMakeLists.txt
+++ b/HLT/TRD/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE AliHLTTRD)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/TRD)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/HLT/BASE/util
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatabase
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatarec

--- a/HLT/VZERO/CMakeLists.txt
+++ b/HLT/VZERO/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE AliHLTVZERO)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/VZERO)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatabase
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatarec
                     ${AliRoot_SOURCE_DIR}/STEER/CDB

--- a/HLT/ZDC/CMakeLists.txt
+++ b/HLT/ZDC/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE AliHLTZDC)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/ZDC)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatabase
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatarec
                     ${AliRoot_SOURCE_DIR}/STEER/CDB

--- a/HLT/comp/CMakeLists.txt
+++ b/HLT/comp/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE AliHLTComp)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/comp)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                    )
 
 # Sources in alphabetical order

--- a/HLT/createGRP/lib/CMakeLists.txt
+++ b/HLT/createGRP/lib/CMakeLists.txt
@@ -31,8 +31,8 @@ include_directories(${CREATEGRPDIR}
                    )
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${DIMDIR}/dim
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${DIMDIR}/dim
                    )
 
 # Sources in alphabetical order

--- a/HLT/global/CMakeLists.txt
+++ b/HLT/global/CMakeLists.txt
@@ -22,8 +22,8 @@ include_directories(${AliRoot_SOURCE_DIR}/HLT/global
                    )
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/ANALYSIS/ANALYSIS
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/ANALYSIS/ANALYSIS
                     ${AliRoot_SOURCE_DIR}/ANALYSIS/ANALYSISalice
                     ${AliRoot_SOURCE_DIR}/ITS/ITSrec
                     ${AliRoot_SOURCE_DIR}/HLT/BASE

--- a/HLT/pendolino/CMakeLists.txt
+++ b/HLT/pendolino/CMakeLists.txt
@@ -22,8 +22,8 @@ include_directories(${AliRoot_SOURCE_DIR}/HLT/pendolino
                    )
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/STEER/CDB
                     ${AliRoot_SOURCE_DIR}/STEER/STEER
                     ${AliRoot_SOURCE_DIR}/STEER/STEERBase

--- a/HLT/rec/CMakeLists.txt
+++ b/HLT/rec/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE HLTrec)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/rec)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/HLT/BASE/HOMER
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatabase
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatarec

--- a/HLT/shuttle/CMakeLists.txt
+++ b/HLT/shuttle/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE HLTshuttle)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/shuttle)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/STEER/CDB
                    )
 

--- a/HLT/sim/CMakeLists.txt
+++ b/HLT/sim/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE HLTsim)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/sim)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/HLT/BASE
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/HLT/BASE/HOMER
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatabase
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatarec

--- a/HLT/trigger/CMakeLists.txt
+++ b/HLT/trigger/CMakeLists.txt
@@ -20,8 +20,8 @@ set(MODULE AliHLTTrigger)
 include_directories(${AliRoot_SOURCE_DIR}/HLT/trigger)
 
 # Additional include folders in alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/ANALYSIS/ANALYSISalice
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/ANALYSIS/ANALYSISalice
                     ${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/HLT/BASE/util
                     ${AliRoot_SOURCE_DIR}/HLT/ITS

--- a/STEER/STEER/CMakeLists.txt
+++ b/STEER/STEER/CMakeLists.txt
@@ -21,8 +21,8 @@ add_definitions(-D_MODULE_="${MODULE}")
 include_directories(${AliRoot_SOURCE_DIR}/STEER/${MODULE})
 
 # Additional include directories - alphabetical order except ROOT
-include_directories(${ROOT_INCLUDE_DIR}
-                    ${AliRoot_SOURCE_DIR}/ANALYSIS/ANALYSIS
+include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
+include_directories(${AliRoot_SOURCE_DIR}/ANALYSIS/ANALYSIS
                     ${AliRoot_SOURCE_DIR}/HLT/BASE
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatabase
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatarec


### PR DESCRIPTION
This pull request includes all root headers in HLT and in STEER/STEER as -isystem, to avoid fake warnings coming from within the headers during AliRoot Compilation.
I would suggest to apply this to all AliRoot libraries.
I have added STEER, such that this will not be merged automatically.