### PR TITLE
ATO-402 - Updated documentation for AliElasticSearch

### DIFF
--- a/STAT/AliElasticSearchRoot.h
+++ b/STAT/AliElasticSearchRoot.h
@@ -3,38 +3,63 @@
 
 /// \ingroup STAT
 /// \class AliElasticSearchRoot
-/// \brief AliElasticSearchRoot - C++ interace to the Elastic --> root tree like-   using gSystem->GetFromPipe, Exec, Elastic, painlsees scripting,  curl,  jq
-///      - Originally planned usage of  higher level C++ inteface not possible for a moment
-///      -- C++11 or better C++14 and ROOT6 needed (e.g https://github.com/QHedgeTech/cpp-elasticsearch/tree/master/src )
-///      - Using older  C++  and Root 5 to represent heirarchiacal structure root trees to be used
-///      - Query language similar to TTree::Draw  - suing elastic painless scriptin langaug (see query expamples)
-/// ### Example usage (expecting acces to Elastic server with alice indexes)
-///  - see also $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.c
-///  - to create indeces needed $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.c:testExportBinary() can be used
-/// \code
-///  hostName="localhost:9200";            // local elastic
-///   // or remote ElastichostName="https://localhost:9206";    //  connect to remote via tunnel e.g ssh mivanov@lxplus.cern.ch -f -N -L 9206:es-alice.cern.ch:9203
-///  //
-///  AliElasticSearchRoot elastic(hostName,kFALSE,1);
-///  elastic.SetCertificate();           // default certification="--insecure --cacert CERNRootCertificationAuthority2.crt --netrc-file $HOME/.globus/.elastic/.netrc"
-///  elastic.ls();                       // list all indeces
-///  elastic.ls("alice");                // list incdeces containing alice
-///  elastic.ls(".alice_mc");             // list indeces containing alice_mc
-///  elastic.Print();
-///  // GetIndexLayeout
-///  elastic.GetIndexLayout("/alice/logbook_test0/")->Print();
-///  elastic.GetIndexLayout("/alice_mc/passguess/")->Print();
-///  // make a Tree like query
-///  TString select="";
-///  select=  elastic.select("/alice/qatpc_test0/","run:meanMIP:meanTPCncl","run>240000&&run<246844&&meanMIP>50",0,1000,"jqEQueryStat,jqEQueryHeader")
-///  select=  elastic.select("/alice/logbook_test0/","run:totalSubEvents:ctpDuration","run>140000",0,10000,"jqEQueryStat,jqEQueryHeader")
-///  select=  elastic.select("/alice_mc/passguess/","*","1",0,1000,"jqEQueryStat,jqEQueryHeader,jqEQueryArrayNamed");  // get list of all runs output in query.json
-///  //
-///  select=  elastic.select("/alice/qatpc_test0/","*","run>240000&&run<246844&&meanMIP>50",0,1000,0)
-///
-/// To do  - json- formatted cvs conversion to enable root like queries
-/// \endcode
-/// \author marian  Ivanov marian.ivanov@cern.ch
+/*!
+ \brief AliElasticSearchRoot - C++ interface to the Elastic --> root tree like-   using gSystem->GetFromPipe, Exec, Elastic, painless scripting,  curl,  jq
+      - Originally planned usage of  higher level C++ interface not possible for a moment
+      -- C++11 or better C++14 and ROOT6 needed (e.g https://github.com/QHedgeTech/cpp-elasticsearch/tree/master/src )
+      - Using older  C++  and Root 5 to represent hierarchical structure root trees to be used
+      - Query language similar to TTree::Draw  - using elastic painless scripting language (see query examples)
+      - jq -  jq is like sed for JSON data - you can use it to slice and filter and map and transform structured data
+      --  see:       https://stedolan.github.io/jq/
+      --- jq player  to check/test jq syntax https://jqplay.org/
+
+### Example usage  (assuming access to Elastic server with alice indexes)
+
+  - see also $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.c
+  - to create indices needed $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.c:testExportBinary() can be used
+
+\code
+   hostName="localhost:9200";            // local elastic
+   // hostName="https://188.184.85.222/krb"
+   AliElasticSearchRoot elastic(hostName,kFALSE,1);
+\endcode
+
+#### Set certification
+
+\code
+   elastic.SetCertificate();           // default certification="--insecure --cacert CERNRootCertificationAuthority2.crt --netrc-file $HOME/.globus/.elastic/.netrc"
+   elastic.SetCertificate("-u elastic:changeme"); // using username(elastic)":pwd(changeme) as in Elastic tutorials
+   // to add Kerberos and negotiate
+   elastic.SetCertificate("-k -u : --negotiate")
+
+\endcode
+
+#### Browse content
+
+\code
+   elastic.ls();                       // list all indices
+   elastic.ls("alice");                // list indices containing alice
+   elastic.ls(".alice_mc");             // list indices containing alice_mc
+   elastic.Print();
+   // GetIndexLayout
+   elastic.GetIndexLayout("/alice/logbook_test0/")->Print();
+   elastic.GetIndexLayout("/alice_mc/passguess/")->Print();
+\endcode
+
+#### TTree like queries
+
+\code
+   TString select="";
+   select=  elastic.select("/alice/qatpc_test0/","run:meanMIP:meanTPCncl","run>240000&&run<246844&&meanMIP>50",0,1000,"jqEQueryStat,jqEQueryHeader")
+   select=  elastic.select("/alice/logbook_test0/","run:totalSubEvents:ctpDuration","run>140000",0,10000,"jqEQueryStat,jqEQueryHeader")
+   select=  elastic.select("/alice_mc/passguess/","*","1",0,1000,"jqEQueryStat,jqEQueryHeader,jqEQueryArrayNamed");  // get list of all runs output in query.json
+   select=  elastic.select("/alice/qatpc_test0/","*","run>240000&&run<246844&&meanMIP>50",0,1000,0)
+\endcode
+
+  ### To do
+
+  \author marian  Ivanov marian.ivanov@cern.ch
+*/
 
 #include "TObject.h"
 #include <map>

--- a/STAT/Macros/AliElasticSearchRootTest.C
+++ b/STAT/Macros/AliElasticSearchRootTest.C
@@ -3,30 +3,30 @@
 ///           - C++11 or better C++14 and ROOT6 needed (e.g https://github.com/QHedgeTech/cpp-elasticsearch/tree/master/src )
 ///  \author marian  Ivanov marian.ivanov@cern.ch
 
-///          In order to run the test Elastic server has to be running = default location hostName="localhost:9200"  - but it can pbe specified as test argument
-/////  to run tests one by one
-/////  \code
-//      .L $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.c
-//    InitElastic();
-//    testGetIndexLayout();
-//    testSelect();
-///// \endcode
-//
-///// To run full test
-/////  \code
-// aliroot -b -q $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.c |tee AliElasticSearchRootTest.log
-//    Parse output
-//    cat AliElasticSearchRootTest.log | grep "I-AliElasticSearchRoot.*Key"
-//I-AliElasticSearchRoot::AliElasticSearchRootTest: KeyValue-Begin
-//I-AliElasticSearchRoot::ExportBinary: KeyValue-Begin
-//I-AliElasticSearchRoot::ExportBinary: KeyValue-End
-//I-AliElasticSearchRoot::GetIndexLayout: KeyValue-Begin
-//I-AliElasticSearchRoot::GetIndexLayout: KeyValue-End
-//I-AliElasticSearchRoot::select: KeyValue-Begin
-//I-AliElasticSearchRoot::select: KeyValue-End
-//I-AliElasticSearchRoot::AliElasticSearchRootTest: KeyValue-End
-///// \endcode
-
+/*!
+    In order to run the test Elastic server has to be running = default location hostName="localhost:9200"  - but it can be specified as test argument
+    to run tests one by one
+    \code
+      .L $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.C
+       InitElastic();
+       testGetIndexLayout();
+       testSelect();
+    \endcode
+     To run full test
+    \code
+    aliroot -b -q $AliRoot_SRC/STAT/Macros/AliElasticSearchRootTest.C |tee AliElasticSearchRootTest.log
+    Parse output
+        cat AliElasticSearchRootTest.log | grep "I-AliElasticSearchRoot.*Key"
+        I-AliElasticSearchRoot::AliElasticSearchRootTest: KeyValue-Begin
+        I-AliElasticSearchRoot::ExportBinary: KeyValue-Begin
+        I-AliElasticSearchRoot::ExportBinary: KeyValue-End
+        I-AliElasticSearchRoot::GetIndexLayout: KeyValue-Begin
+        I-AliElasticSearchRoot::GetIndexLayout: KeyValue-End
+        I-AliElasticSearchRoot::select: KeyValue-Begin
+        I-AliElasticSearchRoot::select: KeyValue-End
+        I-AliElasticSearchRoot::AliElasticSearchRootTest: KeyValue-End
+    \endcode
+*/
 
 
 
@@ -109,10 +109,17 @@ void testExportClass() {
     exportInfo+="run:";
     exportInfo+="grdcar_neg_ASidePhi.";
     Int_t entries = AliTreePlayer::selectWhatWhereOrderBy(tree,exportInfo.Data(),"1", "", 0,100000, "elastic","qatpc_testClass.json");
-     pelastic->ExportBinary("/alice/qatpc_testClass1/","qatpc_testClass.json","xxx");
+    pelastic->ExportBinary("/alice/qatpc_testClass1/","qatpc_testClass.json","xxx");
     ::Info("AliElasticSearchRoot::testExportClass","KeyValue-End");
 }
 
+void testExportClass() {
+    ::Info("AliElasticSearchRoot::testExportClass","KeyValue-Begin");
+    AliExternalInfo info;
+    TTree *tree = info.GetTree("QA.TPC","LHC15n","pass2","Logbook:QA.ITS:QA.TRD");
+    //
+
+}
 
 void testGetIndexLayout(){
     //


### PR DESCRIPTION
* Follow up of documentation discussion in request: https://github.com/alisw/AliRoot/pull/243
* Rename the "Unit" test macro
* Add doxygen documentation in the test macro 