### PR TITLE
Extra flags for Invalid or TPC primary vtx in the AOD

### DIFF
--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
@@ -1968,12 +1968,13 @@ void AliAnalysisTaskESDfilter::ConvertPrimaryVertices(const AliESDEvent& esd)
   // Add primary vertex. The primary tracks will be defined
   // after the loops on the composite objects (V0, cascades, kinks)
   const AliESDVertex *vtx = esd.GetPrimaryVertex();
-  
+  char vType = AliAODVertex::kPrimary;
+  if (!vtx->GetStatus()) vType = AliAODVertex::kPrimaryInvalid;
+  else if (vtx == esd.GetPrimaryVertexTPC()) vType = AliAODVertex::kPrimaryTPC;
   vtx->GetXYZ(pos); // position
   vtx->GetCovMatrix(covVtx); //covariance matrix
-  
   fPrimaryVertex = new(Vertices()[fNumberOfVertices++])
-  AliAODVertex(pos, covVtx, vtx->GetChi2toNDF(), NULL, -1, AliAODVertex::kPrimary);
+  AliAODVertex(pos, covVtx, vtx->GetChi2toNDF(), NULL, -1, vType);
   fPrimaryVertex->SetName(vtx->GetName());
   fPrimaryVertex->SetTitle(vtx->GetTitle());
   fPrimaryVertex->SetBC(vtx->GetBC());

--- a/STEER/AOD/AliAODVertex.h
+++ b/STEER/AOD/AliAODVertex.h
@@ -23,7 +23,7 @@ class AliAODVertex : public AliVVertex {
 
  public :
 
-  enum AODVtx_t {kUndef=-1, kPrimary, kKink, kV0, kCascade, kMulti, kMainSPD, kPileupSPD, kPileupTracks,kMainTPC};
+  enum AODVtx_t {kPrimaryInvalid=-10,kUndef=-1, kPrimary, kKink, kV0, kCascade, kMulti, kMainSPD, kPileupSPD, kPileupTracks,kMainTPC,kPrimaryTPC};
 
   AliAODVertex();
   AliAODVertex(const Double_t *position, 


### PR DESCRIPTION
AODvertex will be create with the flag AliAODVertex::kPrimaryInvalid if there was no valid vertex in the ESD event and with AliAODVertex::kPrimaryTPC if the onlt valid vertex was from the TPC