### PR TITLE
Use static pointer rather than the object

### DIFF
--- a/STEER/STEERBase/AliStack.cxx
+++ b/STEER/STEERBase/AliStack.cxx
@@ -42,7 +42,7 @@
 ClassImp(AliStack)
 
 
-TParticle AliStack::fgDummyParticle(21,999,-1,-1,-1,-1,1,1,999,999,0,0,0,0);
+TParticle* AliStack::fgDummyParticle = 0;
 const Char_t* AliStack::fgkEmbedPathsKey = "embeddingBKGPaths";
 
 //_______________________________________________________________________
@@ -682,7 +682,8 @@ TParticle* AliStack::Particle(Int_t i, Bool_t useInEmbedding)
   // Return particle with specified ID
   if (GetMCEmbeddingFlag() && !useInEmbedding) {
     AliError("Method should not be called by user in embedding mode, returning dummy particle");
-    return (TParticle*)&fgDummyParticle;
+    if (!fgDummyParticle) fgDummyParticle = new TParticle(21,999,-1,-1,-1,-1,1,1,999,999,0,0,0,0);
+    return fgDummyParticle;
   }
   
   if(!fParticleMap.At(i)) {
@@ -716,7 +717,8 @@ TParticle* AliStack::ParticleFromTreeK(Int_t id, Bool_t useInEmbedding) const
 //
   if (GetMCEmbeddingFlag() && !useInEmbedding) {
     AliError("Method should not be called by user in embedding mode, returning dummy particle");
-    return (TParticle*)&fgDummyParticle;
+    if (!fgDummyParticle) fgDummyParticle = new TParticle(21,999,-1,-1,-1,-1,1,1,999,999,0,0,0,0);
+    return (TParticle*)fgDummyParticle;
   }
   Int_t entry;
   if ((entry = TreeKEntry(id,useInEmbedding)) < 0) return 0;

--- a/STEER/STEERBase/AliStack.h
+++ b/STEER/STEERBase/AliStack.h
@@ -120,7 +120,7 @@ class AliStack : public TVirtualMCStack
     TArrayI        fTrackLabelMap;     //! Map of track labels
     Bool_t         fMCEmbeddingFlag;   //! Flag that this is a top stack of embedded MC
 
-    static TParticle fgDummyParticle; // dummy particle returned in Stack::Particle call in embedding mode
+    static TParticle* fgDummyParticle;     // dummy particle returned in Stack::Particle call in embedding mode
     static const Char_t *fgkEmbedPathsKey;       // keyword for embedding paths
 
     ClassDef(AliStack,6) //Particles stack


### PR DESCRIPTION
Creating static object involvint gROOT modification may corrupt the memory in case of
static builds for DA. The static TParticle pointer will be initialized on 1st demand
(never in case of DA)