### PR TITLE
ATO-83 & ATO-46 MC to anchor comparison

### DIFF
--- a/STAT/AliExternalInfo.cxx
+++ b/STAT/AliExternalInfo.cxx
@@ -1170,6 +1170,9 @@ TTree*  AliExternalInfo::GetTreeMCPassGuess(){
                 cout<<"Looking for MC aliphys: "<<tempprod.aliphys<<" MC aliroot: "<<tempprod.aliroot<<endl;
                 if(!((*iter).anchpass).Contains("cpass") && !((*iter).anchpass).Contains("cosmic") && (!isgp || TPRegexp("^pass").MatchB((*iter).anchpass,"i"))){
                 cout<<"Used for guess: RDphys:"<<(*iter).aliphys<<" RDroot: "<<(*iter).aliroot<<" RDpass guess: "<<(*iter).anchpass<<endl;
+                *osrdpass=TObjString(iter->anchpass);
+                *osrdaliphys=TObjString(iter->aliphys);
+                *osrdaliroot=TObjString(iter->aliroot);
                 break;
                     }
                 if(iter==list.begin()) break;
@@ -1218,9 +1221,12 @@ TString  AliExternalInfo::GetMCPassGuess(TString sMCprodname){
 }
  
  char pMCprodname[1000];
+
  TObjString osMCprodname=0;
+ TObjString* osAnchprodname=0;
  TObjString* osMCpassguess=0;
- 
+
+ guesstree->GetBranch("anchorProdTag_ForGuess")->SetAddress(&osAnchprodname); 
  guesstree->GetBranch("prodName")->SetAddress(&pMCprodname);
  guesstree->GetBranch("anchorPassName_guess")->SetAddress(&osMCpassguess);
  
@@ -1229,7 +1235,7 @@ TString  AliExternalInfo::GetMCPassGuess(TString sMCprodname){
      osMCprodname = TObjString(pMCprodname);
      if(osMCprodname.String()==sMCprodname){       //if match found return corresponding guess
          cout<<"Anchor Pass guess for "<<osMCprodname.String()<<": "<<osMCpassguess->String()<<endl;
-         return(osMCpassguess->String());
+         return(osAnchprodname->String()+" "+osMCpassguess->String());
      }
  }
  cout<<osMCprodname.String()<<" was not found in list of MC productions"<<endl;

--- a/STAT/AliTreeTrending.cxx
+++ b/STAT/AliTreeTrending.cxx
@@ -120,8 +120,20 @@ void AliTreeTrending::AddUserDescription(TNamed * description){
   fUserDescription->AddLast(description);
 }
 
+/// Intialize drawing for <detector> QA
 
-Bool_t  AliTreeTrending::InitSummaryTrending(TString statusDescription[3], Float_t descriptionSize){
+///  \param statusDescription       - contains statusbar-vars,-names and -criteria
+///  \param descriptionSize         - Text size of description
+///  \param cutString               - string "selection"
+
+/// Example usage 
+/// \code
+/// Example usage of the AliTreeTrending::InitSummaryTrending
+/// trendingDraw->InitSummaryTrending(statusString,0.015,"defaultcut")
+/// here "defaultcut" refers to an alias set like this:   treeMC->SetAlias("defaultcut","run==TPC.Anchor.run");
+/// \endcode  
+
+Bool_t  AliTreeTrending::InitSummaryTrending(TString statusDescription[3], Float_t descriptionSize, TString cutString){
   //
   // Init drawing for the <detector> QA
   // Detector specific qaConfig() has to be called before invoking this function
@@ -181,10 +193,17 @@ Bool_t  AliTreeTrending::InitSummaryTrending(TString statusDescription[3], Float
   int igr=0;
   for (Int_t vari=oaStatusbarVars->GetEntriesFast()-1; vari>=0; vari--){ // invert the order of the status graphs
     TString sVar = Form("%s:tagID", oaStatusbarVars->At(vari)->GetName()); //e.g. -> dcar:run
-    fStatusGraph->Add( TStatToolkit::MakeStatusMultGr(fTree, sVar.Data(),  "", sCriteria.Data(), igr) );
-    TString sYtitle = oaStatusbarNames->At(vari)->GetName(); // set better name for y axis of statuspad
-    ((TMultiGraph*) fStatusGraph->At(igr))->SetTitle(sYtitle.Data());
-    igr++;
+    TMultiGraph* multGr = TStatToolkit::MakeStatusMultGr(fTree, sVar.Data(),  cutString, sCriteria.Data(), igr);
+    if(multGr){
+        fStatusGraph->Add(multGr);
+        TString sYtitle = oaStatusbarNames->At(vari)->GetName(); // set better name for y axis of statuspad
+        ((TMultiGraph*) fStatusGraph->At(igr))->SetTitle(sYtitle.Data());
+        igr++;
+    }
+    else{
+        AliError("TStatToolkit::MakeStatusMultGr() returned with error -> next");
+        continue;
+    }
   }
   return kTRUE;
 }

--- a/STAT/AliTreeTrending.h
+++ b/STAT/AliTreeTrending.h
@@ -24,7 +24,7 @@ public:
   ~AliTreeTrending(){;}
   void SetTree(TTree * tree) {fTree=tree;};
   void AddUserDescription(TNamed *description);  //
-  Bool_t  InitSummaryTrending(TString statusDescription[3], Float_t descriptionSize=0.015);
+  Bool_t  InitSummaryTrending(TString statusDescription[3], Float_t descriptionSize=0.015, TString cutString="");
   void SetDefaultStyle();  // own style to be used - not yet
   void AppendStatusPad(Float_t padratio, Float_t bottomMargin, Float_t rightMargin);
 public:

--- a/STAT/TStatToolkit.h
+++ b/STAT/TStatToolkit.h
@@ -3,12 +3,13 @@
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */
 
-//
-// some utilities which do net exist in the standard ROOT
-//
+/// \ingroup STAT
 /// \file TStatToolkit.h
 /// \class TStatToolkit
 /// \brief Summary of statistics functions
+/// \author Marian  Ivanov marian.ivanov@cern.ch
+
+
 #include "TMath.h"
 #include "Riostream.h"
 #include "TH1F.h"
@@ -91,7 +92,7 @@ namespace TStatToolkit
   TNamed *GetMetadata(TTree* tree, const char *vartagName, TString *prefix=0);
   TGraph * MakeGraphSparse(TTree * tree, const char * expr="Entry", const char * cut="1",  Int_t mstyle=25, Int_t mcolor=1, Float_t msize=-1, Float_t offset=0.0);
   TGraphErrors * MakeGraphErrors(TTree * tree, const char * expr="Entry", const char * cut="1",  Int_t mstyle=25, Int_t mcolor=1, Float_t msize=-1, Float_t offset=0.0, Int_t entries=10000000, Int_t firstEntry=0);
-  TMultiGraph * MakeMultGraph(TTree * tree, const char *groupName, const char* expr, const char * cut, const char * markers, const char *colors, Bool_t drawSparse, Float_t msize, Float_t sigmaRange, TLegend * legend);
+  TMultiGraph * MakeMultGraph(TTree * tree, const char *groupName, const char* expr, const char * cut, const char * markers, const char *colors, Bool_t drawSparse, Float_t msize, Float_t sigmaRange, TLegend * legend, Bool_t comp=kTRUE );
   //
   // Fitting function
   //


### PR DESCRIPTION
* ATO-46 AliExternalInfo:GetMCPassGuess returns now also the anchor period name
  * fixed bug in anchor pass guessing: in case AliRoot, AliPhysics and production name matched, the wrong pass guess was provided
* ATO-83 error handling in case plotting fails
  * updated Doxygen documentation
* ATO-83 MC to anchor comparison
  * Behaviour of TStatToolkit::MakeMultGraph in case of empty plot for a variable can now be swichted between these options:
    * Demand a plot for every variable or otherwise return empty plot with error msg
    * Accept missing plots for some variables as long as not all are missing, if all are missing return empty plot with error msg