### PR TITLE
AT0-83 - Fix for doxygen documentations for TStatToolkit

### DIFF
--- a/STAT/TStatToolkit.cxx
+++ b/STAT/TStatToolkit.cxx
@@ -13,13 +13,12 @@
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
 
+//-----------------------------------------------------------------------------
+/// \namespace TStatToolkit
+/// \authors Marian Ivanov, Jens Wiechula, Ruben Shahoian,  Sebastian Lehner ...
+/// Subset of  mathematical functions not included in the TMath
+//-----------------------------------------------------------------------------
 
-///////////////////////////////////////////////////////////////////////////
-/// \file TStatToolkit.cxx
-/// \class TStatToolkit
-/// \brief Summary of statistics functions
-/// Subset of  matheamtical functions  not included in the TMath
-//
 //
 /////////////////////////////////////////////////////////////////////////
 #include "TStopwatch.h"
@@ -33,9 +32,7 @@ using std::cerr;
 using std::endl;
 
 //_____________________________________________________________________________
-void TStatToolkit::EvaluateUni(Int_t nvectors, Double_t *data, Double_t &mean
-                           , Double_t &sigma, Int_t hh)
-{
+void TStatToolkit::EvaluateUni(Int_t nvectors, Double_t *data, Double_t &mean, Double_t &sigma, Int_t hh) {
   //
   // Robust estimator in 1D case MI version - (faster than ROOT version)
   //
@@ -91,8 +88,7 @@ void TStatToolkit::EvaluateUni(Int_t nvectors, Double_t *data, Double_t &mean
 
 
 
-void TStatToolkit::EvaluateUniExternal(Int_t nvectors, Double_t *data, Double_t &mean, Double_t &sigma, Int_t hh,  Float_t externalfactor)
-{
+void TStatToolkit::EvaluateUniExternal(Int_t nvectors, Double_t *data, Double_t &mean, Double_t &sigma, Int_t hh,  Float_t externalfactor) {
   // Modified version of ROOT robust EvaluateUni
   // robust estimator in 1D case MI version
   // added external factor to include precision of external measurement

--- a/STAT/TStatToolkit.h
+++ b/STAT/TStatToolkit.h
@@ -2,13 +2,12 @@
 #define TSTATTOOLKIT_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */
+/* $Id$ */
 
 /// \ingroup STAT
-/// \file TStatToolkit.h
-/// \class TStatToolkit
+/// \namespace TStatToolkit
 /// \brief Summary of statistics functions
-/// \author Marian  Ivanov marian.ivanov@cern.ch
-
+/// \authors Marian  Ivanov marian.ivanov@cern.ch, Jens Wiechula, Ruben Shahoian,  Sebastian Lehner ...
 
 #include "TMath.h"
 #include "Riostream.h"
@@ -32,7 +31,7 @@
 #include "TFitResultPtr.h"
 #include "TFitResult.h"
 //
-// includes neccessary for test functions
+// includes necessary for test functions
 //
 #include "TSystem.h"
 #include "TRandom.h"
@@ -50,8 +49,7 @@
 //#include "TGraph.h"
 class THashList;
 
-namespace TStatToolkit
-{
+namespace TStatToolkit {
   enum TStatType {kEntries, kSum, kMean, kRMS, kMedian, kLTM, kLTMRMS}; 
   enum ENormType {kL1, kL2, kLp, kMax, kHamming, kNNormType };   // http://en.wikipedia.org/w/index.php?title=Norm_(mathematics)&oldid=655824636
   //


### PR DESCRIPTION
* using \namespace instead of \class doxygen directive
* small modification in documentations
* modifying curly brackets in some functions
  * once full documntation provided consistent usage of the brackets should be requested