### PR TITLE
Introduction of AliESDcascade::RefitCascade method

### DIFF
--- a/STEER/ESD/AliESDcascade.h
+++ b/STEER/ESD/AliESDcascade.h
@@ -30,6 +30,8 @@ public:
   ~AliESDcascade();
   AliESDcascade& operator=(const AliESDcascade& cas);
   virtual void Copy(TObject &obj) const;
+    
+  Int_t RefitCascade(AliExternalTrackParam *bachelor); //to be invoked immediately after creation
 
 // Start with AliVParticle functions
   virtual Double_t Px() const { return fNmom[0]+fPmom[0]+fBachMom[0]; }
@@ -86,7 +88,7 @@ public:
   void     SetDcaXiDaughters(Double_t rDcaXiDaughters=0.);
   Double_t GetDcaXiDaughters() const {return fDcaXiDaughters;}
   Double_t GetCascadeCosineOfPointingAngle(Double_t refPointX, Double_t refPointY, Double_t refPointZ) const;
-
+    
   void GetPosCovXi(Double_t cov[6]) const;
 
 protected: 


### PR DESCRIPTION
This change introduces a method in AliESDcascade to improve the precision of the cascade decay position estimate by using an error-weighted average for that estimate, as discussed initially [here](https://indico.cern.ch/event/658280/contributions/2685555/attachments/1505439/2345751/DDChinellato-VertexerImprovements-7.pdf). The final implementation employs a covariance matrix calculation that's analogous to what is already done in the AliESDv0::Refit method and borrows from the same function used there for single track covariance estimates (see "GetWeight"). The ::RefitCascade function, as contained in this pull request, is also extensively commented for clarity of purpose and understandability. 

As a side product, the RefitCascade method will also produce a chi2 value for the cascade decay vertex and a cascade position covariance matrix - again analogous to what takes place within AliESDv0::Refit. 

This change will not affect any data members (and hence no ClassDef incrementation was done) and will not affect any current use case, given that unless ::RefitCascade is invoked nothing different will happen wrt current operation. 

Update: Corresponding JIRA Ticket:
https://alice.its.cern.ch/jira/browse/ALIROOT-7485