### PR TITLE
PWGPP-312, ATO-83, ATO-46: Update  TStatToolkit::MakeMultGraph

### DIFF
--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -1,24 +1,47 @@
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */
 
-/// \ingroup base
+/// \ingroup STAT
 /// \class AliDrawStyle
 /// \brief AliDrawStyle
 ///  ### AliDrawStyle - Class to access drawing styles
-///  * Several drawing styles can be regeistered and used in the same moment
-///    * Styles are identified using strings as identifiets
+///  * Several drawing styles can be registered and used in the same moment
+///    * Styles are identified using strings as identifiers
 ///      * TStyle
 ///      * MarkerStyle[]  AliDrawStyle::GetMarkerStyle(const char *style, Int_t index);
 ///      * MarkerColors[] AliDrawStyle::GetMarkerColor(const char *style, Int_t index);
 ///      * FillColors[]   AliDrawStyle::GetFillColor(const char *style, Int_t index);
 ///  * Default styles are created  AliDrawStyle::SetDefaults()
 ///    * default style is based on the fig template -  https://twiki.cern.ch/twiki/pub/ALICE/ALICERecommendationsResultPresentationText/figTemplate.C
-///    * users should be able to regiester their oun styles (e.g in macros)
+///    * users should be able to register their own styles (e.g in macros)
 ///  * Usage (work in progress)
 ///    * performance reports -  with styles as a parameter
 ///    * QA reports
 ///    * AliTreePlayer, and TStatToolkit
 /// \author marian  Ivanov marian.ivanov@cern.ch
+///
+///  ## Example usage
+/*!
+\code
+  AliDrawStyle::SetDefaults()
+  // Style example
+  //
+  AliDrawStyle::PrintStyles(0,TPRegexp("."));
+  AliDrawStyle::ApplyStyle("figTemplate");
+  gPad->UseCurrentStyle();  // force current style for current data
+  //
+  // Standard ALICE latex symbols
+  AliDrawStyle::PrintLatexSymbols(0,TPRegexp("."))
+  AliDrawStyle::GetLatexAlice("qpt")
+  AliDrawStyle::AddLatexSymbol("dphi", "#Delta#it#phi (unit)")
+  AliDrawStyle::GetLatexAlice("dphi")
+  //
+  // Standard ALICE marker/colors arrays
+  AliDrawStyle::GetMarkerStyle("figTemplate",0)
+  AliDrawStyle::GetMarkerColor("figTemplate",0)
+\endcode
+*/
+
 
 
 #include "TObject.h"
@@ -35,8 +58,17 @@ public:
   static void ApplyStyle(const char* styleName);
   static const TStyle *GetStyle(const char * styleName) {return fStyleAlice[styleName];}
   static void SetDefaults();
+  static void SetDefaultStyles(const char * tstyleName, const char* arrayName);
   static TString GetLatexAlice(const char * symbol);
   static void AddLatexSymbol(const char * symbolName, const char * symbolTitle);
+  static const std::vector<int> &    GetMarkerStyles(const char *style){return AliDrawStyle::fMarkerStyles[style];};
+  static const std::vector<float> &  GetMarkerSize(const char *style){return AliDrawStyle::fMarkerSize[style];};
+  static const std::vector<int> &    GetMarkerColors(const char *style){return AliDrawStyle::fMarkerColors[style];};
+  static const std::vector<float> &  GetLineWidth(const char *style){return AliDrawStyle::fLineWidth[style];};
+  static const std::vector<int> &    GetFillColors(const char *style){return AliDrawStyle::fFillColors[style];};
+  //
+  static Int_t   GetIntegerAt(const char * format, Int_t index, const char * separator=";");
+  static Float_t GetFloatAt(const char * format, Int_t index, const char * separator=";");
   static Int_t   GetMarkerStyle(const char *style, Int_t index);
   static Float_t GetMarkerSize(const char *style, Int_t index);
   static Int_t   GetMarkerColor(const char *style, Int_t index);
@@ -45,17 +77,19 @@ public:
   static void PrintLatexSymbols(Option_t *option,TPRegexp& regExp);
   static void PrintStyles(Option_t *option, TPRegexp& regExp);
 protected:
-  static std::map<TString, TString> fLatexAlice;              // map of prefdefiend latex symbols - fomatted according ALICE rules
-  static std::map<TString, TStyle*>  fStyleAlice;             // map of Alice predefined styles (+user defined)
-  static std::map<TString, std::vector<int> > fMarkerStyles;  // map of predefined marker styles arrays
-  static std::map<TString, std::vector<int> > fMarkerColors;  // map of predefined colors  arrays
-  static std::map<TString, std::vector<float> > fMarkerSize;  // map of predefined marker sizes ()
-  static std::map<TString, std::vector<int> > fFillColors;    // map of predefined fill colors arrays
-  static std::map<TString, std::vector<float> > fLineWidth;   // map of predefined line width
+  static TString fDefaultTStyleID;                            ///< ID of the default TStyle
+  static TString fDefaultArrayStyleID;                        ///< ID of the default array styles
+  static std::map<TString, TString> fLatexAlice;              ///< map of predefined latex symbols - fomatted according ALICE rules
+  static std::map<TString, TStyle*>  fStyleAlice;             ///< map of Alice predefined styles (+user defined)
+  static std::map<TString, std::vector<int> > fMarkerStyles;  ///< map of predefined marker styles arrays
+  static std::map<TString, std::vector<int> > fMarkerColors;  ///< map of predefined colors  arrays
+  static std::map<TString, std::vector<float> > fMarkerSize;  ///< map of predefined marker sizes ()
+  static std::map<TString, std::vector<int> > fFillColors;    ///< map of predefined fill colors arrays
+  static std::map<TString, std::vector<float> > fLineWidth;   ///< map of predefined line width
   //
-  static void  RegisterDefaultLatexSymbols();                 // initialize default LatexSymbols
-  static void  RegisterDefaultStyle();                        // initialize default TStyles
-  static void  RegisterDefaultMarkers();                      // initialize default Markers/Colors
+  static void  RegisterDefaultLatexSymbols();                 ///< initialize default LatexSymbols
+  static void  RegisterDefaultStyle();                        ///< initialize default TStyles
+  static void  RegisterDefaultMarkers();                      ///< initialize default Markers/Colors
 
   ClassDef(AliDrawStyle,1);
 };

--- a/STAT/AliTreeTrending.cxx
+++ b/STAT/AliTreeTrending.cxx
@@ -14,9 +14,15 @@
  **************************************************************************/
 
 
-/*
- .L $ALICE_ROOT/../src/STAT/AliTreeTrending.cxx+
 
+///\ingroup STAT
+///\class AliTreeTrending
+///\brief AliTreeTrending class for the visualization of the QA trending/alarms
+///\author Marian Ivanov
+/*!
+ Generalization of the original TPC QA trending visualization code
+ Example usage in the $AliPhysics_SRC/PWGPP/QA
+ Related JIRA task - https://alice.its.cern.ch/jira/browse/ATO-361
 */
 
 #include "TStatToolkit.h"

--- a/STAT/AliTreeTrending.h
+++ b/STAT/AliTreeTrending.h
@@ -5,11 +5,16 @@
 
 /* $Id$ */
 
-////////////////////////////////////////////////
-// class for visualization of trending trees  //
-//
-////////////////////////////////////////////////
 
+///\ingroup STAT
+///\class AliTreeTrending
+///\brief AliTreeTrending class for the visualization of the QA trending/alarms
+///\author Marian Ivanov
+/*!
+ Generalization of the original TPC QA trending visualization code
+ Example usage in the $AliPhysics_SRC/PWGPP/QA
+ Related JIRA task - https://alice.its.cern.ch/jira/browse/ATO-361
+*/
  
 class TTree;
 class TObjArray;
@@ -27,6 +32,7 @@ public:
   Bool_t  InitSummaryTrending(TString statusDescription[3], Float_t descriptionSize=0.015, TString cutString="");
   void SetDefaultStyle();  // own style to be used - not yet
   void AppendStatusPad(Float_t padratio, Float_t bottomMargin, Float_t rightMargin);
+  // TODO void MakeHtml(char *htmlName, char *varList)
 public:
   TObjArray *  GetTexDescription(TLatex *latex);  // Currently only standard variables
   TTree     *  fTree;              // working tree with friends

--- a/STAT/TStatToolkit.cxx
+++ b/STAT/TStatToolkit.cxx
@@ -26,6 +26,7 @@
 #include "TTreeFormula.h"
 #include "TLegend.h"
 #include "TPRegexp.h"
+#include "AliDrawStyle.h"
 
 using std::cout;
 using std::cerr;
@@ -1283,17 +1284,19 @@ TMultiGraph * TStatToolkit::MakeMultGraph(TTree * tree, const char *groupName, c
   }
   TObjArray*exprVarArray = TString(exprVars->At(0)->GetName()).Tokenize(";");
   TObjArray*exprVarErrArray=(exprVars->GetEntries()>2)?  TString(exprVars->At(2)->GetName()).Tokenize(";"):0;
-  TObjArray*exprColors= TString(colors).Tokenize(";");
-  TObjArray*exprMarkers= TString(markers).Tokenize(";");
+  // TObjArray*exprColors= TString(colors).Tokenize(";");
+  // TObjArray*exprMarkers= TString(markers).Tokenize(";");
+  //
+  //Int markerStyle=AliDrawStyle::GetMarkerStyles(markers);
   Int_t notOK=exprVarArray->GetEntries()<1;
-  notOK+=2*(exprVarArray->GetEntriesFast()>exprColors->GetEntriesFast());
-  notOK+=4*(exprVarArray->GetEntriesFast()>exprMarkers->GetEntriesFast());
+  //notOK+=2*(exprVarArray->GetEntriesFast()>exprColors->GetEntriesFast());
+  //notOK+=4*(exprVarArray->GetEntriesFast()>exprMarkers->GetEntriesFast());
   if (exprVarErrArray) notOK+=8*(exprVarArray->GetEntriesFast()!=exprVarErrArray->GetEntriesFast());
   if (notOK>0){
     ::Error("MakeMultGraph","Not compatible arrays of variables:color:markers Problem %d", notOK);
     exprVarArray->Print();
-    exprColors->Print();
-    exprMarkers->Print();
+    //exprColors->Print();
+    //exprMarkers->Print();
     if (exprVarErrArray) exprVarErrArray->Print();
     delete  exprVars;
     return 0;
@@ -1305,8 +1308,8 @@ TMultiGraph * TStatToolkit::MakeMultGraph(TTree * tree, const char *groupName, c
   TVectorF vecMean(ngraphs);
   Bool_t flag = kFALSE;
   for (Int_t igraph=0; igraph<ngraphs; igraph++){
-    Int_t color=TString(exprColors->At(igraph)->GetName()).Atoi();
-    Int_t marker=TString(exprMarkers->At(igraph)->GetName()).Atoi();
+    Int_t color=AliDrawStyle::GetMarkerColor(colors,igraph);   //TString(exprColors->At(igraph)->GetName()).Atoi();
+    Int_t marker=AliDrawStyle::GetMarkerStyle(markers, igraph);  // TString(exprMarkers->At(igraph)->GetName()).Atoi();
     TGraph * gr = 0;
     if (drawSparse){
       if (exprVarErrArray==NULL){
@@ -1341,8 +1344,8 @@ TMultiGraph * TStatToolkit::MakeMultGraph(TTree * tree, const char *groupName, c
             ::Error("MakeMultGraph","Not valid sub-expression %s - return",exprVarArray->At(igraph)->GetName());
             delete exprVarArray;
             delete exprVarErrArray;
-            delete exprColors;
-            delete exprMarkers;
+            //delete exprColors;
+            //delete exprMarkers;
             return 0;  
             }
       else{ 
@@ -1380,8 +1383,8 @@ TMultiGraph * TStatToolkit::MakeMultGraph(TTree * tree, const char *groupName, c
     ::Error("Test::","Number of graphs 0 -return 0");  
     delete exprVarArray;
     delete exprVarErrArray;
-    delete exprColors;
-    delete exprMarkers;
+    //delete exprColors;
+    //delete exprMarkers;
     return 0;  
   }
   Double_t rmsGraphs = TMath::RMS(ngraphs,  vecMean.GetMatrixArray());
@@ -1401,8 +1404,8 @@ TMultiGraph * TStatToolkit::MakeMultGraph(TTree * tree, const char *groupName, c
   
   delete exprVarArray;
   delete exprVarErrArray;
-  delete exprColors;
-  delete exprMarkers;
+  //delete exprColors;
+  //delete exprMarkers;
   return multiGraph;
 }
 


### PR DESCRIPTION
### ATO-418: Updated styles for arrays attributes ￼…
* check ranges of style array
  * handle out of range request. Returning invalid value instead of crash
  * interpret separated string as array of attributes
* Updated/improved doxygen documentation
### ATO-83 & ATO-46: Use AliDrawStyle to specify graph attributes
  * keeping back compatibility (old - string with arrays of values, of style ID)
### 	PWGPP-312: MakeMultiGraph with cut array
* see Doxygen documenation in the  TStatToolkit::MakeMultGraph
  * expr to drow and cuts  can be  array
  * before only expression could be array
```
TMultiGraph * TStatToolkit::MakeMultGraph(TTree * tree, const char *groupName, const char* expr, const char * cut, const char * markers, const char *colors, Bool_t drawSparse, Float_t msize, Float_t sigmaRange, TLegend * legend, Bool_t comp){
///  \param expr       - string <variablearray>:<tagID>:<variablearrayError>
///                      <variablearray>="var0; ...; varN
///                      <variablearrayError>="err0; ...;errN"
///  \param cut        - string "selection", resp. cut array
///                    - <variablearray>="defaultCut;cut0;cut1;...; cutN"
```
* markers and colors array provide using AliDrawStyle interface
  * either style name (ID) or array of codes