### PR TITLE
Avoid issues with the latest cling

### DIFF
--- a/RAW/MDC/AliRawDB.h
+++ b/RAW/MDC/AliRawDB.h
@@ -29,10 +29,11 @@
 #endif
 
 #include "AliDAQ.h"
+#include "AliRawDataArrayV2.h"
 
 // Forward class declarations
 class AliRawEventV2;
-class AliRawDataArrayV2;
+//class AliRawDataArrayV2;
 class TFile;
 class AliESDEvent;
 


### PR DESCRIPTION
The forward declaration of AliRawDataArrayV2 is correct, but the latest cling doesn't accept it. Until we get a fix in Root, I propose to include the header file.