### PR TITLE
fix copying of aodheader

### DIFF
--- a/ANALYSIS/ANALYSISalice/AliAnalysisTaskSE.cxx
+++ b/ANALYSIS/ANALYSISalice/AliAnalysisTaskSE.cxx
@@ -57,7 +57,7 @@
 ClassImp(AliAnalysisTaskSE)
 
 ////////////////////////////////////////////////////////////////////////
-AliVHeader*      AliAnalysisTaskSE::fgAODHeader         = NULL;
+AliAODHeader*    AliAnalysisTaskSE::fgAODHeader         = NULL;
 AliTOFHeader*    AliAnalysisTaskSE::fgTOFHeader         = NULL;
 AliAODVZERO*     AliAnalysisTaskSE::fgAODVZERO          = NULL;
 TClonesArray*    AliAnalysisTaskSE::fgAODTracks         = NULL;
@@ -424,7 +424,7 @@ void AliAnalysisTaskSE::Exec(Option_t* option)
 	    if ((handler->NeedsHeaderReplication() || merging) && (fgAODHeader))
 	    {
 	      // copy the contents by assigment
-	      *fgAODHeader =  *(aod->GetHeader());
+	      *fgAODHeader =  *((AliAODHeader*)aod->GetHeader());
 	    }
             if ((handler->NeedsTOFHeaderReplication() || merging) && (fgTOFHeader))
             {

--- a/ANALYSIS/ANALYSISalice/AliAnalysisTaskSE.h
+++ b/ANALYSIS/ANALYSISalice/AliAnalysisTaskSE.h
@@ -96,7 +96,7 @@ class AliAnalysisTaskSE : public AliAnalysisTask
     // Output histos for QA
     TList*                fHistosQA;        //! Output histos for QA
     // Provisions for replication
-    static AliVHeader*      fgAODHeader;        //! Header for replication
+    static AliAODHeader*    fgAODHeader;        //! Header for replication
     static AliTOFHeader*    fgTOFHeader;        //! TOFHeader for replication
     static AliAODVZERO*     fgAODVZERO;         //! VZERO for replication
     static TClonesArray*    fgAODTracks;        //! Tracks for replication


### PR DESCRIPTION
This fix is needed in order to be able to skim AOD files, without the fix the header info would not be copied.
Note I believe someone has to update the code as not all branches of the AOD are treated (like TZERO, ZDC, and ADA plus more are missing).

This fix is rather urgent.