### PR TITLE
introduce string attributes in NanoAODs

### DIFF
--- a/STEER/AOD/AliNanoAODHeader.cxx
+++ b/STEER/AOD/AliNanoAODHeader.cxx
@@ -12,6 +12,7 @@ AliNanoAODHeader::AliNanoAODHeader():
   fCentrCL0(-1),
   fCentrCL1(-1),
   fMagField(-1),
+  fOfflineTrigger(-1),
   fRunNumber(-1)
 {
 
@@ -28,10 +29,26 @@ AliNanoAODHeader::AliNanoAODHeader(Int_t size):
   fCentrCL0(-1),
   fCentrCL1(-1),
   fMagField(-1),
+  fOfflineTrigger(-1),
+  fRunNumber(-1)
+{
+  AllocateInternalStorage(size, 0);
+}
+
+AliNanoAODHeader::AliNanoAODHeader(Int_t size, Int_t sizeString):
+  AliVAODHeader(),
+  AliNanoAODStorage(),
+  fCentralityMethod("V0M"),
+  fCentr(-1),
+  fCentrTRK(-1),
+  fCentrCL0(-1),
+  fCentrCL1(-1),
+  fMagField(-1),
+  fOfflineTrigger(-1),
   fRunNumber(-1)
 {
 
-AllocateInternalStorage(size);
+  AllocateInternalStorage(size, sizeString);
 
 }
 
@@ -47,7 +64,9 @@ AliNanoAODHeader& AliNanoAODHeader::operator=(const AliNanoAODHeader& evt) {
 void  AliNanoAODHeader::Clear(Option_t * /*opt*/) {
   // empty storage
   fVars.clear();
+  fVarsString.clear();
   fNVars = 0;
+  fNVarsString = 0;
 }
 
 Double_t AliNanoAODHeader::GetCentrality () const {

--- a/STEER/AOD/AliNanoAODHeader.h
+++ b/STEER/AOD/AliNanoAODHeader.h
@@ -13,6 +13,7 @@ public:
   using AliVHeader::ClassName;
   AliNanoAODHeader();
   AliNanoAODHeader(Int_t size);
+  AliNanoAODHeader(Int_t size, Int_t sizeString);
   virtual ~AliNanoAODHeader(){;}
 
 
@@ -53,7 +54,7 @@ public:
   virtual void     SetTriggerMaskNext50(ULong64_t /* trigMsk */) {NotImplemented(); };
   virtual void     SetTriggerCluster(UChar_t /* trigClus */)  {NotImplemented(); };
   virtual void     SetFiredTriggerClasses(TString /* trig */) {NotImplemented(); };
-  virtual TString  GetFiredTriggerClasses() const             {NotImplemented(); return "";};
+  virtual TString  GetFiredTriggerClasses() const             { return TString(GetVarString(fFiredTriggerClasses));};
   virtual Double_t GetZDCN1Energy()         const             {NotImplemented(); return 0;};
   virtual Double_t GetZDCP1Energy()         const             {NotImplemented(); return 0;};
   virtual Double_t GetZDCN2Energy()         const             {NotImplemented(); return 0;};
@@ -75,8 +76,7 @@ public:
   virtual Float_t        GetVZEROEqFactors(Int_t /* i */) const {NotImplemented(); return 0;};
   virtual void           SetVZEROEqFactors(const Float_t* /*factors*/) {NotImplemented(); } 
 
-  virtual UInt_t GetOfflineTrigger()  {NotImplemented(); return 0;};
-
+  virtual UInt_t GetOfflineTrigger()  { return UInt_t(GetVar(fOfflineTrigger));};
 
   virtual void Print(Option_t* /*option = ""*/) const  {Printf("I'm a special header!");}
  
@@ -100,7 +100,9 @@ public:
   void SetCentrTRKIndex   (Int_t var) { fCentrTRK  = var; }
   void SetCentrCL0Index   (Int_t var) { fCentrCL0  = var; }
   void SetCentrCL1Index   (Int_t var) { fCentrCL1  = var; }
+  void SetFiredTriggerClassesIndex   (Int_t var) { fFiredTriggerClasses  = var; }
   void SetMagFieldIndex   (Int_t var) { fMagField  = var; }
+  void SetOfflineTriggerIndex   (Int_t var) { fOfflineTrigger  = var; }
   void SetRunNumberIndex  (Int_t var) { fRunNumber = var; }
 
 
@@ -108,7 +110,9 @@ public:
   Int_t GetCentrTRKIndex   () { return fCentrTRK  ; }
   Int_t GetCentrCL0Index   () { return fCentrCL0  ; }
   Int_t GetCentrCL1Index   () { return fCentrCL1  ; }
+  Int_t GetFiredTriggerClassesIndex () { return fFiredTriggerClasses  ; }
   Int_t GetMagFieldIndex   () { return fMagField  ; }
+  Int_t GetOfflineTriggerIndex () { return fOfflineTrigger  ; }
   Int_t GetRunNumberIndex  () { return fRunNumber ; }
 
   std::map<TString,int> GetMapCstVar () { return fMapCstVar; } 
@@ -116,17 +120,20 @@ public:
 
   Int_t GetVarIndex(TString varName); 
   
-  ClassDef(AliNanoAODHeader, 2)
+  ClassDef(AliNanoAODHeader, 3)
 private:
   void NotImplemented() const;
 
   TString fCentralityMethod;
 
+
   Int_t fCentr;      // index of stored variable
   Int_t fCentrTRK;   // index of stored variable
   Int_t fCentrCL0;   // index of stored variable
   Int_t fCentrCL1;   // index of stored variable
+  Int_t fFiredTriggerClasses;   // index of stored variable
   Int_t fMagField;   // index of stored variable
+  Int_t fOfflineTrigger;//index of stored variable
   Int_t fRunNumber;  // index of stored variable 
 
   std::map<TString,int> fMapCstVar;// Map of indexes of custom variables: CACHE THIS TO CONST INTs IN YOUR TASK TO AVOID CONTINUOUS STRING COMPARISONS

--- a/STEER/AOD/AliNanoAODStorage.cxx
+++ b/STEER/AOD/AliNanoAODStorage.cxx
@@ -5,6 +5,10 @@
 ClassImp(AliNanoAODStorage)
 
 void AliNanoAODStorage::AllocateInternalStorage(Int_t size) {
+  AllocateInternalStorage(size, 0);
+}
+
+void AliNanoAODStorage::AllocateInternalStorage(Int_t size, Int_t sizeString) {
   // Creates the internal array
   if(size == 0){
     AliError("Zero size");
@@ -20,20 +24,48 @@ void AliNanoAODStorage::AllocateInternalStorage(Int_t size) {
   // for (Int_t ivar = 0; ivar<fNVars; ivar++) {
   //   fVars[ivar]=0;
   // }
+
+  if(sizeString>0){
+    fNVarsString = sizeString;
+    fVarsString.clear();
+    fVarsString.resize(sizeString, "");
+  }
+  
 }
 
 AliNanoAODStorage& AliNanoAODStorage::operator=(const AliNanoAODStorage& sto)
 {
   // Assignment operator
-  AllocateInternalStorage(sto.fNVars);
+  AllocateInternalStorage(sto.fNVars, sto.fNVarsString);
   if(this!=&sto) {
     for (Int_t isize = 0; isize<sto.fNVars; isize++) {
       SetVar(isize, sto.GetVar(isize));    
+    }
+    for (Int_t isize = 0; isize<sto.fNVarsString; isize++) {
+      SetVarString(isize, sto.GetVarString(isize));    
     }
     
   }
 
   return *this;
+}
+
+Int_t AliNanoAODStorage::GetStringParameters(const TString varListHeader){
+  const TString stringVariables = "FiredTriggerClasses";//list of all possible string variables in AliNanoAODStorage
+
+  TObjArray * vars = varListHeader.Tokenize(",");
+  Int_t size = vars->GetSize();
+  TIter it(vars);
+  TObjString *token  = 0;
+  Int_t stringVars=0;
+
+  while ((token = (TObjString*) it.Next())) {
+    TString var = token->GetString().Strip(TString::kBoth, ' ');
+    if(stringVariables.Contains(var))
+      stringVars++;
+  }  
+  
+  return stringVars;
 }
 
 void

--- a/STEER/AOD/AliNanoAODStorage.h
+++ b/STEER/AOD/AliNanoAODStorage.h
@@ -9,33 +9,50 @@
 //
 //-------------------------------------------------------------------------
 #include "TObject.h"
+#include "TString.h"
 
 
 class AliNanoAODStorage  {
 
 public:
-  AliNanoAODStorage():fNVars(0), fVars(0) {;}
+  AliNanoAODStorage():fNVars(0), fNVarsString(0), fVars(0), fVarsString(0) {;}
   virtual ~AliNanoAODStorage() {fVars.clear();};
 
   AliNanoAODStorage& operator=(const AliNanoAODStorage& sto);
 
   void AllocateInternalStorage(Int_t size);
+  void AllocateInternalStorage(Int_t size, Int_t sizeString);
+  
+  static Int_t GetStringParameters(const TString varListHeader);
+  
   void SetVar(Int_t index, Double_t var) { 
     if(index>=0 && index < fNVars)  fVars[index] = var;
+    else Complain(index);
+  }
+  void SetVarString(Int_t index, TString var) { 
+    if(index>=0 && index < fNVarsString)  fVarsString[index] = var;
     else Complain(index);
   }
   Double_t GetVar(Int_t index)  const {
     if(index>=0 && index < fNVars) return fVars[index]; 
     Complain(index);
     return 0;}
+
+  TString GetVarString(Int_t index)  const {
+    if(index>=0 && index < fNVarsString) return fVarsString[index]; 
+    Complain(index);
+    return "";}
+  
   virtual const char *ClassName() const {return "AliNanoAODStorage";} // Needed for alifatal. The class cannot inherit from TObject, otherwise we mix (and mess up) inheritance in the track, as it also inherits from AliVTrack which inherits from TObject.
 
 protected:
 
   Int_t    fNVars;     // Number of kimematic variables, set by constructor
+  Int_t    fNVarsString;     // Number of string variables, set by constructor
   std::vector<Double32_t> fVars; // Array of kinematic vars. Here we use an STL vector because it produces ~5% smaller files. It may be aslo splittable
+  std::vector<TString> fVarsString; // Array of string vars. Use same structure as for fVars
 
-  ClassDef(AliNanoAODStorage, 1)
+  ClassDef(AliNanoAODStorage, 2)
 private:
   void Complain(Int_t index) const;
 };


### PR DESCRIPTION
allow NanoAOD header files to also save string variables
remove some compiler warnings from the nano AOD framework