### PR TITLE
Fix overloaded virtual function warning

### DIFF
--- a/ANALYSIS/ANALYSISalice/AliEventPoolManager.cxx
+++ b/ANALYSIS/ANALYSISalice/AliEventPoolManager.cxx
@@ -187,7 +187,7 @@ Long64_t AliEventPool::Merge(TCollection* hlist)
   return hlist->GetEntries() + 1;
 }
 
-void AliEventPool::Clear()
+void AliEventPool::Clear(Option_t * option)
 {
   // Clear the pool without deleting the object
   // Don't touch lock or save flag here to be fully flexible

--- a/ANALYSIS/ANALYSISalice/AliEventPoolManager.h
+++ b/ANALYSIS/ANALYSISalice/AliEventPoolManager.h
@@ -158,7 +158,7 @@ class AliEventPool : public TObject
   Int_t       UpdatePool(TObjArray *trk);
   Long64_t    Merge(TCollection* hlist);
 //  deque<TObjArray*> GetEvents() { return fEvents; }
-  void        Clear();
+  void        Clear(Option_t * /* option */ = "");
 
 protected:
   Bool_t      IsReady(Int_t tracks, Int_t events) const { return (tracks >= fTargetFraction * fTargetTrackDepth) || ((fTargetEvents > 0) && (events >= fTargetEvents)); }


### PR DESCRIPTION
AliEventPool::Clear() shadows TObject::Clear(Option_t *), which causes a large number of warnings for files which include AliEventPoolManager in AliPhysics (which can make the compilation logs more difficult to parse). This pull request contains a minor change to make the AliEventPool::Clear(...) signature align with TObject::Clear(...), but it should have no impact on functionality. 

I think this is quite a trivial change, but comments are welcome, especially in case I've missed something.

An example warning is below:

>In file included from >/alice/sw/SOURCES/AliPhysics/root6/0/PWGCF/EBYE/BalanceFunctions/AliAnalysisTa>skTriggeredBF.cxx:34:
>/alice/sw/osx_x86-64/AliRoot/root6-1/include/AliEventPoolManager.h:161:15: >warning: 'AliEventPool::Clear' hides overloaded virtual function [-Woverloaded-virtual]
>  void        Clear();
>              ^
>/alice/sw/osx_x86-64/ROOT/v6-08-04-1/include/TObject.h:89:24: note: hidden >overloaded virtual function 'TObject::Clear' declared here: different number of parameters (1 vs 0)
>   virtual void        Clear(Option_t * /*option*/ ="") { }
