### PR TITLE
 Store mother particle and decay history in kine tree and two decay tables

### DIFF
--- a/STARLIGHT/AliStarLight/DecayTables/JPSI.EE.DEC
+++ b/STARLIGHT/AliStarLight/DecayTables/JPSI.EE.DEC
@@ -1,0 +1,5 @@
+Decay J/psi
+1.000     e+   e-                       PHOTOS   VLL;    
+Enddecay
+End
+

--- a/STARLIGHT/AliStarLight/DecayTables/JPSI.MUMU.DEC
+++ b/STARLIGHT/AliStarLight/DecayTables/JPSI.MUMU.DEC
@@ -1,0 +1,5 @@
+Decay J/psi
+1.000     mu+  mu-                      PHOTOS   VLL; 
+Enddecay
+End
+


### PR DESCRIPTION
Analysis of J/psi yield enhancement in peripheral events wants to use Starlight event in cocktail with Hijing. Therefore we need mother particle and history of decay to identify the UPC electrons. EvtGen decay tables are for J/psi to lepton decays with QED radiative corrections via Photos package. Whole thing is to re-decay Starlight J/psi in EvtGen with radiative corrections and put it to Hijing event.  