### PR TITLE
Account for beam A/Z in LHC B-field initialization

### DIFF
--- a/HLT/TRD/macros/initGRP.h
+++ b/HLT/TRD/macros/initGRP.h
@@ -125,10 +125,13 @@ Bool_t InitGRP(TString OCDBpath, TString GRPpath="") {
     Int_t  polConvention = GRPData->IsPolarityConventionLHC() ? AliMagF::kConvLHC : AliMagF::kConvDCS2008;
     Bool_t uniformB = GRPData->IsUniformBMap();
 
+    int az0 = GRPData->GetSingleBeamType(0).Atoi();
+    int az1 = GRPData->GetSingleBeamType(1).Atoi();    
+    
     if (ok) { 
       AliMagF* fld = AliMagF::CreateFieldMap(TMath::Abs(l3Current) * (l3Polarity ? -1:1), 
 					     TMath::Abs(diCurrent) * (diPolarity ? -1:1), 
-					     polConvention,uniformB,beamEnergy, beamType.Data());
+					     polConvention,uniformB,beamEnergy, beamType.Data(), az0, az1);
       if (fld) {
 	TGeoGlobalMagField::Instance()->SetField( fld );
 	TGeoGlobalMagField::Instance()->Lock();

--- a/ITS/macrosSDD/ITSQArecoparam.C
+++ b/ITS/macrosSDD/ITSQArecoparam.C
@@ -177,11 +177,14 @@ void ITSQArecoparam(char *iFile, Int_t runNb=150000, Int_t idet=2, Int_t FirstEv
 
    Int_t  polConvention = fGRPData->IsPolarityConventionLHC() ? AliMagF::kConvLHC : AliMagF::kConvDCS2008;
    Bool_t uniformB = fGRPData->IsUniformBMap();
-   
+
+   int az0 = GRPData->GetSingleBeamType(0).Atoi();
+   int az1 = GRPData->GetSingleBeamType(1).Atoi();    
+
    if (ok) { 
      AliMagF* fld = AliMagF::CreateFieldMap(TMath::Abs(l3Current) * (l3Polarity ? -1:1), 
 					    TMath::Abs(diCurrent) * (diPolarity ? -1:1), 
-					    polConvention,uniformB,beamEnergy, beamType.Data());
+					    polConvention,uniformB,beamEnergy, beamType.Data(), az0, az1);
      if (fld) {
        TGeoGlobalMagField::Instance()->SetField( fld );
        TGeoGlobalMagField::Instance()->Lock();

--- a/ITSMFT/MFT/MFTrec/AliMuonForwardTrackFinder.cxx
+++ b/ITSMFT/MFT/MFTrec/AliMuonForwardTrackFinder.cxx
@@ -1809,11 +1809,14 @@ Bool_t AliMuonForwardTrackFinder::InitGRP() {
     // read special bits for the polarity convention and map type
     Int_t  polConvention = fGRPData->IsPolarityConventionLHC() ? AliMagF::kConvLHC : AliMagF::kConvDCS2008;
     Bool_t uniformB = fGRPData->IsUniformBMap();
+    
+    int az0 = GRPData->GetSingleBeamType(0).Atoi();
+    int az1 = GRPData->GetSingleBeamType(1).Atoi();    
 
     if (ok) { 
       AliMagF* fld = AliMagF::CreateFieldMap(TMath::Abs(l3Current) * (l3Polarity ? -1:1), 
 					     TMath::Abs(diCurrent) * (diPolarity ? -1:1), 
-					     polConvention,uniformB,beamEnergy, beamType.Data());
+					     polConvention,uniformB,beamEnergy, beamType.Data(), az0, az1);
       if (fld) {
 	TGeoGlobalMagField::Instance()->SetField( fld );
 	TGeoGlobalMagField::Instance()->Lock();

--- a/STEER/ESD/AliESDRun.cxx
+++ b/STEER/ESD/AliESDRun.cxx
@@ -442,7 +442,8 @@ Bool_t AliESDRun::InitMagneticField() const
   }
   //
   fld = AliMagF::CreateFieldMap(fCurrentL3,fCurrentDip,AliMagF::kConvLHC,
-				TestBit(kUniformBMap), GetBeamEnergy(), GetBeamType());
+				TestBit(kUniformBMap), GetBeamEnergy(), GetBeamType(),
+				GetBeamParticle(0),GetBeamParticle(1));
   if (fld) {
     TGeoGlobalMagField::Instance()->SetField( fld );
     TGeoGlobalMagField::Instance()->Lock();

--- a/STEER/STEER/AliGRPManager.cxx
+++ b/STEER/STEER/AliGRPManager.cxx
@@ -169,10 +169,13 @@ Bool_t AliGRPManager::SetMagField()
   Int_t  polConvention = fGRPData->IsPolarityConventionLHC() ? AliMagF::kConvLHC : AliMagF::kConvDCS2008;
   Bool_t uniformB = fGRPData->IsUniformBMap();
   
+  int az0 = fGRPData->GetSingleBeamType(0).Atoi();
+  int az1 = fGRPData->GetSingleBeamType(1).Atoi();    
+
   if (ok) { 
     AliMagF* fld = AliMagF::CreateFieldMap(TMath::Abs(l3Current) * (l3Polarity ? -1:1), 
 					   TMath::Abs(diCurrent) * (diPolarity ? -1:1), 
-					   polConvention,uniformB,beamEnergy, beamType.Data());
+					   polConvention,uniformB,beamEnergy, beamType.Data(), az0, az1);
     if (fld) {
       TGeoGlobalMagField::Instance()->SetField( fld );
       TGeoGlobalMagField::Instance()->Lock();

--- a/STEER/STEER/AliReconstruction.cxx
+++ b/STEER/STEER/AliReconstruction.cxx
@@ -1336,10 +1336,13 @@ Bool_t AliReconstruction::InitGRP() {
     Int_t  polConvention = fGRPData->IsPolarityConventionLHC() ? AliMagF::kConvLHC : AliMagF::kConvDCS2008;
     Bool_t uniformB = fGRPData->IsUniformBMap();
 
+    int az0 = fGRPData->GetSingleBeamType(0).Atoi();
+    int az1 = fGRPData->GetSingleBeamType(1).Atoi();    
+
     if (ok) { 
       AliMagF* fld = AliMagF::CreateFieldMap(TMath::Abs(l3Current) * (l3Polarity ? -1:1), 
 					     TMath::Abs(diCurrent) * (diPolarity ? -1:1), 
-					     polConvention,uniformB,beamEnergy, beamType.Data());
+					     polConvention,uniformB,beamEnergy, beamType.Data(),az0,az1);
       if (fld) {
 	TGeoGlobalMagField::Instance()->SetField( fld );
 	TGeoGlobalMagField::Instance()->Lock();

--- a/STEER/STEERBase/AliMagF.h
+++ b/STEER/STEERBase/AliMagF.h
@@ -27,7 +27,7 @@ class AliMagF : public TVirtualMagField
   //
   AliMagF();
   AliMagF(const char *name, const char* title,Double_t factorSol=1., Double_t factorDip=1., 
-	  BMap_t maptype = k5kG, BeamType_t btype=kBeamTypepp, Double_t benergy=-1,	
+	  BMap_t maptype = k5kG, BeamType_t btype=kBeamTypepp, Double_t benergy=-1, float a2z=1.0,
 	  Int_t integ=2, Double_t fmax=15,const char* path="$(ALICE_ROOT)/data/maps/mfchebKGI_sym.root");
   AliMagF(const AliMagF& src);             
   AliMagF& operator=(const AliMagF& src);
@@ -74,7 +74,7 @@ class AliMagF : public TVirtualMagField
   static Int_t GetPolarityConvention()                                {return Int_t(fgkPolarityConvention);}
   static AliMagF* CreateFieldMap(Float_t l3Current=-30000., Float_t diCurrent=-6000., 
 				 Int_t convention=0, Bool_t uniform = kFALSE, 
-				 Float_t beamenergy=7000, const Char_t* btype="pp",
+				 Float_t beamenergy=7000, const Char_t* btype="pp", int az0=0, int az1=0,
 				 const Char_t* path="$(ALICE_ROOT)/data/maps/mfchebKGI_sym.root",
 				 Bool_t returnNullOnInvalidCurrent = kFALSE);
   //
@@ -83,7 +83,7 @@ class AliMagF : public TVirtualMagField
   
  protected:
   // not supposed to be changed during the run, set only at the initialization via constructor
-  void         InitMachineField(BeamType_t btype, Double_t benergy);
+  void         InitMachineField(BeamType_t btype, Double_t benergy, float a2z=1.0);
   void         SetBeamType(BeamType_t type)                           {fBeamType = type;}
   void         SetBeamEnergy(Float_t energy)                          {fBeamEnergy = energy;}
   //


### PR DESCRIPTION
Pass A/Z info to field creation to properly rescale rigidity for different ion types