### PR TITLE
Make most HLT initialization and running failures a fatal, such that a failure to decompress TPC clusters is not unnoticed

### DIFF
--- a/HLT/createGRP/lib/AliHLTCreateGRP.cxx
+++ b/HLT/createGRP/lib/AliHLTCreateGRP.cxx
@@ -98,7 +98,7 @@ int AliHLTCreateGRP::CreateGRP(Int_t runNumber, TString detectorList, TString be
 	if (cavernAtmosPressure2 == -123456.f) {printf("Error obtaining Cavern Pressure 2 from DIM\n"); return(1);}
 	if (beamEnergy == -123456.f) {printf("Error obtaining Beam Energy from DIM\n"); return(1);}
 	
-	AliMagF* field = AliMagF::CreateFieldMap(l3Current, dipoleCurrent, 0, kFALSE, beamEnergy, beamType, "$(ALICE_ROOT)/data/maps/mfchebKGI_sym.root", true);
+	AliMagF* field = AliMagF::CreateFieldMap(l3Current, dipoleCurrent, 0, kFALSE, beamEnergy, beamType, 0, 0, "$(ALICE_ROOT)/data/maps/mfchebKGI_sym.root", true);
 	if (field == NULL)
 	{
 		cout << "Cannot create fild map with current magnet currents: L3 " << l3Current << ", Diploe " << dipoleCurrent;

--- a/HLT/rec/AliHLTReconstructor.cxx
+++ b/HLT/rec/AliHLTReconstructor.cxx
@@ -110,17 +110,17 @@ void AliHLTReconstructor::Init()
 {
   // init the reconstructor
   if (!fpPluginBase) {
-    AliError("internal memory error: can not get AliHLTSystem instance from plugin");
+    AliFatal("internal memory error: can not get AliHLTSystem instance from plugin");
     return;
   }
 
   AliHLTSystem* pSystem=fpPluginBase->GetInstance();
   if (!pSystem) {
-    AliError("can not create AliHLTSystem object");
+    AliFatal("can not create AliHLTSystem object");
     return;
   }
   if (pSystem->CheckStatus(AliHLTSystem::kError)) {
-    AliError("HLT system in error state");
+    AliFatal("HLT system in error state");
     return;
   }
 
@@ -190,11 +190,11 @@ void AliHLTReconstructor::Init()
   if (!pSystem->CheckStatus(AliHLTSystem::kReady)) {
     pSystem->SetDetectorMask(GetRunInfo()->GetDetectorMask());
     if (pSystem->ScanOptions(option.Data())<0) {
-      AliError("error setting options for HLT system");
+      AliFatal("error setting options for HLT system");
       return;
     }
     if ((pSystem->Configure())<0) {
-      AliError("error during HLT system configuration");
+      AliFatal("error during HLT system configuration");
       return;
     }
   }
@@ -273,7 +273,7 @@ void AliHLTReconstructor::Reconstruct(AliRawReader* rawReader, TTree* /*clusters
   // The HLTOUT data is finally processed in FillESD
 
   if (!fpPluginBase) {
-    AliError("internal memory error: can not get AliHLTSystem instance from plugin");
+    AliFatal("internal memory error: can not get AliHLTSystem instance from plugin");
     return;
   }
 
@@ -305,7 +305,7 @@ void AliHLTReconstructor::Reconstruct(AliRawReader* rawReader, TTree* /*clusters
       return;
     }
     if (!pSystem->CheckStatus(AliHLTSystem::kReady)) {
-      AliError("HLT system in wrong state");
+      AliFatal("HLT system in wrong state");
       return;
     }
 


### PR DESCRIPTION
Also fixes an incompatibility with HLT GRP creation introduced by Ruben's recent change to magnetic field initialization.