### PR TITLE
make storage of Fired Trigger Particles more efficient in the NanoAODs

### DIFF
--- a/STEER/AOD/AliNanoAODHeader.h
+++ b/STEER/AOD/AliNanoAODHeader.h
@@ -13,7 +13,7 @@ public:
   using AliVHeader::ClassName;
   AliNanoAODHeader();
   AliNanoAODHeader(Int_t size);
-  AliNanoAODHeader(Int_t size, Int_t sizeString);
+  AliNanoAODHeader(Int_t size, Int_t sizeInt);
   virtual ~AliNanoAODHeader(){;}
 
 
@@ -53,8 +53,8 @@ public:
   virtual void     SetTriggerMask(ULong64_t /* trigMsk */)    {NotImplemented(); };
   virtual void     SetTriggerMaskNext50(ULong64_t /* trigMsk */) {NotImplemented(); };
   virtual void     SetTriggerCluster(UChar_t /* trigClus */)  {NotImplemented(); };
-  virtual void     SetFiredTriggerClasses(TString /* trig */) {NotImplemented(); };
-  virtual TString  GetFiredTriggerClasses() const             { return TString(GetVarString(fFiredTriggerClasses));};
+  virtual void     SetFiredTriggerClasses(TString varlist);
+  virtual TString  GetFiredTriggerClasses() const;
   virtual Double_t GetZDCN1Energy()         const             {NotImplemented(); return 0;};
   virtual Double_t GetZDCP1Energy()         const             {NotImplemented(); return 0;};
   virtual Double_t GetZDCN2Energy()         const             {NotImplemented(); return 0;};
@@ -116,11 +116,13 @@ public:
   Int_t GetRunNumberIndex  () { return fRunNumber ; }
 
   std::map<TString,int> GetMapCstVar () { return fMapCstVar; } 
-  void SetMapCstVar (std::map<TString,int> cstmap) { fMapCstVar = cstmap; } 
+  void SetMapCstVar (std::map<TString,int> cstmap) { fMapCstVar = cstmap; }
+  std::map<TString,int> GetMapFiredTriggerClasses () { return fMapFiredTriggerClasses; } 
+  void SetMapFiredTriggerClasses (TString trigClasses);
 
   Int_t GetVarIndex(TString varName); 
   
-  ClassDef(AliNanoAODHeader, 3)
+  ClassDef(AliNanoAODHeader, 4)
 private:
   void NotImplemented() const;
 
@@ -137,6 +139,8 @@ private:
   Int_t fRunNumber;  // index of stored variable 
 
   std::map<TString,int> fMapCstVar;// Map of indexes of custom variables: CACHE THIS TO CONST INTs IN YOUR TASK TO AVOID CONTINUOUS STRING COMPARISONS
+
+  std::map<TString,int> fMapFiredTriggerClasses;// Map of indexes of fired trigger Classes
 };
 
 #endif /* _ALINANOAODHEADER_H_ */

--- a/STEER/AOD/AliNanoAODStorage.cxx
+++ b/STEER/AOD/AliNanoAODStorage.cxx
@@ -8,7 +8,7 @@ void AliNanoAODStorage::AllocateInternalStorage(Int_t size) {
   AllocateInternalStorage(size, 0);
 }
 
-void AliNanoAODStorage::AllocateInternalStorage(Int_t size, Int_t sizeString) {
+void AliNanoAODStorage::AllocateInternalStorage(Int_t size, Int_t sizeInt) {
   // Creates the internal array
   if(size == 0){
     AliError("Zero size");
@@ -25,10 +25,10 @@ void AliNanoAODStorage::AllocateInternalStorage(Int_t size, Int_t sizeString) {
   //   fVars[ivar]=0;
   // }
 
-  if(sizeString>0){
-    fNVarsString = sizeString;
-    fVarsString.clear();
-    fVarsString.resize(sizeString, "");
+  if(sizeInt>0){
+    fNVarsInt = sizeInt;
+    fVarsInt.clear();
+    fVarsInt.resize(sizeInt, 0);
   }
   
 }
@@ -36,13 +36,13 @@ void AliNanoAODStorage::AllocateInternalStorage(Int_t size, Int_t sizeString) {
 AliNanoAODStorage& AliNanoAODStorage::operator=(const AliNanoAODStorage& sto)
 {
   // Assignment operator
-  AllocateInternalStorage(sto.fNVars, sto.fNVarsString);
+  AllocateInternalStorage(sto.fNVars, sto.fNVarsInt);
   if(this!=&sto) {
     for (Int_t isize = 0; isize<sto.fNVars; isize++) {
       SetVar(isize, sto.GetVar(isize));    
     }
-    for (Int_t isize = 0; isize<sto.fNVarsString; isize++) {
-      SetVarString(isize, sto.GetVarString(isize));    
+    for (Int_t isize = 0; isize<sto.fNVarsInt; isize++) {
+      SetVarInt(isize, sto.GetVarInt(isize));    
     }
     
   }
@@ -50,7 +50,7 @@ AliNanoAODStorage& AliNanoAODStorage::operator=(const AliNanoAODStorage& sto)
   return *this;
 }
 
-Int_t AliNanoAODStorage::GetStringParameters(const TString varListHeader){
+Int_t AliNanoAODStorage::GetIntParameters(const TString varListHeader){
   const TString stringVariables = "FiredTriggerClasses";//list of all possible string variables in AliNanoAODStorage
 
   TObjArray * vars = varListHeader.Tokenize(",");

--- a/STEER/AOD/AliNanoAODStorage.h
+++ b/STEER/AOD/AliNanoAODStorage.h
@@ -15,22 +15,22 @@
 class AliNanoAODStorage  {
 
 public:
-  AliNanoAODStorage():fNVars(0), fNVarsString(0), fVars(0), fVarsString(0) {;}
+  AliNanoAODStorage():fNVars(0), fNVarsInt(0), fVars(0), fVarsInt(0) {;}
   virtual ~AliNanoAODStorage() {fVars.clear();};
 
   AliNanoAODStorage& operator=(const AliNanoAODStorage& sto);
 
   void AllocateInternalStorage(Int_t size);
-  void AllocateInternalStorage(Int_t size, Int_t sizeString);
+  void AllocateInternalStorage(Int_t size, Int_t sizeInt);
   
-  static Int_t GetStringParameters(const TString varListHeader);
+  static Int_t GetIntParameters(const TString varListHeader);
   
   void SetVar(Int_t index, Double_t var) { 
     if(index>=0 && index < fNVars)  fVars[index] = var;
     else Complain(index);
   }
-  void SetVarString(Int_t index, TString var) { 
-    if(index>=0 && index < fNVarsString)  fVarsString[index] = var;
+  void SetVarInt(Int_t index, Int_t var) { 
+    if(index>=0 && index < fNVarsInt)  fVarsInt[index] = var;
     else Complain(index);
   }
   Double_t GetVar(Int_t index)  const {
@@ -38,21 +38,21 @@ public:
     Complain(index);
     return 0;}
 
-  TString GetVarString(Int_t index)  const {
-    if(index>=0 && index < fNVarsString) return fVarsString[index]; 
+  Int_t GetVarInt(Int_t index)  const {
+    if(index>=0 && index < fNVarsInt) return fVarsInt[index]; 
     Complain(index);
-    return "";}
+    return 0;}
   
   virtual const char *ClassName() const {return "AliNanoAODStorage";} // Needed for alifatal. The class cannot inherit from TObject, otherwise we mix (and mess up) inheritance in the track, as it also inherits from AliVTrack which inherits from TObject.
 
 protected:
 
   Int_t    fNVars;     // Number of kimematic variables, set by constructor
-  Int_t    fNVarsString;     // Number of string variables, set by constructor
+  Int_t    fNVarsInt;     // Number of int variables, set by constructor
   std::vector<Double32_t> fVars; // Array of kinematic vars. Here we use an STL vector because it produces ~5% smaller files. It may be aslo splittable
-  std::vector<TString> fVarsString; // Array of string vars. Use same structure as for fVars
+  std::vector<Int_t> fVarsInt; // Array of int vars. Use same structure as for fVars, int has to be used for a bitwise variable describing the fired trigger particles, because this is bitwise coded
 
-  ClassDef(AliNanoAODStorage, 2)
+  ClassDef(AliNanoAODStorage, 3)
 private:
   void Complain(Int_t index) const;
 };


### PR DESCRIPTION
change the internal storage of the fired trigger particles to a coded int per event instead of full strings. This requires less disk space.