### PR TITLE
Remove duplicated AliOptionParser entry

### DIFF
--- a/HLT/global/AliHLTGlobalLinkDef.h
+++ b/HLT/global/AliHLTGlobalLinkDef.h
@@ -49,7 +49,6 @@
 #pragma link C++ class AliHLTGlobalPromptRecoQAComponent+;
 #pragma link C++ class AliAnalysisTaskExampleV+;
 #ifdef ZMQ
-#pragma link C++ class AliOptionParser+;
 #pragma link C++ class AliHLTZMQsink+;
 #pragma link C++ class AliHLTZMQsource+;
 #endif


### PR DESCRIPTION
When ROOT 6 is launched, there is a warning:

> Warning in <TInterpreter::ReadRootmapFile>: class  AliOptionParser found in libAliHLTUtil  is already in libAliHLTGlobal

I suspect that the class was not removed from the link def when it was relocated. This should resolve that warning.

@mkrzewic - Would you prefer this pull request here or on the HLT fork?