### PR TITLE
using light-yields in AD MC simulation

### DIFF
--- a/AD/ADbase/AliADConst.h
+++ b/AD/ADbase/AliADConst.h
@@ -6,23 +6,19 @@
 
 #include "TROOT.h"
 
-const Float_t kADIntTimeRes = 0.39; // intrinsic time resolution of the scintillator
-const Float_t kADOffset = 962; // general AD offset between the TDCs and the trigger
-const Int_t   kADNClocks = 21; // Number of ADC clocks that are read out
-const Float_t kADChargePerADC = 0.6e-12; // Charge per ADC
-// const Int_t   kNPhotonsPerMIP = 49000;// Number of photons per MIP
-const Int_t   kNPhotonsPerMIP = 49000 * (93.75 / 88.23); // Number of photons per MIP, added factor to compensate update in light yields
-const Int_t   kADMinTDCWidth = 13; // minimum signal width measured by TDC
-const Int_t   kADMaxTDCWidth = 128; // maximum signal width measured by TDC
-const Float_t kADPMRespTime = 6.0; // PM response time (corresponds to 1.9 ns rise time)
-const Float_t kADPMTransparency = 0.25; // Transparency of the first dynode of the PM
-const Float_t kADPMNbOfSecElec = 6.0;   // Number of secondary electrons emitted from first dynode (per ph.e.)
-const Float_t kPhotoCathodeEfficiency = 0.18; // Photocathode efficiency
-const Int_t   kNCIUBoards = 2; //Number of CIU boards
-/*				    |------------Cside------------|----------Aside-------|   */
-const Int_t   kOfflineChannel[16] = {15, 11, 14, 10, 13, 9, 12, 8, 7, 3, 6, 2, 5, 1, 4, 0};
-/*	      Online->Offline								     */
-const Int_t   kOnlineChannel[16] =  {15, 13, 11, 9, 14, 12, 10, 8, 7, 5, 3, 1, 6, 4, 2, 0};
-/*	      Offline->Online								     */
+const Float_t kADIntTimeRes     = 0.39;    // intrinsic time resolution of the scintillator
+const Float_t kADOffset         = 962;     // general AD offset between the TDCs and the trigger
+const Int_t   kADNClocks        = 21;      // Number of ADC clocks that are read out
+const Float_t kADChargePerADC   = 0.6e-12; // Charge per ADC
+const Int_t   kNPhotonsPerMIP   = 56000;   // Number of photons per MIP
+const Int_t   kADMinTDCWidth    = 13;      // minimum signal width measured by TDC
+const Int_t   kADMaxTDCWidth    = 128;     // maximum signal width measured by TDC
+const Float_t kADPMRespTime     = 6.0;     // PM response time (corresponds to 1.9 ns rise time)
+const Float_t kADPMTransparency = 0.25;    // Transparency of the first dynode of the PM
+const Float_t kADPMNbOfSecElec  = 6.0;     // Number of secondary electrons emitted from first dynode (per ph.e.)
+const Int_t   kNCIUBoards       = 2;       // Number of CIU boards
+//                                  |------------Cside------------|----------Aside-------|
+const Int_t   kOfflineChannel[16] = {15, 11, 14, 10, 13,  9, 12, 8, 7, 3, 6, 2, 5, 1, 4, 0};  // Online  -> Offline
+const Int_t   kOnlineChannel[16]  = {15, 13, 11,  9, 14, 12, 10, 8, 7, 5, 3, 1, 6, 4, 2, 0};  // Offline -> Online
 
 #endif

--- a/AD/ADbase/AliADDataDCS.cxx
+++ b/AD/ADbase/AliADDataDCS.cxx
@@ -99,14 +99,10 @@ AliADDataDCS::AliADDataDCS(Int_t nRun, UInt_t startTime, UInt_t endTime, UInt_t 
 
 //_____________________________________________________________________________
 AliADDataDCS::~AliADDataDCS() {
-  if (fGraphs) {
+  if (fGraphs)
     fGraphs->Clear("C");
-    delete fGraphs;
-  }
-  fGraphs = NULL;
-  if (fFEEParameters)
-    delete fFEEParameters;
-  fFEEParameters = NULL;
+  SafeDelete(fGraphs);
+  SafeDelete(fFEEParameters);
 }
 
 //_____________________________________________________________________________

--- a/AD/ADbase/AliADDataDCS.cxx
+++ b/AD/ADbase/AliADDataDCS.cxx
@@ -28,6 +28,7 @@
 #include <TString.h>
 #include <TObjString.h>
 #include <TH1F.h>
+#include <TVectorD.h>
 
 class TH2;
 class AliCDBMetaData;
@@ -135,16 +136,13 @@ Bool_t AliADDataDCS::ProcessData(TMap& aliasMap){
     TIter iterarray(aliasArr);
 
     if(iAlias<kNHvChannel){ // Treating HV values
-      Int_t nentries = aliasArr->GetEntries();
-
-      Double_t *times = new Double_t[nentries];
-      Double_t *values = new Double_t[nentries];
+      const Int_t nentries = aliasArr->GetEntries();
+      TVectorD times(nentries), values(nentries);
 
       UInt_t iValue=0;
       Float_t variation = 0.0;
-
       while((aValue = (AliDCSValue*) iterarray.Next())) {
-	UInt_t currentTime = aValue->GetTimeStamp();
+	const UInt_t currentTime = aValue->GetTimeStamp();
 	if(currentTime>fCtpEndTime) break;
 
 	values[iValue] = aValue->GetFloat();
@@ -157,34 +155,27 @@ Bool_t AliADDataDCS::ProcessData(TMap& aliasMap){
 	fHv[iAlias]->Fill(values[iValue]);
 	iValue++;
       }
-      CreateGraph(iAlias, iValue, times, values); // fill graphs
+      CreateGraph(iAlias, iValue, times.GetMatrixArray(), values.GetMatrixArray()); // fill graphs
 
       // calculate mean and rms of the first two histos
       // Int_t iChannel	   = iAlias;  not used
       fMeanHV[iAlias]  = fHv[iAlias]->GetMean();
       fWidthHV[iAlias] = fHv[iAlias]->GetRMS();
-
-      delete [] values;
-      delete [] times;
     }
     else if(iAlias >= kNHvChannel && iAlias<2*kNHvChannel){
-      Int_t nentries = aliasArr->GetEntries();
+      const Int_t nentries = aliasArr->GetEntries();
+      TVectorD times(nentries), values(nentries);
 
-      Double_t *times = new Double_t[nentries];
-      Double_t *values = new Double_t[nentries];
       UInt_t iValue=0;
-
       while((aValue = (AliDCSValue*) iterarray.Next())) {
-        UInt_t currentTime = aValue->GetTimeStamp();
+        const UInt_t currentTime = aValue->GetTimeStamp();
         if(currentTime>fCtpEndTime) break;
 
         values[iValue] = aValue->GetFloat();
         times[iValue] = (Double_t) (currentTime);
         iValue++;
       }
-      CreateGraph(iAlias, iValue, times, values); // fill graphs
-      delete [] times;
-      delete [] values;
+      CreateGraph(iAlias, iValue, times.GetMatrixArray(), values.GetMatrixArray()); // fill graphs
     }
     else { // Treating FEE Parameters
       AliDCSValue * lastVal = NULL;

--- a/AD/ADbase/AliADDataDCS.cxx
+++ b/AD/ADbase/AliADDataDCS.cxx
@@ -119,7 +119,7 @@ Bool_t AliADDataDCS::ProcessData(TMap& aliasMap){
 
   // starting loop on aliases
   for(int iAlias=0; iAlias<kNAliases; iAlias++){
-    aliasArr = (TObjArray*) aliasMap.GetValue(fAliasNames[iAlias].Data());
+    aliasArr = dynamic_cast<TObjArray*>(aliasMap.GetValue(fAliasNames[iAlias].Data()));
     if(!aliasArr){
       AliErrorF("Missing data points for alias %s!", fAliasNames[iAlias].Data());
       success = kFALSE;
@@ -141,7 +141,7 @@ Bool_t AliADDataDCS::ProcessData(TMap& aliasMap){
 
       UInt_t iValue=0;
       Float_t variation = 0.0;
-      while((aValue = (AliDCSValue*) iterarray.Next())) {
+      while((aValue = dynamic_cast<AliDCSValue*>(iterarray.Next()))) {
 	const UInt_t currentTime = aValue->GetTimeStamp();
 	if(currentTime>fCtpEndTime) break;
 
@@ -167,7 +167,7 @@ Bool_t AliADDataDCS::ProcessData(TMap& aliasMap){
       TVectorD times(nentries), values(nentries);
 
       UInt_t iValue=0;
-      while((aValue = (AliDCSValue*) iterarray.Next())) {
+      while((aValue = dynamic_cast<AliDCSValue*>(iterarray.Next()))) {
         const UInt_t currentTime = aValue->GetTimeStamp();
         if(currentTime>fCtpEndTime) break;
 
@@ -179,7 +179,7 @@ Bool_t AliADDataDCS::ProcessData(TMap& aliasMap){
     }
     else { // Treating FEE Parameters
       AliDCSValue * lastVal = NULL;
-      while((aValue = (AliDCSValue*) iterarray.Next())) lastVal = aValue; // Take only the last value
+      while((aValue = dynamic_cast<AliDCSValue*>(iterarray.Next()))) lastVal = aValue; // Take only the last value
       fFEEParameters->Add(new TObjString(fAliasNames[iAlias].Data()),lastVal);
     }
   }

--- a/AD/ADbase/AliADPreprocessor.cxx
+++ b/AD/ADbase/AliADPreprocessor.cxx
@@ -193,7 +193,7 @@ UInt_t AliADPreprocessor::ProcessTimeSlewing()
       AliInfoF("Cannot open file %s",fileName.Data());
       return 1;}
 
-    fListSplines = (TList*)f->Get("fListSplines");
+    fListSplines = dynamic_cast<TList*>(f->Get("fListSplines"));
     if ( !fListSplines ) {
       Log("No Spline List in file");
       return 1;}

--- a/AD/ADrec/AliADDecision.cxx
+++ b/AD/ADrec/AliADDecision.cxx
@@ -65,9 +65,7 @@ AliADDecision::AliADDecision()
 //______________________________________________________________________
 AliADDecision::~AliADDecision()
 {
-  if (fEarlyHitCutShape)
-    delete fEarlyHitCutShape;
-  fEarlyHitCutShape = NULL;
+  SafeDelete(fEarlyHitCutShape);
 }
 
 //________________________________________________________________________________

--- a/AD/ADrec/AliADReconstructor.cxx
+++ b/AD/ADrec/AliADReconstructor.cxx
@@ -170,18 +170,9 @@ AliADReconstructor& AliADReconstructor::operator = (const AliADReconstructor&)
 AliADReconstructor::~AliADReconstructor()
 {
   // destructor
-  if (fESDAD) {
-    delete fESDAD;
-    fESDAD = NULL;
-  }
-  if (fESDADfriend) {
-    delete fESDADfriend;
-    fESDADfriend = NULL;
-  }
-  if (fDigitsArray) {
-    delete fDigitsArray;
-    fDigitsArray = NULL;
-  }
+  SafeDelete(fESDAD);
+  SafeDelete(fESDADfriend);
+  SafeDelete(fDigitsArray);
 }
 
 //_____________________________________________________________________________

--- a/AD/ADsim/AliADDigitizer.cxx
+++ b/AD/ADsim/AliADDigitizer.cxx
@@ -756,7 +756,7 @@ void AliADDigitizer::WriteDigits(AliLoader *loader)
   DigitsArray();
   treeD->Branch("ADDigit", &fDigits);
 
-  Short_t *chargeADC = new Short_t[kADNClocks];
+  static Short_t chargeADC[kADNClocks];
   for (Int_t i=0; i<16; i++) {
     for (Int_t j=0; j < kADNClocks; ++j) {
       Int_t tempadc = Int_t(fAdc[i][j]);
@@ -765,7 +765,6 @@ void AliADDigitizer::WriteDigits(AliLoader *loader)
     }
     if(!fCalibData->IsChannelDead(i)) AddDigit(i, fLeadingTime[i], fTimeWidth[i], Bool_t((10+fEvenOrOdd)%2), chargeADC, fBBFlag[i], fBGFlag[i], fLabels[i]);
   }
-  delete [] chargeADC;
 
   treeD->Fill();
   loader->WriteDigits("OVERWRITE");

--- a/AD/ADsim/AliADDigitizer.cxx
+++ b/AD/ADsim/AliADDigitizer.cxx
@@ -213,22 +213,22 @@ Bool_t AliADDigitizer::SetupTailVsTotalCharge()
       Float_t charge0 = tail;
       Float_t charge1 = tail;
       for (Int_t bc=0; bc<fTailBegin; ++bc) {
-	if (!doExtrapolation[bc])
-	  continue;
-	const Bool_t integrator = ((bc%2) == 0); // bc=10 -> integrator=kTRUE
-	f0 = dynamic_cast<TF1*>(f_Int[!integrator]->At(bc));
-	f1 = dynamic_cast<TF1*>(f_Int[ integrator]->At(bc));
+        if (!doExtrapolation[bc])
+          continue;
+        const Bool_t integrator = ((bc%2) == 0); // bc=10 -> integrator=kTRUE
+        f0 = dynamic_cast<TF1*>(f_Int[!integrator]->At(bc));
+        f1 = dynamic_cast<TF1*>(f_Int[ integrator]->At(bc));
 
-	if (!f0 || !f1) {
-	  AliWarning("f0==NULL || f1==NULL");
-	  continue;
-	}
+        if (!f0 || !f1) {
+          AliWarning("f0==NULL || f1==NULL");
+          continue;
+        }
 #if ROOT_VERSION_CODE < ROOT_VERSION(5,99,0) // ROOT version <6
-	f0->Optimize();
-	f1->Optimize();
+        f0->Optimize();
+        f1->Optimize();
 #endif
-	charge0 += TMath::Max(0.0, f0->Eval(tail));
-	charge1 += TMath::Max(0.0, f1->Eval(tail));
+        charge0 += TMath::Max(0.0, f0->Eval(tail));
+        charge1 += TMath::Max(0.0, f1->Eval(tail));
       }
       fTailVsTotalCharge[ch][0]->SetPoint(fTailVsTotalCharge[ch][0]->GetN(), charge0, tail);
       fTailVsTotalCharge[ch][1]->SetPoint(fTailVsTotalCharge[ch][1]->GetN(), charge1, tail);
@@ -323,8 +323,8 @@ Bool_t AliADDigitizer::Init()
 
     const Int_t board = AliADCalibData::GetBoardNumber(i);
     fNBins[i]   = TMath::Nint(((Float_t)(fCalibData->GetMatchWindow(board)+1)*25.0+
-			       (Float_t)kADMaxTDCWidth*fCalibData->GetWidthResolution(board))/
-			      fCalibData->GetTimeResolution(board));
+                               (Float_t)kADMaxTDCWidth*fCalibData->GetWidthResolution(board))/
+                              fCalibData->GetTimeResolution(board));
     fNBinsLT[i] = TMath::Nint(((Float_t)(fCalibData->GetMatchWindow(board)+1)*25.0)/
                               fCalibData->GetTimeResolution(board));
     fBinSize[i] = fCalibData->GetTimeResolution(board);
@@ -613,7 +613,7 @@ void AliADDigitizer::AdjustPulseShapeADC()
     for (Int_t bc=0; bc<kADNClocks; ++bc) {
       newADC[bc] = 0.0;
       if (!doExtrapolation[bc])
-	continue;
+        continue;
       const Bool_t integrator = ((bc+fEvenOrOdd) % 2);
       TF1 *f = dynamic_cast<TF1*>(f_Int[integrator]->At(bc));
 #if ROOT_VERSION_CODE < ROOT_VERSION(5,99,0) // ROOT version <6
@@ -637,7 +637,7 @@ void AliADDigitizer::AdjustPulseShapeADC()
     const Float_t b =   ( (n+1)  *chargeLastBC - tail)/det;
     if (a < 0 || b < 0) {
       AliErrorF("charge redistribution failed for Ch%02d: n=%f a=%e b=%e chargeLastBC=%f tail=%f",
-		ch, n, a, b, chargeLastBC, tail);
+                ch, n, a, b, chargeLastBC, tail);
       continue;
     }
     // fill the tail BCs with linear function
@@ -646,9 +646,9 @@ void AliADDigitizer::AdjustPulseShapeADC()
     }
 
     AliDebugF(5, "OLD: Ch%02d %5.1f %5.1f %5.1f %5.1f %5.1f %5.1f", ch,
-	      fAdc[ch][20], fAdc[ch][19], fAdc[ch][18], fAdc[ch][17], fAdc[ch][16], fAdc[ch][15]);
+              fAdc[ch][20], fAdc[ch][19], fAdc[ch][18], fAdc[ch][17], fAdc[ch][16], fAdc[ch][15]);
     AliDebugF(5, "NEW: Ch%02d %5.1f %5.1f %5.1f %5.1f %5.1f %5.1f", ch,
-	      newADC[20], newADC[19], newADC[18], newADC[17], newADC[16], newADC[15]);
+              newADC[20], newADC[19], newADC[18], newADC[17], newADC[16], newADC[15]);
     Float_t newCharge=0.0;
     for (Int_t bc=0; bc<kADNClocks; ++bc) {
       fAdc[ch][bc] = newADC[bc];
@@ -717,7 +717,7 @@ void AliADDigitizer::ReadSDigits()
         Int_t nbins = sDigit->GetNBins();
         if (nbins != fNBins[pmNumber]) {
           AliErrorF("Incompatible number of bins between digitizer (%d) and sdigit (%d) for PM %d! Skipping sdigit!",
-		    fNBins[pmNumber],nbins,pmNumber);
+                    fNBins[pmNumber],nbins,pmNumber);
           continue;
         }
         // Sum the charges

--- a/AD/ADsim/AliADDigitizer.h
+++ b/AD/ADsim/AliADDigitizer.h
@@ -76,6 +76,8 @@ protected:
   Bool_t SetupTailVsTotalCharge();
   void   AdjustPulseShapeADC();
 
+  Int_t  SimulateLightYield(Int_t pmt, Int_t nPhot) const;
+
 private:
   AliADDigitizer(const AliADDigitizer& /*digitizer*/);
   AliADDigitizer& operator = (const AliADDigitizer& /*digitizer*/);
@@ -104,6 +106,7 @@ private:
   Float_t   fAdcPedestal[16][2];    //! Pedestals, one per integrator
   Float_t   fAdcSigma[16][2];       //! Sigma of pedestals
   Float_t   fPmGain[16];            //! PMT gains
+  Float_t   fLightYield[16];        //! Light Yields times photocatode efficiency
   Int_t     fNBins[16];             //! Number of bins in fTime container
   Int_t     fNBinsLT[16];           //! Number of bins in fTime container (match window only)
   Float_t   fBinSize[16];           //! Bin size in fTime container
@@ -119,7 +122,7 @@ private:
   DigiTask_t fTask;                 //! The task (to be) executed by the digitizer
   AliAD     *fAD;                   //! Pointer to AliDetector object
 
-  ClassDef(AliADDigitizer,6);       // digitizer for AD
+  ClassDef(AliADDigitizer,7);       // digitizer for AD
 } ;
 
 #endif // AliADDigitizer_H

--- a/AD/ADsim/AliADTriggerSimulator.cxx
+++ b/AD/ADsim/AliADTriggerSimulator.cxx
@@ -170,7 +170,7 @@ AliADCalibData * AliADTriggerSimulator::LoadCalibData() const
 
   AliADCalibData *calibData = NULL;
 
-  if (entry) calibData = (AliADCalibData*) entry->GetObject();
+  if (entry) calibData = dynamic_cast<AliADCalibData*>(entry->GetObject());
   if (!calibData)  AliError("No Trigger data from database !");
 
   return calibData;
@@ -189,14 +189,14 @@ void AliADTriggerSimulator::LoadClockOffset()
     AliFatal("AD Calib object is not found in OCDB !");
     return;
   }
-  AliADCalibData *calibdata = (AliADCalibData*) entry0->GetObject();
+  AliADCalibData *calibdata = dynamic_cast<AliADCalibData*>(entry0->GetObject());
 
   AliCDBEntry *entry = AliCDBManager::Instance()->Get("GRP/CTP/CTPtiming");
   if (!entry) {
     AliFatal("CTP timing parameters are not found in OCDB !");
     return;
   }
-  AliCTPTimeParams *ctpParams = (AliCTPTimeParams*)entry->GetObject();
+  AliCTPTimeParams *ctpParams = dynamic_cast<AliCTPTimeParams*>(entry->GetObject());
   Float_t l1Delay = (Float_t)ctpParams->GetDelayL1L0()*25.0;
 
   AliCDBEntry *entry1 = AliCDBManager::Instance()->Get("GRP/CTP/TimeAlign");
@@ -204,7 +204,7 @@ void AliADTriggerSimulator::LoadClockOffset()
     AliFatal("CTP time-alignment is not found in OCDB !");
     return;
   }
-  AliCTPTimeParams *ctpTimeAlign = (AliCTPTimeParams*)entry1->GetObject();
+  AliCTPTimeParams *ctpTimeAlign = dynamic_cast<AliCTPTimeParams*>(entry1->GetObject());
   l1Delay += ((Float_t)ctpTimeAlign->GetDelayL1L0()*25.0);
   //Start of the central clock in HPTDC time
   for(Int_t board = 0; board < kNCIUBoards; ++board) {
@@ -258,11 +258,11 @@ void AliADTriggerSimulator::Run() {
 
     Int_t nDigits = fDigits->GetEntriesFast();
     for (Int_t iDigit=0; iDigit<nDigits; iDigit++) {
-      AliADdigit* digit = (AliADdigit*)fDigits->At(iDigit);
+      AliADdigit* digit = dynamic_cast<AliADdigit*>(fDigits->At(iDigit));
 
       Int_t integrator = digit->Integrator();
       Int_t pmNumber   = digit->PMNumber();
-      Int_t board   = AliADCalibData::GetBoardNumber(pmNumber);
+      Int_t board      = AliADCalibData::GetBoardNumber(pmNumber);
       if (board < 0) continue;
 
       if(fCalibData->GetEnableCharge(pmNumber)) {

--- a/AD/ADsim/AliADTriggerSimulator.cxx
+++ b/AD/ADsim/AliADTriggerSimulator.cxx
@@ -83,20 +83,10 @@ AliADTriggerSimulator::AliADTriggerSimulator()
 
 //_____________________________________________________________________________
 AliADTriggerSimulator::~AliADTriggerSimulator(){
-  // Destructor
   for (Int_t i=0; i<kNCIUBoards; i++) {
-    if (fBBGate[i]) {
-      delete fBBGate[i];
-      fBBGate[i] = NULL;
-    }
-    if (fBGGate[i]) {
-      delete fBGGate[i];
-      fBGGate[i] = NULL;
-    }
-    if (fBCMask[i]) {
-      delete fBCMask[i];
-      fBCMask[i] = NULL;
-    }
+    SafeDelete(fBBGate[i]);
+    SafeDelete(fBGGate[i]);
+    SafeDelete(fBCMask[i]);
   }
 }
 


### PR DESCRIPTION
- photo-cathode efficiency times light-yield is taken into account in the MC simulation, analogously as for VZERO
- the old behavior can be restored by setting AD/Calib/LightYields entries to 1
- nPhotonsPerMIP was adjusted
- code cleanup