### PR TITLE
Fix handling missing X11 libraries (on macos)

### DIFF
--- a/HLT/BASE/util/CMakeLists.txt
+++ b/HLT/BASE/util/CMakeLists.txt
@@ -107,11 +107,13 @@ target_link_libraries(${MODULE} ${LIBDEPS})
 set_target_properties(${MODULE} PROPERTIES COMPILE_FLAGS "")
 
 # System dependent: Modify the way the library is build
-if(${CMAKE_SYSTEM} MATCHES Darwin)
-    set_target_properties(${MODULE} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-    include_directories(${X11_INCLUDE_DIR})
-    SET(CMAKE_EXE_LINKER_FLAGS 
-      "${CMAKE_EXE_LINKER_FLAGS} -L${X11_LIB_DIR}")
+if(${CMAKE_SYSTEM} MATCHES Darwin AND X11_FOUND)
+  set_target_properties(${MODULE} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  include_directories(${X11_INCLUDE_DIR})
+  SET(CMAKE_EXE_LINKER_FLAGS 
+    "${CMAKE_EXE_LINKER_FLAGS} -L${X11_LIB_DIR}")
+else()
+  message(WARNING "X11 libraries not found - will NOT build ZMQhistViewer")
 endif(${CMAKE_SYSTEM} MATCHES Darwin)
 
 # Installation
@@ -134,8 +136,10 @@ if(ZEROMQ_FOUND)
   target_link_libraries(ZMQROOTmerger HLTbase AliHLTGlobal AliZMQhelpers RAWDatabase Geom Graf MathCore Net Tree EG Gpad Matrix Minuit Physics VMC Thread STEERBase XMLParser Graf3d RIO Hist Core pthread)
   add_executable(ZMQhistSource ZMQhistSource.cxx)
   target_link_libraries(ZMQhistSource HLTbase AliHLTGlobal AliZMQhelpers RAWDatabase Geom Graf MathCore Net Tree EG Gpad Matrix Minuit Physics VMC Thread STEERBase XMLParser Graf3d RIO Hist Core)
-  add_executable(ZMQhistViewer ZMQhistViewer.cxx)
-  target_link_libraries(ZMQhistViewer HLTbase AliHLTGlobal AliZMQhelpers AliHLTUtil RAWDatabase Geom Graf MathCore Net Tree EG Gpad Matrix Minuit Physics VMC Thread STEERBase XMLParser Graf3d RIO Hist Core Hist Rint X11)
+  if (X11_FOUND)
+    add_executable(ZMQhistViewer ZMQhistViewer.cxx)
+    target_link_libraries(ZMQhistViewer HLTbase AliHLTGlobal AliZMQhelpers AliHLTUtil RAWDatabase Geom Graf MathCore Net Tree EG Gpad Matrix Minuit Physics VMC Thread STEERBase XMLParser Graf3d RIO Hist Core Hist Rint X11)
+  endif (X11_FOUND)
   add_executable(ZMQproxy ZMQproxy.cxx)
   target_link_libraries(ZMQproxy HLTbase AliHLTGlobal AliZMQhelpers RAWDatabase Geom Graf MathCore Net Tree EG Gpad Matrix Minuit Physics VMC Thread STEERBase XMLParser Graf3d RIO Hist Core)
   add_executable(ZMQHLTchain ZMQHLTchain.cxx)


### PR DESCRIPTION
when missing, throw a warning and don't build ZMQhistViewer


this should fix ALIROOT-7555