### PR TITLE
 remove nested comments that generate a compiler error using icc

### DIFF
--- a/AD/ADrec/AliADDecision.cxx
+++ b/AD/ADrec/AliADDecision.cxx
@@ -219,11 +219,11 @@ void AliADDecision::FillDecisions(AliESDAD *esdAD)
   if(weightRobustADC > 1) timeRobustADC /= weightRobustADC;
   else timeRobustADC = -1024.;
 
-  /*/Use basic time for decisions
+  /*Use basic time for decisions
     timeADA = timeBasicADA; timeADC = timeBasicADC;
     weightADA = weightBasicADA; weightADC = weightBasicADC;
     ntimeADA = ntimeBasicADA; ntimeADC = ntimeBasicADC;
-    for(Int_t i=0; i<8; ++i){itimeADA[i] = itimeBasicADA[i]; itimeADC[i] = itimeBasicADC[i];}/*/
+    for(Int_t i=0; i<8; ++i){itimeADA[i] = itimeBasicADA[i]; itimeADC[i] = itimeBasicADC[i];}*/
 
   //Use Robust time for decisions
   esdAD->SetBit(AliESDAD::kRobustMeanTime,kTRUE);

--- a/AD/ADsim/AliADTriggerSimulator.cxx
+++ b/AD/ADsim/AliADTriggerSimulator.cxx
@@ -235,7 +235,7 @@ void AliADTriggerSimulator::FillFlags(Bool_t *bbFlag, Bool_t *bgFlag, Float_t ti
     Bool_t inBBwindow = fBBGate[board]->IsInCoincidence(time[i]);
     Bool_t inBGwindow = fBGGate[board]->IsInCoincidence(time[i]);
 
-    /*/
+    /*
       Bool_t inBBwindow = kFALSE;
       Bool_t inBGwindow = kFALSE;
 
@@ -250,7 +250,7 @@ void AliADTriggerSimulator::FillFlags(Bool_t *bbFlag, Bool_t *bgFlag, Float_t ti
       if(fBBGateShifted.IsInCoincidence(time[i])) inBBwindow = kTRUE;
       if(fBGGateShifted.IsInCoincidence(time[i])) inBGwindow = kTRUE;
       }
-      /*/
+      */
     bbFlag[i] = inBBwindow;
     bgFlag[i] = inBGwindow;
     //AliInfo(Form("Ch %d Time=%.1f BCM=%d BB=%d BG=%d",i,time[i],inBCmask,bbFlag[i],bgFlag[i] ));

--- a/AD/ADsim/AliADv1.cxx
+++ b/AD/ADsim/AliADv1.cxx
@@ -1755,7 +1755,7 @@ TGeoVolume * AliADv1::Make_UProfileH(const char * volname, TGeoMedium * medium)
   return voprofile;
 }
 //_________________________________________________________
-/*/
+/*
 TGeoVolumeAssembly * AliADv1::CreatePmtBoxC() 
 {
   // Dimensions of the box:
@@ -1854,7 +1854,7 @@ TGeoVolumeAssembly * AliADv1::CreatePmtBoxC()
 
   return volBox;
 
-} /*/
+} */
 //_____________________________________________________________________________
 /* void AliADv1::CreateCurvedBundles(TGeoVolumeAssembly * ad)
 {


### PR DESCRIPTION
nested comments are caught by the intel c++ compiler and treated as an error, it would be great if this (otherwise harmless) pr could be merged

example of compiler error:

/nics/c/home/rbertens/alibuild/sw/SOURCES/AliRoot/0/0/AD/ADrec/AliADDecision.cxx(226): error #9: nested comment is not allowed

compiler used

[rbertens@acf-login2 AliRoot]$ icc --version
icc (ICC) 17.0.2 20170213
Copyright (C) 1985-2017 Intel Corporation.  All rights reserved.

