### PR TITLE
Differenciate selectors for proper input type

### DIFF
--- a/ANALYSIS/ANALYSISalice/AliESDtrackCuts.cxx
+++ b/ANALYSIS/ANALYSISalice/AliESDtrackCuts.cxx
@@ -722,6 +722,12 @@ Long64_t AliESDtrackCuts::Merge(TCollection* list) {
   return count+1;
 }
 
+Bool_t AliESDtrackCuts::IsSelected(TObject *o) {
+  if(o->IsA() == AliESDtrack::Class()) return AcceptTrack(static_cast<AliESDtrack *>(o));
+  else if(o->InheritsFrom(AliVTrack::Class())) return AcceptVTrack(static_cast<AliVTrack *>(o));
+  return false;    // Type unsupported - do not select the object;
+}
+
 void AliESDtrackCuts::SetMinNClustersTPCPtDep(TFormula *f1, Float_t ptmax)
 {
   //

--- a/ANALYSIS/ANALYSISalice/AliESDtrackCuts.h
+++ b/ANALYSIS/ANALYSISalice/AliESDtrackCuts.h
@@ -51,8 +51,7 @@ public:
   AliESDtrackCuts(const Char_t* name = "AliESDtrackCuts", const Char_t* title = "");
   virtual ~AliESDtrackCuts();
 
-  virtual Bool_t IsSelected(TObject* obj)
-       {return AcceptTrack((AliESDtrack*)obj);}
+  virtual Bool_t IsSelected(TObject* obj);
   virtual Bool_t IsSelected(TList* /*list*/) {return kTRUE;}
 
   Bool_t AcceptTrack(const AliESDtrack* esdTrack);


### PR DESCRIPTION
Redirection of IsSelected to proper selector function:
- AcceptTrack in case of AliESDtrack
- AcceptVTrack in case of any other object
  inheriting from AliVTrack (i.e. AliAODTrack)
Would support direct use for AOD tracks without the need
of a temp copy AliESDtrack.

Proposed patch: In case of AliESDtracks as input the functionality is not changed, in case of AOD tracks it is redirected to the proper functions for AliVTrack. With the patch the integration in frameworks using the AliVCuts interface becomes easier. It is possible to use the virtual IsSelected function for both ESD and AOD tracks without downcasting to the specific class and calling specific functions.