### PR TITLE
Add support for AliEn OCDB time machine

### DIFF
--- a/STEER/CDB/AliCDBManager.cxx
+++ b/STEER/CDB/AliCDBManager.cxx
@@ -332,6 +332,7 @@ AliCDBManager::AliCDBManager():
   fStartRunLHCPeriod(-1),
   fEndRunLHCPeriod(-1),
   fLHCPeriod(""),
+  fMaxDate(0),
   fKey(0)
 {
   // default constuctor
@@ -536,6 +537,7 @@ AliCDBStorage* AliCDBManager::GetStorage(const AliCDBParam* param) {
       aStorage->SetURI(param->GetURI());
       if(fRun >= 0) {
         if( aStorage->GetType() == "alien" || aStorage->GetType() == "local" )
+          aStorage->SetMaxDate(fMaxDate);
           aStorage->QueryCDB(fRun);
       }
       return aStorage;
@@ -1738,6 +1740,7 @@ void AliCDBManager::QueryCDB() {
     return;
   }
   if(fDefaultStorage->GetType() == "alien" || fDefaultStorage->GetType() == "local"){
+    fDefaultStorage->SetMaxDate(fMaxDate);
     fDefaultStorage->QueryCDB(fRun);
   //} else {
   //	AliDebug(2,"Skipping query for valid files, it used only in grid...");
@@ -1752,6 +1755,7 @@ void AliCDBManager::QueryCDB() {
       AliDebug(2,Form("Querying specific storage %s",aCalibType->GetName()));
       AliCDBStorage *aStorage = GetStorage(aPar);
       if(aStorage->GetType() == "alien" || aStorage->GetType() == "local"){
+        aStorage->SetMaxDate(fMaxDate);
         aStorage->QueryCDB(fRun, aCalibType->GetName());
       } else {
         AliDebug(2,

--- a/STEER/CDB/AliCDBManager.h
+++ b/STEER/CDB/AliCDBManager.h
@@ -15,6 +15,7 @@
 #include <TMap.h>
 #include <TSystem.h>
 #include <TFile.h>
+#include <TTimeStamp.h>
 
 class AliCDBEntry;
 class AliCDBId;
@@ -111,6 +112,10 @@ class AliCDBManager: public TObject {
 
     void SetRun(Int_t run);
     Int_t GetRun() const {return fRun;}
+
+    void SetMaxDate(time_t maxDate) { fMaxDate = maxDate; }
+    void SetMaxDate(TTimeStamp &maxDate) { fMaxDate = maxDate.GetSec(); }
+    time_t GetMaxDate() const { return fMaxDate; }
 
     void SetMirrorSEs(const char* mirrors);
     const char* GetMirrorSEs() const;
@@ -221,6 +226,8 @@ class AliCDBManager: public TObject {
     Int_t fStartRunLHCPeriod; // 1st run of the LHC period set
     Int_t fEndRunLHCPeriod;   // last run of the LHC period set
     TString fLHCPeriod;       // LHC period alien folder
+
+    time_t fMaxDate;  //! max UNIX timestamp for OCDB objects
 
   private:
     ULong64_t fKey;  //! Key for locking/unlocking

--- a/STEER/CDB/AliCDBStorage.cxx
+++ b/STEER/CDB/AliCDBStorage.cxx
@@ -415,6 +415,26 @@ Bool_t AliCDBStorage::Put(AliCDBEntry* entry, const char* mirrors, AliCDBManager
 }
 
 //_____________________________________________________________________________
+time_t AliCDBStorage::GuidToCreationTimestamp(const TString &guid) const {
+  static const Int_t order[8] = { 14, 16, 9, 11, 0, 2, 4, 6 };
+  char buf[3];
+  buf[2] = '\0';
+  time_t timeval = 0;
+  for (Int_t i=0; i<8; i++) {
+    buf[0] = guid[order[i]];
+    buf[1] = guid[order[i]+1];
+    timeval |= strtol(buf, 0x0, 16);
+    if (timeval & 0xFF00000000000000) {
+      timeval &= 0x0FFFFFFFFFFFFFFF;
+    }
+    else {
+      timeval <<= 8;
+    }
+  }
+  return (timeval - 0x01b21dd213814000L) / 10000000; // result is in seconds
+}
+
+//_____________________________________________________________________________
 void AliCDBStorage::QueryCDB(Int_t run, const char* pathFilter,
     Int_t version, AliCDBMetaData* md){
 // query CDB for files valid for given run, and fill list fValidFileIds

--- a/STEER/CDB/AliCDBStorage.h
+++ b/STEER/CDB/AliCDBStorage.h
@@ -101,6 +101,7 @@ class AliCDBStorage: public TObject {
     void PrintQueryCDB();
     TObjArray* GetQueryCDBList() {return &fValidFileIds;}
     virtual void SetRetry(Int_t nretry, Int_t initsec) = 0;
+    void SetMaxDate(time_t maxDate) { fMaxDate = maxDate; }
 
   protected:
 
@@ -114,6 +115,7 @@ class AliCDBStorage: public TObject {
     virtual void   QueryValidFiles() = 0;
     void 	LoadTreeFromFile(AliCDBEntry* entry) const;
     //void 	SetTreeToFile(AliCDBEntry* entry, TFile* file) const;
+    time_t GuidToCreationTimestamp(const TString &guid) const;
 
     TObjArray fValidFileIds; 	// list of Id's of the files valid for a given run (cached as fRun)
     Int_t fRun;		        // run number, used to manage list of valid files
@@ -127,6 +129,8 @@ class AliCDBStorage: public TObject {
     TString fBaseFolder;    //! Local, Grid: base folder name - Dump: file name
     Short_t    fNretry;              // Number of retries in opening the file
     Short_t    fInitRetrySeconds;        // Seconds for first retry
+
+    time_t fMaxDate;  // max file timestamp to take into account upon queries
 
   private:
     AliCDBStorage(const AliCDBStorage & source);


### PR DESCRIPTION
When using, for instance:

    AliCDBManager *cdb = AliCDBManager::Instance();
    cdb->SetDefaultStorage("raw://");
    cdb->SetRun(277015);
    cdb->SetMaxDate(TTimeStamp(2017, 7, 1, 0, 0, 0));  // new feature

only OCDB files created no later than the given UTC date will be returned.

This feature ensures perfect reproducibility: by setting a certain date it will
be possible to:

* protect jobs from OCDB updates while they are running
* re-run jobs in the future using the exact same OCDB