### PR TITLE
Adapt the trigger raw digit maker to work with raw stream in DATE format

### DIFF
--- a/EMCAL/EMCALbase/AliEMCALTriggerRawDigitMaker.cxx
+++ b/EMCAL/EMCALbase/AliEMCALTriggerRawDigitMaker.cxx
@@ -58,7 +58,8 @@ fSTURawStream(0x0),
 fRawDigits(0x0),
 fRawAnalyzer(0x0),
 fDCSConfig(0x0),
-fTriggerData(0x0)
+fTriggerData(0x0),
+fIsRawRootFormat(kFALSE)
 {
   AliRunLoader* rl = AliRunLoader::Instance();
   if (rl && rl->GetAliRun())
@@ -100,6 +101,13 @@ void AliEMCALTriggerRawDigitMaker::SetIO(AliRawReader* reader, AliCaloRawStreamV
   fRawDigits     = digits;
   fSTURawStream  = &inSTU;
   fTriggerData   = data;
+
+  if (reader && reader->InheritsFrom("AliRawReaderRoot")) {
+    fIsRawRootFormat = kTRUE;
+  }
+  else {
+    fIsRawRootFormat = kFALSE;
+  }
 }
 
 ///
@@ -272,6 +280,8 @@ void AliEMCALTriggerRawDigitMaker::Add(const std::vector<AliCaloBunchInfo> &bunc
 
 bool AliEMCALTriggerRawDigitMaker::IsSTUIncluded(Int_t istu)
 {
+  if (!fIsRawRootFormat) return kTRUE;
+
   const Int_t offsetEMCAL = AliDAQ::DdlIDOffset("EMCAL");
 
   fRawReader->Reset();
@@ -299,8 +309,6 @@ bool AliEMCALTriggerRawDigitMaker::IsSTUIncluded(Int_t istu)
       if (eqId == offsetEMCAL + istu) isSTUin = true;
     }
   }
-
-  fRawReader->Reset();
 
   return isSTUin;
 }
@@ -332,6 +340,8 @@ void AliEMCALTriggerRawDigitMaker::PostProcess()
       continue;
     }
     
+    fRawReader->Reset();
+
     if (fSTURawStream && fSTURawStream->ReadPayLoad())
     {
       trgData->SetL1DataDecoded(1);

--- a/EMCAL/EMCALbase/AliEMCALTriggerRawDigitMaker.h
+++ b/EMCAL/EMCALbase/AliEMCALTriggerRawDigitMaker.h
@@ -62,6 +62,8 @@ protected:
 	
   Int_t                        fRawDigitIndex[kMaxDigitIndex]; ///< Raw digit indexes
 
+  Bool_t                       fIsRawRootFormat; //!<! Whether the current input raw is in root format
+
 private:
 	
         AliEMCALTriggerRawDigitMaker(           const AliEMCALTriggerRawDigitMaker& rhs); // NOT implemented

--- a/EMCAL/EMCALbase/AliEMCALTriggerRawDigitMaker.h
+++ b/EMCAL/EMCALbase/AliEMCALTriggerRawDigitMaker.h
@@ -45,6 +45,8 @@ public:
   
   virtual void PostProcess();
   
+  virtual bool IsSTUIncluded(Int_t istu);
+
   virtual void Reset();
   
 protected:


### PR DESCRIPTION
These changes are needed to use this class also to decode the STU data in the DQM framework.
Nothing changes when this class is used for reconstruction using the raw ROOT format.