### PR TITLE
Fix CMake warning

### DIFF
--- a/HLT/BASE/util/CMakeLists.txt
+++ b/HLT/BASE/util/CMakeLists.txt
@@ -114,7 +114,7 @@ if(${CMAKE_SYSTEM} MATCHES Darwin AND X11_FOUND)
     "${CMAKE_EXE_LINKER_FLAGS} -L${X11_LIB_DIR}")
 else()
   message(WARNING "X11 libraries not found - will NOT build ZMQhistViewer")
-endif(${CMAKE_SYSTEM} MATCHES Darwin)
+endif(${CMAKE_SYSTEM} MATCHES Darwin AND X11_FOUND)
 
 # Installation
 install(TARGETS ${MODULE}


### PR DESCRIPTION
Hi,
This commit should fixes the following warning!
Thank you.
```
DEBUG:AliPhysics:AliRoot:0: CMake Warning (dev) in HLT/BASE/util/CMakeLists.txt:
DEBUG:AliPhysics:AliRoot:0:   A logical block opening on the line
DEBUG:AliPhysics:AliRoot:0:
DEBUG:AliPhysics:AliRoot:0:     ~/alice/sw/SOURCES/AliRoot/0/0/HLT/BASE/util/CMakeLists.txt:110 (if)
DEBUG:AliPhysics:AliRoot:0:
DEBUG:AliPhysics:AliRoot:0:   closes on the line
DEBUG:AliPhysics:AliRoot:0:
DEBUG:AliPhysics:AliRoot:0:     ~/alice/sw/SOURCES/AliRoot/0/0/HLT/BASE/util/CMakeLists.txt:117 (endif)
DEBUG:AliPhysics:AliRoot:0:
DEBUG:AliPhysics:AliRoot:0:   with mis-matching arguments.
DEBUG:AliPhysics:AliRoot:0: This warning is for project developers.  Use -Wno-dev to suppress it.
```