### PR TITLE
Add Cint dependency to libAliHLTUtil.so

### DIFF
--- a/HLT/BASE/CMakeLists.txt
+++ b/HLT/BASE/CMakeLists.txt
@@ -148,7 +148,7 @@ set(HDRS ${HDRS}
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
 generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
-set(ROOT_DEPENDENCIES Core Geom Graf Hist MathCore Net RIO Tree XMLParser)
+set(ROOT_DEPENDENCIES Cint Core Geom Graf Hist MathCore Net RIO Tree XMLParser)
 set(ALIROOT_DEPENDENCIES STEERBase RAWDatabase AliHLTHOMER)
 # Generate the ROOT map
 # Dependecies


### PR DESCRIPTION
Hi,
This commit add Cint dep to AliHLTUtil because AliRoot build fails on macOS 10.13 with the following error. libCint has these missing symbols but it was not directly linked to AliHLTUtil.

```
[64%] Linking CXX shared library libAliHLTUtil.so
Undefined symbols for architecture x86_64:
  "_G__Doubleref", referenced from:
      G__G__AliHLTUtil_517_0_3(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
  "_G__Floatref", referenced from:
      G__G__AliHLTUtil_930_0_33(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
  "_G__UShortref", referenced from:
      G__G__AliHLTUtil_517_0_3(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
  "_G__add_setup_func", referenced from:
      __GLOBAL__sub_I_G__AliHLTUtil.cxx in G__AliHLTUtil.cxx.o
  "_G__call_setup_funcs", referenced from:
      __GLOBAL__sub_I_G__AliHLTUtil.cxx in G__AliHLTUtil.cxx.o
  "_G__check_setup_version", referenced from:
      _G__cpp_setupG__AliHLTUtil in G__AliHLTUtil.cxx.o
  "_G__defined_typename", referenced from:
      G__setup_memvarAliHLTAgentUtil() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTAgentUtil() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTBlockFilterComponent() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTBlockFilterComponent() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTCaloClusterReader() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTCaloClusterReader() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTCompStatCollector() in G__AliHLTUtil.cxx.o
      ...
  "_G__double", referenced from:
      G__G__AliHLTUtil_930_0_27(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_930_0_28(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_930_0_29(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_930_0_30(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_930_0_33(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_930_0_35(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_935_0_11(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      ...
  "_G__get_linked_tagnum", referenced from:
      _G__cpp_setup_inheritanceG__AliHLTUtil in G__AliHLTUtil.cxx.o
      _G__cpp_setup_typetableG__AliHLTUtil in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTAgentUtil() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTAgentUtil() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTBlockFilterComponent() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTBlockFilterComponent() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTCaloClusterReader() in G__AliHLTUtil.cxx.o
      ...
  "_G__get_linked_tagnum_fwd", referenced from:
      _G__cpp_setup_tagtableG__AliHLTUtil in G__AliHLTUtil.cxx.o
  "_G__getaryconstruct", referenced from:
      G__G__AliHLTUtil_509_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_509_0_23(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_513_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_513_0_26(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_517_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_517_0_10(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_524_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      ...
  "_G__getgvp", referenced from:
      G__G__AliHLTUtil_509_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_509_0_23(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_513_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_513_0_26(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_517_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_517_0_10(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_524_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      ...
  "_G__getnumbaseclass", referenced from:
      _G__cpp_setup_inheritanceG__AliHLTUtil in G__AliHLTUtil.cxx.o
  "_G__getsizep2memfunc", referenced from:
      _G__cpp_setupG__AliHLTUtil in G__AliHLTUtil.cxx.o
  "_G__getstructoffset", referenced from:
      G__G__AliHLTUtil_509_0_18(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_509_0_23(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_513_0_21(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_513_0_26(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_517_0_2(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_517_0_3(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_517_0_4(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      ...
  "_G__inheritance_setup", referenced from:
      _G__cpp_setup_inheritanceG__AliHLTUtil in G__AliHLTUtil.cxx.o
  "_G__int", referenced from:
      G__G__AliHLTUtil_517_0_3(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_517_0_4(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_524_0_8(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_563_0_2(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_571_0_7(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_571_0_9(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_895_0_2(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      ...
  "_G__lastifuncposition", referenced from:
      _G__cpp_setup_funcG__AliHLTUtil in G__AliHLTUtil.cxx.o
      _G__cpp_setupG__AliHLTUtil in G__AliHLTUtil.cxx.o
  "_G__letdouble", referenced from:
      G__G__AliHLTUtil_930_0_10(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_930_0_11(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_930_0_30(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
  "_G__letint", referenced from:
      G__G__AliHLTUtil_509_0_11(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_509_0_12(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_509_0_13(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_509_0_19(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_509_0_20(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_509_0_21(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_509_0_22(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      ...
  "_G__memfunc_setup", referenced from:
      G__setup_memfuncAliHLTAgentUtil() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTBlockFilterComponent() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTCaloClusterReader() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTCompStatCollector() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTCorruptorComponent() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTDataGenerator() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTESDCaloClusterMaker() in G__AliHLTUtil.cxx.o
      ...
  "_G__memvar_setup", referenced from:
      G__setup_memvarAliHLTAgentUtil() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTBlockFilterComponent() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTCaloClusterReader() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTCompStatCollector() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTCorruptorComponent() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTDataGenerator() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTESDCaloClusterMaker() in G__AliHLTUtil.cxx.o
      ...
  "_G__remove_setup_func", referenced from:
      G__cpp_setup_initG__AliHLTUtil::~G__cpp_setup_initG__AliHLTUtil() in G__AliHLTUtil.cxx.o
  "_G__resetglobalenv", referenced from:
      _G__cpp_setup_globalG__AliHLTUtil in G__AliHLTUtil.cxx.o
      _G__cpp_setupG__AliHLTUtil in G__AliHLTUtil.cxx.o
  "_G__resetifuncposition", referenced from:
      _G__cpp_setup_funcG__AliHLTUtil in G__AliHLTUtil.cxx.o
      _G__cpp_setupG__AliHLTUtil in G__AliHLTUtil.cxx.o
  "_G__resetplocal", referenced from:
      _G__cpp_setup_globalG__AliHLTUtil in G__AliHLTUtil.cxx.o
      _G__cpp_setupG__AliHLTUtil in G__AliHLTUtil.cxx.o
  "_G__search_typename2", referenced from:
      _G__cpp_setup_typetableG__AliHLTUtil in G__AliHLTUtil.cxx.o
  "_G__set_tagnum", referenced from:
      G__G__AliHLTUtil_509_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_513_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_517_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_524_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_536_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_560_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_563_0_1(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      ...
  "_G__setgvp", referenced from:
      G__G__AliHLTUtil_509_0_23(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_513_0_26(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_517_0_10(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_524_0_33(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_536_0_35(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_560_0_28(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_563_0_17(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      ...
  "_G__setnewtype", referenced from:
      _G__cpp_setup_typetableG__AliHLTUtil in G__AliHLTUtil.cxx.o
  "_G__setnull", referenced from:
      G__G__AliHLTUtil_509_0_14(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_509_0_18(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_509_0_23(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_513_0_17(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_513_0_21(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_513_0_26(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_517_0_4(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      ...
  "_G__setsizep2memfunc", referenced from:
      G__get_sizep2memfuncG__AliHLTUtil() in G__AliHLTUtil.cxx.o
      _G__cpp_setupG__AliHLTUtil in G__AliHLTUtil.cxx.o
  "_G__store_tempobject", referenced from:
      G__G__AliHLTUtil_935_0_4(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
      G__G__AliHLTUtil_969_0_5(G__value*, char const*, G__param*, int) in G__AliHLTUtil.cxx.o
  "_G__tag_memfunc_reset", referenced from:
      G__setup_memfuncAliHLTAgentUtil() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTBlockFilterComponent() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTCaloClusterReader() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTCompStatCollector() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTCorruptorComponent() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTDataGenerator() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTESDCaloClusterMaker() in G__AliHLTUtil.cxx.o
      ...
  "_G__tag_memfunc_setup", referenced from:
      G__setup_memfuncAliHLTAgentUtil() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTBlockFilterComponent() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTCaloClusterReader() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTCompStatCollector() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTCorruptorComponent() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTDataGenerator() in G__AliHLTUtil.cxx.o
      G__setup_memfuncAliHLTESDCaloClusterMaker() in G__AliHLTUtil.cxx.o
      ...
  "_G__tag_memvar_reset", referenced from:
      G__setup_memvarAliHLTAgentUtil() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTBlockFilterComponent() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTCaloClusterReader() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTCompStatCollector() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTCorruptorComponent() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTDataGenerator() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTESDCaloClusterMaker() in G__AliHLTUtil.cxx.o
      ...
  "_G__tag_memvar_setup", referenced from:
      G__setup_memvarAliHLTAgentUtil() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTBlockFilterComponent() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTCaloClusterReader() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTCompStatCollector() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTCorruptorComponent() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTDataGenerator() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTESDCaloClusterMaker() in G__AliHLTUtil.cxx.o
      ...
  "_G__tagtable_setup", referenced from:
      _G__cpp_setup_tagtableG__AliHLTUtil in G__AliHLTUtil.cxx.o
  "G__FastAllocString::Format(char const*, ...)", referenced from:
      G__setup_memvarAliHLTFXSFileWriter() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTMonitoringRelay() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTReadoutListDumpComponent() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTRootSchemaEvolutionComponent() in G__AliHLTUtil.cxx.o
  "G__FastAllocString::GetBuf(unsigned long&)", referenced from:
      G__setup_memvarAliHLTFXSFileWriter() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTMonitoringRelay() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTReadoutListDumpComponent() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTRootSchemaEvolutionComponent() in G__AliHLTUtil.cxx.o
  "G__FastAllocString::~G__FastAllocString()", referenced from:
      G__setup_memvarAliHLTFXSFileWriter() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTMonitoringRelay() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTReadoutListDumpComponent() in G__AliHLTUtil.cxx.o
      G__setup_memvarAliHLTRootSchemaEvolutionComponent() in G__AliHLTUtil.cxx.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [HLT/BASE/util/libAliHLTUtil.so] Error 1
make[1]: *** [HLT/BASE/util/CMakeFiles/AliHLTUtil.dir/all] Error 2
make: *** [all] Error 2
```