### PR TITLE
Fix ROOT6 build linker error introduced in #469

### DIFF
--- a/HLT/BASE/CMakeLists.txt
+++ b/HLT/BASE/CMakeLists.txt
@@ -147,8 +147,11 @@ set(HDRS ${HDRS}
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
 generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
-
-set(ROOT_DEPENDENCIES Cint Core Geom Graf Hist MathCore Net RIO Tree XMLParser)
+if(${ROOT_VERSION_MAJOR} EQUAL 6)
+	set(ROOT_DEPENDENCIES Cling Core Geom Graf Hist MathCore Net RIO Tree XMLParser)
+else()
+	set(ROOT_DEPENDENCIES Cint Core Geom Graf Hist MathCore Net RIO Tree XMLParser)
+endif(${ROOT_VERSION_MAJOR} EQUAL 6)
 set(ALIROOT_DEPENDENCIES STEERBase RAWDatabase AliHLTHOMER)
 # Generate the ROOT map
 # Dependecies


### PR DESCRIPTION
In #469 an explicit dependency on libCint was added to
libHLTbase without checking the ROOT version. As libCint
does not exist for ROOT6 this produces a linker error.
This version distinguishes between ROOT5 and ROOT6 builds
using libCling instead of libCint for ROOT6 builds.