### PR TITLE
ATO-245 BUGfix in PushTracks-KeepTracks(nPart)

### DIFF
--- a/EVGEN/AliGenPerformance.cxx
+++ b/EVGEN/AliGenPerformance.cxx
@@ -55,6 +55,7 @@
 #include <TF3.h>
 #include <TDatabasePDG.h>
 #include <TParticlePDG.h>
+#include "TPDGCode.h"
 
 #include "AliRun.h"
 #include "AliLog.h"
@@ -148,190 +149,220 @@ AliGenPerformance::~AliGenPerformance(){
 
 //-----------------------------------------------------------------------------
 void AliGenPerformance::Generate() {
+  //
+  // Performance generator
+  //
+  const Int_t kStackSize=10000;
+  Int_t naccepted = 0;
+  Int_t njets = gRandom->Poisson(fNJets);
+  TDatabasePDG *databasePDG = TDatabasePDG::Instance();
+  const Int_t nGeant = 14;
+  Int_t geantPartiles[nGeant] = {kElectron, kPositron, kMuonMinus, kMuonPlus, kKMinus, kKPlus, kPiPlus, kPiMinus,
+                                 kProton, kProtonBar, kK0Short, kK0Long, kLambda0, kLambda0Bar};
+  Int_t noGeant[1]={91};
+  Int_t waterMark=0;
+  for (Int_t iparton = 0; iparton < njets; iparton++) {
     //
-    // Performance generator
     //
-    Int_t naccepted =0;
-    Int_t njets=gRandom->Poisson(fNJets);
-    TDatabasePDG *databasePDG = TDatabasePDG::Instance();
-
-    for (Int_t iparton=0; iparton<njets; iparton++){
-        //
-        //
-        //
-        Float_t mom[3];
-        Float_t posf[3];
-        Double_t pos[3];
-        Int_t pdg;
-        Double_t ptot, pt,  phi, theta;
-        //
-        if (fF1Momentum){
-            ptot     = 1./fF1Momentum->GetRandom();
-        }else{
-            ptot     = 0.001+gRandom->Rndm()*0.2;
-            ptot/=ptot;
-        }
-        if (fFPhi){
-            phi      = fFPhi->GetRandom();
-        }else{
-            phi      = gRandom->Rndm()*TMath::TwoPi();
-        }
-        if (fFTheta){
-            theta    = fFTheta->GetRandom();
-        }else{
-            theta    =  (gRandom->Rndm()-0.5)*TMath::Pi()*0.5 +TMath::Pi()/2;
-        }
-        pt     = ptot*TMath::Sin(theta);
-        mom[0] = pt*TMath::Cos(phi);
-        mom[1] = pt*TMath::Sin(phi);
-        mom[2] = ptot*TMath::Cos(theta);
-        pos[0]=fOrigin[0]; pos[1]=fOrigin[1]; pos[2]=fOrigin[2];
-        //
-        if (fFPosition) fFPosition->GetRandom3(pos[0],pos[1],pos[2]); // ???? should be taken from "primary" coctail
-        //
-        posf[0]=pos[0];
-        posf[1]=pos[1];
-        posf[2]=pos[2];
-        if (fFPdg){
-            pdg = TMath::Nint(fFPdg->GetRandom());
-        }else{
-            pdg = 1+TMath::Nint(gRandom->Rndm()*5.);
-        }
-        Float_t polarization[3]= {0,0,0};
-        Int_t nPart;
-        //
-        AliPythia *py=AliPythia::Instance();
-        TParticlePDG *mParticle=databasePDG->GetParticle(pdg);
-        if (mParticle==NULL) continue;
-        Double_t mass=mParticle->Mass();
-        Double_t energy=TMath::Sqrt(mom[0]*mom[0]+mom[1]*mom[1]+mom[2]*mom[2]+mass*mass);
-        py->Py1ent(-1, -pdg, energy, theta, phi);
-        py->Py1ent( 2,  pdg, energy, theta+TMath::Pi(), phi);
-        py->SetMINT(51,0);
-        Int_t it=0;
-        for (it=0;it<2; it++) { // loop used for debuging purposes - later  to be used to enhance particle fraction
-            py->Pyexec();
-            if (py->GetN()>2) break;
-            py->SetMINT(51,0);
-            py->Py1ent(-1, -pdg, energy, theta, phi);
-            py->Py1ent( 2,  pdg, energy, theta+TMath::Pi(), phi);
-            AliSysInfo::AddStamp("test",iparton,it);
-        }
-        if (fVerboseLevel >= 0){
-            // debug output - Tol solve how to propagate Debug/Verbose level using AliDPG code - use Env varaible
-            py->Pylist(0);
-            py->Pylist(1);
-        }
-        TObjArray * array = py->GetPrimaries();
-        Int_t nParticles=array->GetEntries();
-        //array->Print();
-        Int_t pLabel  [nParticles];
-        for (Int_t iparticle=0; iparticle<nParticles;  iparticle++) {
-            TMCParticle *mcParticle = (TMCParticle *) array->At(iparticle);
-            Int_t flavour = mcParticle->GetKF();
-            mom[0] = mcParticle->GetPx();
-            mom[1] = mcParticle->GetPy();
-            mom[2] = mcParticle->GetPz();
-            posf[0] = pos[0];
-            posf[1] = pos[1];
-            posf[2] = pos[2];
-            posf[0] += mcParticle->GetVx();
-            posf[1] += mcParticle->GetVy();
-            posf[2] += mcParticle->GetVz();
-            TParticlePDG *pdgParticle = databasePDG->GetParticle(flavour);
-            Int_t pythiaParent = mcParticle->GetParent() - 1;
-            Int_t decayFlag = (iparticle < 2) ? 1 : 11;
-            pLabel[iparticle] = -1;
-            if (pythiaParent == iparticle) {
-                decayFlag = 1;
-                pythiaParent = -1;
-            }
-            Int_t stackParent = (pythiaParent > 0 && pythiaParent < nParticles) ? pLabel[pythiaParent] : -1;
-            //
-            Bool_t isOK = kTRUE;
-            if (mcParticle->GetEnergy() < mcParticle->GetMass()) {
-                if (fVerboseLevel > 0) {
-                    ::Error("AliGenPerformance::Generate", "Unphysical particle %d", flavour);
-                }
-                isOK = kFALSE;
-            }
-            if (pythiaParent == iparticle) {
-                if (fVerboseLevel > 0) {
-                    ::Error("AliGenPerformance::Generate", "Incorrect particle ID parent=this  %d", pythiaParent);
-                }
-                isOK = kFALSE;
-            }
-            Int_t done = (mcParticle->GetFirstChild() <= 0);
-
-            if ((fVerboseLevel & kFastOnly) == 0 && pdgParticle != NULL) {
-                // Missing info in order to apply reweighting
-                // 1.) validate mother/daughter relationship
-                // 2.) validate position distribution (like in AliGenCorrHF::LoadTracks)
-                // Note : code fr the mother/daughter inspired by the  AliGenCorrHF::LoadTracks
-                TMCProcess type = (stackParent >= 0) ? kPDecay : kPPrimary;
-                if (isOK) {
-                    if (TMath::Abs(flavour) == 211) done = 0; // TEMPORARY hack to get geant to track pion, kaon protons
-                    if (TMath::Abs(flavour) == 321) done = 0;
-                    if (TMath::Abs(flavour) == 2212) done = 0;
-                    if (TMath::Abs(flavour) == 11) done = 0;
-                    if (TMath::Abs(flavour) == 13) done = 0;
-                    PushTrack(done, stackParent, flavour, mom, posf, polarization, 0, type, nPart, 1., decayFlag);
-                    pLabel[iparticle] = nPart;
-                    if (done) {
-                        KeepTrack(nPart);
-                        SetHighWaterMark(nPart);
-                    }
-                    if (stackParent > 0) {
-                        if (databasePDG->GetParticle(stackParent) != NULL) KeepTrack(stackParent);
-                    }
-                }
-                //fNprimaries++;
-            }
-            if (fStreamer){
-                if (pdgParticle){
-                    Double_t charge=pdgParticle->Charge();
-                    Double_t mass=pdgParticle->Mass();
-                    Double_t  pt=TMath::Sqrt(mcParticle->GetPx()*mcParticle->GetPx()+mcParticle->GetPy()*mcParticle->GetPy());
-                    (*fStreamer)<<"testGener"<<
-                                "isOK="<<isOK<<
-                                "done="<<done<<
-                                "njets="<<njets<<
-                                "ptot="<<ptot<<
-                                "theta="<<theta<<
-                                "phi="<<phi<<
-                                "pdg="<<pdg<<
-                                "charge="<<charge<<
-                                "mass="<<mass<<
-                                "pt="<<pt<<
-                                "nParticles="<<nParticles<<
-                                "ipart="<<iparticle<<
-                                "mcParticle.="<<mcParticle<<
-                                "\n";
-                }
-            }
-            naccepted++;
-        }
-    }
-
-    // Passes header either to the container or to gAlice
-    AliGenEventHeader* header = new AliGenEventHeader("THn");
-    if (fContainer) {
-      header->SetName(fName);
-      fContainer->AddHeader(header);
+    //
+    Float_t mom[3];
+    Float_t posf[3];
+    Double_t pos[3];
+    Int_t pdg;
+    Double_t ptot, pt, phi, theta;
+    //
+    if (fF1Momentum) {
+      ptot = 1. / fF1Momentum->GetRandom();
     } else {
-      gAlice->SetGenEventHeader(header);
+      ptot = 0.001 + gRandom->Rndm() * 0.2;
+      ptot /= ptot;
     }
+    if (fFPhi) {
+      phi = fFPhi->GetRandom();
+    } else {
+      phi = gRandom->Rndm() * TMath::TwoPi();
+    }
+    if (fFTheta) {
+      theta = fFTheta->GetRandom();
+    } else {
+      theta = (gRandom->Rndm() - 0.5) * TMath::Pi() * 0.5 + TMath::Pi() / 2;
+    }
+    pt = ptot * TMath::Sin(theta);
+    mom[0] = pt * TMath::Cos(phi);
+    mom[1] = pt * TMath::Sin(phi);
+    mom[2] = ptot * TMath::Cos(theta);
+    //Set vertex
+    pos[0] = fOrigin[0];
+    pos[1] = fOrigin[1];
+    pos[2] = fOrigin[2];
+    //
+    if (fFPosition) { // use parameterization if specified
+      fFPosition->GetRandom3(pos[0], pos[1], pos[2]);
+    }else{  /// use external vertex
+      Vertex();
+      for (j=0; j < 3; j++) pos[j] = fVertex[j];
+    }
+    //
+    posf[0] = pos[0];
+    posf[1] = pos[1];
+    posf[2] = pos[2];
+    if (fFPdg) {
+      pdg = TMath::Nint(fFPdg->GetRandom());
+    } else {
+      pdg = 1 + TMath::Nint(gRandom->Rndm() * 5.);
+    }
+    Float_t polarization[3] = {0, 0, 0};
+    Int_t nPart;
+    //
+    AliPythia *py = AliPythia::Instance();
+    TParticlePDG *mParticle = databasePDG->GetParticle(pdg);
+    if (mParticle == NULL) continue;
+    Double_t mass = mParticle->Mass();
+    Double_t energy = TMath::Sqrt(mom[0] * mom[0] + mom[1] * mom[1] + mom[2] * mom[2] + mass * mass);
+    py->Py1ent(-1, -pdg, energy, theta, phi);
+    py->Py1ent(2, pdg, energy, theta + TMath::Pi(), phi);
+    py->SetMINT(51, 0);
+    Int_t it = 0;
+    for (it = 0; it < 2; it++) { // loop used for debuging purposes - later  to be used to enhance particle fraction
+      py->Pyexec();
+      if (py->GetN() > 2) break;
+      py->SetMINT(51, 0);
+      py->Py1ent(-1, -pdg, energy, theta, phi);
+      py->Py1ent(2, pdg, energy, theta + TMath::Pi(), phi);
+      AliSysInfo::AddStamp("test", iparton, it);
+    }
+    if (fVerboseLevel >= 0) {
+      // debug output - Tol solve how to propagate Debug/Verbose level using AliDPG code - use Env varaible
+      py->Pylist(0);
+      py->Pylist(1);
+    }
+    TObjArray *array = py->GetPrimaries();
+    Int_t nParticles = array->GetEntries();
+    //array->Print();
+    TArrayI pLabel(nParticles);        //  particle label on stack
+    TArrayI isGeantFlag(nParticles);   //  indicator particle track by GEANT
 
-    if (fStreamer){   // in standard simulation destructor of the streamer (and file->Close() is not called - force writing)
-        ((*fStreamer)<<"testGener").GetTree()->Write();
-        fStreamer->GetFile()->Flush();
+    for (Int_t iParticle = 0; iParticle < nParticles; iParticle++) {
+      pLabel[iParticle]=-1;
+      isGeantFlag[iParticle]=0;
+      TMCParticle *mcParticle = (TMCParticle *) array->At(iParticle);
+      Int_t flavour = mcParticle->GetKF();
+      mom[0] = mcParticle->GetPx();
+      mom[1] = mcParticle->GetPy();
+      mom[2] = mcParticle->GetPz();
+      posf[0] = pos[0];
+      posf[1] = pos[1];
+      posf[2] = pos[2];
+      posf[0] += mcParticle->GetVx();
+      posf[1] += mcParticle->GetVy();
+      posf[2] += mcParticle->GetVz();
+      TParticlePDG *pdgParticle = databasePDG->GetParticle(flavour);
+      Int_t pythiaParent = mcParticle->GetParent() - 1;
+
+      Int_t decayFlag = (iParticle < 2) ? 1 : 11;
+      pLabel[iParticle] = -1;
+      if (pythiaParent == iParticle) {
+        decayFlag = 1;
+        pythiaParent = -1;
+      }
+      Int_t stackParent = -1;
+      Bool_t isOK = kTRUE;
+      if (pythiaParent >= 0 && pythiaParent < nParticles) {
+        stackParent = pLabel[pythiaParent];
+        if (isGeantFlag[pythiaParent]) {
+          isGeantFlag[iParticle] = kTRUE;
+        }
+      }
+      //
+      if (mcParticle->GetEnergy() < mcParticle->GetMass()) {
+        if (fVerboseLevel > 0) {
+          ::Error("AliGenPerformance::Generate", "Unphysical particle %d", flavour);
+        }
+        isOK = kFALSE;
+      }
+      if (pythiaParent == iParticle) {
+        if (fVerboseLevel > 0) {
+          ::Error("AliGenPerformance::Generate", "Incorrect particle ID parent=this  %d", pythiaParent);
+        }
+        isOK = kFALSE;
+      }
+      Int_t done = (mcParticle->GetFirstChild() >= 0);  // indicator particle was decayed using Pythia -sign it done
+
+      if ((fVerboseLevel & kFastOnly) == 0 && pdgParticle != NULL) {
+        // Missing info in order to apply reweighting
+        // 1.) validate mother/daughter relationship
+        // 2.) validate position distribution (like in AliGenCorrHF::LoadTracks)
+        // Note : code fr the mother/daughter inspired by the  AliGenCorrHF::LoadTracks
+        TMCProcess type = (stackParent >= 0) ? kPDecay : kPPrimary;
+        if (isOK) {
+          if (isGeantFlag[iParticle] == kFALSE) {
+            Float_t isGeant = 0;
+            for (Int_t i = 0; i < nGeant; i++) if (flavour == geantPartiles[i]) isGeant = 1;
+            isGeantFlag[iParticle] = isGeant;
+            if (isGeant) {
+              if (pythiaParent>=0 && pLabel[pythiaParent]<0){
+                AliError("Inconsistent labels");
+                stackParent=-1;
+              }
+              PushTrack(1, stackParent, flavour, mom, posf, polarization, 0, type, nPart, 1., decayFlag);
+              //PushTrack(1, -1, flavour, mom, posf, polarization, 0, type, nPart, 1., decayFlag);
+              KeepTrack(nPart);
+              waterMark=nPart;
+              pLabel[iParticle] = nPart;
+            } else {
+              if (pythiaParent>=0 &&pLabel[pythiaParent]<0){
+                AliError("Inconsistent labels");
+                stackParent=-1;
+              }
+              if (flavour==92) flavour=1;  ///HACK to check bad flavours for AliRoot - not fixed problem
+              PushTrack(0, stackParent, flavour, mom, posf, polarization, 0, type, nPart, 1., decayFlag);
+              //PushTrack(1, -1, flavour, mom, posf, polarization, 0, type, nPart, 1., decayFlag);
+              KeepTrack(nPart);
+              waterMark=nPart;
+              pLabel[iParticle] = nPart;
+              if (stackParent >= 0) {
+                if (databasePDG->GetParticle(stackParent) != NULL) KeepTrack(stackParent);
+              }
+            }
+          }
+          //fNprimaries++;
+        }
+      }
+      if (fStreamer) {
+        if (pdgParticle) {
+          Double_t charge = pdgParticle->Charge();
+          Double_t mass = pdgParticle->Mass();
+          Double_t pt = TMath::Sqrt(
+                  mcParticle->GetPx() * mcParticle->GetPx() + mcParticle->GetPy() * mcParticle->GetPy());
+          (*fStreamer) << "testGener" << "isOK=" << isOK << "done=" << done << "njets=" << njets << "ptot=" << ptot
+                       << "theta=" << theta << "phi=" << phi << "pdg=" << pdg << "charge=" << charge << "mass=" << mass
+                       << "pt=" << pt << "nParticles=" << nParticles << "ipart=" << iParticle << "mcParticle.="
+                       << mcParticle << "\n";
+        }
+      }
+      naccepted++;
     }
-    if ( (fVerboseLevel&kStreamEvent)>0  && fStreamer){
-        TString name=fStreamer->GetFile()->GetName();
-        delete fStreamer;
-        fStreamer = new TTreeSRedirector(name.Data(),"update");
-    }
-    return;
+  }
+  SetHighWaterMark(waterMark);
+  // Passes header either to the container or to gAlice
+  AliGenEventHeader *header = new AliGenEventHeader("THn");
+  if (fContainer) {
+    header->SetName(fName);
+    fContainer->AddHeader(header);
+  } else {
+    gAlice->SetGenEventHeader(header);
+  }
+
+  if (fStreamer) {   // in standard simulation destructor of the streamer (and file->Close() is not called - force writing)
+    ((*fStreamer) << "testGener").GetTree()->Write();
+    fStreamer->GetFile()->Flush();
+  }
+  if ((fVerboseLevel & kStreamEvent) > 0 && fStreamer) {
+    TString name = fStreamer->GetFile()->GetName();
+    delete fStreamer;
+    fStreamer = new TTreeSRedirector(name.Data(), "update");
+  }
+  return;
 }
 
 

--- a/EVGEN/AliGenPerformance.cxx
+++ b/EVGEN/AliGenPerformance.cxx
@@ -200,7 +200,7 @@ void AliGenPerformance::Generate() {
       fFPosition->GetRandom3(pos[0], pos[1], pos[2]);
     }else{  /// use external vertex
       Vertex();
-      for (j=0; j < 3; j++) pos[j] = fVertex[j];
+      for (Int_t j=0; j < 3; j++) pos[j] = fVertex[j];
     }
     //
     posf[0] = pos[0];


### PR DESCRIPTION
### AliGenPerformace changes:
* Pythia decayer used to decay particles
  * Pythia particle array created
* NEW: for particles specified in "geant particles" array special treatment
  * particles are treated by GEANT
  * daughter particles of geant particles are removed from pythia stack
* Bug fix
  * in the previous version of the AliGenPerformance KeepTrack were not called
    for fraction of tracks
  * in new version all particles pushed to stack were signed to be keept
````
                    KeepTrack(nPart);
                    SetHighWaterMark(nPart);
````
* Use external vertex if default vertex distribution not set
* Usage:
  * Generator for  the MC validation
  * New generator used in the AliDPG/MC/CustomGenerators/
https://github.com/miranov25/AliDPG/blob/master/MC/CustomGenerators/DPG/PerformaceGenerator.C
