### PR TITLE
Fix missing member initialization

### DIFF
--- a/STEER/CDB/AliCDBStorage.cxx
+++ b/STEER/CDB/AliCDBStorage.cxx
@@ -38,7 +38,8 @@ AliCDBStorage::AliCDBStorage():
   fType(),
   fBaseFolder(),
   fNretry(0),
-  fInitRetrySeconds(0)
+  fInitRetrySeconds(0),
+  fMaxDate(0)
 {
   // constructor
 


### PR DESCRIPTION
Feature introduced in #465 is missing a member initialization causing an
undetermined and very dangerous behaviour in most cases.