### PR TITLE
Improve OCDB Time Machine

### DIFF
--- a/STEER/CDB/AliCDBManager.cxx
+++ b/STEER/CDB/AliCDBManager.cxx
@@ -1606,6 +1606,13 @@ void AliCDBManager::SetRun(Int_t run) {
 }
 
 //_____________________________________________________________________________
+void AliCDBManager::SetMaxDate(time_t maxDate) {
+  if (maxDate == fMaxDate) return;
+  if (fRun > -1) AliFatal("Cannot call AliCDBManager::SetMaxDate() after run was set!");
+  fMaxDate = maxDate;
+}
+
+//_____________________________________________________________________________
 void AliCDBManager::ClearPromptCache(){
 // clear AliCDBEntry prompt cache
 
@@ -1740,7 +1747,7 @@ void AliCDBManager::QueryCDB() {
     return;
   }
   if(fDefaultStorage->GetType() == "alien" || fDefaultStorage->GetType() == "local"){
-    fDefaultStorage->SetMaxDate(fMaxDate);
+    if (!fDefaultStorage->GetMaxDate()) fDefaultStorage->SetMaxDate(fMaxDate);  // no override if set per storage
     fDefaultStorage->QueryCDB(fRun);
   //} else {
   //	AliDebug(2,"Skipping query for valid files, it used only in grid...");
@@ -1755,7 +1762,7 @@ void AliCDBManager::QueryCDB() {
       AliDebug(2,Form("Querying specific storage %s",aCalibType->GetName()));
       AliCDBStorage *aStorage = GetStorage(aPar);
       if(aStorage->GetType() == "alien" || aStorage->GetType() == "local"){
-        aStorage->SetMaxDate(fMaxDate);
+        if (!aStorage->GetMaxDate()) aStorage->SetMaxDate(fMaxDate);  // no override if set per storage
         aStorage->QueryCDB(fRun, aCalibType->GetName());
       } else {
         AliDebug(2,

--- a/STEER/CDB/AliCDBManager.h
+++ b/STEER/CDB/AliCDBManager.h
@@ -113,8 +113,8 @@ class AliCDBManager: public TObject {
     void SetRun(Int_t run);
     Int_t GetRun() const {return fRun;}
 
-    void SetMaxDate(time_t maxDate) { fMaxDate = maxDate; }
-    void SetMaxDate(TTimeStamp &maxDate) { fMaxDate = maxDate.GetSec(); }
+    void SetMaxDate(time_t maxDate);
+    void SetMaxDate(TTimeStamp &maxDate) { SetMaxDate(maxDate.GetSec()); }
     time_t GetMaxDate() const { return fMaxDate; }
 
     void SetMirrorSEs(const char* mirrors);

--- a/STEER/CDB/AliCDBStorage.cxx
+++ b/STEER/CDB/AliCDBStorage.cxx
@@ -503,6 +503,13 @@ void AliCDBStorage::PrintQueryCDB(){
 }
 
 //_____________________________________________________________________________
+void AliCDBStorage::SetMaxDate(time_t maxDate) {
+  if (maxDate == fMaxDate) return;
+  if (fRun > -1) AliFatal("Cannot call SetMaxDate() after run was set!");
+  fMaxDate = maxDate;
+}
+
+//_____________________________________________________________________________
 AliCDBManager::DataType AliCDBStorage::GetDataType() const {
 // returns the type of the data that should be stored into this storage:
 // kConditions: conditions data; kReference: reference data; kPrivate: private (user-defined) data type

--- a/STEER/CDB/AliCDBStorage.h
+++ b/STEER/CDB/AliCDBStorage.h
@@ -101,7 +101,9 @@ class AliCDBStorage: public TObject {
     void PrintQueryCDB();
     TObjArray* GetQueryCDBList() {return &fValidFileIds;}
     virtual void SetRetry(Int_t nretry, Int_t initsec) = 0;
-    void SetMaxDate(time_t maxDate) { fMaxDate = maxDate; }
+    void SetMaxDate(time_t maxDate);
+    void SetMaxDate(TTimeStamp maxDate) { SetMaxDate(maxDate.GetSec()); }
+    time_t GetMaxDate() const { return fMaxDate; }
 
   protected:
 


### PR DESCRIPTION
* Exit with `AliFatal` in case `SetMaxDate()` is called after the run was set already
* Support setting the date for individual storages: individual storage settings will override global ones

**Note:** OCDB Time Machine feature introduced in #465, with a bug fix in #477.