### PR TITLE
Usage of the CSS style  +QA development

### DIFF
--- a/EVGEN/AliGenPerformance.cxx
+++ b/EVGEN/AliGenPerformance.cxx
@@ -14,28 +14,28 @@
  **************************************************************************/
 
 // Generator for particles according generic functions
-// For high pt performance studies realistic distribution of the particles - local density in jets to be approximated 
+// For high pt performance studies realistic distribution of the particles - local density in jets to be approximated
 //
-//  
-//  TF1 *   fF1Momentum;          // 1/momentum distribution function inGeV 
+//
+//  TF1 *   fF1Momentum;          // 1/momentum distribution function inGeV
 //  TF1 *   fFPhi;                // phi distribution function in rad     - if not set flat 0-2pi used
 //  TF1 *   fFTheta;              // theta distribution function in rad   - if not set flat pi/4-3pi/4 used
 //  TF3 *   fFPosition;           // position distribution function in cm - TO FIX if not set 0 used ()
-//  TF1 *   fFPdg;                // pdg distribution function            - if not set flat jet pdg used 
-//  We assume that the moment, postion and PDG code of particles are independent  
+//  TF1 *   fFPdg;                // pdg distribution function            - if not set flat jet pdg used
+//  We assume that the moment, postion and PDG code of particles are independent
 //  Only tracks/particle crossing the reference radius at given z range
 //
 // Origin: marian.ivanov@cern.ch
 
 
 /*
-  To test generator for particular setting run   
+  To test generator for particular setting run
   AliGenPerformance::TestAliGenPerformance(Int_t nEvents, TF1 *f1pt, TF1 *fpdg){
-  For distribution of 
+  For distribution of
     fF1Momentum=new TF1("f1pt","1-10*x",0,0.1);
     AliGenPerformance::TestAliGenPerformance(1000, fF1Momentum,0)
     pt distribution of charged primary particles described by powerlaw with slope -1.7
-  
+
   gSystem->Load("libpythia6");
   gSystem->Load("libEGPythia6");
   gSystem->Load("liblhapdf");
@@ -47,7 +47,7 @@
 
 */
 
-  
+
 
 
 #include <TParticle.h>
@@ -76,18 +76,18 @@ ClassImp(AliGenPerformance)
 AliGenPerformance::AliGenPerformance():
   AliGenerator(),
   fNJets(1),                // mean number of jets per event
-  fF1Momentum(0),           // momentum distribution function 
+  fF1Momentum(0),           // momentum distribution function
   fFPhi(0),                 // phi distribution function
   fFTheta(0),               // theta distribution function
-  fFPosition(0),            // position distribution function 
-  fFPdg(0),                 // pdg distribution function  
+  fFPosition(0),            // position distribution function
+  fFPdg(0),                 // pdg distribution function
   fStreamer(0),           // test stream - used for tuning of parameters of generator
   fVerboseLevel(0)            // verbose level
 {
   //
   // Default constructor
   //
-  SetNumberParticles(1);  
+  SetNumberParticles(1);
 }
 //-----------------------------------------------------------------------------
 AliGenPerformance::AliGenPerformance(const char* generName, Int_t verboseLevel):
@@ -369,10 +369,10 @@ void AliGenPerformance::Generate() {
 //-----------------------------------------------------------------------------
 void AliGenPerformance::Init()
 {
-  // 
+  //
   // Initialisation, check consistency of selected ranges
   //
-  
+
 
   printf("************ AliGenPerformance ****************\n");
   printf("************************************************\n");
@@ -438,14 +438,14 @@ TChain *  AliGenPerformance::MakeKineChain(){
     TList * kineList = fkine->GetListOfKeys();
     for (Int_t iKey=0; iKey<kineList->GetEntries();iKey++){
       chain->AddFile(kineArray->At(iFile)->GetName(), TChain::kBigNumber, TString::Format("%s/TreeK",kineList->At(iKey)->GetName()).Data());
-    }    
+    }
   }
   return chain;
   /*
     // using following lines properties of mother particles and daughter particles can be correlated
-    // Unfortuantelly to do it fix in the TChain needed. 
+    // Unfortuantelly to do it fix in the TChain needed.
     //    1.) problem with aliases (fix prepared)
-    //    2.) 
+    //    2.)
     TChain * chainMother = AliGenPerformance::MakeKineChain();
     TChain * chainDaughter = AliGenPerformance::MakeKineChain();
     chainMother->SetAlias("index0","(Particles.GetDaughter(0)+1000000*This->GetTreeNumber()+0)");
@@ -453,6 +453,6 @@ TChain *  AliGenPerformance::MakeKineChain(){
     //
     chainMother->BuildIndex("index0");
     chainDaughter->BuildIndex("index0");
-    chainMother->AddFriend(chainDaughter,"D");    
+    chainMother->AddFriend(chainDaughter,"D");
   */
 }

--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -429,3 +429,73 @@ TStyle*  RegisterDefaultStyleFigTemplate(Bool_t graypalette) {
   figStyle->SetLegendFont(42);
   return figStyle;
 }
+
+/// CSS sttle parsing functions
+///
+
+///
+/// \param input      - input string
+/// \param tagName    - name of tag to find
+/// \return           - attribute tagName from the input string using CSS like parsing, empty string in case not found
+///
+TString  AliDrawStyle::GetAttributeValue(TString input, TString tagName){
+  Int_t index0 = input.Index(tagName.Data());
+  if (index0<0) return "";
+  Int_t index1 = input.Index(':',index0)+1;
+  Int_t index2= input.Index(';',index1)-1;
+  if (index2-index1-1<0) return "";
+  TString result(input(index1,index2-index1+1));
+  return result;
+}
+///
+/// \param input    - input string (CSS record - find proper name in the w3c)
+/// \param tagName  -  name of tag to find
+/// \param index    - index of value to find
+/// \return         - value as a integer  -1 if does not exist, resp , separated value at index index
+/*!
+ ####  Example use:
+  TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
+  AliDrawStyle::GetNamedIntegerAt(input,"marker_style",0);  //  return  25
+  AliDrawStyle::GetNamedIntegerAt(input,"marker_style",3);  //  return  23
+  AliDrawStyle::GetNamedIntegerAt(input,"marker_color",2);  //  return  4
+ */
+Int_t    AliDrawStyle::GetNamedIntegerAt(TString input, TString tagName, Int_t index){
+  TString  value = AliDrawStyle::GetAttributeValue(input,tagName);
+  Int_t indexStart=0;
+  Int_t indexFinish=value.Index(',',indexStart);
+  for (Int_t j=0; j<index; j++){
+    indexStart=value.Index(',',indexStart)+1;
+    indexFinish=value.Index(',',indexStart);
+    if (indexStart<0 || index>value.CountChar(',')) return -1;
+    if (indexFinish<0) indexFinish = value.Length();
+  }
+  TString valueAt(value(indexStart, indexFinish - indexStart));
+  if (valueAt.IsFloat()) return valueAt.Atoi();
+  else return -1;
+}
+
+/// \param input    - input string (CSS record - find proper name in the w3c)
+/// \param tagName  -  name of tag to find
+/// \param index    - index of value to find
+/// \return         - value as a float  -1 if does not exist, resp , separated value at index index
+/*!
+ ####  Example use:
+  TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
+  AliDrawStyle::GetNamedIntegerAt(input,"marker_style",0);  //  return  25
+  AliDrawStyle::GetNamedIntegerAt(input,"marker_style",3);  //  return  23
+  AliDrawStyle::GetNamedIntegerAt(input,"marker_color",2);  //  return  4
+ */
+Float_t  AliDrawStyle::GetNamedFloatAt(TString input, TString tagName, Int_t index){
+  TString  value = AliDrawStyle::GetAttributeValue(input,tagName);
+  Int_t indexStart=0;
+  Int_t indexFinish=value.Index(',',indexStart);
+  for (Int_t j=0; j<index; j++){
+    indexStart=value.Index(',',indexStart)+1;
+    indexFinish=value.Index(',',indexStart);
+    if (indexStart<0 || index>value.CountChar(',')) return -1;
+    if (indexFinish<0) indexFinish = value.Length();
+  }
+  TString valueAt(value(indexStart, indexFinish - indexStart));
+  if (valueAt.IsFloat()) return valueAt.Atof();
+  else return -1;
+}

--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -258,8 +258,6 @@ Float_t AliDrawStyle::GetLineWidth(const char *style, Int_t index){
   return  AliDrawStyle::fLineWidth[style][index];
 }
 
-
-
 void AliDrawStyle::PrintLatexSymbols(Option_t */*option*/, TPRegexp& regExp){
   //print latex symbols
   typedef std::map<TString,TString>::const_iterator it_type;
@@ -459,6 +457,12 @@ TStyle*  RegisterDefaultStyleFigTemplate(Bool_t grayPalette) {
 /// \param propertyName - name of property to find
 /// \return             - property propertyName from the input string using CSS like parsing, empty string in case not found
 ///
+/*!
+ ####  Example use:
+  TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
+  AliDrawStyle::GetPropertyValue(input,"marker_style",0);  //  return  "25,21,22,23"
+  AliDrawStyle::GetPropertyValue(input,"marker_color",2);  //  return  "1,2,4,5"
+ */
 TString  AliDrawStyle::GetPropertyValue(TString input, TString propertyName){
   Int_t index0 = input.Index(propertyName.Data());
   if (index0<0) return "";
@@ -472,21 +476,26 @@ TString  AliDrawStyle::GetPropertyValue(TString input, TString propertyName){
 /// \param input    - input string (CSS record - find proper name in the w3c)
 /// \param propertyName  -  name of property to find
 /// \param index    - index of value to find
+/// \param status   - predefined Bool_t variable, change initial value to false if value or property doesn't exist
 /// \return         - value as a integer  -1 if does not exist, resp , separated value at index index
 /*!
  ####  Example use:
   TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
-  AliDrawStyle::GetNamedIntegerAt(input,"marker_style",0);  //  return  25
-  AliDrawStyle::GetNamedIntegerAt(input,"marker_style",3);  //  return  23
-  AliDrawStyle::GetNamedIntegerAt(input,"marker_color",2);  //  return  4
+  AliDrawStyle::GetNamedIntegerAt(input,"marker_style",10,status);  //  return  -1, status will be false
+  AliDrawStyle::GetNamedIntegerAt(input,"marker_size",3,status);  //  return  -1, status will be false
+  AliDrawStyle::GetNamedIntegerAt(input,"marker_color",2,status);  //  return  4, status will be true
  */
-Int_t    AliDrawStyle::GetNamedIntegerAt(TString input, TString propertyName, Int_t index){
+Int_t    AliDrawStyle::GetNamedIntegerAt(TString input, TString propertyName, Int_t index, Bool_t &status){
+  status=kFALSE;
   TString  value;
   if(propertyName != "") value = AliDrawStyle::GetPropertyValue(input,propertyName);
   else value = input;
   Int_t indexStart=0;
   Int_t indexFinish=value.Index(',',indexStart);
-  if(indexFinish < 0 && value.IsFloat()) return value.Atoi();
+  if(indexFinish < 0 && value.IsFloat()) {
+    status=kTRUE;
+    return value.Atoi();
+  }
   for (Int_t j=0; j<index; j++){
     indexStart=value.Index(',',indexStart)+1;
     indexFinish=value.Index(',',indexStart);
@@ -494,28 +503,39 @@ Int_t    AliDrawStyle::GetNamedIntegerAt(TString input, TString propertyName, In
     if (indexFinish<0) indexFinish = value.Length();
   }
   TString valueAt(value(indexStart, indexFinish - indexStart));
-  if (valueAt.IsFloat()) return valueAt.Atoi();
-  else return -1;
+  if (valueAt.IsFloat()) {
+    status = true;
+    return valueAt.Atoi();
+  }
+  else {
+    status = false;
+    return -1;
+  }
 }
 
-/// \param input    - input string (CSS record - find proper name in the w3c)
+/// \param input         - input string (CSS record - find proper name in the w3c)
 /// \param propertyName  -  name of tag to find
-/// \param index    - index of value to find
-/// \return         - value as a float  -1 if does not exist, resp , separated value at index index
+/// \param index         - index of value to find
+/// \param status        - predefined Bool_t variable, change initial value to false if value or property doesn't exist
+/// \return              - value as a float  -1 if does not exist, resp , separated value at index index
 /*!
  ####  Example use:
-  TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
-  AliDrawStyle::GetNamedIntegerAt(input,"marker_style",0);  //  return  25
-  AliDrawStyle::GetNamedIntegerAt(input,"marker_style",3);  //  return  23
-  AliDrawStyle::GetNamedIntegerAt(input,"marker_color",2);  //  return  4
+  TString input="{\nmarker_style:25.36,21,22,23.1; \nmarker_color:1,2,4,5; \n}";
+  AliDrawStyle::GetNamedFloatAt(input,"marker_style",10,status);  //  return  -1.0, status will be false
+  AliDrawStyle::GetNamedFloatAt(input,"marker_size",3,status);  //  return  -1.0, status will be false
+  AliDrawStyle::GetNamedFloatAt(input,"marker_color",2,status);  //  return  4.0, status will be true
  */
-Float_t  AliDrawStyle::GetNamedFloatAt(TString input, TString propertyName, Int_t index){
+Float_t  AliDrawStyle::GetNamedFloatAt(TString input, TString propertyName, Int_t index, Bool_t &status){
+  status=kFALSE;
   TString  value;
   if(propertyName != "") value = AliDrawStyle::GetPropertyValue(input,propertyName);
   else value = input;
   Int_t indexStart=0;
   Int_t indexFinish=value.Index(',',indexStart);
-  if(indexFinish < 0 && value.IsFloat()) return value.Atof();
+  if(indexFinish < 0 && value.IsFloat()) {
+    status=kTRUE;
+    return value.Atof();
+  }
   for (Int_t j=0; j<index; j++){
     indexStart=value.Index(',',indexStart)+1;
     indexFinish=value.Index(',',indexStart);
@@ -523,8 +543,14 @@ Float_t  AliDrawStyle::GetNamedFloatAt(TString input, TString propertyName, Int_
     if (indexFinish<0) indexFinish = value.Length();
   }
   TString valueAt(value(indexStart, indexFinish - indexStart));
-  if (valueAt.IsFloat()) return valueAt.Atof();
-  else return -1;
+  if (valueAt.IsFloat()) {
+    status = true;
+    return valueAt.Atof();
+  }
+  else {
+    status = false;
+    return -1.0;
+  }
 }
 
 /// Read CSS html like files  (*see also AliRoot modification in CSS)
@@ -533,19 +559,22 @@ Float_t  AliDrawStyle::GetNamedFloatAt(TString input, TString propertyName, Int_
 ///   * code should not fail
 ///   * return 0 pointer if inconsistent content
 ///   * Use ::Error verbosity according debug level
-/// * proper CSS comments handling (Boris) @done
 /// * include CSS files  (should be included as )
 /// \param inputName     - input file to read
 /// \param verbose       - specify verbose level for ::error and ::info (Int_t should be interpreted as an bit-mask)
 /// \return              - TObjArray  with the pairs TNamed of the CSS <Selector, declaration> or  TObjArray (recursive structure like includes)
 TObjArray * AliDrawStyle::ReadCSSFile(const char *  inputName, TObjArray * cssArray, Int_t verbose){
   //check file exist
+  if (gSystem->GetFromPipe(TString("[ -f ") + TString(inputName) +  TString(" ] && echo 1 || echo 0")) == "0") {
+    ::Error("AliDrawStyle::ReadCSSFile","File %s doesn't exist", inputName);
+    return NULL;
+  }
   TString inputCSS = gSystem->GetFromPipe(TString::Format("cat %s",inputName).Data());     // I expect this variable is defined
   //remove comments:
   while (inputCSS.Index("*/") > 0){
     inputCSS = inputCSS(0, inputCSS.Index("/*")) + inputCSS(inputCSS.Index("*/")+2, inputCSS.Length());
   }
-    //inputCSS.ReplaceAll("\n", ""); we can add this, in the other case ClassName will be like "\n .TH*", but I suppose it doesn't matter.
+  //inputCSS.ReplaceAll("\n", ""); //  check perfomance and implement better variant;
   TObjArray *tokenArray = inputCSS.Tokenize("{}");   //assuming we can not use {} symbols in the style IDS
   Int_t entries = tokenArray->GetEntries();
   if (cssArray==NULL) {
@@ -563,11 +592,12 @@ TObjArray * AliDrawStyle::ReadCSSFile(const char *  inputName, TObjArray * cssAr
 /// Write cssArray to the file as a plain array (recursive function)
 /// \param cssArray    - input css array to write
 /// \param outputName  - output file
-/// \param cssOut     - output stream ( )
+/// \param pCssOut     - output stream ( )
 void    AliDrawStyle::WriteCSSFile(TObjArray * cssArray, const char *  outputName, fstream *pCssOut) {
+
   if (pCssOut == NULL) {
     pCssOut=new fstream;
-    pCssOut->open("test.css", ios_base::out|ios_base::trunc);
+    pCssOut->open(outputName, ios_base::out|ios_base::trunc);
   }
   fstream &cssOut = *pCssOut;
   for (Int_t i=0;i<cssArray->GetEntries();i++) {
@@ -588,325 +618,437 @@ void    AliDrawStyle::WriteCSSFile(TObjArray * cssArray, const char *  outputNam
   }
 }
 /// Function to check  match between "CSS" selector and pair of className, objectName
-/// \param selectors    - selector ID
+/// \param selectors   - selector ID
 /// \param elementName - name of element
 /// \param className   - name of class
 /// \param objectName  - object name
 /// \return            - kTRUE if selector match class name and object name
 /// TODO
-///   - pre-calculate the tree ? yes, in best practice we should use trees for css parsing. I think later we can implement simple variant.
-Bool_t  AliDrawStyle::IsSelected(TString selectors, TString elementName, TString className, TString objectName){
-  //TString selectors = "TH1.Status#obj1, TH1.Warning#obj1, TH1.Warning#obj3 \tTGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1 \tTGraph.Warning#TPC.QA.dcar_posA_2 \tTF1.Status, .Status#obj1, #obj3"
+///   - pre-calculate the tree ?
+///   - try to use existing parsers (check bison, webKit).
+/*!
+ ####  Example use:
+ \code
+  TString selectors = "\n\n\nTH1.Status#obj1, TH1.Warning#obj1, TH1.Warning#obj3 \tTGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1 \tTGraph.Warning#TPC.QA.dcar_posA_2 \tTF1.Status, .Status#obj1, #obj3";
+  AliDrawStyle::IsSelected(selectors, "", "", "obj3")            // return true
+  AliDrawStyle::IsSelected(selectors, "TF1", "Warning", "obj3")  // return true
+  AliDrawStyle::IsSelected(selectors, "TH1C", "Warning", "obj1") // return false
+  \endcode
+ */
+Bool_t  AliDrawStyle::IsSelected(TString selectors, TString elementID, TString classID, TString objectID){
 
-  Bool_t elementCatched;
-  Bool_t classCatched;
-  Bool_t objectCatched;
-  Ssiz_t fromStart=0;
-  Ssiz_t fromStart1;
+  Bool_t    elementCatched = false;
+  Bool_t    classCatched   = false;
+  Bool_t    objectCatched  = false;
+  Ssiz_t    fromStart0     = 0;
+  Ssiz_t    fromStart1     = 0;
+  TObjArray *classIDs      = classID.Tokenize(",");
+  Int_t     nC              = 0;
+  TString   subSelectors   = "";
+  TString   selector       = "";
+  TString   className      = "";
+  TPRegexp  elemPat(".*?[.]");
+  TPRegexp  classPat("[.].*[#]");
+  TPRegexp  objPat("[#].*");
 
-  TString subSelectors;
-  TString selector;
+  if (classIDs->GetEntriesFast() == 0) nC = 1;
+  else nC = classIDs->GetEntriesFast();
 
-  TPRegexp elemPat(".*?[.]");
-  TPRegexp classPat("[.].*[#]");
-  TPRegexp objPat("[#].*");
-
-  while(selectors.Tokenize(subSelectors,fromStart," \t")){
-    fromStart1 = 0;
-   while(subSelectors.Tokenize(selector,fromStart1,", ")){
-     selector = selector.Strip(TString::kBoth, ' ');
-     elementCatched = false;
-     classCatched = false;
-     objectCatched = false;
-
-     if(selector(objPat) == ""){
-        objectCatched = true;
-        selector.Append("#anyObjects");
+  for (Int_t i = 0; i < nC; i++) {
+    if (classIDs->GetEntriesFast() == 0) className = "";
+    else className = classIDs->At(i)->GetName();
+    while (selectors.Tokenize(subSelectors, fromStart0, " \t")) {
+      fromStart1 = 0;
+      while (subSelectors.Tokenize(selector, fromStart1, ", ")) {
+        selector = selector.Strip(TString::kBoth, ' ');
+        elementCatched = false;
+        classCatched = false;
+        objectCatched = false;
+        // check object
+        if (selector(objPat) == "" || objectID == "") {
+          objectCatched = true;
+          selector.Append("#anyObjects");
+        } else if (selector(objPat) == ("#" + objectID)) objectCatched = true;
+        // check class
+        if (selector(classPat) == "" || className == "") {
+          classCatched = true;
+          selector.Insert(selector.Index("#"), ".anyClasses");
+        } else if (selector(classPat) == ("." + className + "#")) classCatched = true;
+        //check element
+        if (selector(elemPat) == "." || selector(elemPat) == "" ||
+            selector(elemPat) == (elementID + ".") || elementID == "")
+          elementCatched = true;
+        if (elementCatched && classCatched && objectCatched) return true;
       }
-      else if (selector(objPat) == ("#" + objectName)) objectCatched = true;
-      if(selector(classPat) == ""){
-         classCatched = true;
-         selector.Insert(selector.Index("#"), ".anyClasses");
-       }
-       else if (selector(classPat) == ("." + className + "#")) classCatched = true;
-     if(selector(elemPat) == "." || selector(elemPat) == "" || selector(elemPat) == (elementName + ".")) elementCatched = true;
-     if (elementCatched && classCatched && objectCatched)  return true;
-   }
+    }
   }
-  return false;
-}
+    return false;
+  }
 
 ///
-/// \param styleName
+/// \param styleName      - name of predefined array with styles (see. AliDrawStyle::SetCssStyle())
+/// \param propertyName   - name of property according to css notation
 /// \param elementID
 /// \param classID
 /// \param objectID
-/// \return
+/// \return TString with values according to input propertyName
 /*!
-\code
-AliDrawStyle::SetCssStyle("alirootTestStyle.css",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
-AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "", "obj1");                     // "   1,1,1,1" as it should be
-AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "", "TPC.QA.dcar_posA_1");       // empty as it should
-AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "Status", "TPC.QA.dcar_posA_1"); // should be "   1,1,1,1"
-
-
-\endcode
+  ####  Example use:
+   \code
+   AliDrawStyle::SetCssStyle("alirootTestStyle.css",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
+   AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "", "obj1");                      // "33,34,35,36"
+   AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "", "TPC.QA.dcar_posA_1");        // "1,2,3,4"
+   AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "Warning", "TPC.QA.dcar_posA_1"); // ""
+    \endcode
 */
-TString AliDrawStyle::GetProperty(const char *styleName, TString propertyName, TString elementID, TString classID, TString objectID){
+TString AliDrawStyle::GetProperty(const char *styleName, TString propertyName,
+                                  TString elementID, TString classID, TString objectID){
+  if (fCssStyleAlice[styleName] == NULL) return "";
 
-  if(fCssStyleAlice[styleName] == NULL) return "";
+  TString value       = "";
+  TString actProperty = "";
+  Int_t   entries     = fCssStyleAlice[styleName]->GetEntriesFast();
+  TString declaration = "";
 
-  Int_t entries = fCssStyleAlice[styleName]->GetEntriesFast();
-  TString declaration="";
-  for(Int_t i = 0; i < entries; i++){
-    if(IsSelected(TString(fCssStyleAlice[styleName]->At(i)->GetName()), elementID, classID, objectID)){
-      TString  value = GetPropertyValue(fCssStyleAlice[styleName]->At(i)->GetTitle(),propertyName);
-      if (value.Length()>0) return value.Strip(TString::kBoth, ' ');
+  for(Int_t i = 0; i < entries; i++) {
+    if (AliDrawStyle::IsSelected(TString(fCssStyleAlice[styleName]->At(i)->GetName()),
+                                 elementID, classID, objectID)) {
+      value = AliDrawStyle::GetPropertyValue(fCssStyleAlice[styleName]->At(i)->GetTitle(), propertyName);
+      if (value != "") actProperty = value.Strip(TString::kBoth, ' ');
     }
   }
-  return "";
-}
-/// Function to get string with selectors from fCssStyleAlice[styleName]
-/// \param styleName    - styleName
-/// \return
-TString AliDrawStyle::GetSelector(const char *styleName){
-  if(fCssStyleAlice[styleName] == NULL) return "";
-  TObjArray *cssStyle = (TObjArray *) AliDrawStyle::GetCssStyle(styleName);
-  TString selectors = "";
-  for(Int_t i = 0; i < cssStyle->GetEntriesFast(); i++){
-    selectors += cssStyle->At(i)->GetName();
-    selectors += " \t";
-  }
-  return selectors;
-}
-/// Function return quantity of objects with specified class from TPad
-/// \param cPad         - name of pad
-/// \param className    - name of class
-/// \return
-Int_t AliDrawStyle::CountObjects(TPad *cPad, TString className){
-  Int_t cnt = 0;
-  for(Int_t c = 0; c < cPad->GetListOfPrimitives()->GetEntries(); c++) if(cPad->GetListOfPrimitives()->At(c)->InheritsFrom(className)) cnt++;
-  return cnt;
+
+  return actProperty;
 }
 
 ///
-/// \param styleName
-/// \param tempGraph
-/// \param elementName
-/// \param className
-/// \param objName
-/// \param objNum
-void AliDrawStyle::TGraphApplyStyle(const char* styleName, TGraph *tempGraph, TString elementName, TString className, TString objName, Int_t objNum){
-  // if styleName not exist use defaults?
-  if(AliDrawStyle::IsSelected(AliDrawStyle::GetSelector(styleName),elementName, className, objName)){
-    tempGraph->SetMarkerColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "marker_color", elementName, className, objName), "", objNum));
-    tempGraph->SetMarkerSize(AliDrawStyle::GetNamedFloatAt(AliDrawStyle::GetProperty(styleName, "marker_size", elementName, className, objName), "", objNum));
-    tempGraph->SetMarkerStyle(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "marker_style", elementName, className, objName), "", objNum));
-    /// lines
-    tempGraph->SetLineColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "line_color", elementName, className, objName), "", objNum));
-    tempGraph->SetLineWidth(AliDrawStyle::GetNamedFloatAt(AliDrawStyle::GetProperty(styleName, "line_width", elementName, className, objName), "", objNum));
-    tempGraph->SetLineStyle(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "line_style", elementName, className, objName), "", objNum));
-    /// area
-    tempGraph->SetFillColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "fill_color", elementName, className, objName), "", objNum));
-    tempGraph->SetFillStyle(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "fill_style", elementName, className, objName), "", objNum));
-  }
+/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::SetCssStyle())
+/// \param cGraph       - object inherited from TGraph in which you want to change style
+/*!
+  ####  Example use:
+  See AliDrawStyle::ApplyCssStyle();
+*/
+void AliDrawStyle::TGraphApplyStyle(const char* styleName, TGraph *cGraph){
+
+  Bool_t  status    = false;
+  TString elementID = "";
+  TString classID   = "";
+  TString objectID  = "";
+  Int_t   objectNum = 0;
+  TString property  = "";
+  Int_t   valueI    = 0;
+  Float_t valueF    = 0.0;
+
+  AliDrawStyle::GetIds(cGraph, elementID, classID, objectID, objectNum);
+
+  property = AliDrawStyle::GetProperty(styleName, "marker_color", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cGraph->SetMarkerColor(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "marker_size", elementID, classID, objectID);
+  valueF = AliDrawStyle::GetNamedFloatAt(property, "", objectNum, status);
+  if (property != "" && status) cGraph->SetMarkerSize(valueF);
+
+  property = AliDrawStyle::GetProperty(styleName, "marker_style", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cGraph->SetMarkerStyle(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "line_color", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cGraph->SetLineColor(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "line_width", elementID, classID, objectID);
+  valueF = AliDrawStyle::GetNamedFloatAt(property, "", objectNum, status);
+  if (property != "" && status) cGraph->SetLineWidth(valueF);
+
+  property = AliDrawStyle::GetProperty(styleName, "line_style", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cGraph->SetLineStyle(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "fill_color", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cGraph->SetFillColor(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "fill_style", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cGraph->SetFillStyle(valueI);
 }
 
 ///
-/// \param styleName
-/// \param tempHis
-/// \param elementName
-/// \param className
-/// \param objName
-/// \param objNum
-void AliDrawStyle::TH1ApplyStyle(const char* styleName, TH1 *tempHis, TString elementName, TString className, TString objName, Int_t objNum){
-  if(AliDrawStyle::IsSelected(AliDrawStyle::GetSelector(styleName),elementName, className, objName)){
-    tempHis->SetMarkerColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "marker_color", elementName, className, objName), "", objNum));
-    tempHis->SetMarkerSize(AliDrawStyle::GetNamedFloatAt(AliDrawStyle::GetProperty(styleName, "marker_size", elementName, className, objName), "", objNum));
-    tempHis->SetMarkerStyle(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "marker_style", elementName, className, objName), "", objNum));
-    /// lines
-    tempHis->SetLineColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "line_color", elementName, className, objName), "", objNum));
-    tempHis->SetLineWidth(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "line_width", elementName, className, objName), "", objNum));
-    tempHis->SetLineStyle(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "line_style", elementName, className, objName), "", objNum));
-    /// area
-    tempHis->SetFillColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "fill_color", elementName, className, objName), "", objNum));
-    tempHis->SetFillStyle(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "fill_style", elementName, className, objName), "", objNum));
-  }
+/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::SetCssStyle())
+/// \param cHis       - object inherited from TH1 in which you want to change style
+/*!
+  ####  Example use:
+  See AliDrawStyle::ApplyCssStyle();
+*/
+void AliDrawStyle::TH1ApplyStyle(const char* styleName, TH1 *cHis){
+
+  Bool_t  status    = false;
+  TString elementID = "";
+  TString classID   = "";
+  TString objectID  = "";
+  Int_t   objectNum = 0;
+  TString property  = "";
+  Int_t   valueI    = 0;
+  Float_t valueF    = 0.0;
+
+  AliDrawStyle::GetIds(cHis, elementID, classID, objectID, objectNum);
+
+  property = AliDrawStyle::GetProperty(styleName, "marker_color", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cHis->SetMarkerColor(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "marker_size", elementID, classID, objectID);
+  valueF = AliDrawStyle::GetNamedFloatAt(property, "", objectNum, status);
+  if (property != "" && status) cHis->SetMarkerSize(valueF);
+
+  property = AliDrawStyle::GetProperty(styleName, "marker_style", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cHis->SetMarkerStyle(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "line_color", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cHis->SetLineColor(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "line_width", elementID, classID, objectID);
+  valueF = AliDrawStyle::GetNamedFloatAt(property, "", objectNum, status);
+  if (property != "" && status) cHis->SetLineWidth(valueF);
+
+  property = AliDrawStyle::GetProperty(styleName, "line_style", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cHis->SetLineStyle(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "fill_color", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cHis->SetFillColor(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "fill_style", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cHis->SetFillStyle(valueI);
 }
 
 ///
-/// \param styleName
-/// \param tempFunc
-/// \param elementName
-/// \param className
-/// \param objName
-/// \param objNum
-void AliDrawStyle::TF1ApplyStyle(const char* styleName, TF1 *tempFunc, TString elementName, TString className, TString objName, Int_t objNum){
+/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::SetCssStyle())
+/// \param cFunc       - object inherited from TF1 in which you want to change style
+/*!
+  ####  Example use:
+  See AliDrawStyle::ApplyCssStyle();
   //still not implemented applyStyle for fitFunction for TH1
-  if(AliDrawStyle::IsSelected(AliDrawStyle::GetSelector(styleName),elementName, className, objName)){
-    tempFunc->SetMarkerColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "marker_color", elementName, className, objName), "", objNum));
-    tempFunc->SetMarkerSize(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "marker_size", elementName, className, objName), "", objNum));
-    tempFunc->SetMarkerStyle(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "marker_style", elementName, className, objName), "", objNum));
-    /// lines
-    tempFunc->SetLineColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "line_color", elementName, className, objName), "", objNum));
-    tempFunc->SetLineWidth(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "line_width", elementName, className, objName), "", objNum));
-    tempFunc->SetLineStyle(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "line_style", elementName, className, objName), "", objNum));
-    /// area
-    tempFunc->SetFillColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "fill_color", elementName, className, objName), "", objNum));
-    tempFunc->SetFillStyle(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "fill_style", elementName, className, objName), "", objNum));
-  }
+*/
+void AliDrawStyle::TF1ApplyStyle(const char* styleName, TF1 *cFunc) {
+
+  Bool_t  status    = false;
+  TString elementID = "";
+  TString classID   = "";
+  TString objectID  = "";
+  Int_t   objectNum = 0;
+  TString property  = "";
+  Int_t   valueI    = 0;
+  Float_t valueF    = 0.0;
+
+  AliDrawStyle::GetIds(cFunc, elementID, classID, objectID, objectNum);
+
+  property = AliDrawStyle::GetProperty(styleName, "marker_color", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cFunc->SetMarkerColor(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "marker_size", elementID, classID, objectID);
+  valueF = AliDrawStyle::GetNamedFloatAt(property, "", objectNum, status);
+  if (property != "" && status) cFunc->SetMarkerSize(valueF);
+
+  property = AliDrawStyle::GetProperty(styleName, "marker_style", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cFunc->SetMarkerStyle(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "line_color", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cFunc->SetLineColor(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "line_width", elementID, classID, objectID);
+  valueF = AliDrawStyle::GetNamedFloatAt(property, "", objectNum, status);
+  if (property != "" && status) cFunc->SetLineWidth(valueF);
+
+  property = AliDrawStyle::GetProperty(styleName, "line_style", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cFunc->SetLineStyle(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "fill_color", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cFunc->SetFillColor(valueI);
+
+  property = AliDrawStyle::GetProperty(styleName, "fill_style", elementID, classID, objectID);
+  valueI = AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status);
+  if (property != "" && status) cFunc->SetFillStyle(valueI);
 }
 
 ///
-/// \param styleName
-/// \param tempPad
-/// \param elementName
-/// \param className
-/// \param objName
-void AliDrawStyle::TPadApplyStyle(const char* styleName, TPad *tempPad, TString elementName, TString className, TString objName){
-  if(AliDrawStyle::IsSelected(AliDrawStyle::GetSelector(styleName),elementName, className, objName)){
-    tempPad->SetFillColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "fill_color", elementName, className, objName), "", 0));
-    tempPad->SetBottomMargin(AliDrawStyle::GetNamedFloatAt(AliDrawStyle::GetProperty(styleName, "bottom_margin", elementName, className, objName), "", 0));
-    tempPad->SetTopMargin(AliDrawStyle::GetNamedFloatAt(AliDrawStyle::GetProperty(styleName, "top_margin", elementName, className, objName), "", 0));
-    tempPad->SetLeftMargin(AliDrawStyle::GetNamedFloatAt(AliDrawStyle::GetProperty(styleName, "left_margin", elementName, className, objName), "", 0));
-    tempPad->SetRightMargin(AliDrawStyle::GetNamedFloatAt(AliDrawStyle::GetProperty(styleName, "right_margin", elementName, className, objName), "", 0));
-    tempPad->SetBorderSize(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "border_size", elementName, className, objName), "", 0));
-    tempPad->SetBorderMode(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "border_mode", elementName, className, objName), "", 0));
-    tempPad->SetGridx(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "gridX", elementName, className, objName), "", 0));
-    tempPad->SetGridy(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "gridY", elementName, className, objName), "", 0));
-    tempPad->SetTickx(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "tickX", elementName, className, objName), "", 0));
-    tempPad->SetTicky(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "tickY", elementName, className, objName), "", 0));
-    tempPad->SetLogx(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "logX", elementName, className, objName), "", 0));
-    tempPad->SetLogy(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "logY", elementName, className, objName), "", 0));
-    tempPad->SetLogz(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "logZ", elementName, className, objName), "", 0));
-  }
+/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::SetCssStyle())
+/// \param cPad       - object inherited from TPad in which you want to change style
+/*!
+  ####  Example use:
+  See AliDrawStyle::ApplyCssStyle();
+*/
+void AliDrawStyle::TPadApplyStyle(const char* styleName, TPad *cPad){
+
+  Bool_t  status    = false;
+  TString elementID = "";
+  TString classID   = "";
+  TString objectID  = "";
+  Int_t   objectNum = 0;
+  TString property  = "";
+
+  AliDrawStyle::GetIds(cPad, elementID, classID, objectID, objectNum);
+
+  property = AliDrawStyle::GetProperty(styleName, "fill_color", elementID, classID, objectID);
+  if (property != "") cPad->SetFillColor(AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "bottom_margin", elementID, classID, objectID);
+  if (property != "") cPad->SetBottomMargin(AliDrawStyle::GetNamedFloatAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "top_margin", elementID, classID, objectID);
+  if (property != "") cPad->SetTopMargin(AliDrawStyle::GetNamedFloatAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "left_margin", elementID, classID, objectID);
+  if (property != "") cPad->SetLeftMargin(AliDrawStyle::GetNamedFloatAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "right_margin", elementID, classID, objectID);
+  if (property != "") cPad->SetRightMargin(AliDrawStyle::GetNamedFloatAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "border_size", elementID, classID, objectID);
+  if (property != "") cPad->SetBorderSize(AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "border_mode", elementID, classID, objectID);
+  if (property != "") cPad->SetBorderMode(AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "gridX", elementID, classID, objectID);
+  if (property != "") cPad->SetGridx(AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "gridY", elementID, classID, objectID);
+  if (property != "") cPad->SetGridy(AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "tickX", elementID, classID, objectID);
+  if (property != "") cPad->SetTickx(AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "tickY", elementID, classID, objectID);
+  if (property != "") cPad->SetTicky(AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "logX", elementID, classID, objectID);
+  if (property != "") cPad->SetLogx(AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "logY", elementID, classID, objectID);
+  if (property != "") cPad->SetLogy(AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "logZ", elementID, classID, objectID);
+  if (property != "") cPad->SetLogz(AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status));
+
 }
 
 ///
-/// \param styleName
-/// \param tempCanvas
-/// \param elementName
-/// \param className
-/// \param objName
-void AliDrawStyle::TCanvasApplyCssStyle(const char* styleName, TCanvas *tempCanvas, TString elementName, TString className, TString objName){
-  if(AliDrawStyle::IsSelected(AliDrawStyle::GetSelector(styleName),elementName, className, objName)){
-    tempCanvas->SetFillColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "fill_color", elementName, className, objName), "", 0));
-    tempCanvas->SetBorderSize(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "border_size", elementName, className, objName), "", 0));
-    tempCanvas->SetBorderMode(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "border_mode", elementName, className, objName), "", 0));
-  }
+/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::SetCssStyle())
+/// \param cCanvas       - object inherited from TCanvas in which you want to change style
+/*!
+  ####  Example use:
+  See AliDrawStyle::ApplyCssStyle();
+*/
+void AliDrawStyle::TCanvasApplyCssStyle(const char* styleName, TCanvas *cCanvas){
+
+  Bool_t  status    = false;
+  TString elementID = "";
+  TString classID   = "";
+  TString objectID  = "";
+  Int_t   objectNum = 0;
+  TString property  = "";
+
+  AliDrawStyle::GetIds(cCanvas, elementID, classID, objectID, objectNum);
+
+  property = AliDrawStyle::GetProperty(styleName, "fill_color", elementID, classID, objectID);
+  if (property != "") cCanvas->SetFillColor(AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "border_size", elementID, classID, objectID);
+  if (property != "") cCanvas->SetBorderSize(AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status));
+
+  property = AliDrawStyle::GetProperty(styleName, "border_mode", elementID, classID, objectID);
+  if (property != "") cCanvas->SetBorderMode(AliDrawStyle::GetNamedIntegerAt(property, "", objectNum, status));
 }
 
 ///
-/// \param pad
-/// \param styleName
+/// \brief Method get IDs from the cObject->GetName() and parse it into input reference.
+///        Names of objects should according to css notation.
+///        #### Example of name:
+///        \code
+///           TH1F *hisArray[nHis];
+///           for (Int_t i=0; i<nHis; i++){
+///             hisArray[i] = new TH1F(TString::Format("his[%d].class(Raw,Error)",i).Data(),
+///                                    TString::Format("his[%d].class(Raw,Error)",i).Data(), 100, -2, 2);
+///           }
+///        \endcode
+///         Schema of parsing:
+///
+/// \param cObject    - input TObject
+/// \param elementID  - cObject->GetName()           (in example - TH1)
+/// \param classID    - values from .class(*)        (in example - Raw,Error)
+/// \param objectID   - value before number or class (in example - his )
+/// \param objNum     - number between [*]           (in example - i)
+void AliDrawStyle::GetIds(TObject *cObject, TString &elementID, TString &classID, TString &objectID, Int_t &objNum) {
+
+  elementID = cObject->ClassName();
+  objectID  = TString(cObject->GetName());
+  TPRegexp    classPat("[(].*[)]");
+  classID   = objectID(classPat);
+  classID   = classID(1, classID.Index(")") - 1);
+  TPRegexp    numPat0("[[].*[]]");
+  TPRegexp    numPat1("[0-9]+");
+  objNum    = TString(TString(objectID(numPat0))(numPat1)).Atoi();
+  TPRegexp    objPat(".*[[?]|.*[.]class|.*");
+  objectID  = TString(objectID(objPat)).ReplaceAll("[", "").ReplaceAll(".class", "");
+
+}
+
+/// \brief Applies style from css to all objects from Pad or Canvas.
+///        In case if pad inherited from TCanvas will work recursively for all pads from input canvas.
+/// \param pad       - Input TPad object. You can specify TCanvas in this case style will be apply recursively to all objects (TH1, TF1, TGraph) on pad.
+/// \param styleName - Name of style specify in AliDrawStyle::SetCssStyle()
+/*!
+  ####  Example use:
+   \code
+     .L $AliRoot_SRC/STAT/Macros/AliDrawStyleExample.C+
+     MakeTestPlot(); //           styleName,     ReadCssFile returns TOBjArray with set of attributes and values from css file.
+     AliDrawStyle::SetCssStyle("testStyle", AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
+     AliDrawStyle::ApplyCssStyle(gPad->GetCanvas(), "testStyle")
+   \endcode
+*/
 void AliDrawStyle::ApplyCssStyle(TPad *pad, const char* styleName){
-  /// if property not found nothig will be
-  TObjArray *pads = NULL;
-  TH1 *tempHis  = NULL;
-  TGraph *tempGraph  = NULL;
-  TF1 *tempFunc = NULL;
-  TPad *tempPad = NULL;
-  TObject *tempObj = NULL;
-  TCanvas *tempCanvas = NULL;
-  TList *oList = NULL;
-  Int_t objNum = 0;
-  TString classSet = "";
-  Ssiz_t fromStart;
-  TString elementName = "";
-  TString objName = "";
-  TString className = "";
-  TPRegexp classPat("[(].*[)]");
-  TPRegexp numPat0("[[].*[]]");
-  TPRegexp numPat1("[0-9]+");
-  TPRegexp objPat(".*[[?]|.*[.]class|.*");
+  if(pad == NULL){
+    ::Error("AliDrawStyle::ApplyCssStyle","Pad doesn't exist");
+    return;
+  }
+
+  TObject *cObj     = NULL;
+  TList   *oList    = NULL;
+  TString elementID = "";
+  TString objectID  = "";
+  TString classID   = "";
+  Int_t   objectNum = 0;
 
   oList = pad->GetListOfPrimitives();
+  GetIds(pad, elementID, classID, objectID, objectNum);
 
-  elementName = pad->ClassName();
-  objName = TString(pad->GetName());
-  classSet = objName(classPat);
-  objName = TString(objName(objPat)).ReplaceAll("[", "").ReplaceAll(".class", "");
-  classSet = classSet(1, classSet.Index(")") - 1);
-  fromStart = 0;
-
-  if(TString(pad->ClassName()) == "TCanvas"){
-    objName = TString(pad->GetTitle());
-    classSet = objName(classPat);
-    objName = TString(objName(objPat)).ReplaceAll("[", "").ReplaceAll(".class", "");
-    classSet = classSet(1, classSet.Index(")") - 1);
-    while(classSet.Tokenize(className,fromStart,",")){
-      tempCanvas = (TCanvas *) pad;
-      AliDrawStyle::TCanvasApplyCssStyle(styleName, tempCanvas, elementName, className, objName);
-    }
+  if (elementID == "TCanvas") {
+    AliDrawStyle::TCanvasApplyCssStyle(styleName, (TCanvas *) pad);
     pad->Modified();
-    for(Int_t c = 0; c < oList->GetEntries(); c++){
-      tempPad = (TPad *) oList->At(c);
-      AliDrawStyle::ApplyCssStyle(tempPad, styleName);
+    for(Int_t c = 0; c < oList->GetEntries(); c++) {
+      AliDrawStyle::ApplyCssStyle((TPad *) oList->At(c), styleName);
     }
   }
 
-  if(TString(pad->ClassName()) == "TPad") while(classSet.Tokenize(className,fromStart,",")) AliDrawStyle::TPadApplyStyle(styleName, pad, elementName, className, objName);
+  if (elementID == "TPad") AliDrawStyle::TPadApplyStyle(styleName, pad);
 
-  for (Int_t k = 0;k < oList->GetEntries(); k++)
-  {
-      tempObj = oList->At(k);
-      if(tempObj->InheritsFrom("TH1") || tempObj->InheritsFrom("TGraph") || tempObj->InheritsFrom("TF1")){
-        elementName = tempObj->ClassName();
-        objName = TString(tempObj->GetName());
-        classSet = objName(classPat);
-        objNum = TString(TString(objName(numPat0))(numPat1)).Atoi();
-        objName = TString(objName(objPat)).ReplaceAll("[", "").ReplaceAll(".class", "");
-        classSet = classSet(1, classSet.Index(")") - 1);
-        fromStart = 0;
-        while(classSet.Tokenize(className,fromStart,",")){
-          if(tempObj->InheritsFrom("TH1") && AliDrawStyle::CountObjects(pad, elementName) > objNum) AliDrawStyle::TH1ApplyStyle(styleName, (TH1 *) tempObj, elementName, className, objName, objNum);
-          if(tempObj->InheritsFrom("TGraph") && AliDrawStyle::CountObjects(pad, elementName) > objNum) AliDrawStyle::TGraphApplyStyle (styleName, (TGraph *) tempObj, elementName, className, objName, objNum);
-          if(tempObj->InheritsFrom("TF1") && AliDrawStyle::CountObjects(pad, elementName) > objNum) AliDrawStyle::TF1ApplyStyle(styleName, (TF1 *) tempObj, elementName, className, objName, objNum);
-      }
-    }
+  for (Int_t k = 0; k < oList->GetEntries(); k++) {
+      cObj = oList->At(k);
+      GetIds(cObj, elementID, classID, objectID, objectNum);
+      if (cObj->InheritsFrom("TH1")) AliDrawStyle::TH1ApplyStyle(styleName, (TH1 *) cObj);
+      if (cObj->InheritsFrom("TGraph")) AliDrawStyle::TGraphApplyStyle (styleName, (TGraph *) cObj);
+      if (cObj->InheritsFrom("TF1")) AliDrawStyle::TF1ApplyStyle(styleName, (TF1 *) cObj);
   }
-   pad->Modified();
-}
-
-
-
-///
-/// \param pad
-/// \param division
-/// \param token
-void AliDrawStyle::DivideTPad(TPad*pad, const char *division, const char *token) {
-  // divide pads
-  Int_t nPads = 0, nRows = 0;
-  TObjArray *padRows = TString(division).Tokenize("[](),");
-  nRows = padRows->GetEntries();
-  for (Int_t iRow = 0; iRow < nRows; iRow++) {
-    Int_t nCols = TString(padRows->At(iRow)->GetName()).Atoi();
-    for (Int_t iCol = 0; iCol < nCols; iCol++) {
-      pad->cd();
-      TPad *newPad = new TPad(Form("pad%d", nPads), Form("pad%d", nPads), iCol / Double_t(nCols),
-                              (nRows - iRow - 1) / Double_t(nRows), (iCol + 1) / Double_t(nCols),
-                              (nRows - iRow) / Double_t(nRows));
-      newPad->Draw();
-      nPads++;
-      newPad->SetNumber(nPads);
-    }
-  }
-}
-
-
-///
-/// \param graph
-/// \param option
-void AliDrawStyle::SetMultiGraphTimeAxis(TMultiGraph *graph, TString option){
-  TAxis *axis = NULL;
-  for (Int_t i=0; i<graph->GetListOfGraphs()->GetEntries(); i++) {
-    TGraph *cGraph=(TGraph *) graph->GetListOfGraphs()->At(i);
-    if (option.Contains("X")) axis = cGraph->GetXaxis();
-    if (option.Contains("Y")) axis = cGraph->GetYaxis();
-    if (axis) {
-      axis->SetNdivisions(510, kFALSE);
-      axis->SetTimeDisplay(1);
-      axis->SetTimeFormat("%d/%m");
-    }
-  }
+  pad->Modified();
 }

--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -333,7 +333,8 @@ void  AliDrawStyle::RegisterDefaultMarkers(){
   (fMarkerSize["figTemplate"])=std::vector<float>(10);
   (fFillColors["figTemplate"])=std::vector<int>(10);
   (fLineWidth["figTemplate"])=std::vector<float>(10);
-  (fLineColor["figTemplate"])=std::vector<float>(10);  
+  (fLineColor["figTemplate"])=std::vector<float>(10);
+  (fLineStyle["figTemplate"])=std::vector<float>(10);
   for (Int_t i=0;i<10; i++){
     (fMarkerStyles["figTemplate"])[i]=markers[i];
     (fMarkerColors["figTemplate"])[i]=colors[i];
@@ -364,12 +365,13 @@ void  AliDrawStyle::RegisterDefaultMarkers(){
   (fMarkerSize["figTemplateTRD"])=std::vector<float>(10);
   (fFillColors["figTemplateTRD"])=std::vector<int>(10);
   (fLineWidth["figTemplateTRD"])=std::vector<float>(10);
+  (fLineStyle["figTemplateTRD"])=std::vector<float>(10);
   (fMarkerStyles["figTemplateTRDPair"])=std::vector<int>(10);
   (fMarkerColors["figTemplateTRDPair"])=std::vector<int>(10);
   (fMarkerSize["figTemplateTRDPair"])=std::vector<float>(10);
   (fFillColors["figTemplateTRDPair"])=std::vector<int>(10);
   (fLineWidth["figTemplateTRDPair"])=std::vector<float>(10);
-
+  (fLineStyle["figTemplateTRDPair"])=std::vector<float>(10);
   for (Int_t i=0; i<10; i++){
     (fMarkerStyles["figTemplateTRD"])[i]=markersTRD[i];
     (fMarkerColors["figTemplateTRD"])[i]=TColor::GetColorDark(colorsTRD[i]);

--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -70,6 +70,8 @@ std::map<TString, std::vector<int> > AliDrawStyle::fMarkerColors;  // IN ORDER T
 std::map<TString, std::vector<float> > AliDrawStyle::fMarkerSize;  // NATIVE SLC6 COMPILER!!!
 std::map<TString, std::vector<int> > AliDrawStyle::fFillColors;
 std::map<TString, std::vector<float> > AliDrawStyle::fLineWidth;
+std::map<TString, std::vector<float> > AliDrawStyle::fLineStyle;
+std::map<TString, std::vector<float> > AliDrawStyle::fLineColor;
 
 void AliDrawStyle::SetDefaults(){
   AliDrawStyle::RegisterDefaultLatexSymbols();
@@ -168,6 +170,28 @@ Int_t AliDrawStyle::GetMarkerStyle(const char *style, Int_t index){
     return GetIntegerAt(style,index);
   }
   return  AliDrawStyle::fMarkerStyles[style][index];
+}
+
+// GetLineStyle associated to the style.
+/// \param  style - name of style used
+/// \param index  - marker index
+/// \return marker style for given stylename, index
+Int_t AliDrawStyle::GetLineStyle(const char *style, Int_t index){
+  if (AliDrawStyle::fLineStyle[style].size() <= index) {
+    return GetIntegerAt(style,index);
+  }
+  return  AliDrawStyle::fLineStyle[style][index];
+}
+
+// GetLineColor associated to the style.
+/// \param  style - name of style used
+/// \param index  - marker index
+/// \return marker style for given stylename, index
+Int_t AliDrawStyle::GetLineColor(const char *style, Int_t index){
+  if (AliDrawStyle::fLineColor[style].size() <= index) {
+    return GetIntegerAt(style,index);
+  }
+  return  AliDrawStyle::fLineColor[style][index];
 }
 
 /// GetMarkerColor associated to the style.
@@ -309,12 +333,15 @@ void  AliDrawStyle::RegisterDefaultMarkers(){
   (fMarkerSize["figTemplate"])=std::vector<float>(10);
   (fFillColors["figTemplate"])=std::vector<int>(10);
   (fLineWidth["figTemplate"])=std::vector<float>(10);
+  (fLineColor["figTemplate"])=std::vector<float>(10);  
   for (Int_t i=0;i<10; i++){
     (fMarkerStyles["figTemplate"])[i]=markers[i];
     (fMarkerColors["figTemplate"])[i]=colors[i];
     (fMarkerSize["figTemplate"])[i]=1;
     (fFillColors["figTemplate"])[i]=fillColors[i];
     (fLineWidth["figTemplate"])[i]=0.5;
+    (fLineStyle["figTemplate"])[i]=i+1;   
+    (fLineColor["figTemplate"])[i]=colors[i];    
   }
   // style inspired by TRD performance paper
   Int_t colorsTRD[12]={0};

--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -74,6 +74,11 @@
 #include <iostream>
 #include <fstream>
 #include <iomanip>
+#include "TPad.h"
+#include "TGraph.h"
+#include "TMultiGraph.h"
+#include "TAxis.h"
+#include "TList.h"
 #include <ios>
 
 using namespace std;

--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -538,7 +538,7 @@ Float_t  AliDrawStyle::GetNamedFloatAt(TString input, TString propertyName, Int_
 /// \param inputName     - input file to read
 /// \param verbose       - specify verbose level for ::error and ::info (Int_t should be interpreted as an bit-mask)
 /// \return              - TObjArray  with the pairs TNamed of the CSS <Selector, declaration> or  TObjArray (recursive structure like includes)
-TObjArray * AliDrawStyle::ReadCSSFile(const char *  inputName, Int_t verbose){
+TObjArray * AliDrawStyle::ReadCSSFile(const char *  inputName, TObjArray * cssArray, Int_t verbose){
   //check file exist
   TString inputCSS = gSystem->GetFromPipe(TString::Format("cat %s",inputName).Data());     // I expect this variable is defined
   //remove comments:
@@ -548,7 +548,9 @@ TObjArray * AliDrawStyle::ReadCSSFile(const char *  inputName, Int_t verbose){
     //inputCSS.ReplaceAll("\n", ""); we can add this, in the other case ClassName will be like "\n .TH*", but I suppose it doesn't matter.
   TObjArray *tokenArray = inputCSS.Tokenize("{}");   //assuming we can not use {} symbols in the style IDS
   Int_t entries = tokenArray->GetEntries();
-  TObjArray *cssArray = new TObjArray(entries / 2);
+  if (cssArray==NULL) {
+    cssArray = new TObjArray(entries / 2);
+  }
   for (Int_t i = 0; i < entries; i += 2) {
     if (i + 1 >= entries) continue;
     TString selector = tokenArray->At(i)->GetName();
@@ -687,16 +689,22 @@ Int_t AliDrawStyle::CountObjects(TPad *cPad, TString className){
   return cnt;
 }
 
-
+///
+/// \param styleName
+/// \param tempGraph
+/// \param elementName
+/// \param className
+/// \param objName
+/// \param objNum
 void AliDrawStyle::TGraphApplyStyle(const char* styleName, TGraph *tempGraph, TString elementName, TString className, TString objName, Int_t objNum){
   // if styleName not exist use defaults?
   if(AliDrawStyle::IsSelected(AliDrawStyle::GetSelector(styleName),elementName, className, objName)){
     tempGraph->SetMarkerColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "marker_color", elementName, className, objName), "", objNum));
-    tempGraph->SetMarkerSize(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "marker_size", elementName, className, objName), "", objNum));
+    tempGraph->SetMarkerSize(AliDrawStyle::GetNamedFloatAt(AliDrawStyle::GetProperty(styleName, "marker_size", elementName, className, objName), "", objNum));
     tempGraph->SetMarkerStyle(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "marker_style", elementName, className, objName), "", objNum));
     /// lines
     tempGraph->SetLineColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "line_color", elementName, className, objName), "", objNum));
-    tempGraph->SetLineWidth(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "line_width", elementName, className, objName), "", objNum));
+    tempGraph->SetLineWidth(AliDrawStyle::GetNamedFloatAt(AliDrawStyle::GetProperty(styleName, "line_width", elementName, className, objName), "", objNum));
     tempGraph->SetLineStyle(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "line_style", elementName, className, objName), "", objNum));
     /// area
     tempGraph->SetFillColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "fill_color", elementName, className, objName), "", objNum));
@@ -704,10 +712,17 @@ void AliDrawStyle::TGraphApplyStyle(const char* styleName, TGraph *tempGraph, TS
   }
 }
 
+///
+/// \param styleName
+/// \param tempHis
+/// \param elementName
+/// \param className
+/// \param objName
+/// \param objNum
 void AliDrawStyle::TH1ApplyStyle(const char* styleName, TH1 *tempHis, TString elementName, TString className, TString objName, Int_t objNum){
   if(AliDrawStyle::IsSelected(AliDrawStyle::GetSelector(styleName),elementName, className, objName)){
     tempHis->SetMarkerColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "marker_color", elementName, className, objName), "", objNum));
-    tempHis->SetMarkerSize(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "marker_size", elementName, className, objName), "", objNum));
+    tempHis->SetMarkerSize(AliDrawStyle::GetNamedFloatAt(AliDrawStyle::GetProperty(styleName, "marker_size", elementName, className, objName), "", objNum));
     tempHis->SetMarkerStyle(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "marker_style", elementName, className, objName), "", objNum));
     /// lines
     tempHis->SetLineColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "line_color", elementName, className, objName), "", objNum));
@@ -719,6 +734,13 @@ void AliDrawStyle::TH1ApplyStyle(const char* styleName, TH1 *tempHis, TString el
   }
 }
 
+///
+/// \param styleName
+/// \param tempFunc
+/// \param elementName
+/// \param className
+/// \param objName
+/// \param objNum
 void AliDrawStyle::TF1ApplyStyle(const char* styleName, TF1 *tempFunc, TString elementName, TString className, TString objName, Int_t objNum){
   //still not implemented applyStyle for fitFunction for TH1
   if(AliDrawStyle::IsSelected(AliDrawStyle::GetSelector(styleName),elementName, className, objName)){
@@ -735,6 +757,12 @@ void AliDrawStyle::TF1ApplyStyle(const char* styleName, TF1 *tempFunc, TString e
   }
 }
 
+///
+/// \param styleName
+/// \param tempPad
+/// \param elementName
+/// \param className
+/// \param objName
 void AliDrawStyle::TPadApplyStyle(const char* styleName, TPad *tempPad, TString elementName, TString className, TString objName){
   if(AliDrawStyle::IsSelected(AliDrawStyle::GetSelector(styleName),elementName, className, objName)){
     tempPad->SetFillColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "fill_color", elementName, className, objName), "", 0));
@@ -754,15 +782,23 @@ void AliDrawStyle::TPadApplyStyle(const char* styleName, TPad *tempPad, TString 
   }
 }
 
+///
+/// \param styleName
+/// \param tempCanvas
+/// \param elementName
+/// \param className
+/// \param objName
 void AliDrawStyle::TCanvasApplyCssStyle(const char* styleName, TCanvas *tempCanvas, TString elementName, TString className, TString objName){
   if(AliDrawStyle::IsSelected(AliDrawStyle::GetSelector(styleName),elementName, className, objName)){
     tempCanvas->SetFillColor(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "fill_color", elementName, className, objName), "", 0));
     tempCanvas->SetBorderSize(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "border_size", elementName, className, objName), "", 0));
     tempCanvas->SetBorderMode(AliDrawStyle::GetNamedIntegerAt(AliDrawStyle::GetProperty(styleName, "border_mode", elementName, className, objName), "", 0));
   }
-
 }
 
+///
+/// \param pad
+/// \param styleName
 void AliDrawStyle::ApplyCssStyle(TPad *pad, const char* styleName){
   /// if property not found nothig will be
   TObjArray *pads = NULL;

--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -354,7 +354,7 @@ void  AliDrawStyle::RegisterDefaultMarkers(){
   }
   // style inspired by TRD performance paper
   Int_t colorsTRD[12]={0};
-  const Int_t markersTRD[]    = {kOpenCircle,kFullCircle, kOpenSquare,kFullSquare, kOpenStar,kFullStar, kOpenDiamond,kFullDiamond, kOpenCross,kFullCross };
+  const Int_t markersTRD[]    = {kOpenSquare,kFullSquare, kOpenStar,kFullStar, kOpenCircle,kFullCircle, kOpenDiamond,kFullDiamond, kOpenCross,kFullCross };
   const Float_t markerTRDSize[]    = {1,1, 0.9,0.9, 1.4,1.4, 1.1,1.1, 1.2,1.2 };
   colorsTRD[0]=TColor::GetColor("#0000DD");
   colorsTRD[1]=TColor::GetColor("#00EE00");

--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -686,7 +686,7 @@ Bool_t  AliDrawStyle::IsSelected(TString selectors, TString elementID, TString c
   }
 
 ///
-/// \param styleName      - name of predefined array with styles (see. AliDrawStyle::SetCssStyle())
+/// \param styleName      - name of predefined array with styles (see. AliDrawStyle::RegisterCssStyle())
 /// \param propertyName   - name of property according to css notation
 /// \param elementID
 /// \param classID
@@ -695,7 +695,7 @@ Bool_t  AliDrawStyle::IsSelected(TString selectors, TString elementID, TString c
 /*!
   ####  Example use:
    \code
-   AliDrawStyle::SetCssStyle("alirootTestStyle.css",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
+   AliDrawStyle::RegisterCssStyle("alirootTestStyle.css",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
    AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "", "obj1");                      // "33,34,35,36"
    AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "", "TPC.QA.dcar_posA_1");        // "1,2,3,4"
    AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "Warning", "TPC.QA.dcar_posA_1"); // ""
@@ -722,7 +722,7 @@ TString AliDrawStyle::GetProperty(const char *styleName, TString propertyName,
 }
 
 ///
-/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::SetCssStyle())
+/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::RegisterCssStyle())
 /// \param cGraph       - object inherited from TGraph in which you want to change style
 /*!
   ####  Example use:
@@ -775,7 +775,7 @@ void AliDrawStyle::TGraphApplyStyle(const char* styleName, TGraph *cGraph){
 }
 
 ///
-/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::SetCssStyle())
+/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::RegisterCssStyle())
 /// \param cHis       - object inherited from TH1 in which you want to change style
 /*!
   ####  Example use:
@@ -828,7 +828,7 @@ void AliDrawStyle::TH1ApplyStyle(const char* styleName, TH1 *cHis){
 }
 
 ///
-/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::SetCssStyle())
+/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::RegisterCssStyle())
 /// \param cFunc       - object inherited from TF1 in which you want to change style
 /*!
   ####  Example use:
@@ -882,7 +882,7 @@ void AliDrawStyle::TF1ApplyStyle(const char* styleName, TF1 *cFunc) {
 }
 
 ///
-/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::SetCssStyle())
+/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::RegisterCssStyle())
 /// \param cPad       - object inherited from TPad in which you want to change style
 /*!
   ####  Example use:
@@ -944,7 +944,7 @@ void AliDrawStyle::TPadApplyStyle(const char* styleName, TPad *cPad){
 }
 
 ///
-/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::SetCssStyle())
+/// \param styleName    - name of predefined array with styles (see. AliDrawStyle::RegisterCssStyle())
 /// \param cCanvas       - object inherited from TCanvas in which you want to change style
 /*!
   ####  Example use:
@@ -1007,13 +1007,13 @@ void AliDrawStyle::GetIds(TObject *cObject, TString &elementID, TString &classID
 /// \brief Applies style from css to all objects from Pad or Canvas.
 ///        In case if pad inherited from TCanvas will work recursively for all pads from input canvas.
 /// \param pad       - Input TPad object. You can specify TCanvas in this case style will be apply recursively to all objects (TH1, TF1, TGraph) on pad.
-/// \param styleName - Name of style specify in AliDrawStyle::SetCssStyle()
+/// \param styleName - Name of style specify in AliDrawStyle::RegisterCssStyle()
 /*!
   ####  Example use:
    \code
      .L $AliRoot_SRC/STAT/Macros/AliDrawStyleExample.C+
      MakeTestPlot(); //           styleName,     ReadCssFile returns TOBjArray with set of attributes and values from css file.
-     AliDrawStyle::SetCssStyle("testStyle", AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
+     AliDrawStyle::RegisterCssStyle("testStyle", AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
      AliDrawStyle::ApplyCssStyle(gPad->GetCanvas(), "testStyle")
    \endcode
 */

--- a/STAT/AliDrawStyle.cxx
+++ b/STAT/AliDrawStyle.cxx
@@ -831,3 +831,46 @@ void AliDrawStyle::ApplyCssStyle(TPad *pad, const char* styleName){
   }
    pad->Modified();
 }
+
+
+
+///
+/// \param pad
+/// \param division
+/// \param token
+void AliDrawStyle::DivideTPad(TPad*pad, const char *division, const char *token) {
+  // divide pads
+  Int_t nPads = 0, nRows = 0;
+  TObjArray *padRows = TString(division).Tokenize("[](),");
+  nRows = padRows->GetEntries();
+  for (Int_t iRow = 0; iRow < nRows; iRow++) {
+    Int_t nCols = TString(padRows->At(iRow)->GetName()).Atoi();
+    for (Int_t iCol = 0; iCol < nCols; iCol++) {
+      pad->cd();
+      TPad *newPad = new TPad(Form("pad%d", nPads), Form("pad%d", nPads), iCol / Double_t(nCols),
+                              (nRows - iRow - 1) / Double_t(nRows), (iCol + 1) / Double_t(nCols),
+                              (nRows - iRow) / Double_t(nRows));
+      newPad->Draw();
+      nPads++;
+      newPad->SetNumber(nPads);
+    }
+  }
+}
+
+
+///
+/// \param graph
+/// \param option
+void AliDrawStyle::SetMultiGraphTimeAxis(TMultiGraph *graph, TString option){
+  TAxis *axis = NULL;
+  for (Int_t i=0; i<graph->GetListOfGraphs()->GetEntries(); i++) {
+    TGraph *cGraph=(TGraph *) graph->GetListOfGraphs()->At(i);
+    if (option.Contains("X")) axis = cGraph->GetXaxis();
+    if (option.Contains("Y")) axis = cGraph->GetYaxis();
+    if (axis) {
+      axis->SetNdivisions(510, kFALSE);
+      axis->SetTimeDisplay(1);
+      axis->SetTimeFormat("%d/%m");
+    }
+  }
+}

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -61,16 +61,22 @@ class AliDrawStyle : public TObject{
 public:
   static void ApplyStyle(const char * styleName);
   static const TStyle *GetStyle(const char * styleName) {return fStyleAlice[styleName];}
+  /// \brief Get Css style by styleName.
+  ///  Getter for css style.
+  /// \param styleName  - name of style.
+  /// \return           - TObjArray with pair selector and declaration from css file.
   static const TObjArray *GetCssStyle(const char *styleName){return fCssStyleAlice[styleName];}
-  static TString GetSelector(const char *styleName);
-  static Int_t CountObjects(TPad *cPad, TString className);
-  static void TGraphApplyStyle(const char* styleName, TGraph *tempGraph, TString elementName, TString className, TString objName, Int_t objNum);
-  static void TH1ApplyStyle(const char* styleName, TH1 *tempHis, TString elementName, TString className, TString objName, Int_t objNum);
-  static void TF1ApplyStyle(const char* styleName, TF1 *tempFunc, TString elementName, TString className, TString objName, Int_t objNum);
-  static void TPadApplyStyle(const char* styleName, TPad *tempPad, TString elementName, TString className, TString objName);
-  static void TCanvasApplyCssStyle(const char* styleName, TCanvas *tempCanvas, TString elementName, TString className, TString objName);
+  static void TGraphApplyStyle(const char* styleName, TGraph *cGraph);
+  static void TH1ApplyStyle(const char* styleName, TH1 *cHis);
+  static void TF1ApplyStyle(const char* styleName, TF1 *cFunc);
+  static void TPadApplyStyle(const char* styleName, TPad *cPad);
+  static void TCanvasApplyCssStyle(const char* styleName, TCanvas *cCanvas);
   static void ApplyCssStyle(TPad *pad, const char* styleName);
-  static void  SetCssStyle(const char *styleName, TObjArray*array ){ fCssStyleAlice[styleName]=array;}
+  /// \brief Set Css style by styleName.
+  ///  Setter for css style.
+  /// \param styleName  - name of style.
+  /// \param array      - TObjArray with pair selector and declaration from css file.
+  static void SetCssStyle(const char *styleName, TObjArray*array ){ fCssStyleAlice[styleName]=array;}
   static void SetDefaults();
   static void SetDefaultStyles(const char * styleName, const char* arrayName);
   static TString GetLatexAlice(const char * symbol);
@@ -81,11 +87,13 @@ public:
   static const std::vector<float> &  GetLineWidth(const char *style){return AliDrawStyle::fLineWidth[style];};
   static const std::vector<int> &    GetFillColors(const char *style){return AliDrawStyle::fFillColors[style];};
   // CSS like attribute fields parsing
-  static TString GetProperty(const char * styleName, TString propertyName, TString elementName, TString className, TString objectName);
+  static Bool_t  IsSelected(TString selectors, TString elementID, TString classID, TString objectID);
+  static TString GetProperty(const char * styleName, TString propertyName, TString elementID, TString classID, TString objectID);
   static TString  GetPropertyValue(TString input, TString propertyName);
-  static Int_t    GetNamedIntegerAt(TString input, TString propertyName, Int_t index);
-  static Float_t  GetNamedFloatAt(TString input, TString propertyName, Int_t index);
-  static Bool_t  IsSelected(TString selectors, TString elementName, TString className, TString objectName);
+  //static Int_t    GetObjectIndex(TString &objName);
+  static void     GetIds(TObject *cObj, TString &elementID, TString &classSet, TString &objectID, Int_t &objNum);
+  static Int_t    GetNamedIntegerAt(TString input, TString propertyName, Int_t index, Bool_t &status);
+  static Float_t  GetNamedFloatAt(TString input, TString propertyName, Int_t index, Bool_t &status);
   static TObjArray * ReadCSSFile(const char *  inputName, TObjArray * array=NULL, Int_t verbose=0);
   static void    WriteCSSFile(TObjArray * cssArray, const char *  outputName, fstream *cssOut=NULL);
   //
@@ -101,9 +109,6 @@ public:
   static Float_t GetLineWidth(const char *style, Int_t index);
   static void PrintLatexSymbols(Option_t *option,TPRegexp& regExp);
   static void PrintStyles(Option_t *option, TPRegexp& regExp);
-  // Drawing part - will be another class
-  static void DivideTPad(TPad*pad, const char *division, const char *token=",");
-  static void SetMultiGraphTimeAxis(TMultiGraph *graph, TString option);
 protected:
   static TString fDefaultTStyleID;                            ///< ID of the default TStyle
   static TString fDefaultArrayStyleID;                        ///< ID of the default array styles

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -66,6 +66,10 @@ public:
   static const std::vector<int> &    GetMarkerColors(const char *style){return AliDrawStyle::fMarkerColors[style];};
   static const std::vector<float> &  GetLineWidth(const char *style){return AliDrawStyle::fLineWidth[style];};
   static const std::vector<int> &    GetFillColors(const char *style){return AliDrawStyle::fFillColors[style];};
+  // CSS like attribute fields parsing
+  static TString  GetAttributeValue(TString input, TString tagName);
+  static Int_t    GetNamedIntegerAt(TString input, TString tagName, Int_t index);
+  static Float_t  GetNamedFloatAt(TString input, TString tagName, Int_t index);
   //
   static Int_t   GetIntegerAt(const char * format, Int_t index, const char * separator=";");
   static Float_t GetFloatAt(const char * format, Int_t index, const char * separator=";");

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -73,6 +73,8 @@ public:
   static Float_t GetMarkerSize(const char *style, Int_t index);
   static Int_t   GetMarkerColor(const char *style, Int_t index);
   static Int_t   GetFillColor(const char *style, Int_t index);
+  static Int_t   GetLineStyle(const char *style, Int_t index);  
+  static Int_t   GetLineColor(const char *style, Int_t index);    
   static Float_t GetLineWidth(const char *style, Int_t index);
   static void PrintLatexSymbols(Option_t *option,TPRegexp& regExp);
   static void PrintStyles(Option_t *option, TPRegexp& regExp);
@@ -86,6 +88,8 @@ protected:
   static std::map<TString, std::vector<float> > fMarkerSize;  ///< map of predefined marker sizes ()
   static std::map<TString, std::vector<int> > fFillColors;    ///< map of predefined fill colors arrays
   static std::map<TString, std::vector<float> > fLineWidth;   ///< map of predefined line width
+  static std::map<TString, std::vector<float> > fLineStyle;   ///< map of predefined line style 
+  static std::map<TString, std::vector<float> > fLineColor;   ///< map of predefined line color
   //
   static void  RegisterDefaultLatexSymbols();                 ///< initialize default LatexSymbols
   static void  RegisterDefaultStyle();                        ///< initialize default TStyles

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -70,6 +70,10 @@ public:
   static TString  GetAttributeValue(TString input, TString tagName);
   static Int_t    GetNamedIntegerAt(TString input, TString tagName, Int_t index);
   static Float_t  GetNamedFloatAt(TString input, TString tagName, Int_t index);
+  static Bool_t  IsSelected(TString selector, TString className, TString objectName);
+  static TObjArray * ReadCSSFile(const char *  inputName,Int_t verbose);
+  static void    WriteCSSFile(TObjArray * cssArray, const char *  outputName, fstream *pcssOut=NULL);
+  //
   //
   static Int_t   GetIntegerAt(const char * format, Int_t index, const char * separator=";");
   static Float_t GetFloatAt(const char * format, Int_t index, const char * separator=";");

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -76,7 +76,7 @@ public:
   ///  Setter for css style.
   /// \param styleName  - name of style.
   /// \param array      - TObjArray with pair selector and declaration from css file.
-  static void SetCssStyle(const char *styleName, TObjArray*array ){ fCssStyleAlice[styleName]=array;}
+  static void RegisterCssStyle(const char *styleName, TObjArray*array ){ fCssStyleAlice[styleName]=array;}
   static void SetDefaults();
   static void SetDefaultStyles(const char * styleName, const char* arrayName);
   static TString GetLatexAlice(const char * symbol);

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -52,12 +52,24 @@
 class TPRegexp;
 class TStyle;
 class TPad;
+class TCanvas;
+class TF1;
+class TH1;
+class TGraph;
 
 class AliDrawStyle : public TObject{
 public:
   static void ApplyStyle(const char * styleName);
   static const TStyle *GetStyle(const char * styleName) {return fStyleAlice[styleName];}
   static const TObjArray *GetCssStyle(const char *styleName){return fCssStyleAlice[styleName];}
+  static TString GetSelector(const char *styleName);
+  static Int_t CountObjects(TPad *cPad, TString className);
+  static void TGraphApplyStyle(const char* styleName, TGraph *tempGraph, TString elementName, TString className, TString objName, Int_t objNum);
+  static void TH1ApplyStyle(const char* styleName, TH1 *tempHis, TString elementName, TString className, TString objName, Int_t objNum);
+  static void TF1ApplyStyle(const char* styleName, TF1 *tempFunc, TString elementName, TString className, TString objName, Int_t objNum);
+  static void TPadApplyStyle(const char* styleName, TPad *tempPad, TString elementName, TString className, TString objName);
+  static void TCanvasApplyCssStyle(const char* styleName, TCanvas *tempCanvas, TString elementName, TString className, TString objName);
+  static void ApplyCssStyle(TPad *pad, const char* styleName);
   static void  SetCssStyle(const char *styleName, TObjArray*array ){ fCssStyleAlice[styleName]=array;}
   static void SetDefaults();
   static void SetDefaultStyles(const char * styleName, const char* arrayName);

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -49,6 +49,8 @@
 #include <vector>
 #include <string>
 #include "TString.h"
+#include <iostream>     // std::cout
+#include <fstream>
 class TPRegexp;
 class TStyle;
 class TPad;
@@ -94,8 +96,9 @@ public:
   static void     GetIds(TObject *cObj, TString &elementID, TString &classSet, TString &objectID, Int_t &objNum);
   static Int_t    GetNamedIntegerAt(TString input, TString propertyName, Int_t index, Bool_t &status);
   static Float_t  GetNamedFloatAt(TString input, TString propertyName, Int_t index, Bool_t &status);
+  static Double_t UnitsConverter(TString value, Double_t k);
   static TObjArray * ReadCSSFile(const char *  inputName, TObjArray * array=NULL, Int_t verbose=0);
-  static void    WriteCSSFile(TObjArray * cssArray, const char *  outputName, fstream *cssOut=NULL);
+  static void    WriteCSSFile(TObjArray * cssArray, const char *  outputName, std::fstream *cssOut=NULL);
   //
   //
   static Int_t   GetIntegerAt(const char * format, Int_t index, const char * separator=";");

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -86,7 +86,7 @@ public:
   static Int_t    GetNamedIntegerAt(TString input, TString propertyName, Int_t index);
   static Float_t  GetNamedFloatAt(TString input, TString propertyName, Int_t index);
   static Bool_t  IsSelected(TString selectors, TString elementName, TString className, TString objectName);
-  static TObjArray * ReadCSSFile(const char *  inputName,Int_t verbose);
+  static TObjArray * ReadCSSFile(const char *  inputName, TObjArray * array=NULL, Int_t verbose=0);
   static void    WriteCSSFile(TObjArray * cssArray, const char *  outputName, fstream *cssOut=NULL);
   //
   //

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -56,7 +56,7 @@ class TCanvas;
 class TF1;
 class TH1;
 class TGraph;
-
+class TMultiGraph;
 class AliDrawStyle : public TObject{
 public:
   static void ApplyStyle(const char * styleName);
@@ -101,6 +101,9 @@ public:
   static Float_t GetLineWidth(const char *style, Int_t index);
   static void PrintLatexSymbols(Option_t *option,TPRegexp& regExp);
   static void PrintStyles(Option_t *option, TPRegexp& regExp);
+  // Drawing part - will be another class
+  static void DivideTPad(TPad*pad, const char *division, const char *token=",");
+  static void SetMultiGraphTimeAxis(TMultiGraph *graph, TString option);
 protected:
   static TString fDefaultTStyleID;                            ///< ID of the default TStyle
   static TString fDefaultArrayStyleID;                        ///< ID of the default array styles

--- a/STAT/AliDrawStyle.h
+++ b/STAT/AliDrawStyle.h
@@ -55,10 +55,12 @@ class TPad;
 
 class AliDrawStyle : public TObject{
 public:
-  static void ApplyStyle(const char* styleName);
+  static void ApplyStyle(const char * styleName);
   static const TStyle *GetStyle(const char * styleName) {return fStyleAlice[styleName];}
+  static const TObjArray *GetCssStyle(const char *styleName){return fCssStyleAlice[styleName];}
+  static void  SetCssStyle(const char *styleName, TObjArray*array ){ fCssStyleAlice[styleName]=array;}
   static void SetDefaults();
-  static void SetDefaultStyles(const char * tstyleName, const char* arrayName);
+  static void SetDefaultStyles(const char * styleName, const char* arrayName);
   static TString GetLatexAlice(const char * symbol);
   static void AddLatexSymbol(const char * symbolName, const char * symbolTitle);
   static const std::vector<int> &    GetMarkerStyles(const char *style){return AliDrawStyle::fMarkerStyles[style];};
@@ -67,12 +69,13 @@ public:
   static const std::vector<float> &  GetLineWidth(const char *style){return AliDrawStyle::fLineWidth[style];};
   static const std::vector<int> &    GetFillColors(const char *style){return AliDrawStyle::fFillColors[style];};
   // CSS like attribute fields parsing
-  static TString  GetAttributeValue(TString input, TString tagName);
-  static Int_t    GetNamedIntegerAt(TString input, TString tagName, Int_t index);
-  static Float_t  GetNamedFloatAt(TString input, TString tagName, Int_t index);
-  static Bool_t  IsSelected(TString selector, TString className, TString objectName);
+  static TString GetProperty(const char * styleName, TString propertyName, TString elementName, TString className, TString objectName);
+  static TString  GetPropertyValue(TString input, TString propertyName);
+  static Int_t    GetNamedIntegerAt(TString input, TString propertyName, Int_t index);
+  static Float_t  GetNamedFloatAt(TString input, TString propertyName, Int_t index);
+  static Bool_t  IsSelected(TString selectors, TString elementName, TString className, TString objectName);
   static TObjArray * ReadCSSFile(const char *  inputName,Int_t verbose);
-  static void    WriteCSSFile(TObjArray * cssArray, const char *  outputName, fstream *pcssOut=NULL);
+  static void    WriteCSSFile(TObjArray * cssArray, const char *  outputName, fstream *cssOut=NULL);
   //
   //
   static Int_t   GetIntegerAt(const char * format, Int_t index, const char * separator=";");
@@ -81,22 +84,23 @@ public:
   static Float_t GetMarkerSize(const char *style, Int_t index);
   static Int_t   GetMarkerColor(const char *style, Int_t index);
   static Int_t   GetFillColor(const char *style, Int_t index);
-  static Int_t   GetLineStyle(const char *style, Int_t index);  
-  static Int_t   GetLineColor(const char *style, Int_t index);    
+  static Int_t   GetLineStyle(const char *style, Int_t index);
+  static Int_t   GetLineColor(const char *style, Int_t index);
   static Float_t GetLineWidth(const char *style, Int_t index);
   static void PrintLatexSymbols(Option_t *option,TPRegexp& regExp);
   static void PrintStyles(Option_t *option, TPRegexp& regExp);
 protected:
   static TString fDefaultTStyleID;                            ///< ID of the default TStyle
   static TString fDefaultArrayStyleID;                        ///< ID of the default array styles
-  static std::map<TString, TString> fLatexAlice;              ///< map of predefined latex symbols - fomatted according ALICE rules
+  static std::map<TString, TString> fLatexAlice;              ///< map of predefined latex symbols - formatted according ALICE rules
   static std::map<TString, TStyle*>  fStyleAlice;             ///< map of Alice predefined styles (+user defined)
+  static std::map<TString, TObjArray*>  fCssStyleAlice;       ///< map of Alice predefined styles corresponding to css notation
   static std::map<TString, std::vector<int> > fMarkerStyles;  ///< map of predefined marker styles arrays
   static std::map<TString, std::vector<int> > fMarkerColors;  ///< map of predefined colors  arrays
   static std::map<TString, std::vector<float> > fMarkerSize;  ///< map of predefined marker sizes ()
   static std::map<TString, std::vector<int> > fFillColors;    ///< map of predefined fill colors arrays
   static std::map<TString, std::vector<float> > fLineWidth;   ///< map of predefined line width
-  static std::map<TString, std::vector<float> > fLineStyle;   ///< map of predefined line style 
+  static std::map<TString, std::vector<float> > fLineStyle;   ///< map of predefined line style
   static std::map<TString, std::vector<float> > fLineColor;   ///< map of predefined line color
   //
   static void  RegisterDefaultLatexSymbols();                 ///< initialize default LatexSymbols

--- a/STAT/AliExternalInfo.cxx
+++ b/STAT/AliExternalInfo.cxx
@@ -462,7 +462,7 @@ TTree*  AliExternalInfo::GetTree(TString type, TString period, TString pass, TSt
 /// \param pass E.g. 'pass2' or 'passMC'. Here you can use wildcards like in 'ls', e.g. 'pass*'
 /// Returns a chain with the information from the corresponding resources.
 /// \return TChain*
-TChain* AliExternalInfo::GetChain(TString type, TString period, TString pass){
+TChain* AliExternalInfo::GetChain(TString type, TString period, TString pass, Int_t buildIndex){
   // FIXME  - here we should also fix Leave name bug
   TChain* chain = 0x0;
   TString internalFilename = ""; // Resulting path to the file
@@ -515,10 +515,41 @@ TChain* AliExternalInfo::GetChain(TString type, TString period, TString pass){
   if (cache>0) chain->SetCacheSize(cache);
 
   AddChain(type, period, pass);
+  BuildIndex(chain,type);
+  TString metadataMacro=fConfigMap[type + ".metadataMacro"];
+  chain->Draw("Entry$","1","goff",1);
+  if (metadataMacro.Length()>0 && chain->GetTree()) {  // rename branch  with index if specified in configuration file
+    if (fVerbose>1) printf("Processing metadata macro:\n gROOT->ProcessLine(.x %s((TTree*)%p,%d);",     metadataMacro.Data(),chain->GetTree(), fVerbose);
+    gROOT->ProcessLine(TString::Format(".x %s((TTree*)%p,%d);",metadataMacro.Data(),chain->GetTree(),fVerbose).Data());
+  }
+
   delete arrFiles;
   delete arrTreeName;
   return chain;
 };
+
+/// \param type Type of the resource as described in the config file, e.g. QA.TPC, MonALISA.RCT
+/// \param period Period, e.g. 'LHC15f'. Here you can use wildcards like in 'ls', e.g. 'LHC15*'
+/// \param pass E.g. 'pass2' or 'passMC'. Here you can use wildcards like in 'ls', e.g. 'pass*'
+/// Returns a chain with the information from the corresponding resources.
+/// \return TChain*
+TChain* AliExternalInfo::GetChain(TString type, TString period, TString pass, TString friendList){
+  TChain *chain = GetChain(type.Data(),period.Data(),pass.Data(),kFALSE);
+  if (chain==0){
+    ::Error("AliExternalInfo::GetChain", "Invalid tree description %s\t%s\t%s",type.Data(), period.Data(),pass.Data());
+  }
+  TObjArray * arrFriendList= friendList.Tokenize(";");
+  for (Int_t ilist=0; ilist<arrFriendList->GetEntriesFast(); ilist++) {
+    TChain *chainF = GetChain(arrFriendList->At(ilist)->GetName(), period.Data(), pass.Data(),kTRUE);
+    if (chainF){
+      chain->AddFriend(chainF,arrFriendList->At(ilist)->GetName());
+    }else{
+      ::Error("AliExternalInfo::GetChain", "Invalid friend tree\t%s\t%s",arrFriendList->At(ilist)->GetName(), friendList.Data());
+      continue;
+    }
+  }
+  return chain;
+}
 
 /// Every tree you create is added to a big tree acting as a friend.
 /// You can have access to this tree with the GetFriendsTree() function.
@@ -536,11 +567,11 @@ Bool_t AliExternalInfo::BuildIndex(TTree* tree, TString type){
   //
   if (oldIndexName.Length()>0){  // rename branch  with index if specified in configuration file
     if (tree->GetBranch(oldIndexName.Data())) {
-      tree->GetBranch(oldIndexName.Data())->SetName(indexName.Data());
     }
   }
   if (indexName.Length()<=0) { // set default index name
-    if (tree->GetListOfBranches()->FindObject("run"))  indexName="run";    
+     indexName="run";
+    if (tree->GetListOfBranches()!=NULL) if (tree->GetListOfBranches()->FindObject("run"))  indexName="run";
   }
   if (indexName.Length()<=0) {
     ::Error("AliExternalInfo::BuildIndex","Index %s not avaible for type %s", indexName.Data(), type.Data());

--- a/STAT/AliExternalInfo.h
+++ b/STAT/AliExternalInfo.h
@@ -97,7 +97,8 @@ public:
   TTree*  GetTreeMCPassGuess();
   TString GetMCPassGuess(TString MCprodname);
   
-  TChain* GetChain(TString type, TString period, TString pass);
+  TChain* GetChain(TString type, TString period, TString pass, Int_t buildIndex=1);
+  TChain* GetChain(TString type, TString period, TString pass, TString friendList);
   TChain* GetChainMC()                                                  {return GetChain("MonALISA.MC", "", "");}
   TChain* GetChainRCT(TString period, TString pass)                     {return GetChain("MonALISA.RCT", period, pass);}
   TChain* GetChainDataQA(TString detector, TString period, TString pass){return GetChain("QA." + detector, period, pass);}

--- a/STAT/AliPainter.cxx
+++ b/STAT/AliPainter.cxx
@@ -1,0 +1,454 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: The ALICE Off-line Project.                                    *
+ * Contributors are mentioned in the code where appropriate.              *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+#include "AliPainter.h"
+#include <iostream>
+#include "TPad.h"
+#include "TList.h"
+#include "TAxis.h"
+#include "TPRegexp.h"
+#include "TMultiGraph.h"
+#include "TGraph.h"
+#include "TError.h"
+#include "THn.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TH3.h"
+
+///
+/// \brief Method allow to divide pad according to specify properties.
+///
+///
+/// \param pad           - input pad to divide
+/// \param division      - division string
+///                         <NULL,vertical,horizontal>[div0,div1b, ...]
+///                            divi - specify number of pads in row (resp. column)
+///                                 - sharing parameter for axis
+///                                 - btlrm  (bottom, left, top, right, middle) middle means rl for horizontal and tb for vertical
+///                                 - set margin0 in case specified
+///                                 - technically attribute can be added to the object name  axis-sharing=""
+///                                 - 1lpx30 - means set for pad left margin equal 30pixels
+/// \param classID        - adds classID to name of the pad
+/*!
+  #### Example use:
+
+  1. Let's add some tree with Histogramm:
+        For this you can use
+        \code
+          AliExternalInfo info("","",0);
+          tree = info.GetTree("QA.TPC","LHC15o","pass1");
+         \endcode
+  2. Create canvas and divide it:
+          \code
+            TCanvas * canvasQA = new TCanvas("canvasQA","canvasQA", 1200,800);
+            AliPainter::DivideTPad(canvasQA,"<horizontal>[1,1,1,1]", "Raw,Error");
+            canvasQA->cd(1);
+            TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:run","1","25", "1",1,1,5,0),"ap");
+            canvasQA->cd(2);
+            TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:run","1","25", "1",1,1,5,0),"ap");
+            canvasQA->cd(3);
+            TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+            canvasQA->cd(4);
+            TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+         \endcode
+         In this simple case we have four vertical pads:
+         \image html $AliRoot_SRC/doxygen/canvasQA4v.jpg
+         In case with horizontal position we will have next plot:
+         \image html $AliRoot_SRC/doxygen/canvasQA4h.jpg
+  3. You can sharing choosen axis (see meanings of flags in description.):
+        \code
+            TCanvas * canvasQA = new TCanvas("canvasQA","canvasQA", 1200,800);
+            AliPainter::DivideTPad(canvasQA,"<vertical>[1r,1l,1r,1l]", "Raw,Error");
+            ...
+         \endcode
+         \image html $AliRoot_SRC/doxygen/canvasQA4hbt.jpg
+
+       and for vertical
+       \code
+            TCanvas * canvasQA = new TCanvas("canvasQA","canvasQA", 1200,800);
+            AliPainter::DivideTPad(canvasQA,"<vertical>[1r,1l,1r,1l]", "Raw,Error");
+            ...
+       \endcode
+        \image html $AliRoot_SRC/doxygen/canvasQA4vrl.jpg
+    \code
+  4. You can specify more than one pads in one raw:
+         \code
+            TCanvas * canvasQA = new TCanvas("canvasQA","canvasQA", 1200,800);
+            AliPainter::DivideTPad(canvasQA,"<horizontal>[1,3,2,1]", "Raw,Error");
+            canvasQA->cd(1);
+            TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:run","1","25", "1",1,1,5,0),"ap");
+            canvasQA->cd(2);
+            TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:run","1","25", "1",1,1,5,0),"ap");
+            canvasQA->cd(3);
+            TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+            canvasQA->cd(4);
+            TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+            canvasQA->cd(5);
+            TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+            canvasQA->cd(6);
+            TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+            canvasQA->cd(7);
+            TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+        \endcode
+        \image html $AliRoot_SRC/doxygen/canvasQA13m2m1h.jpg
+    or column:
+        \code
+            TCanvas * canvasQA = new TCanvas("canvasQA","canvasQA", 1200,800);
+            AliPainter::DivideTPad(canvasQA,"<vertical>[1,3m,2m,1]", "Raw,Error");
+             ...
+        \endcode
+        \image html $AliRoot_SRC/doxygen/canvasQA1321v.jpg
+
+  5. You can specify special flag "m" if you want to join middle pads in column:
+        \code
+            TCanvas * canvasQA = new TCanvas("canvasQA","canvasQA", 1200,800);
+            AliPainter::DivideTPad(canvasQA,"<vertical>[1,3m,2m,1]", "Raw,Error");
+             ...
+        \endcode
+        \image html $AliRoot_SRC/doxygen/canvasQA13m2m1v.jpg
+
+     or row:
+             \code
+            TCanvas * canvasQA = new TCanvas("canvasQA","canvasQA", 1200,800);
+            AliPainter::DivideTPad(canvasQA,"<horizontal>[1,3m,2m,1]", "Raw,Error");
+             ...
+        \endcode
+        \image html $AliRoot_SRC/doxygen/canvasQA13m2m1h.jpg
+
+  6. All previous case set choosen margin equal 0, but you can set your own value in absolute units, now we are supporting
+     only pixel("px" flag) and standart("st" flag) root values (percent from canvas size):
+        \code
+            TCanvas * canvasQA = new TCanvas("canvasQA","canvasQA", 1200,800);
+            AliPainter::DivideTPad(canvasQA,"<horizontal>[1rpx200,1,1,1]", "Raw,Error");
+             ...
+
+            TCanvas * canvasQA = new TCanvas("canvasQA","canvasQA", 1200,800);
+            AliPainter::DivideTPad(canvasQA,"<horizontal>[1rst0.2,1,1,1]", "Raw,Error");
+             ...
+        \endcode
+
+//    TFile*f=new TFile("/Users/bdrum/Projects/alicesw/TPC_trending.root");
+//    TTree*tree=(TTree*)f.Get("trending");
+
+
+
+    canvasQA->cd(1);
+    TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:run","1","25", "1",1,1,5,0),"ap");
+     canvasQA->cd(2);
+    TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:run","1","25", "1",1,1,5,0),"ap");
+    canvasQA->cd(3);
+    TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+    canvasQA->cd(4);
+    TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+    canvasQA->cd(5);
+    TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+    canvasQA->cd(6);
+    TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+    canvasQA->cd(7);
+    TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+    canvasQA->cd(8);
+    TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+    canvasQA->cd(9);
+    TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+    canvasQA->cd(10);
+    TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+    canvasQA->cd(11);
+    TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+    canvasQA->cd(12);
+    TStatToolkit::DrawMultiGraph(TStatToolkit::MakeMultGraph(tree,"", "meanMIPele:meanMIP","1","25", "1",0,1,5,0),"ap");
+    \endcode
+*/
+void AliPainter::DivideTPad(TPad*pad, const char *division, const char* classID) {
+
+  Int_t    nPads    = 0, nRows = 0, maxNCols = 0, n = 0;
+  Double_t xl       = 0.0, yl = 0.0, xu = 0.0, yu = 0.0, a = 0.0, b = 0.0, mValue = 0.0;
+  TString  position = "";
+  TString  tempStr  = "";
+  TString  wMargin  = ""; // margin zero
+  TString  units    = ""; // set margin
+
+  TObjArray *padRows = TString(division).Tokenize("<>[],");
+  position = padRows->At(0)->GetName();
+  nRows = padRows->GetEntries() - 1;
+
+  for (Int_t iRow = 0; iRow < nRows; iRow++)
+    if (maxNCols < TString(padRows->At(iRow + 1)->GetName()).Atoi())
+      maxNCols = TString(padRows->At(iRow + 1)->GetName()).Atoi();
+
+  for (Int_t iRow = 0; iRow < nRows; iRow++) {
+
+    tempStr = TString(padRows->At(iRow + 1)->GetName());
+    Int_t nCols = TString(tempStr(0, 1)).Atoi();
+    wMargin  = TString(tempStr(1, 1));
+    units = TString(tempStr(2, 2));
+    mValue = TString(tempStr(4, tempStr.Length())).Atof();
+
+    for (Int_t iCol = 0; iCol < nCols; iCol++) {
+      pad->cd();
+      xl = iCol / Double_t(nCols);
+      yl = (nRows - iRow - 1) / Double_t(nRows);
+      xu = (iCol + 1) / Double_t(nCols);
+      yu = (nRows - iRow) / Double_t(nRows);
+
+      if (position == "vertical") {
+        a = xl;
+        b = yl;
+        yl = a;       //yl -> xl
+        xl = 1 - b;   //xl -> 1 - yl
+        a = xu;
+        b = yu;
+        yu = a;       //yu -> xu
+        xu = 1 - b;   //xu -> 1 - yu
+      }
+      TPad *newPad = new TPad(Form("pad[%d].class(%s)", nPads, classID), Form("pad[%d].class(%s)", nPads, classID), xl, yl, xu, yu);
+      if (position == "vertical") {
+        newPad->SetTopMargin(nCols * newPad->GetLeftMargin() / maxNCols);
+        newPad->SetBottomMargin(nCols * newPad->GetRightMargin() / maxNCols);
+      }
+      else {
+        newPad->SetLeftMargin(nCols * newPad->GetLeftMargin() / maxNCols);
+        newPad->SetRightMargin(nCols * newPad->GetRightMargin() / maxNCols);
+      }
+      newPad = AliPainter::SetPadMargin(newPad, position, wMargin, units, mValue, iCol, nCols);
+      newPad->Draw();
+      nPads++;
+      newPad->SetNumber(nPads);
+    }
+  }
+}
+///
+/// \brief Function parse division string from AliPainter::DivideTPad and set attributes.
+/// \param cPad
+/// \param position
+/// \param units
+/// \param value
+TPad *AliPainter::SetPadMargin(TPad *cPad, const char *position, const char *wMargin, const char *units, Double_t mValue, Int_t iCol, Int_t nCols) {
+  Float_t rlValue  = 0.0, btValue = 0.0;
+  if (TString(units) == "px") {
+    rlValue = mValue / cPad->GetWw();
+    btValue = mValue / cPad->GetWh();
+  }
+  else if (TString(units) == "st") {
+    rlValue = mValue;
+    btValue = mValue;
+  }
+  else {
+    rlValue = 0.0;
+    btValue = 0.0;
+  }
+
+  if (TString(wMargin) == "r") cPad->SetRightMargin(rlValue);
+  if (TString(wMargin) == "l") cPad->SetLeftMargin(rlValue);
+  if (TString(wMargin) == "t") cPad->SetTopMargin(btValue);
+  if (TString(wMargin) == "b") cPad->SetBottomMargin(btValue);
+
+  if (TString(position) == "vertical") {
+    if (nCols > 1 && TString(wMargin) == "m" && iCol == 0) cPad->SetTopMargin(btValue);  //top pad in the m
+    if (nCols > 1 && TString(wMargin) == "m" && iCol > 0 && (iCol + 1) < nCols) { // middle pads in the m
+      cPad->SetTopMargin(btValue);
+      cPad->SetBottomMargin(btValue);
+    }
+    if (nCols > 1 && TString(wMargin) == "m" && (iCol + 1) == nCols) cPad->SetBottomMargin(btValue); //bottom in the m
+    if (TString(wMargin) == "m" && nCols == 1) { // only 1 with m
+      cPad->SetLeftMargin(rlValue);
+      cPad->SetRightMargin(rlValue);
+    }
+  }
+  else { //the same for horizontal
+    if (nCols > 1 && TString(wMargin) == "m" && iCol == 0) cPad->SetRightMargin(rlValue);
+    if (nCols > 1 && TString(wMargin) == "m" && iCol > 0 && (iCol + 1) < nCols) {
+      cPad->SetRightMargin(0);
+      cPad->SetLeftMargin(0);
+    }
+    if (nCols > 1 && TString(wMargin) == "m" && (iCol + 1) == nCols) cPad->SetLeftMargin(rlValue);
+    if (TString(wMargin) == "m" && nCols == 1) {
+      cPad->SetTopMargin(btValue);
+      cPad->SetBottomMargin(btValue);
+    }
+  }
+  return cPad;
+}
+///
+/// \param graph
+/// \param option
+void AliPainter::SetMultiGraphTimeAxis(TMultiGraph *graph, TString option){
+  TAxis *axis = NULL;
+  for (Int_t i=0; i<graph->GetListOfGraphs()->GetEntries(); i++) {
+    TGraph *cGraph=(TGraph *) graph->GetListOfGraphs()->At(i);
+    if (option.Contains("X")) axis = cGraph->GetXaxis();
+    if (option.Contains("Y")) axis = cGraph->GetYaxis();
+    if (axis) {
+      axis->SetNdivisions(510, kFALSE);
+      axis->SetTimeDisplay(1);
+      axis->SetTimeFormat("%d/%m");
+    }
+  }
+}
+
+///
+/// \brief Method find histogram in inputArray and draw specified projection according to properties.
+/// \param expresion        - histogram draw expression
+///                         - syntax
+///                           histogramName(<axisRange>)(<projection string>)(operation)(option)
+///                             axisRange: @done
+///                                if integer bin range   - TAxis::SetRange(min, max)
+///                                if float   user range  - TAxis::SetRangeUser(min,max)
+///                                if Expression is empty - do not specify anything
+///                             projectionString (i0,i1) @done
+///                                new projection created THn his = hisInput->Projection(i0,i1....)
+///                                at minimum one dimension should be specified, maximum 3D
+///                             operation
+///
+/// \param inputArray       - array of input objects
+///                         - Object to draw - histogramArray->FindObject(histogramName)
+///                         - in case histogramArray is NULL or histogram not found gROOT->FindObject() will be used
+/// \param metaData         - array with metadata describing histogram axis
+///                         - for example in the trees we optionally keep metadata (array of TNamed ()tag,value) in the array "metaTable"
+///                         - in case not specified -"metaTable" object from the histogramArray used
+/// \param keepArray        - array to keep temporary objects
+///
+/// \return
+/*!
+   #### Example use:
+   \code
+   TFile::SetCacheFileDir(".");
+   TFile * finput = TFile::Open("http://aliqatrkeos.web.cern.ch/aliqatrkeos/performance/alice/data/2015/LHC15o/pass1/LHC15o.pass1.B1.Bin0/performanceHisto.root", "CACHEREAD");
+   TTree* tree=(TTree*) finput.Get("hisPtAll");
+   hisArray = new TObjArray();
+   TList *keys = finput->GetListOfKeys();
+   for (Int_t iKey = 0; iKey < keys->GetEntries(); iKey++) {
+    TObject *o = finput->Get(TString::Format("%s;%d", keys->At(iKey)->GetName(), ((TKey *) keys->At(iKey))->GetCycle()).Data());
+    hisArray->AddLast(o);
+   }
+   AliPainter::DrawHistogram("hisK0DMassQPtTgl()(0)()(err)", hisArray, NULL, NULL);
+  \endcode
+ */
+///axis title, title, entries, description, all info from histogram
+
+TObject* AliPainter::DrawHistogram(char *expression,const TObjArray* histogramArray, TObjArray *metaData, TObjArray * keepArray){
+
+  // TString operationType[8]={"f-mean","f-rms","f-ltm","f-ltmsigma","f-gmean","f-grms","f-median","f-gmean"};
+  TString   exprsn  = expression;
+  TString   hisName = "";
+  TString   atts[4] = {"", "", "", ""};
+  TPRegexp          attPat("[(].*?[)]");
+  TString   tStr    = "";
+  THn *his    = NULL;
+
+  if (exprsn.CountChar('(') != exprsn.CountChar(')')) {
+    ::Error("AliPainter::DrawHistogram","check brackets in %s", expression);
+    return NULL;
+  }
+
+  hisName = exprsn(0,exprsn.Index("(",0));
+  his     = (THn *) histogramArray->FindObject(hisName);
+
+  if (his == NULL) {
+    ::Info("AliPainter::DrawHistogram", "%s not found", (const char*)hisName);
+    return NULL;
+  }
+
+  int startIndex  = 0;
+  int finishIndex = 0;
+
+  for (Int_t i = 0; i < 4; i++) {
+    finishIndex = exprsn.Index(")",startIndex);
+    tStr = exprsn(attPat,startIndex);
+    atts[i] = tStr(1, tStr.Length() - 2);
+    startIndex = finishIndex + 1;
+  }
+
+  Int_t nDims = his->GetNdimensions();
+
+  if (nDims < atts[1].CountChar(',') + 1) {
+    ::Error("AliPainter::DrawHistogram", "%s has only %d dimensions", (const char*)hisName, nDims);
+    return NULL; //does ::Error already break the program?
+  }
+
+  // TH1
+  if (atts[1].CountChar(',') + 1 == 1) {
+    TH1 *his1 = NULL;
+    his1 = his->Projection(atts[1].Atoi());
+    if (SetHistogramRange((TObject *) his1,atts[0]) != NULL) his1 = (TH1 *) SetHistogramRange((TObject *) his1,atts[0]);
+    his1->Draw();
+    return (TObject *) his1;
+  }
+  // TH2
+  else if (atts[1].CountChar(',') + 1 == 2) {
+    TH2 *his2 = NULL;
+    his2 = his->Projection(TString(atts[1].Tokenize(",")->At(0)->GetName()).Atoi(),
+                           TString(atts[1].Tokenize(",")->At(1)->GetName()).Atoi());
+    if (SetHistogramRange((TObject *) his2,atts[0]) != NULL) his2 = (TH2 *) SetHistogramRange((TObject *) his2,atts[0]);
+    his2->Draw();
+    return (TObject *) his2;
+  }
+    // TH3
+  else if (atts[1].CountChar(',') + 1 == 3) {
+    TH3 *his3 = NULL;
+    his3 = his->Projection(TString(atts[1].Tokenize(",")->At(0)->GetName()).Atoi(),
+                           TString(atts[1].Tokenize(",")->At(1)->GetName()).Atoi(),
+                           TString(atts[1].Tokenize(",")->At(2)->GetName()).Atoi());
+    if (SetHistogramRange((TObject *) his3,atts[0]) != NULL) his3 = (TH3 *) SetHistogramRange((TObject *) his3,atts[0]);
+    his3->Draw();
+    return (TObject *) his3;
+  }
+  else if (atts[1].CountChar(',') + 1 > 3) {
+    return (TObject *) his->Projection(atts[1].CountChar(',') + 1);
+  }
+  else {
+    return his;
+  }
+
+}
+///
+/// \param hisN   - Object from TH1, TH2, TH3, THn classes;
+/// \param range  - only for Xaxis. e.g. (100, 200) or (100.1, 200.2)
+TObject *AliPainter::SetHistogramRange(TObject *hisN, TString range) {
+  if (range != "") {
+  if (hisN->InheritsFrom("TH1")) {
+    TH1 *his1 = (TH1 *) hisN;
+    if (range.Index(".") > 0)
+      his1->GetXaxis()->SetRangeUser(TString(range.Tokenize(",")->At(0)->GetName()).Atof(),
+                                    TString(range.Tokenize(",")->At(1)->GetName()).Atof());
+    else
+      his1->GetXaxis()->SetRange(TString(range.Tokenize(",")->At(0)->GetName()).Atoi(),
+                                TString(range.Tokenize(",")->At(1)->GetName()).Atoi());
+    return (TObject *) his1;
+  }
+  else if (hisN->InheritsFrom("TH2")) {
+    TH2 *his2 = (TH2 *) hisN;
+    if (range.Index(".") > 0)
+    his2->GetXaxis()->SetRangeUser(TString(range.Tokenize(",")->At(0)->GetName()).Atof(),
+                                   TString(range.Tokenize(",")->At(1)->GetName()).Atof());
+    else
+    his2->GetXaxis()->SetRange(TString(range.Tokenize(",")->At(0)->GetName()).Atoi(),
+                               TString(range.Tokenize(",")->At(1)->GetName()).Atoi());
+    return (TObject *) his2;
+  }
+  else if (hisN->InheritsFrom("TH3")) {
+    TH3 *his3 = (TH3 *) hisN;
+    if (range.Index(".") > 0)
+    his3->GetXaxis()->SetRangeUser(TString(range.Tokenize(",")->At(0)->GetName()).Atof(),
+                                   TString(range.Tokenize(",")->At(1)->GetName()).Atof());
+    else
+    his3->GetXaxis()->SetRange(TString(range.Tokenize(",")->At(0)->GetName()).Atoi(),
+                               TString(range.Tokenize(",")->At(1)->GetName()).Atoi());
+    return (TObject *) his3;
+  }
+  else return NULL;
+
+  }
+  else return NULL;
+}

--- a/STAT/AliPainter.h
+++ b/STAT/AliPainter.h
@@ -1,0 +1,34 @@
+#ifndef ALIPAINTER_H
+#define ALIPAINTER_H
+
+/// \ingroup STAT
+/// \class AliPainter
+/*!
+\brief AliPainter
+\code
+/// TODO add documentation
+\endcode
+
+  \author marian  Ivanov marian.ivanov@cern.ch, Boris
+*/
+
+class TPad;
+class TMultiGraph;
+#include "TObject.h"
+
+
+class AliPainter : public TObject{
+
+public:
+  static void     DivideTPad(TPad*pad, const char *division, const char *classID);
+  static void     SetMultiGraphTimeAxis(TMultiGraph *graph, TString option);
+  static TObject* DrawHistogram(char *expresion, const TObjArray* histogramArray=NULL, TObjArray *metaData=NULL, TObjArray * keepArray=NULL);
+  static TObject* SetHistogramRange(TObject *hisN, TString range);
+  static TPad *SetPadMargin(TPad *cPad, const char *position, const char *wMargin, const char *units, Double_t mValue, Int_t iCol, Int_t nCols);
+public:
+
+private:
+  ClassDef(AliPainter,1);
+};
+
+#endif

--- a/STAT/AliTMinuitToolkit.h
+++ b/STAT/AliTMinuitToolkit.h
@@ -31,10 +31,10 @@ public:
     kCovarFailed=0x0001     // flag - problem to extract covariance matrix 
   };
 
-  AliTMinuitToolkit(const char *streamerName=0);
+  AliTMinuitToolkit(const char *streamerName=0, const char *mode="recreate");
   virtual ~AliTMinuitToolkit();  
   // streaming intermediate results
-  void  SetStreamer(const char *streamerName);
+  void  SetStreamer(const char *streamerName, const char *mode="recreate");
   TTreeSRedirector *GetStreamer(){return fStreamer;}
   
   //
@@ -44,7 +44,7 @@ public:
   void  FitGraph(TGraph *const gr, Option_t* option = "");
   //  Int_t UnbinnedFit(TTree * inputTree, TString values, TString variables, TString selection, Int_t firstEntry, Int_t nentries);
   Int_t FillFitter(TTree * inputTree, TString values, TString variables, TString selection, Int_t firstEntry, Int_t nentries, Bool_t doReset=kTRUE);
-  TString GetFitFunctionAsAlias();
+  TString GetFitFunctionAsAlias(Option_t *option="", TTree * tree=NULL);
   void Bootstrap(Int_t nIter, const char* reportName, Option_t  *option=0);
   void TwoFoldCrossValidation(Int_t nIter, const char*reportName, Option_t *option=0);
   void MISAC(Int_t nFitPoints, Int_t nIter, const char*reportName, Option_t *option=0);

--- a/STAT/AliTreePlayer.cxx
+++ b/STAT/AliTreePlayer.cxx
@@ -658,11 +658,16 @@ Int_t  AliTreePlayer::selectWhatWhereOrderBy(TTree * tree, TString what, TString
       TNamed *tHeadName = TStatToolkit::GetMetadata(tree,TString(columnNameList[iCol]->GetName())+".thead");
       TNamed *tooltipName = TStatToolkit::GetMetadata(tree,TString(columnNameList[iCol]->GetName())+".tooltip");
       TString sthName=(tHeadName!=NULL) ? tHeadName->GetTitle() : columnNameList[iCol]->GetName();
-      if (tooltipName==NULL){
-        fprintf(default_fp, "\t\t<th>%s</th>\n", sthName.Data()); // add metadata info
-      }else {
-        fprintf(default_fp, "\t\t<th class=\"tooltip\" data-tooltip=\"%s\">%s</th>\n", tooltipName->GetTitle(), sthName.Data()); // add metadata info
-      }
+      TNamed *descriptionName = TStatToolkit::GetMetadata(tree,TString(columnNameList[iCol]->GetName())+".headerTooltip");
+      fprintf(default_fp, "\t\t<th");
+      if (tooltipName!=0)  fprintf(default_fp, " class=\"tooltip\" data-tooltip=\"%s\"", tooltipName->GetTitle());
+      if (descriptionName!=0)  fprintf(default_fp, " title=\"%s\"", descriptionName->GetTitle());
+      fprintf(default_fp, ">%s</th>\n",  sthName.Data()); // add metadata info
+//      if (tooltipName==NULL){
+//        fprintf(default_fp, "\t\t<th>%s</th>\n", sthName.Data()); // add metadata info
+//      }else {
+//        fprintf(default_fp, "\t\t<th class=\"tooltip\" data-tooltip=\"%s\">%s</th>\n", tooltipName->GetTitle(), sthName.Data()); // add metadata info
+//      }
     }
     fprintf(default_fp,"\t</tr>\n"); // add metadata info
     fprintf(default_fp,"\t</thead>\n"); // add metadata info

--- a/STAT/AliTreePlayer.cxx
+++ b/STAT/AliTreePlayer.cxx
@@ -71,7 +71,7 @@ AliTreePlayer::AliTreePlayer(const char *name, const char *title)
 
 ///
 /// Selected metadata fil filing query
-/// retun ObjArray of selected metadatas
+/// retun ObjArray of selected metadata
 /// param
 
 			  
@@ -363,319 +363,331 @@ TString  AliTreePlayer::printSelectedTreeInfo(TTree*tree, TString infoType,  TSt
 /// \return                - status
 
 Int_t  AliTreePlayer::selectWhatWhereOrderBy(TTree * tree, TString what, TString where, TString /*orderBy*/,  Int_t firstentry, Int_t nentries, TString outputFormat, TString outputName){
-    //
-    // Select entry similar to the SQL select
-    //    tree instead - SQL FROM statement used
-    //         - it is supposed that all infomtation is contained in the tree and related friend trees
-    //         - build tree with friends done in separate function
-    //    what -
-    // code inspired by the TTreePlay::Scan but another tretment of arrays needed
-    // but wih few changes realted to different output formating
-    // NOTICE:
-    // for the moment not all parameters used
-    // Example usage:
-    /*
-      AliTreePlayer::selectWhatWhereOrderBy(treeTPC,"run:Logbook.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"html","qatpc.html");
+  //
+  // Select entry similar to the SQL select
+  //    tree instead - SQL FROM statement used
+  //         - it is supposed that all infomtation is contained in the tree and related friend trees
+  //         - build tree with friends done in separate function
+  //    what -
+  // code inspired by the TTreePlay::Scan but another tretment of arrays needed
+  // but wih few changes realted to different output formating
+  // NOTICE:
+  // for the moment not all parameters used
+  // Example usage:
+  /*
+    AliTreePlayer::selectWhatWhereOrderBy(treeTPC,"run:Logbook.run:meanMIP:meanMIPele:meanMIPvsSector.fElements:fitMIP.fElements","meanMIP>0", "", 0,10,"html","qatpc.html");
 
-    */
+  */
 
-    if (tree==NULL || tree->GetPlayer()==NULL){
-        ::Error("AliTreePlayer::selectWhatWhereOrderBy","Input tree not defiend");
-        return -1;
-    }
-    // limit number of entries - shorter version of the TTreePlayer::GetEntriesToProcess - but not fully correct ()
-    if (firstentry +nentries >tree->GetEntriesFriend()) nentries=tree->GetEntriesFriend()-firstentry;
-    if (tree->GetEntryList()){ //
-        if (tree->GetEntryList()->GetN()<nentries) nentries=tree->GetEntryList()->GetN();
-    }
-    //
-    Int_t  tnumber = -1;
-    Bool_t isHTML=outputFormat.Contains("html",TString::kIgnoreCase );
-    Bool_t isCSV=outputFormat.Contains("csv",TString::kIgnoreCase);
-    Bool_t isElastic=outputFormat.Contains("elastic",TString::kIgnoreCase);
-    Bool_t isJSON=outputFormat.Contains("json",TString::kIgnoreCase)||isElastic;
+  if (tree==NULL || tree->GetPlayer()==NULL){
+    ::Error("AliTreePlayer::selectWhatWhereOrderBy","Input tree not defiend");
+    return -1;
+  }
+  // limit number of entries - shorter version of the TTreePlayer::GetEntriesToProcess - but not fully correct ()
+  if (firstentry +nentries >tree->GetEntriesFriend()) nentries=tree->GetEntriesFriend()-firstentry;
+  if (tree->GetEntryList()){ //
+    if (tree->GetEntryList()->GetN()<nentries) nentries=tree->GetEntryList()->GetN();
+  }
+  //
+  Int_t  tnumber = -1;
+  Bool_t isHTML=outputFormat.Contains("html",TString::kIgnoreCase );
+  Bool_t isCSV=outputFormat.Contains("csv",TString::kIgnoreCase);
+  Bool_t isElastic=outputFormat.Contains("elastic",TString::kIgnoreCase);
+  Bool_t isJSON=outputFormat.Contains("json",TString::kIgnoreCase)||isElastic;
 
-    //
-    FILE *default_fp = stdout;
-    if (outputName.Length()>0){
-        default_fp=fopen (outputName.Data(),"w");
+  //
+  FILE *default_fp = stdout;
+  if (outputName.Length()>0){
+    default_fp=fopen (outputName.Data(),"w");
+  }
+  TObjArray *fArray=what.Tokenize(":");
+  Int_t      nCols=fArray->GetEntries();
+  TObjArray *fFormulaList       = new TObjArray(nCols+1);
+  TTreeFormula ** rFormulaList  = new TTreeFormula*[nCols+1];
+  TObjString **printFormatList  = new TObjString*[nCols];     // how to format variables
+  TObjString **columnNameList   = new TObjString*[nCols];
+  TObjString **outputFormatList = new TObjString*[nCols];     // root header formatting
+  Bool_t isIndex[nCols];
+  Bool_t isParent[nCols];
+  TClass*  isClass[nCols];       // is object
+  TPRegexp indexPattern("^%I"); // pattern for index
+  TPRegexp parentPattern("^%P"); // pattern for parent index
+  for (Int_t iCol=0; iCol<nCols; iCol++){
+    isClass[iCol]=NULL;
+    rFormulaList[iCol]=NULL;
+    TObjArray * arrayDesc = TString(fArray->At(iCol)->GetName()).Tokenize(";");
+    if (arrayDesc->GetEntries()<=0) {
+      ::Error("AliTreePlayer::selectWhatWhereOrderBy","Invalid descriptor %s", arrayDesc->At(iCol)->GetName());
+      //return -1;
     }
-    TObjArray *fArray=what.Tokenize(":");
-    Int_t      nCols=fArray->GetEntries();
-    TObjArray *fFormulaList       = new TObjArray(nCols+1);
-    TTreeFormula ** rFormulaList  = new TTreeFormula*[nCols+1];
-    TObjString **printFormatList  = new TObjString*[nCols];     // how to format variables
-    TObjString **columnNameList   = new TObjString*[nCols];
-    TObjString **outputFormatList = new TObjString*[nCols];     // root header formatting
-    Bool_t isIndex[nCols];
-    Bool_t isParent[nCols];
-    TClass*  isClass[nCols];       // is object
-    TPRegexp indexPattern("^%I"); // pattern for index
-    TPRegexp parentPattern("^%P"); // pattern for parent index
+    TString  fieldName=arrayDesc->At(0)->GetName();    // variable content
+    if (tree->GetBranch(fieldName.Data())){
+      if (TString(tree->GetBranch(fieldName.Data())->GetClassName()).Length()>0) {
+        isClass[iCol]=TClass::GetClass(tree->GetBranch(fieldName.Data())->GetClassName());
+      }
+    }
+    if (fieldName.Contains(indexPattern)){             // variable is index
+      isIndex[iCol]=kTRUE;
+      indexPattern.Substitute(fieldName,"");
+    }else{
+      isIndex[iCol]=kFALSE;
+    }
+    if (fieldName.Contains(parentPattern)){             // variable is parent
+      isParent[iCol]=kTRUE;
+      parentPattern.Substitute(fieldName,"");
+    }else{
+      isParent[iCol]=kFALSE;
+    }
+    TTreeFormula * formula = new TTreeFormula(fieldName.Data(), fieldName.Data(), tree);
+    if (formula->GetTree()==NULL){
+      ::Error("AliTreePlayer::selectWhatWhereOrderBy","Invalid formula %s, parsed from the original string %s",fieldName.Data(),what.Data());
+      if (isJSON==kFALSE) return -1;
+    }
+    TString  printFormat="";                       // printing format          - column 1 - use default if not specified
+    TString  colName=arrayDesc->At(0)->GetName();  // variable name in ouptut  - column 2 - using defaut ("variable name") as in input
+    TString  outputFormat="";                      // output column format specification for TLeaf (see also reading using TTree::ReadFile)
+    if (arrayDesc->At(1)!=NULL){  // format
+      printFormat=arrayDesc->At(1)->GetName();
+    }else{
+      if (formula->IsInteger()) {
+        printFormat="1.20";
+      }else{
+        printFormat="1.20";
+      }
+    }
+    if (arrayDesc->At(2)!=NULL)  {
+      colName=arrayDesc->At(2)->GetName();
+    }else{
+      colName=arrayDesc->At(0)->GetName();
+    }
+    //colName = (arrayDesc->GetEntries()>1) ? arrayDesc->At(2)->GetName() : arrayDesc->At(0)->GetName();
+    if (arrayDesc->At(3)!=NULL){  //outputFormat (for csv)
+      outputFormat= arrayDesc->At(3)->GetName();
+    }else{
+      outputFormat="/D";
+      if (formula->IsInteger()) outputFormat="/I";
+      if (formula->IsString())  outputFormat="/C";
+    }
+    fFormulaList->AddAt(formula,iCol);
+    rFormulaList[iCol]=formula;
+    printFormatList[iCol]=new TObjString(printFormat);
+    outputFormatList[iCol]=new TObjString(outputFormat);
+    columnNameList[iCol]=new TObjString(colName);
+  }
+  TTreeFormula *select = new TTreeFormula("Selection",where.Data(),tree);
+  fFormulaList->AddLast(select);
+  rFormulaList[nCols]=select;
+
+
+  Bool_t hasArray = kFALSE;
+  Bool_t forceDim = kFALSE;
+  for (Int_t iCol=0; iCol<nCols; iCol++){
+    if (rFormulaList[iCol]!=NULL) rFormulaList[iCol]->UpdateFormulaLeaves();
+    // if ->GetManager()->GetMultiplicity()>0 mean there is at minimum one array
+    switch( rFormulaList[iCol]->GetManager()->GetMultiplicity() ) {
+      case  1:
+      case  2:
+        hasArray = kTRUE;
+        forceDim = kTRUE;
+        break;
+      case -1:
+        forceDim = kTRUE;
+        break;
+      case  0:
+        break;
+    }
+  }
+
+
+  // print header
+  if (isHTML){
+    fprintf(default_fp,"<table class=\"display\" cellspacing=\"0\" width=\"100%\">\n"); // add metadata info
+    fprintf(default_fp,"\t<thead class=\"header\">\n"); // add metadata info
+    fprintf(default_fp,"\t<tr>\n"); // add metadata info
     for (Int_t iCol=0; iCol<nCols; iCol++){
-        isClass[iCol]=NULL;
-        rFormulaList[iCol]=NULL;
-        TObjArray * arrayDesc = TString(fArray->At(iCol)->GetName()).Tokenize(";");
-        if (arrayDesc->GetEntries()<=0) {
-            ::Error("AliTreePlayer::selectWhatWhereOrderBy","Invalid descriptor %s", arrayDesc->At(iCol)->GetName());
-            //return -1;
+      fprintf(default_fp,"\t\t<th>%s</th>\n",columnNameList[iCol]->GetName()); // add metadata info
+    }
+    fprintf(default_fp,"\t</tr>\n"); // add metadata info
+    fprintf(default_fp,"\t</thead>\n"); // add metadata info
+    //
+    fprintf(default_fp,"\t<tfoot class=\"header\">\n"); // add metadata info
+    fprintf(default_fp,"\t<tr>\n"); // add metadata info
+    for (Int_t iCol=0; iCol<nCols; iCol++){
+      fprintf(default_fp,"\t\t<th>%s</th>\n",columnNameList[iCol]->GetName()); // add metadata info
+    }
+    fprintf(default_fp,"\t</tr>\n"); // add metadata info
+    fprintf(default_fp,"\t</tfoot>\n"); // add metadata info
+    fprintf(default_fp,"\t<tbody>\n"); // add metadata info
+  }
+  if (isCSV){
+    // add header info
+    for (Int_t iCol=0; iCol<nCols; iCol++){
+      fprintf(default_fp,"%s%s",columnNameList[iCol]->GetName(), outputFormatList[iCol]->GetName());
+      if (iCol<nCols-1)  {
+        fprintf(default_fp,":");
+      }else{
+        fprintf(default_fp,"\n"); // add metadata info
+      }
+    }
+  }
+
+  Int_t selected=0;
+  for (Int_t ientry=firstentry; ientry<firstentry+nentries; ientry++){
+    Int_t entryNumber = tree->GetEntryNumber(ientry);
+    if (entryNumber < 0) break;
+    Long64_t localEntry = tree->LoadTree(entryNumber);
+    //
+    if (tnumber != tree->GetTreeNumber()) {
+      tnumber = tree->GetTreeNumber();
+      for(Int_t iCol=0;iCol<nCols;iCol++) {
+        rFormulaList[iCol]->UpdateFormulaLeaves();
+      }
+      select->UpdateFormulaLeaves();
+    }
+    if (select) {
+      //      if (select->EvalInstance(inst) == 0) {
+      if (select->EvalInstance(0) == 0) {  // for the moment simplified version of selection - not treating "array" selection
+        continue;
+      }
+    }
+    selected++;
+    // if json out
+    if (isJSON){
+      if (selected>1){
+        if (isElastic) {
+          fprintf(default_fp,"}\n{\"index\":{\"_id\": \"");
         }
-        TString  fieldName=arrayDesc->At(0)->GetName();    // variable content
-        if (tree->GetBranch(fieldName.Data())){
-            if (TString(tree->GetBranch(fieldName.Data())->GetClassName()).Length()>0) {
-                isClass[iCol]=TClass::GetClass(tree->GetBranch(fieldName.Data())->GetClassName());
-            }
+        else{
+          fprintf(default_fp,"},\n{\n");
         }
-        if (fieldName.Contains(indexPattern)){             // variable is index
-            isIndex[iCol]=kTRUE;
-            indexPattern.Substitute(fieldName,"");
+      }else{
+        if (isElastic){
+          fprintf(default_fp,"{\"index\":{\"_id\": \"");
         }else{
-            isIndex[iCol]=kFALSE;
+          fprintf(default_fp,"{{\n");
         }
-        if (fieldName.Contains(parentPattern)){             // variable is parent
-            isParent[iCol]=kTRUE;
-            parentPattern.Substitute(fieldName,"");
+      }
+      for (Int_t icol=0; icol<nCols; icol++){
+        TString obuffer="";
+        if (isClass[icol]){
+          const char*bname=rFormulaList[icol]->GetName();
+          TBranch *br = tree->GetBranch(bname);
+          br->GetEntry(entryNumber); // not sure if the entry is loaded
+          void **ppobject=(void**)br->GetAddress();
+          if (ppobject) {
+            obuffer = TBufferJSON::ConvertToJSON(*ppobject, isClass[icol]);
+            if (isElastic) obuffer.ReplaceAll("\n","");
+            //fprintf(default_fp,"%s",clbuffer.Data());
+          }
+        }
+        if (rFormulaList[icol]->GetTree()==NULL) continue;
+        Int_t nData=rFormulaList[icol]->GetNdata();
+        if (isElastic==kFALSE){
+          fprintf(default_fp,"\t\"%s\":",rFormulaList[icol]->GetName());
         }else{
-            isParent[iCol]=kFALSE;
-        }
-        TTreeFormula * formula = new TTreeFormula(fieldName.Data(), fieldName.Data(), tree);
-        if (formula->GetTree()==NULL){
-            ::Error("AliTreePlayer::selectWhatWhereOrderBy","Invalid formula %s, parsed from the original string %s",fieldName.Data(),what.Data());
-            if (isJSON==kFALSE) return -1;
-        }
-        TString  printFormat="";                       // printing format          - column 1 - use default if not specified
-        TString  colName=arrayDesc->At(0)->GetName();  // variable name in ouptut  - column 2 - using defaut ("variable name") as in input
-        TString  outputFormat="";                      // output column format specification for TLeaf (see also reading using TTree::ReadFile)
-        if (arrayDesc->At(1)!=NULL){  // format
-            printFormat=arrayDesc->At(1)->GetName();
-        }else{
-            if (formula->IsInteger()) {
-                printFormat="1.20";
+          if (isIndex[icol]==kFALSE && isParent[icol]==kFALSE){
+            TString fieldName(rFormulaList[icol]->GetName());
+            if (isClass[icol]) fieldName.Remove(fieldName.Length()-1);
+            fieldName.ReplaceAll(".","%_");
+            if (icol>0 && isIndex[icol-1]==kFALSE && isParent[icol-1]==kFALSE ){
+              fprintf(default_fp,"\t,\"%s\":",fieldName.Data());
             }else{
-                printFormat="1.20";
+              fprintf(default_fp,"\t\"%s\":",fieldName.Data());
             }
+          }
         }
-        if (arrayDesc->At(2)!=NULL)  {
-            colName=arrayDesc->At(2)->GetName();
+        if (nData<=1){
+          if ((isIndex[icol]==kFALSE)&&(isParent[icol]==kFALSE)){
+            if (isClass[icol]!=NULL){
+              fprintf(default_fp,"%s",obuffer.Data());
+            }else {
+              if (isElastic && rFormulaList[icol]->IsString()) {
+                fprintf(default_fp, "\t\"%s\"",
+                        rFormulaList[icol]->PrintValue(0, 0, printFormatList[icol]->GetName()));
+              } else {
+                fprintf(default_fp, "\t%s",
+                        rFormulaList[icol]->PrintValue(0, 0, printFormatList[icol]->GetName()));
+              }
+            }
+          }
+          if (isIndex[icol]){
+            fprintf(default_fp,"%s",rFormulaList[icol]->PrintValue(0,0,printFormatList[icol]->GetName()));
+            if (isIndex[icol+1]){
+              fprintf(default_fp,".");
+            }else
+            if (isParent[icol+1]==kFALSE){
+              fprintf(default_fp,"\"}}\n{");
+            }
+          }
+          if (isParent[icol]==kTRUE){
+            fprintf(default_fp,"\", \"parent\": \"%s\"}}\n{",rFormulaList[icol]->PrintValue(0,0,printFormatList[icol]->GetName()));
+          }
         }else{
-            colName=arrayDesc->At(0)->GetName();
+          fprintf(default_fp,"\t[");
+          for (Int_t iData=0; iData<nData;iData++){
+            fprintf(default_fp,"%f",rFormulaList[icol]->EvalInstance(iData));
+            if (iData<nData-1) {
+              fprintf(default_fp,",");
+            }   else{
+              fprintf(default_fp,"]");
+            }
+          }
         }
-        //colName = (arrayDesc->GetEntries()>1) ? arrayDesc->At(2)->GetName() : arrayDesc->At(0)->GetName();
-        if (arrayDesc->At(3)!=NULL){  //outputFormat (for csv)
-            outputFormat= arrayDesc->At(3)->GetName();
-        }else{
-            outputFormat="/D";
-            if (formula->IsInteger()) outputFormat="/I";
-            if (formula->IsString())  outputFormat="/C";
-        }
-        fFormulaList->AddAt(formula,iCol);
-        rFormulaList[iCol]=formula;
-        printFormatList[iCol]=new TObjString(printFormat);
-        outputFormatList[iCol]=new TObjString(outputFormat);
-        columnNameList[iCol]=new TObjString(colName);
-    }
-    TTreeFormula *select = new TTreeFormula("Selection",where.Data(),tree);
-    fFormulaList->AddLast(select);
-    rFormulaList[nCols]=select;
-
-
-    Bool_t hasArray = kFALSE;
-    Bool_t forceDim = kFALSE;
-    for (Int_t iCol=0; iCol<nCols; iCol++){
-        if (rFormulaList[iCol]!=NULL) rFormulaList[iCol]->UpdateFormulaLeaves();
-        // if ->GetManager()->GetMultiplicity()>0 mean there is at minimum one array
-        switch( rFormulaList[iCol]->GetManager()->GetMultiplicity() ) {
-            case  1:
-            case  2:
-                hasArray = kTRUE;
-                forceDim = kTRUE;
-                break;
-            case -1:
-                forceDim = kTRUE;
-                break;
-            case  0:
-                break;
-        }
+        //	if (icol<nCols-1 && (isIndex[icol]==kFALSE && isParent[icol]==kFALSE) ) fprintf(default_fp,",");
+        //fprintf(default_fp,"\n");
+      }
     }
 
-
-    // print header
+    //
     if (isHTML){
-        fprintf(default_fp,"<table>"); // add metadata info
-        fprintf(default_fp,"<tr>"); // add metadata info
-        for (Int_t iCol=0; iCol<nCols; iCol++){
-            fprintf(default_fp,"<th>%s</th>",columnNameList[iCol]->GetName()); // add metadata info
+      fprintf(default_fp,"<tr>\n");
+      for (Int_t icol=0; icol<nCols; icol++){
+        Int_t nData=rFormulaList[icol]->GetNdata();
+        if (nData<=1){
+          fprintf(default_fp,"\t<td>%s</td>",rFormulaList[icol]->PrintValue(0,0,printFormatList[icol]->GetName()));
+        }else{
+          fprintf(default_fp,"\t<td>");
+          for (Int_t iData=0; iData<nData;iData++){
+            fprintf(default_fp,"%f",rFormulaList[icol]->EvalInstance(iData));
+            if (iData<nData-1) {
+              fprintf(default_fp,",");
+            }else{
+              fprintf(default_fp,"</td>");
+            }
+          }
         }
-        fprintf(default_fp,"<tr>"); // add metadata info
+        fprintf(default_fp,"\n");
+      }
+      fprintf(default_fp,"</tr>\n");
     }
+    //
     if (isCSV){
-        // add header info
-        for (Int_t iCol=0; iCol<nCols; iCol++){
-            fprintf(default_fp,"%s%s",columnNameList[iCol]->GetName(), outputFormatList[iCol]->GetName());
-            if (iCol<nCols-1)  {
-                fprintf(default_fp,":");
+      for (Int_t icol=0; icol<nCols; icol++){  // formula loop
+        Int_t nData=rFormulaList[icol]->GetNdata();
+        if (nData<=1){
+          fprintf(default_fp,"%s\t",rFormulaList[icol]->PrintValue(0,0,printFormatList[icol]->GetName()));
+        }else{
+          for (Int_t iData=0; iData<nData;iData++){  // array loo
+            fprintf(default_fp,"%f",rFormulaList[icol]->EvalInstance(iData));
+            if (iData<nData-1) {
+              fprintf(default_fp,",");
             }else{
-                fprintf(default_fp,"\n"); // add metadata info
+              fprintf(default_fp,"\t");
             }
+          }
         }
+      }
+      fprintf(default_fp,"\n");
     }
+  }
+  if (isJSON) fprintf(default_fp,"}\n");
+  if (isHTML){
+    fprintf(default_fp,"\t</tbody>"); // add metadata info
+    fprintf(default_fp,"</table>"); // add metadata info
+  }
 
-    Int_t selected=0;
-    for (Int_t ientry=firstentry; ientry<firstentry+nentries; ientry++){
-        Int_t entryNumber = tree->GetEntryNumber(ientry);
-        if (entryNumber < 0) break;
-        Long64_t localEntry = tree->LoadTree(entryNumber);
-        //
-        if (tnumber != tree->GetTreeNumber()) {
-            tnumber = tree->GetTreeNumber();
-            for(Int_t iCol=0;iCol<nCols;iCol++) {
-                rFormulaList[iCol]->UpdateFormulaLeaves();
-            }
-            select->UpdateFormulaLeaves();
-        }
-        if (select) {
-            //      if (select->EvalInstance(inst) == 0) {
-            if (select->EvalInstance(0) == 0) {  // for the moment simplified version of selection - not treating "array" selection
-                continue;
-            }
-        }
-        selected++;
-        // if json out
-        if (isJSON){
-            if (selected>1){
-                if (isElastic) {
-                    fprintf(default_fp,"}\n{\"index\":{\"_id\": \"");
-                }
-                else{
-                    fprintf(default_fp,"},\n{\n");
-                }
-            }else{
-                if (isElastic){
-                    fprintf(default_fp,"{\"index\":{\"_id\": \"");
-                }else{
-                    fprintf(default_fp,"{{\n");
-                }
-            }
-            for (Int_t icol=0; icol<nCols; icol++){
-                TString obuffer="";
-                if (isClass[icol]){
-                    const char*bname=rFormulaList[icol]->GetName();
-                    TBranch *br = tree->GetBranch(bname);
-                    br->GetEntry(entryNumber); // not sure if the entry is loaded
-                    void **ppobject=(void**)br->GetAddress();
-                    if (ppobject) {
-                        obuffer = TBufferJSON::ConvertToJSON(*ppobject, isClass[icol]);
-                        if (isElastic) obuffer.ReplaceAll("\n","");
-                        //fprintf(default_fp,"%s",clbuffer.Data());
-                    }
-                }
-                if (rFormulaList[icol]->GetTree()==NULL) continue;
-                Int_t nData=rFormulaList[icol]->GetNdata();
-                if (isElastic==kFALSE){
-                    fprintf(default_fp,"\t\"%s\":",rFormulaList[icol]->GetName());
-                }else{
-                    if (isIndex[icol]==kFALSE && isParent[icol]==kFALSE){
-                        TString fieldName(rFormulaList[icol]->GetName());
-                        if (isClass[icol]) fieldName.Remove(fieldName.Length()-1);
-                        fieldName.ReplaceAll(".","%_");
-                        if (icol>0 && isIndex[icol-1]==kFALSE && isParent[icol-1]==kFALSE ){
-                            fprintf(default_fp,"\t,\"%s\":",fieldName.Data());
-                        }else{
-                            fprintf(default_fp,"\t\"%s\":",fieldName.Data());
-                        }
-                    }
-                }
-                if (nData<=1){
-                    if ((isIndex[icol]==kFALSE)&&(isParent[icol]==kFALSE)){
-                        if (isClass[icol]!=NULL){
-                            fprintf(default_fp,"%s",obuffer.Data());
-                        }else {
-                            if (isElastic && rFormulaList[icol]->IsString()) {
-                                fprintf(default_fp, "\t\"%s\"",
-                                        rFormulaList[icol]->PrintValue(0, 0, printFormatList[icol]->GetName()));
-                            } else {
-                                fprintf(default_fp, "\t%s",
-                                        rFormulaList[icol]->PrintValue(0, 0, printFormatList[icol]->GetName()));
-                            }
-                        }
-                    }
-                    if (isIndex[icol]){
-                        fprintf(default_fp,"%s",rFormulaList[icol]->PrintValue(0,0,printFormatList[icol]->GetName()));
-                        if (isIndex[icol+1]){
-                            fprintf(default_fp,".");
-                        }else
-                        if (isParent[icol+1]==kFALSE){
-                            fprintf(default_fp,"\"}}\n{");
-                        }
-                    }
-                    if (isParent[icol]==kTRUE){
-                        fprintf(default_fp,"\", \"parent\": \"%s\"}}\n{",rFormulaList[icol]->PrintValue(0,0,printFormatList[icol]->GetName()));
-                    }
-                }else{
-                    fprintf(default_fp,"\t[");
-                    for (Int_t iData=0; iData<nData;iData++){
-                        fprintf(default_fp,"%f",rFormulaList[icol]->EvalInstance(iData));
-                        if (iData<nData-1) {
-                            fprintf(default_fp,",");
-                        }   else{
-                            fprintf(default_fp,"]");
-                        }
-                    }
-                }
-                //	if (icol<nCols-1 && (isIndex[icol]==kFALSE && isParent[icol]==kFALSE) ) fprintf(default_fp,",");
-                //fprintf(default_fp,"\n");
-            }
-        }
-
-        //
-        if (isHTML){
-            fprintf(default_fp,"<tr>\n");
-            for (Int_t icol=0; icol<nCols; icol++){
-                Int_t nData=rFormulaList[icol]->GetNdata();
-                if (nData<=1){
-                    fprintf(default_fp,"\t<td>%s</td>",rFormulaList[icol]->PrintValue(0,0,printFormatList[icol]->GetName()));
-                }else{
-                    fprintf(default_fp,"\t<td>");
-                    for (Int_t iData=0; iData<nData;iData++){
-                        fprintf(default_fp,"%f",rFormulaList[icol]->EvalInstance(iData));
-                        if (iData<nData-1) {
-                            fprintf(default_fp,",");
-                        }else{
-                            fprintf(default_fp,"</td>");
-                        }
-                    }
-                }
-                fprintf(default_fp,"\n");
-            }
-            fprintf(default_fp,"</tr>\n");
-        }
-        //
-        if (isCSV){
-            for (Int_t icol=0; icol<nCols; icol++){  // formula loop
-                Int_t nData=rFormulaList[icol]->GetNdata();
-                if (nData<=1){
-                    fprintf(default_fp,"%s\t",rFormulaList[icol]->PrintValue(0,0,printFormatList[icol]->GetName()));
-                }else{
-                    for (Int_t iData=0; iData<nData;iData++){  // array loo
-                        fprintf(default_fp,"%f",rFormulaList[icol]->EvalInstance(iData));
-                        if (iData<nData-1) {
-                            fprintf(default_fp,",");
-                        }else{
-                            fprintf(default_fp,"\t");
-                        }
-                    }
-                }
-            }
-            fprintf(default_fp,"\n");
-        }
-    }
-    if (isJSON) fprintf(default_fp,"}\n");
-    if (isHTML){
-        fprintf(default_fp,"</table>"); // add metadata info
-    }
-
-    if (default_fp!=stdout) fclose (default_fp);
-    return selected;
+  if (default_fp!=stdout) fclose (default_fp);
+  return selected;
 }
 
 // Get the enumeration type from a string

--- a/STAT/AliTreePlayer.cxx
+++ b/STAT/AliTreePlayer.cxx
@@ -111,6 +111,13 @@ Int_t AliTreeFormulaF::Compile(const char *expression) {
   fTextArray->AddAtAndExpand(new TObjString(stext.Data()), nVars);
 }
 
+///
+/// \param mode
+/// \return
+char *AliTreeFormulaF::PrintValue(Int_t mode) const {
+   PrintValue(mode, 0, "");
+}
+
 /// Overwrite TTreeFormula PrintValue
 /// \param mode
 /// \param instance

--- a/STAT/AliTreePlayer.h
+++ b/STAT/AliTreePlayer.h
@@ -2,41 +2,101 @@
 #define ALITREEPLAYER_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */
-
 /* $Id$ */
 
-////////////////////////////////////////////////
-//  Alice extension of TTreePlayer            //
-////////////////////////////////////////////////
 
-class TPad; 
-#include "AliTreePlayer.h"
+/// \ingroup STAT
+/// \class AliTreeFormulaF
+/// \brief Helper class for AliTreePlayer - formatted string to query tree
+/// ### Example usage
+/// #### Example: Construct directory path
+/// \code
+/// AliExternalInfo info;TTree * tree = info.GetTree("QA.TPC","LHC15o","pass1");
+/// formula = new AliTreeFormulaF("xxx","xxx/%d{year}/%d{period.GetName()}/%d{pass.GetName()}/%d{run}/xxx",tree);
+/// tree->GetEntry(0);
+/// formula->PrintValue(0,0,"")
+/// Output: "xxx/2015/LHC15o/pass1/245683/xxx"
+/// \endcode
+///
+/// #### Example: Construct directory path
+/// \code
+///  AliExternalInfo info;TTree * tree = info.GetTree("QA.TPC","LHC15o","pass1");
+///  formula = new AliTreeFormulaF("xxx","<a href=\"https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=%d{run}\"\a>",tree);
+///  tree->GetEntry(0);
+///  formula->PrintValue(0,0,"")
+///  Output: "<a href=\"https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=245683\"a>"
+/// \endcode
+///
+/// #### Example: Variable formatting
+/// * Internally root formatting  are used for the individual data variables. This formatting is different than standard printf formatting
+/// * TODO -  Implement own formatting also for variables -
+///\code
+/// formula = new AliTreeFormulaF("xxx","<a href=\"https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=%2.1f{run}\"\a>",tree);
+/// Ouptut: "<a href=\"https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=245683.0\"a>"
+///\endcode
+///\code
+/// formula = new AliTreeFormulaF("xxx","<a href=\"https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=%0.5f{run}\"\a>",tree);
+/// Output: "<a href=\"https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=245683.00000\"a>"
+/// \endcode
+/// \author Marian Ivanov
+///
+/// \class AliTreePlayer
+/// \brief Set of functions to extend functionality of the TTreePlayer
+/// * Input data sources  - TTree Friend trees
+/// * Data source can be configured independently using class AliExternalInfo and subdet of fuctionality in the TStatToolkit
+///   * friend relation
+///   * indices
+///   * metatadata for branches,aliases (class, Axis,AxisTitle,Legen, Html, description ...)
+/// ### Functionality
+///
+/// * function to support metadata and collumn annotation
+/// * filtering function (branch, aliases metadata)
+/// * select function  - export to (json, csv,  html, JIRA) + metadata (not yet implemented)
+///   * subset of metadata for columns included in select export outputName.metadata
+///         * select function  - for root trees
+///   * to be done using TTree::CopyTree  functionality switching ON/OFF selected branches - metadata should be exported automatically (to check)
+///
+///  See  example usage in the test macro AliTreePlayerTest.C
+///  \code
+///    AliTreePlayerTest.C::testAll();
+///    AliTreePlayerTest.C::testSelectMetadata()
+///    AliTreePlayerTest.C::testselectTreeInfo()
+///    AliTreePlayerTest.C:testselectWhatWhereOrderByForTRD()
+///  \endcode
+///
+/// \author Marian Ivanov
+
+
+class TPad;
+#include "TTreePlayer.h"
+#include "TTreeFormula.h"
+
+class AliTreeFormulaF : public TTreeFormula {
+public:
+  AliTreeFormulaF();
+  ~AliTreeFormulaF();
+  AliTreeFormulaF(const char *name, const char *formula, TTree *tree);
+  virtual Int_t Compile(const char *expression = "");
+  virtual char *PrintValue(Int_t mode = 0) const { PrintValue(mode, 0, ""); }
+  virtual char *PrintValue(Int_t mode, Int_t instance, const char *decform = "9.9") const;
+  virtual void        UpdateFormulaLeaves();
+  virtual Int_t       GetNdata(){return 1;} // TODO - support for vectors
+public:
+  TObjArray *fTextArray;       /// array of text inputs
+  TObjArray *fFormatArray;     /// array of format strings to draw
+  TObjArray *fFormulaArray;    /// array of TFormulas
+  ClassDef(AliTreeFormulaF,1)  ///
+};
+
 
 class AliTreePlayer : public TNamed {
-
 public:
   AliTreePlayer() {}
   AliTreePlayer(const char *name, const char *title);
   static TObjArray  * selectMetadata(TTree * tree, TString query, Int_t verbose);
-  static TObjArray  * selectTreeInfo(TTree* tree, TString query,Int_t verbose); 
+  static TObjArray  * selectTreeInfo(TTree* tree, TString query,Int_t verbose);
   static Int_t selectWhatWhereOrderBy(TTree * tree, TString what, TString where, TString orderBy,  Int_t firstentry, Int_t nentries, TString outputFormat, TString outputName);
   static TString  printSelectedTreeInfo(TTree*tree, TString infoType,  TString regExpFriend, TString regExpTag, Int_t verbose);
-  // to add
-  // Metadata query from the TStatToolkit (GetMetadata, AddMetadata)
-  // TH1* DrawSorted(const char * expression, const char weights, Bool_t down, Int_t cut);  // draw sorted version of histogram 
-  // Friend tree queries for time series using (time in entry or in array)
-  //       - calculate nearest entry
-  //       -- cache adding  branch   
-  //       - calculate (index, mean, median, rms ...) entry in interval
-  //       -- cache adding branch
-  // To solve/consider: 
-  //       - index branches have to have the same names - indeces to be created in all trees
-  //       - can we change indeces? is it needed ?
-  //       - implemntations for indeces er entry and internal indices within array will be different
-  //       -- are both implementation needed - in which order ... 
-  
-  //static TH1* DrawSorted(TTree * tree, const char* varexp, const TCut& selection, Bool_t nbins=20, Long64_t nentries = 1000000000, Long64_t firstentry = 0);
-  //
   static TObjArray  * MakeHistograms(TTree * tree, TString hisString, TString defaultCut, Int_t firstEntry, Int_t lastEntry, Int_t chunkSize=-1, Int_t verbose=1);
   static TPad *  DrawHistograms(TPad  * pad, TObjArray * hisArray, TString drawExpression, TObjArray *keepArray=0, Int_t verbose=0);
   static void MakeCacheTree(TTree * tree, TString varList, TString outFile, TString outTree, TCut selection);
@@ -46,21 +106,38 @@ public:
   static Int_t GetStatType(const TString &stat);
   static void AddStatInfo(TTree* treeLeft,  TTree * treeRight , const TString refQuery, Double_t deltaT,
 		   const TString statString="median:medianLeft:medianRight:RMS:Mean:LTM0.60:LTMRMS0.60:Max:Min",
-		   Int_t maxEntries=100000000); 
+		   Int_t maxEntries=100000000);
+  /// TODO -
+  /// Metadata query from the TStatToolkit (GetMetadata, AddMetadata)
+  /// TH1* DrawSorted(const char * expression, const char weights, Bool_t down, Int_t cut);  // draw sorted version of histogram
+  /// Friend tree queries for time series using (time in entry or in array)
+  ///       - calculate nearest entry
+  ///       -- cache adding  branch
+  ///       - calculate (index, mean, median, rms ...) entry in interval
+  ///       -- cache adding branch
+  /// To solve/consider:
+  ///       - index branches have to have the same names - indeces to be created in all trees
+  ///       - can we change indices? is it needed ?
+  ///       - implementations for indices er entry and internal indices within array will be different
+  ///       -- are both implementation needed - in which order ...
+  ///static TH1* DrawSorted(TTree * tree, const char* varexp, const TCut& selection, Bool_t nbins=20, Long64_t nentries = 1000000000, Long64_t firstentry = 0);
+  ///
 protected:
-  
   ClassDef(AliTreePlayer,1)  // Extension of the TTreePlayer
 };
 
 
-//__________________________________________________________
+/// Binary search in an array of n values to locate value.
+/// Array is supposed  to be sorted prior to this call.
+// function gives nearest element smaller than value (different than in the TMath::BinarySearch
+// See TMath::BinarySearch
+/// \tparam T     - template (float,double,int ..)
+/// \param n      - size of array
+/// \param array  - pointer to raw array
+/// \param value  - value to find
+/// \return nearest element smaller than value.
 template <typename T> Long64_t AliTreePlayer::BinarySearchSmaller(Long64_t n, const T *array, T value)
 {
-  // Binary search in an array of n values to locate value.
-  //
-  // Array is supposed  to be sorted prior to this call.
-  // function gives nearest element smaller than value.
-  // See TMath::BinarySearch
   const T* pind;
   pind = std::lower_bound(array, array + n, value);
   return ( pind - array - 1);

--- a/STAT/AliTreePlayer.h
+++ b/STAT/AliTreePlayer.h
@@ -75,7 +75,7 @@ class AliTreeFormulaF : public TTreeFormula {
 public:
   AliTreeFormulaF();
   ~AliTreeFormulaF();
-  AliTreeFormulaF(const char *name, const char *formula, TTree *tree);
+  AliTreeFormulaF(const char *name, const char *formula, TTree *tree, Int_t debug=0);
   virtual Int_t Compile(const char *expression = "");
   virtual char *PrintValue(Int_t mode = 0) const { PrintValue(mode, 0, ""); }
   virtual char *PrintValue(Int_t mode, Int_t instance, const char *decform = "9.9") const;
@@ -85,6 +85,8 @@ public:
   TObjArray *fTextArray;       /// array of text inputs
   TObjArray *fFormatArray;     /// array of format strings to draw
   TObjArray *fFormulaArray;    /// array of TFormulas
+  mutable TString    fValue;   /// current cache value of the formula
+  Int_t      fDebug;           /// debug level
   ClassDef(AliTreeFormulaF,1)  ///
 };
 

--- a/STAT/AliTreePlayer.h
+++ b/STAT/AliTreePlayer.h
@@ -93,7 +93,7 @@ class AliTreePlayer : public TNamed {
 public:
   AliTreePlayer() {}
   AliTreePlayer(const char *name, const char *title);
-  static TObjArray  * selectMetadata(TTree * tree, TString query, Int_t verbose);
+  static TObjArray  * selectMetadata(TTree * tree, TString query, Int_t verbose, TString *idList=NULL);
   static TObjArray  * selectTreeInfo(TTree* tree, TString query,Int_t verbose);
   static Int_t selectWhatWhereOrderBy(TTree * tree, TString what, TString where, TString orderBy,  Int_t firstentry, Int_t nentries, TString outputFormat, TString outputName);
   static TString  printSelectedTreeInfo(TTree*tree, TString infoType,  TString regExpFriend, TString regExpTag, Int_t verbose);

--- a/STAT/AliTreePlayer.h
+++ b/STAT/AliTreePlayer.h
@@ -77,7 +77,7 @@ public:
   ~AliTreeFormulaF();
   AliTreeFormulaF(const char *name, const char *formula, TTree *tree, Int_t debug=0);
   virtual Int_t Compile(const char *expression = "");
-  virtual char *PrintValue(Int_t mode = 0) const { PrintValue(mode, 0, ""); }
+  virtual char *PrintValue(Int_t mode = 0) const; // { PrintValue(mode, 0, ""); }
   virtual char *PrintValue(Int_t mode, Int_t instance, const char *decform = "9.9") const;
   virtual void        UpdateFormulaLeaves();
   virtual Int_t       GetNdata(){return 1;} // TODO - support for vectors

--- a/STAT/AliTreeTrending.cxx
+++ b/STAT/AliTreeTrending.cxx
@@ -13,8 +13,6 @@
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
 
-
-
 ///\ingroup STAT
 ///\class AliTreeTrending
 ///\brief AliTreeTrending class for the visualization of the QA trending/alarms
@@ -23,6 +21,7 @@
  Generalization of the original TPC QA trending visualization code
  Example usage in the $AliPhysics_SRC/PWGPP/QA
  Related JIRA task - https://alice.its.cern.ch/jira/browse/ATO-361
+ // TODO -automatic resizing of pad to addapt to number of entries shown
 */
 
 #include "TStatToolkit.h"
@@ -42,6 +41,7 @@
 #include "AliLog.h"
 #include "TStyle.h"
 #include "TROOT.h"
+#include "TLegend.h"
 #include "AliTreeTrending.h"
 
 using std::cout;
@@ -67,8 +67,7 @@ AliTreeTrending::AliTreeTrending():
   fTree(NULL),
   fUserDescription(NULL),
   fLatexDescription(NULL),
-  fStatusGraph(NULL)    
-{
+  fStatusGraphM(NULL) {
 }
 //_____________________________________________________________________________
 AliTreeTrending::AliTreeTrending(const char *name, const char *title):
@@ -76,13 +75,14 @@ AliTreeTrending::AliTreeTrending(const char *name, const char *title):
   fTree(NULL),
   fUserDescription(NULL),
   fLatexDescription(NULL),
-  fStatusGraph(NULL) 
-{
+  fStatusGraphM(NULL) {
   //
   //
 }
 
-
+///
+/// \param latex
+/// \return
 TObjArray * AliTreeTrending::GetTexDescription(TLatex *latex){
   //
   // Get latex version of description
@@ -91,22 +91,22 @@ TObjArray * AliTreeTrending::GetTexDescription(TLatex *latex){
   TString sTimestamp  = TString::Format("Creation time:%s",gSystem->GetFromPipe("date").Data());
   TString sUser=TString::Format("User:%s",gSystem->GetFromPipe("echo $USER").Data());  
   TString sAlirootVer;
-  TString sAliphysicsVer;
+  TString sAliPhysicsVer;
   if (gSystem->GetFromPipe("echo $ALICE_VER") == "master" || gSystem->GetFromPipe("echo $ALICE_VER") == ""){
-    sAlirootVer = "AliRoot: " + gSystem->GetFromPipe("wdir=`pwd`; cd $ALICE_ROOT/../src; git describe; cd $wdir;");
+    sAlirootVer = "AliRoot: " + gSystem->GetFromPipe("wdir=`pwd`; cd $AliRoot_SRC/; git describe; cd $wdir;");
   }else {
     sAlirootVer = "AliRoot: " + gSystem->GetFromPipe("echo $ALIROOT_VERSION");
   }
   if (gSystem->GetFromPipe("echo $ALIPHYSICS_VER") == "master" || gSystem->GetFromPipe("echo $ALIPHYSICS_VER") == ""){
-    sAliphysicsVer = "AliPhysics: " + gSystem->GetFromPipe("wdir=`pwd`; cd $ALICE_PHYSICS/../src; git describe; cd $wdir;");
+    sAliPhysicsVer = "AliPhysics: " + gSystem->GetFromPipe("wdir=`pwd`; cd $AliPhysics_SRC/; git describe; cd $wdir;");
   }else {
-    sAliphysicsVer = "AliPhysics: " + gSystem->GetFromPipe("echo $ALIPHYSICS_VERSION");
+    sAliPhysicsVer = "AliPhysics: " + gSystem->GetFromPipe("echo $ALIPHYSICS_VERSION");
   }
   //
   description->AddLast(latex->DrawLatexNDC(latex->GetX(), latex->GetY(),sTimestamp.Data()));
   description->AddLast(latex->DrawLatexNDC(latex->GetX(), latex->GetY()-1.1*latex->GetTextSize(),sUser.Data()));
   description->AddLast(latex->DrawLatexNDC(latex->GetX(), latex->GetY()-4.4*latex->GetTextSize(),sAlirootVer.Data()));
-  description->AddLast(latex->DrawLatexNDC(latex->GetX(), latex->GetY()-5.5*latex->GetTextSize(),sAliphysicsVer.Data()));
+  description->AddLast(latex->DrawLatexNDC(latex->GetX(), latex->GetY()-5.5*latex->GetTextSize(),sAliPhysicsVer.Data()));
   if (fUserDescription!=NULL){
     Int_t entries=fUserDescription->GetEntries();
     for (Int_t i=0; i<entries; i++){
@@ -117,6 +117,8 @@ TObjArray * AliTreeTrending::GetTexDescription(TLatex *latex){
   return description;
 }
 
+/// Add user description to the report
+/// \param description
 void AliTreeTrending::AddUserDescription(TNamed * description){
   //
   // Add user description 
@@ -126,30 +128,26 @@ void AliTreeTrending::AddUserDescription(TNamed * description){
   fUserDescription->AddLast(description);
 }
 
-/// Intialize drawing for <detector> QA
-
-///  \param statusDescription       - contains statusbar-vars,-names and -criteria
+/// ### Initialize drawing for <detector> QA
+///  \param statusDescription       - contains status bar description array [variables,names,criteria]
 ///  \param descriptionSize         - Text size of description
 ///  \param cutString               - string "selection"
-
-/// Example usage 
+/// #### Example usage:
 /// \code
 /// Example usage of the AliTreeTrending::InitSummaryTrending
-/// trendingDraw->InitSummaryTrending(statusString,0.015,"defaultcut")
-/// here "defaultcut" refers to an alias set like this:   treeMC->SetAlias("defaultcut","run==TPC.Anchor.run");
-/// \endcode  
-
+/// trendingDraw->InitSummaryTrending(statusString,0.015,"defaultCut")
+/// here "defaultCut" refers to an alias set like this:   treeMC->SetAlias("defaultCut","run==TPC.Anchor.run");
+/// \endcode
 Bool_t  AliTreeTrending::InitSummaryTrending(TString statusDescription[3], Float_t descriptionSize, TString cutString){
   //
   // Init drawing for the <detector> QA
   // Detector specific qaConfig() has to be called before invoking this function
   //    0.) Make descriptor 
-  //    1.) Make default canvas - addopt canvas width to the number of entries to draw
+  //    1.) Make default canvas - addapt canvas width to the number of entries to draw
+  //    2.) initialize status aliases (outliers etc.), status bar criteria, status lines, ...
   //    3.) compute detector  status graphs
 
-  //
-  //   0.) Make descriptor 
-  //
+  //   0.) Make descriptor
   if (fTree==NULL) {
     AliError("Input tree not defined");
     return 0;
@@ -163,9 +161,7 @@ Bool_t  AliTreeTrending::InitSummaryTrending(TString statusDescription[3], Float
   latex->SetY(0.8);
   latex->SetTextSize(descriptionSize);
   fLatexDescription = GetTexDescription(latex);
-  //
-  //   1.) Make default canvas - addopt canvas width to the number of entries to draw
-  //
+  //   1.) Make default canvas - addapt canvas width to the number of entries to draw
   TGraphErrors *gr = (TGraphErrors*) TStatToolkit::MakeGraphSparse(fTree,"tagID:tagID","");
   Int_t numberOfTags = gr->GetN();
   cout<<"number of graph entries: "<<numberOfTags<<endl;
@@ -180,45 +176,25 @@ Bool_t  AliTreeTrending::InitSummaryTrending(TString statusDescription[3], Float
   fWorkingCanvas->cd();
   gPad->SetTicks(1,2);
   // fWorkingCanvas->SetRightMargin(SpaceForLegend/canvas_width);
-  double leftlegend  = 1 - 180./fWorkingCanvas->GetWw();
-  double rightlegend = 1 - 10./fWorkingCanvas->GetWw();
-  //
-  // 2.) process config file qaConfig.C to initialize status aliases (outliers etc.), status bar criteria, status lines, ...
-  //
-  TString sStatusbarVars  = statusDescription[0];
-  TString sStatusbarNames = statusDescription[1];
+  double leftLegend  = 1 - 180./fWorkingCanvas->GetWw();
+  double rightLegend = 1 - 10./fWorkingCanvas->GetWw();
+
+  // 2.) initialize status aliases (outliers etc.), status bar criteria, status lines, ...
+  TString sStatusBarVars  = statusDescription[0];
+  TString sStatusBarNames = statusDescription[1];
   TString sCriteria       = statusDescription[2];
-  cout << "sStatusbarVars = " << sStatusbarVars.Data() << endl;
+  cout << "sStatusBarVars = " << sStatusBarVars.Data() << endl;
   cout << "sCriteria      = " << sCriteria.Data() << endl;
-  //
+
   // 3.) compute detector status graphs
-  //
-  TObjArray* oaStatusbarVars = sStatusbarVars.Tokenize(";");
-  TObjArray* oaStatusbarNames = sStatusbarNames.Tokenize(";");
-  fStatusGraph = new TObjArray();
-  int igr=0;
-  for (Int_t vari=oaStatusbarVars->GetEntriesFast()-1; vari>=0; vari--){ // invert the order of the status graphs
-    TString sVar = Form("%s:tagID", oaStatusbarVars->At(vari)->GetName()); //e.g. -> dcar:run
-    TMultiGraph* multGr = TStatToolkit::MakeStatusMultGr(fTree, sVar.Data(),  cutString, sCriteria.Data(), igr);
-    if(multGr){
-        fStatusGraph->Add(multGr);
-        TString sYtitle = oaStatusbarNames->At(vari)->GetName(); // set better name for y axis of statuspad
-        ((TMultiGraph*) fStatusGraph->At(igr))->SetTitle(sYtitle.Data());
-        igr++;
-    }
-    else{
-        AliError("TStatToolkit::MakeStatusMultGr() returned with error -> next");
-        continue;
-    }
-  }
+  fStatusGraphM = MakeMultiGraphStatus(fTree,"statusBar", sStatusBarVars+";tagID",sStatusBarNames,cutString.Data(),sCriteria,kTRUE);
+  fStatusGraphM->GetYaxis()->SetTitle("");
+  fStatusGraphM->GetHistogram()->SetTitle("");
   return kTRUE;
 }
 
+/// TODO - use CSS style
 void  AliTreeTrending::SetDefaultStyle(){
-  //
-  // ??? Who is owner of drawing style ??? 
-  //
-  //
   gROOT->SetStyle("Plain");
   gStyle->SetPalette(1);
   gStyle->SetLabelSize(0.04,"x");
@@ -226,14 +202,16 @@ void  AliTreeTrending::SetDefaultStyle(){
   gStyle->SetPadTickY(1);
 }
 
-
-
-void AliTreeTrending::AppendStatusPad(Float_t padratio, Float_t bottomMargin, Float_t rightMargin){
+///
+/// \param padRatio
+/// \param bottomMargin
+/// \param rightMargin
+void AliTreeTrending::AppendStatusPad(Float_t padRatio, Float_t bottomMargin, Float_t rightMargin){
   //
   // Add status pad and latex description to the canvas (can be pad?)
-  // status pad and latex description using data mbers of trendingDraw class
+  // status pad and latex description using data members of trendingDraw class
   //
-  // 1.) Split canvase
+  // 1.) Split canvas
   // 2.) Draw status bar in lower part of canvas
   //
   if (fLatexDescription==NULL){
@@ -250,11 +228,11 @@ void AliTreeTrending::AppendStatusPad(Float_t padratio, Float_t bottomMargin, Fl
   c1->Clear();
   // produce new pads
   c1->cd();
-  TPad* pad1 = new TPad("pad1", "pad1", 0., padratio, 1., 1.); 
+  TPad* pad1 = new TPad("pad1", "pad1", 0., padRatio, 1., 1.);
   pad1->Draw();
   pad1->SetNumber(1); // so it can be called via "c1->cd(1);"
   c1->cd();
-  TPad* pad2 = new TPad("pad2", "pad2", 0., 0., 1., padratio);
+  TPad* pad2 = new TPad("pad2", "pad2", 0., 0., 1., padRatio);
   pad2->Draw();
   pad2->SetNumber(2);
   // draw original canvas into first pad
@@ -266,30 +244,209 @@ void AliTreeTrending::AppendStatusPad(Float_t padratio, Float_t bottomMargin, Fl
   c1->cd(2);
   pad2->SetGrid(3);
   pad2->SetTopMargin(0);
-  pad2->SetBottomMargin(bottomMargin); // for the long x-axis labels (runnumbers)
-  pad2->SetRightMargin(rightMargin);  
-  //
-  //
-  const Int_t nvars = fStatusGraph->GetEntriesFast();
-  TGraph* grAxis = (TGraph*) ((TMultiGraph*) fStatusGraph->At(0))->GetListOfGraphs()->At(0);
-  grAxis->SetMaximum(0.5*nvars+0.5);
-  grAxis->SetMinimum(0);
-  grAxis->GetYaxis()->SetLabelSize(0);
-  grAxis->GetYaxis()->SetTitle("");
-  grAxis->SetTitle("");
+  pad2->SetBottomMargin(bottomMargin); // for the long x-axis labels (run numbers)
+  pad2->SetRightMargin(rightMargin);
+  const Int_t nVars = fStatusGraphM->GetYaxis()->GetNbins();
+  TGraph* grAxis = (TGraph*) fStatusGraphM->GetListOfGraphs()->At(0);
   Int_t entries = grAxis->GetN();
-  grAxis->GetXaxis()->SetLabelSize(5.7*TMath::Min(TMath::Max(5./entries,0.01),0.03));
-  grAxis->GetXaxis()->LabelsOption("v");
-  grAxis->Draw("ap");
-  //
-  // draw multigraphs & names of status variables on the y axis
-  for (Int_t i=0; i<nvars; i++){
-    ((TMultiGraph*) fStatusGraph->At(i))->Draw("p");
-    TLatex* ylabel = new TLatex(-0.1, 0.5*i+0.5, ((TMultiGraph*) fStatusGraph->At(i))->GetTitle());
-    ylabel->SetTextAlign(32); //hor:right & vert:centered
-    ylabel->SetTextSize(0.025/gPad->GetHNDC());
-    ylabel->Draw();
-  } 
+  fStatusGraphM->GetXaxis()->SetLabelSize(5.7*TMath::Min(TMath::Max(5./entries,0.01),0.03));
+  fStatusGraphM->GetYaxis()->SetLabelSize(0.025/gPad->GetHNDC());
+  fStatusGraphM->Draw("ap");
   c1->cd(1)->Draw();
 }
+
+
+/// \param fTree          - input tree
+/// \param mgrName        - name of the output TMultiGraph // TODO - to use together CSS
+/// \param expression     - expression to draw
+/// \param varTitle       - title description
+/// \param cutString      - selection string
+/// \param sCriteria      - criteria to draw
+/// \return               - return status MultiGraph
+/*!
+### Example usage
+\code
+  TString expression="dcarAP0;dcarAP1;dcarCP0;dcarCP1;dcar_posA_0;dcar_posA_1;dcar_posA_2;dcar_posC_0;dcar_posC_1;dcar_posC_2;";
+  TString varTitle="dcarAP0;dcarAP1;dcarCP0;dcarCP1;dcar_posA_0;dcar_posA_1;dcar_posA_2;dcar_posC_0;dcar_posC_1;dcar_posC_2;";
+  expression+="TPC.Anchor.dcarAP0;TPC.Anchor.dcarAP1;TPC.Anchor.dcarCP0;TPC.Anchor.dcarCP1;TPC.Anchor.dcar_posA_0;TPC.Anchor.dcar_posA_1;TPC.Anchor.dcar_posA_2;TPC.Anchor.dcar_posC_0;TPC.Anchor.dcar_posC_1;TPC.Anchor.dcar_posC_2;run";
+  varTitle+="TPC.Anchor.dcarAP0;TPC.Anchor.dcarAP1;TPC.Anchor.dcarCP0;TPC.Anchor.dcarCP1;TPC.Anchor.dcar_posA_0;TPC.Anchor.dcar_posA_1;TPC.Anchor.dcar_posA_2;TPC.Anchor.dcar_posC_0;TPC.Anchor.dcar_posC_1;TPC.Anchor.dcar_posC_2";
+  TString sCriteria("1-2*(varname_Warning):(statisticOK):(varname_Warning):(varname_Outlier):(varname_PhysAcc)"); // or to just show veto : (varname_PhysAcc&&varname_Warning)
+  cutString="defaultCut";
+  grTest0=AliTreeTrending::MakeMultiGraphStatus(treeMC, "DCA Status", expression, varTitle, cutString,sCriteria);
+  TStatToolkit::DrawMultiGraph(grTest0,"ap");
+  trendingDraw->AppendStatusPad(0.3, 0.4, 0.05);
+
+\endcode
+ */
+TMultiGraph * AliTreeTrending::MakeMultiGraphStatus(TTree *fTree, TString mgrName, TString expression, TString varTitle, TCut cutString, TString sCriteria, Bool_t setAxis) {
+  // 1. Make TMultiGraph for each group
+  TObjArray *oaStatusBarVars = expression.Tokenize(";:");
+  TObjArray *oaStatusBarNames = varTitle.Tokenize(";:");
+  Int_t nVars = oaStatusBarVars->GetEntriesFast() - 1;
+  TObjArray *graphArray = new TObjArray(nVars);
+  for (Int_t iVar = 0; iVar < nVars; iVar++) {
+    TString sVar = Form("%s:%s", oaStatusBarVars->At(iVar)->GetName(),
+                        oaStatusBarVars->At(nVars)->GetName()); //e.g. -> dcar:run
+    TMultiGraph *multGr = TStatToolkit::MakeStatusMultGr(fTree, sVar.Data(), cutString, sCriteria.Data(), 2*iVar);
+    if (multGr) {
+      graphArray->AddAt(multGr, iVar);
+      ((TMultiGraph *) graphArray->At(iVar))->SetTitle(oaStatusBarNames->At(iVar)->GetName());
+      for (Int_t igr = 0; igr < multGr->GetListOfGraphs()->GetEntries(); igr++) {  // Code names and codes to the object names
+        TGraph *cgr = (TGraph *) multGr->GetListOfGraphs()->At(igr);
+        cgr->SetName(TString((oaStatusBarNames->At(iVar)->GetName())).Data());
+      }
+    } else {
+      ::Error("AliTreeTrending::MakeMultiGraphStatus", "TStatToolkit::MakeStatusMultGr() returned with error -> next");
+      continue;
+    }
+  }
+  // 2.) Set Y ranges and Y labels for each graph
+  Double_t *yBins = new Double_t[nVars+1];
+  for(Int_t i=0; i<=nVars;i++) yBins[i] = Double_t(i);
+  TMultiGraph *mgrCombined=new TMultiGraph(mgrName,"Status");
+  for (Int_t i=0; i<nVars; i++) {
+    TMultiGraph * mgr=((TMultiGraph*) graphArray->At(i));
+    if (mgr==NULL) continue;
+    for (Int_t igr=0; igr<mgr->GetListOfGraphs()->GetEntries(); igr++) {
+      TGraph *cgr = (TGraph *) mgr->GetListOfGraphs()->At(igr);
+      cgr->SetTitle(""); cgr->GetYaxis()->SetTitle("");
+      cgr->GetYaxis()->Set(nVars, yBins);
+      cgr->GetYaxis()->SetRangeUser(0,nVars);
+      for (Int_t jgr=0; jgr<nVars; jgr++)  cgr->GetYaxis()->SetBinLabel(jgr+1, graphArray->At(jgr)->GetTitle());
+      mgrCombined->Add(cgr);
+    }
+  }
+  // TStatToolkit::DrawMultiGraph(mgrCombined,"ap");
+  if (setAxis) {      //TODO  - to get axis graph has to be drawn - is there other option ?
+    TGraph *gr0=(TGraph *) mgrCombined->GetListOfGraphs()->At(0);
+    mgrCombined->Draw("ap");
+    mgrCombined->GetXaxis()->Set(gr0->GetXaxis()->GetNbins(), gr0->GetXaxis()->GetXbins()->GetArray());
+    for (Int_t jgr = 0; jgr < gr0->GetXaxis()->GetNbins(); jgr++)
+      mgrCombined->GetXaxis()->SetBinLabel(jgr + 1, gr0->GetXaxis()->GetBinLabel(jgr+1));
+    mgrCombined->GetYaxis()->Set(nVars, yBins);
+    mgrCombined->GetYaxis()->SetRangeUser(0, nVars);
+    for (Int_t jgr = 0; jgr < nVars; jgr++)
+      mgrCombined->GetYaxis()->SetBinLabel(jgr + 1, graphArray->At(jgr)->GetTitle());
+    mgrCombined->GetYaxis()->SetTitle("");
+    mgrCombined->Draw("ap");
+  }
+  delete oaStatusBarVars;
+  delete oaStatusBarNames;
+  delete graphArray;
+  return mgrCombined;
+}
+
+/// #### MakePlot
+/// * make a MultiGraph using array of TTree expression queries
+/// * format legend
+///   * crate legend box
+///   * append variable.<legend> metadata into legend
+/// * save resulting figure into file
+/// TODO - use css style for default variables
+/// \param outputDir      - directory to save figure
+/// \param figureName     - name of the output figure file
+/// \param LegendTitle    - legend  title
+/// \param legendPos      - boundary box of legend
+/// \param groupName      - name of the plot group (TO BE used in combination with the CSS )
+/// \param expr           - semicolon separated list of graphs (TFormula) expression  to draw
+/// \param cut            - selection
+/// \param markers        - marker style specification (AliDrawStyle::GetXXXStyle())  //TODO - finish  CSS style
+/// \param colors         - marker style specification (AliDrawStyle::GetXXXStyle())  //TODO - finish  CSS style
+/// \param drawSparse     - kTRUE  - SparseGraph created, kFALSE - normal graph is produced
+/// \param markerSize     - size of marker  //TODO - finish  CSS style
+/// \param sigmaRange     - sigma range for automatic // TO use CSS style
+/// \param comp           - ????
+void AliTreeTrending::MakePlot(const char* outputDir, const char *figureName, const char *LegendTitle, std::vector<Double_t>& legendPos, const char *groupName, const char* expr, const char * cut, const char * markers, const char *colors, Bool_t drawSparse, Float_t markerSize, Float_t sigmaRange, Bool_t comp) {
+  TMultiGraph *graph=0;
+  fWorkingCanvas->Clear();
+  TLegend *legend = new TLegend(legendPos[0],legendPos[1],legendPos[2],legendPos[3],LegendTitle);
+  legend->SetBorderSize(0);
+  graph = TStatToolkit::MakeMultGraph(fTree,groupName,expr,cut,markers,colors,drawSparse,markerSize,sigmaRange,legend,comp);
+  if (groupName) graph->SetName(groupName);
+  if(!graph){
+    ::Error("MakePlot","No plot returned -> dummy plot!");
+  }
+  else {
+    if (drawSparse) TStatToolkit::RebinSparseMultiGraph(graph,(TGraph*)fStatusGraphM->GetListOfGraphs()->At(0));
+    TStatToolkit::DrawMultiGraph(graph,"alp");
+    AppendStatusPad(0.3, 0.4, 0.05);
+    legend->SetFillStyle(0);
+    legend->Draw();
+  }
+  if(outputDir!=0){
+    fWorkingCanvas->SaveAs(TString(outputDir)+"/"+TString(figureName));
+    fWorkingCanvas->Print(TString(outputDir)+"/report.pdf");
+  }
+}
+
+/// ### AppendBand to existing plots
+/// * draw line bands
+/// * optionally save figure into file
+/// TO BE used for indication of dead bands
+/// TODO  - add css style
+/// \param outputDir     -  directory to save figure - Optional
+/// \param figureName    -  output figure name - Optional
+/// \param expr          -  semicolon separate list of lines (TTreeFormula)
+/// \param cut           -  selection criteria
+/// \param lineStyle     -  line style     //TODO use CSS style
+/// \param colors        -  line colors    //TODO use CSS style
+/// \param drawSparse    -  indication draw sparse
+/// \param sigmaRange    -  Not used
+/// \param comp          -  to remove
+void AliTreeTrending::AppendBand(const char* outputDir, const char *figureName, const char* expr, const char * cut, const char * lineStyle, const char *colors, Bool_t drawSparse, Float_t sigmaRange, Bool_t comp) {
+  TMultiGraph *graph=0;
+  graph = TStatToolkit::MakeMultGraph(fTree,"",expr,cut,lineStyle,colors,drawSparse,0,sigmaRange,0,comp);
+  if(!graph){
+    ::Error("MakePlot","No plot returned -> dummy plot!");
+  }
+  else {
+    if (drawSparse) TStatToolkit::RebinSparseMultiGraph(graph,(TGraph*)fStatusGraphM->GetListOfGraphs()->At(0));
+    TStatToolkit::DrawMultiGraph(graph,"l");
+  }
+  if(outputDir!=0){
+    fWorkingCanvas->SaveAs(TString(outputDir)+"/"+TString(figureName));
+    fWorkingCanvas->Print(TString(outputDir)+"/report.pdf");
+  }
+  static Int_t counter=0;
+  AliSysInfo::AddStamp(expr,2,counter++);
+}
+
+/// #### MakeStatusPlot
+/// * make status graphs
+/// * optionally save figure
+/// \param outputDir      - directory to save file
+/// \param figureName     - figure name
+/// \param expression     - semicolon separated list of the status variables (variables to be evaluated)
+/// \param varTitle       - titles to show on y axis
+/// \param cutString      - selection string - cut
+/// \param sCriteria      - criteria to draw ()
+/// \return               - return status TMultiGraph
+/*!
+#### Example usage:
+* assuming trendingDraw was properly initialized)
+\code
+  TString expression="dcarAP0;dcarAP1;dcarCP0;dcarCP1;dcar_posA_0;dcar_posA_1;dcar_posA_2;dcar_posC_0;dcar_posC_1;dcar_posC_2;";
+  TString varTitle="dcarAP0;dcarAP1;dcarCP0;dcarCP1;dcar_posA_0;dcar_posA_1;dcar_posA_2;dcar_posC_0;dcar_posC_1;dcar_posC_2;";
+  expression+="TPC.Anchor.dcarAP0;TPC.Anchor.dcarAP1;TPC.Anchor.dcarCP0;TPC.Anchor.dcarCP1;TPC.Anchor.dcar_posA_0;TPC.Anchor.dcar_posA_1;TPC.Anchor.dcar_posA_2;TPC.Anchor.dcar_posC_0;TPC.Anchor.dcar_posC_1;TPC.Anchor.dcar_posC_2;run";
+  varTitle+="TPC.Anchor.dcarAP0;TPC.Anchor.dcarAP1;TPC.Anchor.dcarCP0;TPC.Anchor.dcarCP1;TPC.Anchor.dcar_posA_0;TPC.Anchor.dcar_posA_1;TPC.Anchor.dcar_posA_2;TPC.Anchor.dcar_posC_0;TPC.Anchor.dcar_posC_1;TPC.Anchor.dcar_posC_2";
+  cutString="defaultCut";
+  trendingDraw->MakeStatusPlot("./", "dcaStatus.png", expression, varTitle, cutString,sCriteria);
+\endcode
+*/
+void AliTreeTrending::MakeStatusPlot(const char *outputDir, const char *figureName,  TString expression, TString varTitle,
+                    TCut cutString, TString sCriteria) {
+  fWorkingCanvas->Clear();
+  TMultiGraph *multiGraph = AliTreeTrending::MakeMultiGraphStatus(fTree,"",  expression, varTitle, cutString, sCriteria);
+  TStatToolkit::DrawMultiGraph(multiGraph, "ap");
+  AppendStatusPad(0.3, 0.4, 0.05);
+  if (outputDir != NULL) {
+    fWorkingCanvas->SaveAs(TString(outputDir) + "/" + TString(figureName));
+    fWorkingCanvas->Print(TString(outputDir) + "/report.pdf");
+  }
+  static Int_t counter=0;
+  AliSysInfo::AddStamp(expression.Data(),3,counter++);
+}
+
+
+
 

--- a/STAT/AliTreeTrending.cxx
+++ b/STAT/AliTreeTrending.cxx
@@ -43,6 +43,7 @@
 #include "TROOT.h"
 #include "TLegend.h"
 #include "AliTreeTrending.h"
+#include "AliDrawStyle.h"
 
 using std::cout;
 using std::cerr;
@@ -374,18 +375,26 @@ TMultiGraph * AliTreeTrending::MakeMultiGraphStatus(TTree *fTree, TString mgrNam
 /// \param sigmaRange     - sigma range for automatic // TO use CSS style
 /// \param comp           - ????
 void AliTreeTrending::MakePlot(const char* outputDir, const char *figureName, const char *LegendTitle, std::vector<Double_t>& legendPos, const char *groupName, const char* expr, const char * cut, const char * markers, const char *colors, Bool_t drawSparse, Float_t markerSize, Float_t sigmaRange, Bool_t comp) {
-  TMultiGraph *graph=0;
+  TMultiGraph *mgraph=0;
   fWorkingCanvas->Clear();
   TLegend *legend = new TLegend(legendPos[0],legendPos[1],legendPos[2],legendPos[3],LegendTitle);
   legend->SetBorderSize(0);
-  graph = TStatToolkit::MakeMultGraph(fTree,groupName,expr,cut,markers,colors,drawSparse,markerSize,sigmaRange,legend,comp);
-  if (groupName) graph->SetName(groupName);
-  if(!graph){
+  mgraph = TStatToolkit::MakeMultGraph(fTree,groupName,expr,cut,markers,colors,drawSparse,markerSize,sigmaRange,legend,comp);
+  
+  AliDrawStyle::SetCssStyle("testStyle",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
+  for(Int_t it=0; it<mgraph->GetListOfGraphs()->GetSize(); it++){
+    TGraph* graph = (TGraph*) mgraph->GetListOfGraphs()->At(it);
+    graph->SetName(TString::Format("graph[%d].class(multiGraphPair)",it).Data());
+    AliDrawStyle::TGraphApplyStyle("testStyle",graph);
+  }
+  
+  if (groupName) mgraph->SetName(groupName);
+  if(!mgraph){
     ::Error("MakePlot","No plot returned -> dummy plot!");
   }
   else {
-    if (drawSparse) TStatToolkit::RebinSparseMultiGraph(graph,(TGraph*)fStatusGraphM->GetListOfGraphs()->At(0));
-    TStatToolkit::DrawMultiGraph(graph,"alp");
+    if (drawSparse) TStatToolkit::RebinSparseMultiGraph(mgraph,(TGraph*)fStatusGraphM->GetListOfGraphs()->At(0));
+    TStatToolkit::DrawMultiGraph(mgraph,"alp");
     AppendStatusPad(0.3, 0.4, 0.05);
     legend->SetFillStyle(0);
     legend->Draw();

--- a/STAT/AliTreeTrending.cxx
+++ b/STAT/AliTreeTrending.cxx
@@ -621,4 +621,43 @@ void AliTreeTrending::DecomposeStatusAlias(TTree* tree, TString currentString, T
 }
 
 
+/// Print to the output string object names fulfilling criteria sRegExp
+/// \param array            - input TCollection
+/// \param regExp           - regular expression to select
+/// \param separator        -
+/// \return                 - string
+TString AliTreeTrending::ArrayNameToString(TCollection *array, TString sRegExp, TString separator){
+  TString output="";
+  TPRegexp regExp(sRegExp);
+  TIter next(array);
+  TObject *object;
+  while ( ( object =next())) {
+    if (regExp.Match(object->GetName())) {
+      output += object->GetName();
+      output += separator;
+    }
+  }
+  return output;
+}
+
+
+/// AddHtmlLink - helper function to build html page for JSROOT
+/// \param pFile   - pointer to the output html text file
+/// \param title   - Title of the section
+/// \param prefix  - prefix Query
+/// \param items   - comma separated list of figures to include
+/*!
+    TString prefix="http://localhost:90/data/jsroot/index.htm?file=http://localhost:90/data/alice-tpc-notes/JIRA/ATO-83/test/report.root"
+    items=AliTreeTrending::ArrayNameToString(fReport->GetListOfKeys(),".*tatus.*",",");
+    AliTreeTrending::AddJSROOTHtmlLink(pFile,"Status", prefix, Form("items=[%s]",items.Data()));
+*/
+void AliTreeTrending::AddJSROOTHtmlLink(FILE * pFile, TString title,  TString prefix, TString items){
+  fprintf(pFile, "<b>%s</b>",title.Data());
+  fprintf(pFile, "<a href=\"%s&%s&layout=tabs\">[all,</a>",prefix.Data(),items.Data());
+  fprintf(pFile, "<a href=\"%s&%s&layout=collapsible&nobrowser\">col,</a>",prefix.Data(),items.Data());
+  fprintf(pFile, "<a href=\"%s&%s&layout=tabs&nobrowser\">tabs,</a>",prefix.Data(),items.Data());
+  fprintf(pFile, "<a href=\"%s&%s&layout=flex&nobrowser\">flex]</a>",prefix.Data(),items.Data());
+  fprintf(pFile, "<br>");
+}
+
 

--- a/STAT/AliTreeTrending.cxx
+++ b/STAT/AliTreeTrending.cxx
@@ -43,6 +43,7 @@
 #include "TROOT.h"
 #include "TLegend.h"
 #include "AliTreeTrending.h"
+#include <stdexcept>      // std::invalid_argument
 #include "AliDrawStyle.h"
 
 using std::cout;

--- a/STAT/AliTreeTrending.h
+++ b/STAT/AliTreeTrending.h
@@ -33,8 +33,9 @@ public:
   //
   void MakePlot(const char* outputDir, const char *figureName, const char *LegendTitle, std::vector<Double_t>& legendPos, const char *groupName, const char* expr, const char * cut, const char * markers, const char *colors, Bool_t drawSparse, Float_t markerSize, Float_t sigmaRange, Bool_t comp);
   void AppendBand(const char* outputDir, const char *figureName, const char* expr, const char * cut, const char * lineStyle, const char *colors, Bool_t drawSparse, Float_t sigmaRange, Bool_t comp) ;
-  void MakeStatusPlot(const char* outputDir, const char *figureName, TString expression, TString varTitle, TCut cutString, TString sCriteria);
+  void MakeStatusPlot(const char* outputDir, const char *figureName, TString expression, TString varTitle, TCut cutString, TString sCriteria, TString friendName="");
   static TMultiGraph * MakeMultiGraphStatus(TTree *fTree, TString mgrName, TString expression, TString varTitle, TCut cutString, TString sCriteria, Bool_t setAxis=kFALSE);
+  static void  DecomposeStatusAlias(TTree* tree, TString currentString, TString &statusVar, TString &statusTitle, TPRegexp &suffix, Int_t &counter);
   // TODO void MakeHtml(char *htmlName, char *varList)
 public:
   TObjArray *  GetTexDescription(TLatex *latex);  /// Currently only standard variables

--- a/STAT/AliTreeTrending.h
+++ b/STAT/AliTreeTrending.h
@@ -2,10 +2,7 @@
 #define ALITREETRENDING_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */
-
 /* $Id$ */
-
-
 ///\ingroup STAT
 ///\class AliTreeTrending
 ///\brief AliTreeTrending class for the visualization of the QA trending/alarms
@@ -15,14 +12,15 @@
  Example usage in the $AliPhysics_SRC/PWGPP/QA
  Related JIRA task - https://alice.its.cern.ch/jira/browse/ATO-361
 */
- 
+
 class TTree;
 class TObjArray;
 class TNamed;
 class TStyle;
+class TMultiGraph;
+class TLegend;
 
 class AliTreeTrending : public TNamed {
-
 public:
   AliTreeTrending();
   AliTreeTrending(const char *name, const char *title);
@@ -31,18 +29,22 @@ public:
   void AddUserDescription(TNamed *description);  //
   Bool_t  InitSummaryTrending(TString statusDescription[3], Float_t descriptionSize=0.015, TString cutString="");
   void SetDefaultStyle();  // own style to be used - not yet
-  void AppendStatusPad(Float_t padratio, Float_t bottomMargin, Float_t rightMargin);
+  void AppendStatusPad(Float_t padRatio, Float_t bottomMargin, Float_t rightMargin);
+  //
+  void MakePlot(const char* outputDir, const char *figureName, const char *LegendTitle, std::vector<Double_t>& legendPos, const char *groupName, const char* expr, const char * cut, const char * markers, const char *colors, Bool_t drawSparse, Float_t markerSize, Float_t sigmaRange, Bool_t comp);
+  void AppendBand(const char* outputDir, const char *figureName, const char* expr, const char * cut, const char * lineStyle, const char *colors, Bool_t drawSparse, Float_t sigmaRange, Bool_t comp) ;
+  void MakeStatusPlot(const char* outputDir, const char *figureName, TString expression, TString varTitle, TCut cutString, TString sCriteria);
+  static TMultiGraph * MakeMultiGraphStatus(TTree *fTree, TString mgrName, TString expression, TString varTitle, TCut cutString, TString sCriteria, Bool_t setAxis=kFALSE);
   // TODO void MakeHtml(char *htmlName, char *varList)
 public:
-  TObjArray *  GetTexDescription(TLatex *latex);  // Currently only standard variables
-  TTree     *  fTree;              // working tree with friends
-  TObjArray *  fUserDescription;   // user defined description
-  TObjArray *  fLatexDescription;  // description of process  (time/aliroot/root/user)
-  TCanvas   *  fWorkingCanvas;     // default canvas
-  TObjArray *  fStatusGraph;       // fStatusGraph
-  //TVectorF   fPadMargin;         // pad margin
-  TStyle    *  fDrawStyle;         // TreeTrending owner of drawing style - currently gStyle used
-  ClassDef(AliTreeTrending,1)       
+  TObjArray *  GetTexDescription(TLatex *latex);  /// Currently only standard variables
+  TTree     *  fTree;              /// working tree with friends
+  TObjArray *  fUserDescription;   /// user defined description
+  TObjArray *  fLatexDescription;  /// description of process  (time/aliroot/root/user)
+  TCanvas   *  fWorkingCanvas;     /// default canvas
+  TMultiGraph *fStatusGraphM;      /// status graph
+  TStyle    *  fDrawStyle;         /// TreeTrending owner of drawing style - currently gStyle used
+  ClassDef(AliTreeTrending,2)
 };
 
 

--- a/STAT/AliTreeTrending.h
+++ b/STAT/AliTreeTrending.h
@@ -44,7 +44,8 @@ public:
   TObjArray *  fLatexDescription;  /// description of process  (time/aliroot/root/user)
   TCanvas   *  fWorkingCanvas;     /// default canvas
   TMultiGraph *fStatusGraphM;      /// status graph
-  TStyle    *  fDrawStyle;         /// TreeTrending owner of drawing style - currently gStyle used
+  TStyle    *  fDrawStyle;         /// TreeTrending owner of drawing style - currently gStyle used  // TODO make  OBSOLETE
+  TString      fCurrentCSSStyle;   /// Name of the  CSS style to be used - if empty string current CSS style used
   TFile     *  fReport;            /// root report file
   ClassDef(AliTreeTrending,2)
 };

--- a/STAT/AliTreeTrending.h
+++ b/STAT/AliTreeTrending.h
@@ -39,6 +39,9 @@ public:
   static TMultiGraph * MakeMultiGraphStatus(TTree *fTree, TString mgrName, TString expression, TString varTitle, TCut cutString, TString sCriteria, Bool_t setAxis=kFALSE);
   static void  DecomposeStatusAlias(TTree* tree, TString currentString, TString &statusVar, TString &statusTitle, TPRegexp &suffix, Int_t &counter, TString &maskAlias);
   // TODO void MakeHtml(char *htmlName, char *varList)
+  // JSROOT export related helper functions
+  static TString ArrayNameToString(TCollection *array, TString sRegExp, TString separator);
+  static void AddJSROOTHtmlLink(FILE * pFile, TString title,  TString prefix, TString items);
 public:
   TObjArray *  GetTexDescription(TLatex *latex);  /// Currently only standard variables
   TTree     *  fTree;              /// working tree with friends

--- a/STAT/AliTreeTrending.h
+++ b/STAT/AliTreeTrending.h
@@ -23,16 +23,18 @@ class TLegend;
 class AliTreeTrending : public TNamed {
 public:
   AliTreeTrending();
-  AliTreeTrending(const char *name, const char *title);
+  AliTreeTrending(const char *name, const char *title, const char *cssStyle="");
   ~AliTreeTrending(){;}
   void SetTree(TTree * tree) {fTree=tree;};
   void AddUserDescription(TNamed *description);  //
   Bool_t  InitSummaryTrending(TString statusDescription[3], Float_t descriptionSize=0.015, TString cutString="");
   void SetDefaultStyle();  // own style to be used - not yet
+  Bool_t SetCssStyle(const char *cssStyle="");
   void AppendStatusPad(Float_t padRatio, Float_t bottomMargin, Float_t rightMargin);
   //
   void MakePlot(const char* outputDir, const char *figureName, const char *LegendTitle, std::vector<Double_t>& legendPos, const char *groupName, const char* expr, const char * cut, const char * markers, const char *colors, Bool_t drawSparse, Float_t markerSize, Float_t sigmaRange, Bool_t comp);
   void AppendBand(const char* outputDir, const char *figureName, const char* expr, const char * cut, const char * lineStyle, const char *colors, Bool_t drawSparse, Float_t sigmaRange, Bool_t comp) ;
+  void AppendDefaultBands(const char *outputDir, const char *figureName,const char * refVariable,const char * bandNamePrefix, const char * selection, const char* groupName);
   void MakeStatusPlot(const char* outputDir, const char *figureName, TString expression, TString varTitle, TCut cutString, TString sCriteria, TString friendName="");
   static TMultiGraph * MakeMultiGraphStatus(TTree *fTree, TString mgrName, TString expression, TString varTitle, TCut cutString, TString sCriteria, Bool_t setAxis=kFALSE);
   static void  DecomposeStatusAlias(TTree* tree, TString currentString, TString &statusVar, TString &statusTitle, TPRegexp &suffix, Int_t &counter, TString &maskAlias);
@@ -45,7 +47,7 @@ public:
   TCanvas   *  fWorkingCanvas;     /// default canvas
   TMultiGraph *fStatusGraphM;      /// status graph
   TStyle    *  fDrawStyle;         /// TreeTrending owner of drawing style - currently gStyle used  // TODO make  OBSOLETE
-  TString      fCurrentCSSStyle;   /// Name of the  CSS style to be used - if empty string current CSS style used
+  TString      fCurrentCssStyle;   /// Name of the  CSS style to be used - if empty string current CSS style used
   TFile     *  fReport;            /// root report file
   ClassDef(AliTreeTrending,2)
 };

--- a/STAT/AliTreeTrending.h
+++ b/STAT/AliTreeTrending.h
@@ -35,7 +35,7 @@ public:
   void AppendBand(const char* outputDir, const char *figureName, const char* expr, const char * cut, const char * lineStyle, const char *colors, Bool_t drawSparse, Float_t sigmaRange, Bool_t comp) ;
   void MakeStatusPlot(const char* outputDir, const char *figureName, TString expression, TString varTitle, TCut cutString, TString sCriteria, TString friendName="");
   static TMultiGraph * MakeMultiGraphStatus(TTree *fTree, TString mgrName, TString expression, TString varTitle, TCut cutString, TString sCriteria, Bool_t setAxis=kFALSE);
-  static void  DecomposeStatusAlias(TTree* tree, TString currentString, TString &statusVar, TString &statusTitle, TPRegexp &suffix, Int_t &counter);
+  static void  DecomposeStatusAlias(TTree* tree, TString currentString, TString &statusVar, TString &statusTitle, TPRegexp &suffix, Int_t &counter, TString &maskAlias);
   // TODO void MakeHtml(char *htmlName, char *varList)
 public:
   TObjArray *  GetTexDescription(TLatex *latex);  /// Currently only standard variables
@@ -45,6 +45,7 @@ public:
   TCanvas   *  fWorkingCanvas;     /// default canvas
   TMultiGraph *fStatusGraphM;      /// status graph
   TStyle    *  fDrawStyle;         /// TreeTrending owner of drawing style - currently gStyle used
+  TFile     *  fReport;            /// root report file
   ClassDef(AliTreeTrending,2)
 };
 

--- a/STAT/CMakeLists.txt
+++ b/STAT/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SRCS
     AliTreeTrending.cxx
     AliNDFormulaBrowser.cxx
     AliDrawStyle.cxx
+        AliPainter.cxx
     AliElasticSearchRoot.cxx)
 
 # Dependencies (libraries)

--- a/STAT/Macros/aliExternalInfo.C
+++ b/STAT/Macros/aliExternalInfo.C
@@ -118,14 +118,15 @@ void drawLogbookMultiCut(TString period, TString pass,TString runSelection="", T
 /// \param source"       - source list          e.g:   : Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT
 /// ##Example usage:
 /*!
+\code
  .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C
  makeHTMLPage("LHC15o","pass1", "QA.TPC.meanTPCncl>0", "run:runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:QA.TPC.meanMIP:QA.TPC.meanMIP", "Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT")
  makeHTMLPage("LHC15o","pass1", "QA.TPC.meanTPCncl>0", "run:runDuration:totalEventsPhysics:ocdbStatusCounter:ocdbHVStatusCounter:TPC_Status:meanTPCncl_Status:PID_Status:DCAz_Status:DCAr_Status:tpcItsMatch_Status", "Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT")
-
+\endcode
  */
 void makeHTMLPage(TString  period,TString  pass, TString runSelection, TString varSelection, TString source){
   TTree * tree = info.GetTree("Logbook",period,pass,source);
   AliTreePlayer::selectWhatWhereOrderBy(tree,varSelection.Data(), runSelection.Data(),"",0,100000,"html","table.html");
   delete tree;
-  gSystem->GetFromPipe("$NOTES/JIRA/ATO-360/code/makeHtml.sh table.html index.html 0");
+  gSystem->GetFromPipe(" table.html index.html 0");
 }

--- a/STAT/Macros/aliExternalInfo.C
+++ b/STAT/Macros/aliExternalInfo.C
@@ -131,5 +131,6 @@ void makeHTMLPage(TString  period,TString  pass, TString runSelection, TString v
   TTree * tree = info.GetTree("Logbook",period,pass,source);
   AliTreePlayer::selectWhatWhereOrderBy(tree,varSelection.Data(), runSelection.Data(),"",0,100000,"html","table.html");
   delete tree;
-  gSystem->GetFromPipe("$AliPhysics_SRC/PWGPP/scripts/makeHtml.sh index.html table.html 0");
+  gSystem->GetFromPipe("$AliPhysics_SRC/PWGPP/scripts/makeHtmlv1.sh index.html table.html 0");
+
 }

--- a/STAT/Macros/aliExternalInfo.C
+++ b/STAT/Macros/aliExternalInfo.C
@@ -20,7 +20,7 @@
 /*!
     .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C
     // define some example selection and copy past the code below
-    TString  period="LHC15o", pass="pass1", runSelection="QA.TPC.meanTPCncl>0", varSelection="run:runDuration:totalEventsPhysics:totalNumberOfFilesMigrated";
+    TString  period="LHC15o", pass="pass1", runSelection="QA.TPC.meanTPCncl>0", varSelection="run:runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:QA.TPC.meanMIP";
     TString source="Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT";
 */
 
@@ -106,18 +106,26 @@ void drawLogbookMultiExpr(TString period, TString pass,TString runSelection="", 
  */
 void drawLogbookMultiCut(TString period, TString pass,TString runSelection="", TString varSelection="LHCperiod:runDuration:totalEventsPhysics:totalNumberOfFilesMigrated") {
   TTree *treeLogbook = info.GetTree("Logbook", period, pass, "QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT");
-  TMultiGraph *m1 = TStatToolkit::MakeMultGraph(treeLogbook,"","runDuration:run","totalNumberOfFilesMigrated>2000;(run<245000);abs(run-245500)<500;(run>246000)","25;21;22;24","1;2;4", kFALSE, 1,6,0);
+  TMultiGraph *m1 = TStatToolkit::MakeMultGraph(treeLogbook,"","runDuration:run","totalNumberOfFilesMigrated>2000;(run<245000);abs(run-245500)<500;(run>246000)","figTemplateTRD","figTemplateTRD", kFALSE, 1,6,0);
   m1->Draw("ap");
 }
 
-/// makeHTMLPage
-/// \param period
-/// \param pass
-/// \param runSelection
-/// \param varSelection
-/// \param source
-void makeHTMLPage(TString  period,TSring  pass, TString runSelection, TString varSelection, TString source){
-  TTree * tree = info.GetTree("Logbook",period,pass,source);
+/// makeHTMLPage - make a standard html page
+/// \param period        - period               e.g.   : LHC15o
+/// \param pass          - reconstruction pass  e.g.   : pass1
+/// \param runSelection  - run selection cut    e.g.   : MonALISA.RCT.tpc_value>0&&QA.TPC.meanTPCncl>0
+/// \param varSelection  - list of variables to export : run:runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:QA.TPC.meanMIP:QA.TPC.meanMIP
+/// \param source"       - source list          e.g:   : Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT
+/// ##Example usage:
+/*!
+ .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C
+ makeHTMLPage("LHC15o","pass1", "QA.TPC.meanTPCncl>0", "run:runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:QA.TPC.meanMIP:QA.TPC.meanMIP", "Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT")
+ makeHTMLPage("LHC15o","pass1", "QA.TPC.meanTPCncl>0", "run:runDuration:totalEventsPhysics:ocdbStatusCounter:ocdbHVStatusCounter:TPC_Status:meanTPCncl_Status:PID_Status:DCAz_Status:DCAr_Status:tpcItsMatch_Status", "Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT")
 
+ */
+void makeHTMLPage(TString  period,TString  pass, TString runSelection, TString varSelection, TString source){
+  TTree * tree = info.GetTree("Logbook",period,pass,source);
+  AliTreePlayer::selectWhatWhereOrderBy(tree,varSelection.Data(), runSelection.Data(),"",0,100000,"html","table.html");
   delete tree;
+  gSystem->GetFromPipe("$NOTES/JIRA/ATO-360/code/makeHtml.sh table.html index.html 0");
 }

--- a/STAT/Macros/aliExternalInfo.C
+++ b/STAT/Macros/aliExternalInfo.C
@@ -128,5 +128,5 @@ void makeHTMLPage(TString  period,TString  pass, TString runSelection, TString v
   TTree * tree = info.GetTree("Logbook",period,pass,source);
   AliTreePlayer::selectWhatWhereOrderBy(tree,varSelection.Data(), runSelection.Data(),"",0,100000,"html","table.html");
   delete tree;
-  gSystem->GetFromPipe(" table.html index.html 0");
+  gSystem->GetFromPipe("$AliPhysics_SRC/PWGPP/scripts/makeHtml.sh index.html table.html 0");
 }

--- a/STAT/Macros/aliExternalInfo.C
+++ b/STAT/Macros/aliExternalInfo.C
@@ -21,7 +21,7 @@
     .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C
     // define some example selection and copy past the code below
     TString  period="LHC15o", pass="pass1", runSelection="QA.TPC.meanTPCncl>0", varSelection="run:runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:QA.TPC.meanMIP";
-    TString source="Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT";
+    TString source="Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT;QA.EVS";
 */
 
 AliExternalInfo info;
@@ -122,6 +122,10 @@ void drawLogbookMultiCut(TString period, TString pass,TString runSelection="", T
  .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C
  makeHTMLPage("LHC15o","pass1", "QA.TPC.meanTPCncl>0", "run:runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:QA.TPC.meanMIP:QA.TPC.meanMIP", "Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT")
  makeHTMLPage("LHC15o","pass1", "QA.TPC.meanTPCncl>0", "run:runDuration:totalEventsPhysics:ocdbStatusCounter:ocdbHVStatusCounter:TPC_Status:meanTPCncl_Status:PID_Status:DCAz_Status:DCAr_Status:tpcItsMatch_Status", "Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT")
+ makeHTMLPage("LHC15o","pass1", "QA.TPC.meanTPCncl>0", "run:runDuration:totalEventsPhysics:ocdbStatusCounter:ocdbHVStatusCounter:MonALISA.RCT.tpc_value:rctMismatch:TPC_Status:meanTPCncl_Status:PID_Status:DCAz_Status:DCAr_Status:tpcItsMatch_Status", "Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT")
+
+
+
 \endcode
  */
 void makeHTMLPage(TString  period,TString  pass, TString runSelection, TString varSelection, TString source){

--- a/STAT/Macros/aliExternalInfo.C
+++ b/STAT/Macros/aliExternalInfo.C
@@ -123,10 +123,9 @@ void drawLogbookMultiCut(TString period, TString pass,TString runSelection="", T
  makeHTMLPage("LHC15o","pass1", "QA.TPC.meanTPCncl>0", "run:runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:QA.TPC.meanMIP:QA.TPC.meanMIP", "Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT")
  makeHTMLPage("LHC15o","pass1", "QA.TPC.meanTPCncl>0", "run:runDuration:totalEventsPhysics:ocdbStatusCounter:ocdbHVStatusCounter:TPC_Status:meanTPCncl_Status:PID_Status:DCAz_Status:DCAr_Status:tpcItsMatch_Status", "Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT")
  makeHTMLPage("LHC15o","pass1", "QA.TPC.meanTPCncl>0", "run:runDuration:totalEventsPhysics:ocdbStatusCounter:ocdbHVStatusCounter:MonALISA.RCT.tpc_value:rctMismatch:TPC_Status:meanTPCncl_Status:PID_Status:DCAz_Status:DCAr_Status:tpcItsMatch_Status", "Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT")
-
-
-
-\endcode
+//
+ makeHTMLPage("LHC15o","pass1", "QA.TPC.meanTPCncl>0", "run:runDuration:#%d{year}/%d{period.GetName()}/%d{pass.GetName()}/%d{run}:totalEventsPhysics:totalNumberOfFilesMigrated:QA.TPC.meanMIP", "Logbook;QA.TPC;")
+ \endcode
  */
 void makeHTMLPage(TString  period,TString  pass, TString runSelection, TString varSelection, TString source){
   TTree * tree = info.GetTree("Logbook",period,pass,source);

--- a/STAT/Macros/aliExternalInfo.C
+++ b/STAT/Macros/aliExternalInfo.C
@@ -1,0 +1,123 @@
+/// \ingroup Macros
+/// \file    aliExternalInfo.C
+/// \brief   Demo usage of the information from the AliExternalInfo and visualization using the TStatToolkit, AliTreePlayer and AliDrawStyle
+///
+/// \author  Marian Ivanov
+///
+/// Demo usage of the information from the AliExternalInfo and visualization using the TStatToolkit, AliTreePlayer and AliDrawStyle
+/// See documentation in following functions:
+/// * logbook/QA/RCT  multi figure export multipad
+///   * ::drawLogbook
+/// * logbook/QA/RCT  multi figure export multigraph
+/// * TODO:  logbook/QA/RCT  multi figure export multiselection
+/// * TODO:  makeHtml
+/// * TODO:  add period pass to the legend in standard plots
+
+/// The code can be used as it is.
+/// It will be running as part of UnitTest
+/// ## Example usage
+/// ###   Load library and define some example variables
+/*!
+    .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C
+    // define some example selection and copy past the code below
+    TString  period="LHC15o", pass="pass1", runSelection="QA.TPC.meanTPCncl>0", varSelection="run:runDuration:totalEventsPhysics:totalNumberOfFilesMigrated";
+    TString source="Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT";
+*/
+
+AliExternalInfo info;
+TLatex latex;
+
+/// AliExternalInfo demo - Generic draw of the logbook information - per period
+/// external source .e.g "QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT" could be used in selection.
+/// \param period
+/// \param pass
+/// \param runSelection
+/// \param varSelection
+/*!
+ * ### Example usage:
+\code
+    .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C
+    drawLogbook("LHC15o","pass1","QA.TPC.meanTPCncl>0","runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:MonALISA.RCT.tpc_value");
+    drawLogbook("LHC10h","pass2","totalEventsPhysics>1000&&totalNumberOfFilesMigrated>20","runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:MonALISA.RCT.tpc_value");
+    drawLogbook("LHC11h","pass2","totalEventsPhysics>1000&&totalNumberOfFilesMigrated>20","runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:MonALISA.RCT.tpc_value");
+\endcode
+*/
+void drawLogbook(TString period, TString pass,TString runSelection="", TString varSelection="runDuration:totalEventsPhysics:totalNumberOfFilesMigrated"){
+  TTree * treeLogbook = info.GetTree("Logbook",period,pass,"QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT");
+  TObjArray *varList=0;
+  if (varSelection[0]=="["){ //variable list using class selection
+    // Use class selection to select variables
+    varList=AliTreePlayer::selectMetadata(treeLogbook,varSelection,0);
+    Int_t nvars=varList->GetEntries();
+    for (Int_t i=0; i<nvars;i++){
+      TString vname=varList->At(i)->GetName();
+      vname.ReplaceAll(".class","");
+    }
+    // varList=AliTreePlayer::selectMetadata(treeLogbook, "[class==\"Logbook&&Time\"]",0);
+  }else{
+    varList=varSelection.Tokenize(":");
+  }
+  Int_t nvars=varList->GetEntries();
+  TCanvas * canvas = new TCanvas("drawLogbook","drawLogbook",1200,1000);
+  canvas->Divide(1,nvars);
+  for (Int_t i=0; i<nvars; i++){
+    canvas->cd(i+1);
+    TString var=TString::Format("%s:run",varList->At(i)->GetName());
+    TStatToolkit::MakeGraphSparse(treeLogbook,var,runSelection,25,1,1)->Draw("ap");
+    Double_t mean = TMath::Mean(treeLogbook->GetSelectedRows(),treeLogbook->GetV1());
+    Double_t sum  = treeLogbook->GetSelectedRows()*mean;
+    latex.DrawLatexNDC(0.15,0.8,TString::Format("Mean=%0.0f",mean));
+    latex.DrawLatexNDC(0.15,0.7,TString::Format("Sum=%0.0f",sum));
+  }
+  canvas->SaveAs(TString::Format("%s_%s.png",pass.Data(),period.Data()).Data());
+}
+
+/// AliExternalInfo - MultiGraph example
+/*!
+ * @param period        -  period - e.g LHC15o
+ * @param pass          -  reconstruction pass  - e.g pass2 (needed in case QA selection)
+ * @param runSelection  -  runSelection (standard tree cut )
+ * @param varSelection  -  array of variables to show
+*/
+/*!
+ * ## Example usage:
+ \code
+   .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C
+  drawLogbookMultiExpr("LHC15o","pass1", "totalNumberOfFilesMigrated>2000", "runDuration;totalEventsPhysics/1000;totalNumberOfFilesMigrated:run");
+  drawLogbookMultiExpr("LHC15o","pass1", "totalNumberOfFilesMigrated>2000&&QA.TPC.meanMIP>40", "runDuration;totalEventsPhysics/1000;totalNumberOfFilesMigrated:run");
+\endcode
+*/
+void drawLogbookMultiExpr(TString period, TString pass,TString runSelection="", TString varSelection="runDuration;totalEventsPhysics/1000;totalNumberOfFilesMigrated:run") {
+  TTree *treeLogbook = info.GetTree("Logbook", period, pass, "QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT");
+  TLegend * legend = new TLegend(0.15,0.7,0.4,0.8, "Trending");
+  TMultiGraph *m0 = TStatToolkit::MakeMultGraph(treeLogbook, "", varSelection.Data(), runSelection.Data(), "25;21;22;24", "1;2;4", kTRUE, 1, 6, legend);
+  m0->Draw("ap");
+  legend->Draw();
+  delete tree;
+}
+
+/// drawLogbookMultiCut - example of usage of multigraph
+/// \param period
+/// \param pass
+/// \param runSelection
+/// \param varSelection
+/// TODO - implemnetation missing. Only hardwired selection
+/*!
+ */
+void drawLogbookMultiCut(TString period, TString pass,TString runSelection="", TString varSelection="LHCperiod:runDuration:totalEventsPhysics:totalNumberOfFilesMigrated") {
+  TTree *treeLogbook = info.GetTree("Logbook", period, pass, "QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT");
+  TMultiGraph *m1 = TStatToolkit::MakeMultGraph(treeLogbook,"","runDuration:run","totalNumberOfFilesMigrated>2000;(run<245000);abs(run-245500)<500;(run>246000)","25;21;22;24","1;2;4", kFALSE, 1,6,0);
+  m1->Draw("ap");
+}
+
+/// makeHTMLPage
+/// \param period
+/// \param pass
+/// \param runSelection
+/// \param varSelection
+/// \param source
+void makeHTMLPage(TString  period,TSring  pass, TString runSelection, TString varSelection, TString source){
+  TTree * tree = info.GetTree("Logbook",period,pass,source);
+
+  delete tree;
+}

--- a/STAT/Macros/logbookAddMetadata.C
+++ b/STAT/Macros/logbookAddMetadata.C
@@ -51,7 +51,7 @@ void logbookAddMetadata(TTree*tree, Int_t verbose=0){
   // Index
   TStatToolkit::AddMetadata(tree,"run.class","Base Logbook Index");
   TStatToolkit::AddMetadata(tree,"LHCperiod.class","Base Logbook Index");
-  TStatToolkit::AddMetadata(tree,"LHCfillNumber.class","Base Logbook Index");
+  TStatToolkit::AddMetadata(tree,"LHCFillNumber.class","Base Logbook Index");
   // Stat
   TStatToolkit::AddMetadata(tree,"totalEvents.class","Base Logbook Stat");
   TStatToolkit::AddMetadata(tree,"totalEventsPhysics.class","Base Logbook Stat");

--- a/STAT/Macros/logbookAddMetadata.C
+++ b/STAT/Macros/logbookAddMetadata.C
@@ -65,6 +65,27 @@ void logbookAddMetadata(TTree*tree, Int_t verbose=0){
   TStatToolkit::AddMetadata(tree,"HLTmode.class","Base Logbook Setup");
   TStatToolkit::AddMetadata(tree,"numberOfDetectors.class","Base Logbook Setup");  
   //
+   // Logbook html metadata
+  TStatToolkit::AddMetadata(treeMC,"ctpDuration.thead","&Delta;T(s)");
+  TStatToolkit::AddMetadata(treeMC,"ctpDuration.tooltip","Logbook CTP duration ");
+  TStatToolkit::AddMetadata(treeMC,"ctpDuration.html","<a href=https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=%d{run}&p_tab=gi&p_subtab=rs>%d{ctpDuration}</a>");
+  TStatToolkit::AddMetadata(treeMC,"detectorMask.thead","mask");
+  TStatToolkit::AddMetadata(treeMC,"detectorMask.tooltip","Detector mask");
+  TStatToolkit::AddMetadata(treeMC,"DAQ_time_start.thead","T<sub>start</sub>");
+  TStatToolkit::AddMetadata(treeMC,"LHCperiod.thead","period");
+  TStatToolkit::AddMetadata(treeMC,"LHCFillNumber.thead","fill");
+  TStatToolkit::AddMetadata(treeMC,"HLTmode.thead","H L T");
+  TStatToolkit::AddMetadata(treeMC,"numberOfDetectors.thead","N<sub>det</sub>");
+  TStatToolkit::AddMetadata(treeMC,"numberOfDetectors.tooltip","Number of detectors");
+  TStatToolkit::AddMetadata(treeMC,"totalEventsPhysics.thead","N<sub>evphys</sub>");
+  TStatToolkit::AddMetadata(treeMC,"interactionRate.thead","rate(Hz)");
+
+  TStatToolkit::AddMetadata(treeMC,"DAQ_time_start.html","<a href=https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=%d{run}&p_tab=gi&p_subtab=rs>%t{DAQ_time_start}</a>");
+  TStatToolkit::AddMetadata(treeMC,"run.html","<a href=\"000%d{run}/index.html\">%d{run}</a>");
+  TStatToolkit::AddMetadata(treeMC,"detectorMask.html","%x{detectorMask&0xFFFF}");
+  TStatToolkit::AddMetadata(treeMC,"interactionRate.html","%2.2f{interactionRate}");
+
+  //
   TList * mlist = (TList*)(tree->GetUserInfo()->FindObject("metaTable"));
   mlist->Sort();
   if (verbose==1){

--- a/STAT/Macros/logbookAddMetadata.C
+++ b/STAT/Macros/logbookAddMetadata.C
@@ -66,24 +66,24 @@ void logbookAddMetadata(TTree*tree, Int_t verbose=0){
   TStatToolkit::AddMetadata(tree,"numberOfDetectors.class","Base Logbook Setup");  
   //
    // Logbook html metadata
-  TStatToolkit::AddMetadata(treeMC,"ctpDuration.thead","&Delta;T(s)");
-  TStatToolkit::AddMetadata(treeMC,"ctpDuration.tooltip","Logbook CTP duration ");
-  TStatToolkit::AddMetadata(treeMC,"ctpDuration.html","<a href=https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=%d{run}&p_tab=gi&p_subtab=rs>%d{ctpDuration}</a>");
-  TStatToolkit::AddMetadata(treeMC,"detectorMask.thead","mask");
-  TStatToolkit::AddMetadata(treeMC,"detectorMask.tooltip","Detector mask");
-  TStatToolkit::AddMetadata(treeMC,"DAQ_time_start.thead","T<sub>start</sub>");
-  TStatToolkit::AddMetadata(treeMC,"LHCperiod.thead","period");
-  TStatToolkit::AddMetadata(treeMC,"LHCFillNumber.thead","fill");
-  TStatToolkit::AddMetadata(treeMC,"HLTmode.thead","H L T");
-  TStatToolkit::AddMetadata(treeMC,"numberOfDetectors.thead","N<sub>det</sub>");
-  TStatToolkit::AddMetadata(treeMC,"numberOfDetectors.tooltip","Number of detectors");
-  TStatToolkit::AddMetadata(treeMC,"totalEventsPhysics.thead","N<sub>evphys</sub>");
-  TStatToolkit::AddMetadata(treeMC,"interactionRate.thead","rate(Hz)");
+  TStatToolkit::AddMetadata(tree,"ctpDuration.thead","&Delta;T(s)");
+  TStatToolkit::AddMetadata(tree,"ctpDuration.tooltip","Logbook CTP duration ");
+  TStatToolkit::AddMetadata(tree,"ctpDuration.html","<a href=https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=%d{run}&p_tab=gi&p_subtab=rs>%d{ctpDuration}</a>");
+  TStatToolkit::AddMetadata(tree,"detectorMask.thead","mask");
+  TStatToolkit::AddMetadata(tree,"detectorMask.tooltip","Detector mask");
+  TStatToolkit::AddMetadata(tree,"DAQ_time_start.thead","T<sub>start</sub>");
+  TStatToolkit::AddMetadata(tree,"LHCperiod.thead","period");
+  TStatToolkit::AddMetadata(tree,"LHCFillNumber.thead","fill");
+  TStatToolkit::AddMetadata(tree,"HLTmode.thead","H L T");
+  TStatToolkit::AddMetadata(tree,"numberOfDetectors.thead","N<sub>det</sub>");
+  TStatToolkit::AddMetadata(tree,"numberOfDetectors.tooltip","Number of detectors");
+  TStatToolkit::AddMetadata(tree,"totalEventsPhysics.thead","N<sub>evphys</sub>");
+  TStatToolkit::AddMetadata(tree,"interactionRate.thead","rate(Hz)");
 
-  TStatToolkit::AddMetadata(treeMC,"DAQ_time_start.html","<a href=https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=%d{run}&p_tab=gi&p_subtab=rs>%t{DAQ_time_start}</a>");
-  TStatToolkit::AddMetadata(treeMC,"run.html","<a href=\"000%d{run}/index.html\">%d{run}</a>");
-  TStatToolkit::AddMetadata(treeMC,"detectorMask.html","%x{detectorMask&0xFFFF}");
-  TStatToolkit::AddMetadata(treeMC,"interactionRate.html","%2.2f{interactionRate}");
+  TStatToolkit::AddMetadata(tree,"DAQ_time_start.html","<a href=https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=%d{run}&p_tab=gi&p_subtab=rs>%t{DAQ_time_start}</a>");
+  TStatToolkit::AddMetadata(tree,"run.html","<a href=\"000%d{run}/index.html\">%d{run}</a>");
+  TStatToolkit::AddMetadata(tree,"detectorMask.html","%x{detectorMask&0xFFFF}");
+  TStatToolkit::AddMetadata(tree,"interactionRate.html","%2.2f{interactionRate}");
 
   //
   TList * mlist = (TList*)(tree->GetUserInfo()->FindObject("metaTable"));

--- a/STAT/Macros/qatpcAddMetadata.C
+++ b/STAT/Macros/qatpcAddMetadata.C
@@ -1,4 +1,4 @@
-/*
+/*!
   Append QA TPC  metadata decribing tree structure,  and annotating branche variables. 
   Partialy inspired by CSS (https://de.wikipedia.org/wiki/Cascading_Style_Sheets) but not full functionality implemented
   
@@ -26,10 +26,10 @@
      1.) Metadata can be setup invoking macro:
          AliExternalInfo info;
          TTree * tree = info.GetTree("QA.TPC","LHC15o","cpass1_pass1","QA.TPC;QA.TRD;QA.TOF;QA.ITS;QA.EVS;Logbook.detector");             
-	 .x $ALICE_ROOT/../src/STAT/Macros/qatpcAddMetadata.C+(tree,4)
+	 .x $AliRoot_SRC/STAT/Macros/qatpcAddMetadata.C+(tree,4)
 
             
-     2.) Macro can be executed automatically if proper configuation file leaded AliExternalInfo.cfg - see line:
+     2.) Macro can be executed automatically if proper configuration file leaded AliExternalInfo.cfg - see line:
          QA.TPC.metadataMacro $ALICE_ROOT/STAT/Macros/qatpcAddMetadata.C+
 
      3.) Printing all metadata:
@@ -37,9 +37,9 @@
 	 AliTreePlayer::selectMetadata(tree, "[class==\"\"]",0)->Print();
 
      3.) Example query particular info:
-           AliTreePlayer::selectMetadata(tree, "[class==\"DCAR&&!ERR&&!CHI2\"]",0)->Print();
-	   AliTreePlayer::selectMetadata(tree, "[class==\"DCAR&&ERR\"]",0)->Print();
-           AliTreePlayer::selectMetadata(tree, "[class==\"DCAZ\"]",0)->Print();
+           AliTreePlayer::selectMetadata(tree, "[class==\"DCAr&&!Err&&!CHI2\"]",0)->Print();
+	         AliTreePlayer::selectMetadata(tree, "[class==\"DCAr&&Err\"]",0)->Print();
+           AliTreePlayer::selectMetadata(tree, "[class==\"DCAz\"]",0)->Print();
 	   
 	   AliTreePlayer::selectMetadata(tree,"[class==DCAr&&!Pos&&!Neg",0).Print();
 	   // alternative
@@ -99,12 +99,27 @@ void addTPCAliases(TTree * tree){
   tree->SetAlias("DCAr_Status", "(1*dcar_Warning+10*dcar_Outlier+100*(dcar_PhysAcc==0))");
   tree->SetAlias("tpcItsMatch_Status", "(1*tpcItsMatch_Warning+10*tpcItsMatch_Outlier+100*(tpcItsMatch_PhysAcc==0))");
   tree->SetAlias("itsTpcPulls_Status", "(1*itsTpcPulls_Warning+10*itsTpcPulls_Outlier+100*(itsTpcPulls_PhysAcc==0))");
+  tree->SetAlias("htmlLink","1"); // formal variable to link for logbook
+  //
 }
 
+///
+void addHtmlMetadata(TTree * tree){
+  //
+  // add html preview  metadata associated to the figure
+  // Logbook: run https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=244917
+  //        : https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=244917&p_tab=gi&p_subtab=rs
+  //        :
+  TStatToolkit::AddMetadata(tree,"PID_Status.html","%d<run>/TPC_dEdx_track_info.png");    // PID status
+  TStatToolkit::AddMetadata(tree,"DCAz_Status.html","%d<run>/dca_and_phi.png");           // DCAz status run plot
+  TStatToolkit::AddMetadata(tree,"DCAr_Status.html","%d<run>/dca_and_phi.png");           // DCAr status run plot
+  TStatToolkit::AddMetadata(tree,"rawLowCounter75.html","%d<run>/rawQAInformation.png");  // missing clusters sector counter
+  TStatToolkit::AddMetadata(tree,"htmlLink.html","https://alice-logbook.cern.ch/logbook/date_online.php?p_cont=rund&p_run=%d<run>");    // logbook link
+}
 
 void qatpcAddMetadata(TTree*tree, Int_t verbose){
   //
-  // Set metadata infomation 
+  // Set metadata information
   //
   if (tree==NULL) {
     ::Error("qatpcAddMetadata","Start processing. Emtpy tree");
@@ -263,6 +278,7 @@ void qatpcAddMetadata(TTree*tree, Int_t verbose){
   TStatToolkit::AddMetadata(tree,"run.class","Base Index");
   TStatToolkit::AddMetadata(tree,"run.Title","run");
   TStatToolkit::AddMetadata(tree,"run.AxisTitle","run");
+  addHtmlMetadata(tree);
   //
   TList * mlist = (TList*)(tree->GetUserInfo()->FindObject("metaTable"));
   mlist->Sort();

--- a/STAT/Macros/qatpcAddMetadata.C
+++ b/STAT/Macros/qatpcAddMetadata.C
@@ -156,9 +156,9 @@ void qatpcAddMetadata(TTree*tree, Int_t verbose){
   //   QA variables  
   const Int_t nQA=8;
   const TString qaVariableClass[nQA]={"Ncl", "Eff","dEdx", "DCAr", "DCAz","Occ","Attach","Electron"};
-  const TString qaVariableAxisTitle[nQA]={"Ncl(#)", "Eff(unit)","dEdx(MIP/50)", "DCAr(cm)", "DCAz(cm)", "Occupancy","Attach","Electron"};
-  const TString qaVariableLegend[nQA]={"Ncl", "Eff","dEdx", "DCAr", "DCAz","Occ.","Attach","e-"};
-  const TString qaVariableTitle[nQA]={"Ncl", "Eff","dEdx", "DCAr", "DCAz", "Occupancy","Attach","e-"};
+  const TString qaVariableAxisTitle[nQA]={"Ncl(#)", "Eff(unit)","dEdx(MIP/50)", "DCA_{xy}(cm)", "DCA_{z}(cm)", "Occupancy","Attach","Electron"};
+  const TString qaVariableLegend[nQA]={"Ncl", "Eff","dEdx", "DCA_{xy}", "DCA_{z}","Occ.","Attach","e-"};
+  const TString qaVariableTitle[nQA]={"Ncl", "Eff","dEdx", "DCA_{xy}", "DCA_{z}", "Occupancy","Attach","e-"};
   TPRegexp regQAVariable[nQA];
   regQAVariable[0]=TPRegexp("ncl");               // Ncl
   regQAVariable[1]=TPRegexp("tpcitsmatch");       // TPC->ITS eff

--- a/STAT/STATLinkDef.h
+++ b/STAT/STATLinkDef.h
@@ -58,7 +58,7 @@
 #pragma link C++ class std::map<UInt_t,THn*>+;
 #pragma link C++ class std::map<Int_t,TClonesArray*>+;
 #pragma link C++ class std::map<std::string,std::string>+;
-
+#pragma link C++ class std::map<Int_t,std::string>+;
 /*
 // RS At the moment is not recognized by the CINT...
 

--- a/STAT/STATLinkDef.h
+++ b/STAT/STATLinkDef.h
@@ -21,6 +21,7 @@
 
 #ifdef ROOT_HAS_HTTP
 #pragma link C++ class AliTreePlayer+;
+#pragma link C++ class AliTreeFormulaF+;
 #endif
 
 #pragma link C++ class AliExternalInfo+;

--- a/STAT/STATLinkDef.h
+++ b/STAT/STATLinkDef.h
@@ -28,6 +28,7 @@
 #pragma link C++ class AliTreeTrending+;
 #pragma link C++ class AliNDFormulaBrowser+;
 #pragma link C++ class AliDrawStyle+;
+#pragma link C++ class AliPainter+;
 #pragma link C++ class AliElasticSearchRoot++;
 
 #pragma link C++ namespace AliFFTsmoother+;

--- a/STAT/TStatToolkit.cxx
+++ b/STAT/TStatToolkit.cxx
@@ -1376,7 +1376,11 @@ TMultiGraph * TStatToolkit::MakeMultGraph(TTree * tree, const char *groupName, c
       TString legendName="";
       TNamed*named = TStatToolkit::GetMetadata(tree,TString::Format("%s.Legend",expName).Data(),&prefix);
       if (named) {
-        legendName+=named->GetName();
+        if (prefix.Length()>0){
+          legendName+=prefix.Data();
+          legendName+=" ";
+        }
+        legendName+=named->GetTitle();
       }else{
         legendName=expName;
       }
@@ -1384,7 +1388,7 @@ TMultiGraph * TStatToolkit::MakeMultGraph(TTree * tree, const char *groupName, c
         legendName+=" ";
         named = TStatToolkit::GetMetadata(tree,TString::Format("%s.Legend",exprCutArray->At(iCut+1)->GetName()).Data(),&prefix);
         if (named) {
-          legendName+=named->GetName();
+          legendName+=named->GetTitle();
         }else{
           legendName=exprCutArray->At(iCut+1)->GetName();
         }

--- a/STAT/TStatToolkit.cxx
+++ b/STAT/TStatToolkit.cxx
@@ -1722,8 +1722,9 @@ void TStatToolkit::MakeAnchorAlias(TTree * tree, TString& sTrendVars, Int_t doCh
     tree->SetAlias((aName+"WarningBand").Data(), (TString("1.*")+variables[2+0]).Data());
     tree->SetAlias((aName+"OutlierBand").Data(), (TString("1.*")+variables[2+1]).Data());
     tree->SetAlias((aName+"PhysAccBand").Data(), (TString("1.*")+variables[2+2]).Data());
-    ::Info("makeAnchorAlias", "SetAlias \t%s\t%s", (aName+"WarningBand").Data(), variables[2+0].Data());
-
+	if (verbose > 0) {
+    	::Info("makeAnchorAlias", "SetAlias \t%s\t%s", (aName+"WarningBand").Data(), variables[2+0].Data());
+    }
     delete descriptor;
   }
   delete aTrendVars;

--- a/STAT/TStatToolkit.cxx
+++ b/STAT/TStatToolkit.cxx
@@ -1719,9 +1719,10 @@ void TStatToolkit::MakeAnchorAlias(TTree * tree, TString& sTrendVars, Int_t doCh
       }
     }
     TString aName = TString::Format("absDiff.%s_", variables[0].Data());
-    tree->SetAlias((aName+"_WarningBand").Data(), variables[2+0].Data());
-    tree->SetAlias((aName+"_OutlierBand").Data(), variables[2+1].Data());
-    tree->SetAlias((aName+"_PhyAccBand").Data(), variables[2+2].Data());
+    tree->SetAlias((aName+"WarningBand").Data(), (TString("1.*")+variables[2+0]).Data());
+    tree->SetAlias((aName+"OutlierBand").Data(), (TString("1.*")+variables[2+1]).Data());
+    tree->SetAlias((aName+"PhysAccBand").Data(), (TString("1.*")+variables[2+2]).Data());
+    ::Info("makeAnchorAlias", "SetAlias \t%s\t%s", (aName+"WarningBand").Data(), variables[2+0].Data());
 
     delete descriptor;
   }

--- a/STAT/TStatToolkit.cxx
+++ b/STAT/TStatToolkit.cxx
@@ -1644,8 +1644,8 @@ Int_t  TStatToolkit::SetStatusAlias(TTree * tree, const char * expr, const char 
   // dcaR resolution
   sTrendVars+="QA.TPC.dcarAP0,TPC.Anchor.dcarAP0,0.02,0.05,0.02;";     // dcarAP0;  warning 0.02cm; error 0.05 cm  (nominal ~ 0.2 cm)
 
-*/    
-void TStatToolkit::MakeAnchorAlias(TTree * tree, TString& sTrendVars, Int_t doCheck, Int_t verbose){  
+*/
+void TStatToolkit::MakeAnchorAlias(TTree * tree, TString& sTrendVars, Int_t doCheck, Int_t verbose){
   const char* aType[4]={"Warning","Outlier","PhysAcc"};
   TObjArray *aTrendVars  = sTrendVars.Tokenize(";");
   Int_t entries= aTrendVars->GetEntries();
@@ -1656,38 +1656,38 @@ void TStatToolkit::MakeAnchorAlias(TTree * tree, TString& sTrendVars, Int_t doCh
     TObjArray *descriptor=TString(aTrendVars->At(ientry)->GetName()).Tokenize(",");
     // check if valid sysntax
     if (descriptor->GetEntries()!=5){
-      ::Error("makeAnchorAlias"," Invalid status descriptor. %s has %d mebers instead of 5 (variable, deltaWarning,deltaError, PhysAcc) ",aTrendVars->At(ientry)->GetName(),descriptor->GetEntries());
+      ::Error("makeAnchorAlias"," Invalid status descriptor. %s has %d members instead of 5 (variable, deltaWarning,deltaError, PhysAcc) ",aTrendVars->At(ientry)->GetName(),descriptor->GetEntries());
       continue;
     }
     // check individual variables
     for (Int_t ivar=0; ivar<5; ivar++){
       variables[ivar]=descriptor->At(ivar)->GetName();
       if (doCheck&1>0){  // check input formulas in case specified
-	TTreeFormula *form=new TTreeFormula("dummy",descriptor->At(ivar)->GetName(),tree);
-	if (form->GetTree()==NULL){
-	  isOK=kFALSE;
-	  ::Error("makeAnchorAlias"," Invalid element %d,  %s in %s",ivar, descriptor->At(ivar)->GetName(),aTrendVars->At(ientry)->GetName());
-	  continue;
-	}      
+        TTreeFormula *form=new TTreeFormula("dummy",descriptor->At(ivar)->GetName(),tree);
+        if (form->GetTree()==NULL){
+          isOK=kFALSE;
+          ::Error("makeAnchorAlias"," Invalid element %d,  %s in %s",ivar, descriptor->At(ivar)->GetName(),aTrendVars->At(ientry)->GetName());
+          continue;
+        }
       }
     }
     if (!isOK) continue;
     for (Int_t itype=0; itype<3; itype++){
       TString aName=TString::Format("%s_%s",variables[1].Data(), aType[itype]);
-      TString aValue=TString::Format("abs(%s-%s)<%s",variables[0].Data(), variables[1].Data(),variables[2+itype].Data());
+      TString aValue=TString::Format("abs(%s-%s)>%s",variables[0].Data(), variables[1].Data(),variables[2+itype].Data());
       tree->SetAlias(aName.Data(),aValue.Data());
       if ((doCheck&2)>0){
-	TTreeFormula *form=new TTreeFormula("dummy",aName.Data(),tree);
-	if (form->GetTree()==NULL){
-	  isOK=kFALSE;
-	  ::Error("makeAnchorAlias","Alias not valid  \t%s\t%s", aName.Data(),aValue.Data());
-	}
+        TTreeFormula *form=new TTreeFormula("dummy",aName.Data(),tree);
+        if (form->GetTree()==NULL){
+          isOK=kFALSE;
+          ::Error("makeAnchorAlias","Alias not valid  \t%s\t%s", aName.Data(),aValue.Data());
+        }
       }
       if (verbose>0){
-	::Info("makeAnchorAlias","SetAlias\t%s\t%s", aName.Data(),aValue.Data());
-      }      
+        ::Info("makeAnchorAlias","SetAlias\t%s\t%s", aName.Data(),aValue.Data());
+      }
     }
-    
+
     delete descriptor;
   }
   delete aTrendVars;

--- a/STAT/TStatToolkit.cxx
+++ b/STAT/TStatToolkit.cxx
@@ -3074,3 +3074,29 @@ void TStatToolkit::MakeMultiGraphSparse(TMultiGraph *multiGraph) {
       multiGraph->GetXaxis()->SetBinLabel(iValue + 1, TString::Format("%d", valueArray[iValue]).Data());
   }
 }
+
+
+/// Adapt style for histogram created by TTree queries
+/// \param tree          - input tree (owner of metadata)
+/// \param histogram     - pointer to histogram to AdaptStyle
+///                       if NULL tree->GetHistogram used
+/// \param option        - draw option
+/// \return
+Int_t TStatToolkit::AdaptHistoMetadata(TTree* tree, TH1 *histogram, TString option){
+  if (histogram==NULL) histogram= tree->GetHistogram();
+  if (histogram==NULL) return -1;
+  TNamed *named=0;
+  named = TStatToolkit::GetMetadata(tree,TString(histogram->GetXaxis()->GetTitle())+".AxisTitle");
+  if (named) histogram->GetXaxis()->SetTitle(named->GetTitle());
+  named = TStatToolkit::GetMetadata(tree,TString(histogram->GetYaxis()->GetTitle())+".AxisTitle");
+  if (named) histogram->GetYaxis()->SetTitle(named->GetTitle());
+  if (histogram->GetZaxis()){
+    named = TStatToolkit::GetMetadata(tree,TString(histogram->GetZaxis()->GetTitle())+".AxisTitle");
+    if (named) histogram->GetZaxis()->SetTitle(named->GetTitle());
+  }
+  /// TODO - TEMPORARY -make z tilte vissible  - using pallet size  should be done using CSS
+  TPaletteAxis *palette = (TPaletteAxis*)histogram->GetListOfFunctions()->FindObject("palette");
+  if (palette) palette->SetX2NDC(0.92);
+  histogram->Draw(option.Data());
+  return 1;
+}

--- a/STAT/TStatToolkit.cxx
+++ b/STAT/TStatToolkit.cxx
@@ -28,7 +28,7 @@
 #include "TPRegexp.h"
 #include "AliDrawStyle.h"
 #include <stdlib.h>
-
+#include <stdexcept>      // std::invalid_argument
 using std::cout;
 using std::cerr;
 using std::endl;

--- a/STAT/TStatToolkit.cxx
+++ b/STAT/TStatToolkit.cxx
@@ -32,6 +32,7 @@
 using std::cout;
 using std::cerr;
 using std::endl;
+using namespace std;
 
 //_____________________________________________________________________________
 void TStatToolkit::EvaluateUni(Int_t nvectors, Double_t *data, Double_t &mean, Double_t &sigma, Int_t hh) {

--- a/STAT/TStatToolkit.cxx
+++ b/STAT/TStatToolkit.cxx
@@ -1696,26 +1696,32 @@ void TStatToolkit::MakeAnchorAlias(TTree * tree, TString& sTrendVars, Int_t doCh
       }
     }
     if (!isOK) continue;
-    for (Int_t itype=0; itype<3; itype++){
-      TString aName=TString::Format("absDiff.%s_%s",variables[0].Data(), aType[itype]);
-      TString aValue="";
-      if (itype<2){
-        aValue=TString::Format("abs(%s-%s)>%s",variables[0].Data(), variables[1].Data(),variables[2+itype].Data());  // Warning or Error
-      }else{
-        aValue=TString::Format("abs(%s-%s)<%s",variables[0].Data(), variables[1].Data(),variables[2+itype].Data());  // Physics acreptable inside
+    for (Int_t itype=0; itype<3; itype++) {
+      TString aName = TString::Format("absDiff.%s_%s", variables[0].Data(), aType[itype]);
+      TString aValue = "";
+      if (itype < 2) {
+        aValue = TString::Format("abs(%s-%s)>%s", variables[0].Data(), variables[1].Data(),
+                                 variables[2 + itype].Data());  // Warning or Error
+      } else {
+        aValue = TString::Format("abs(%s-%s)<%s", variables[0].Data(), variables[1].Data(),
+                                 variables[2 + itype].Data());  // Physics acceptable inside
       }
-      tree->SetAlias(aName.Data(),aValue.Data());
-      if ((doCheck&2)>0){
-        TTreeFormula *form=new TTreeFormula("dummy",aName.Data(),tree);
-        if (form->GetTree()==NULL){
-          isOK=kFALSE;
-          ::Error("makeAnchorAlias","Alias not valid  \t%s\t%s", aName.Data(),aValue.Data());
+      tree->SetAlias(aName.Data(), aValue.Data());
+      if ((doCheck & 2) > 0) {
+        TTreeFormula *form = new TTreeFormula("dummy", aName.Data(), tree);
+        if (form->GetTree() == NULL) {
+          isOK = kFALSE;
+          ::Error("makeAnchorAlias", "Alias not valid  \t%s\t%s", aName.Data(), aValue.Data());
         }
       }
-      if (verbose>0){
-        ::Info("makeAnchorAlias","SetAlias\t%s\t%s", aName.Data(),aValue.Data());
+      if (verbose > 0) {
+        ::Info("makeAnchorAlias", "SetAlias\t%s\t%s", aName.Data(), aValue.Data());
       }
     }
+    TString aName = TString::Format("absDiff.%s_", variables[0].Data());
+    tree->SetAlias((aName+"_WarningBand").Data(), variables[2+0].Data());
+    tree->SetAlias((aName+"_OutlierBand").Data(), variables[2+1].Data());
+    tree->SetAlias((aName+"_PhyAccBand").Data(), variables[2+2].Data());
 
     delete descriptor;
   }

--- a/STAT/TStatToolkit.h
+++ b/STAT/TStatToolkit.h
@@ -91,6 +91,9 @@ namespace TStatToolkit {
   TGraph * MakeGraphSparse(TTree * tree, const char * expr="Entry", const char * cut="1",  Int_t mstyle=25, Int_t mcolor=1, Float_t msize=-1, Float_t offset=0.0);
   TGraphErrors * MakeGraphErrors(TTree * tree, const char * expr="Entry", const char * cut="1",  Int_t mstyle=25, Int_t mcolor=1, Float_t msize=-1, Float_t offset=0.0, Int_t entries=10000000, Int_t firstEntry=0);
   TMultiGraph * MakeMultGraph(TTree * tree, const char *groupName, const char* expr, const char * cut, const char * markers, const char *colors, Bool_t drawSparse, Float_t msize, Float_t sigmaRange, TLegend * legend, Bool_t comp=kTRUE );
+  void RebinSparseGraph(TGraph * graph0, TGraph *graph1, Option_t * option="");
+  void RebinSparseMultiGraph(TMultiGraph *multiGraph, TGraph *graphRef);
+  void MakeMultiGraphSparse(TMultiGraph *multiGraph);
   //
   // Fitting function
   //

--- a/STAT/TStatToolkit.h
+++ b/STAT/TStatToolkit.h
@@ -87,7 +87,7 @@ namespace TStatToolkit {
   // Graph tools
   //
   THashList *AddMetadata(TTree*, const char *vartagName,const char *varTagValue);
-  TNamed *GetMetadata(TTree* tree, const char *vartagName, TString *prefix=0);
+  TNamed *GetMetadata(TTree* tree, const char *vartagName, TString *prefix=0, Bool_t fullMatch=kFALSE);
   TGraph * MakeGraphSparse(TTree * tree, const char * expr="Entry", const char * cut="1",  Int_t mstyle=25, Int_t mcolor=1, Float_t msize=-1, Float_t offset=0.0);
   TGraphErrors * MakeGraphErrors(TTree * tree, const char * expr="Entry", const char * cut="1",  Int_t mstyle=25, Int_t mcolor=1, Float_t msize=-1, Float_t offset=0.0, Int_t entries=10000000, Int_t firstEntry=0);
   TMultiGraph * MakeMultGraph(TTree * tree, const char *groupName, const char* expr, const char * cut, const char * markers, const char *colors, Bool_t drawSparse, Float_t msize, Float_t sigmaRange, TLegend * legend, Bool_t comp=kTRUE );

--- a/STAT/TStatToolkit.h
+++ b/STAT/TStatToolkit.h
@@ -30,6 +30,7 @@
 #include "THashList.h"
 #include "TFitResultPtr.h"
 #include "TFitResult.h"
+#include "TPaletteAxis.h"
 //
 // includes necessary for test functions
 //
@@ -143,6 +144,7 @@ namespace TStatToolkit {
   // TTree function for robust draw
   //
   TH1* DrawHistogram(TTree * tree, const char* drawCommand, const char* cuts = "1", const char* hname = "histo", const char* htitle = "histo", Int_t nsigma = 4, Float_t fraction = 0.75, TObjArray *description=0 );
+  Int_t AdaptHistoMetadata(TTree* tree, TH1 *histogram, TString option);
   //
   // TestFunctions:
   //

--- a/STAT/test/AliDrawStyleTest.C
+++ b/STAT/test/AliDrawStyleTest.C
@@ -18,22 +18,29 @@ root.exe -b -q  $AliRoot_SRC/STAT/test/AliDrawStyleTest.C+ | tee AliDrawStyleTes
 #include <iostream>
 #include "TSystem.h"
 #include "TStopwatch.h"
+#include "TROOT.h"
+#include "TH1.h"
+#include "TGraph.h"
+#include "TRandom.h"
+#include "TCanvas.h"
+#include "TSystem.h"
+#include "TPad.h"
+#include "TLegend.h"
+#include "AliPainter.h"
 
 void AliDrawStyleTest_StyleArray();
 void AliDrawStyleTest_Attributes();
 void AliDrawStyleTest_GetIntValues();
 void AliDrawStyleTest_GetFloatValues();
 //  void AliDrawStyleTest_CSSReadWrite();
-void AliDrawStyleTest_IsSelected();
 void AliDrawStyleTest_GetProperty();
-void AliDrawStyleTest_GetSelector();
-// void AliDrawStyleTest_CountObjects();
 // void AliDrawStyleTest_TGraphApplyStyle();
 // void AliDrawStyleTest_TH1ApplyStyle();
 // void AliDrawStyleTest_TF1ApplyStyle();
 // void AliDrawStyleTest_TPadApplyStyle();
 // void AliDrawStyleTest_TCanvasApplyCssStyle();
-// void AliDrawStyleTest_ApplyCssStyle();
+void AliDrawStyleTest_ApplyCssStyle();
+TCanvas *MakeTestPlot(Int_t nHis);
 
 void AliDrawStyleTest(){
   AliDrawStyleTest_StyleArray();
@@ -41,16 +48,13 @@ void AliDrawStyleTest(){
   AliDrawStyleTest_GetIntValues();
   AliDrawStyleTest_GetFloatValues();
   //  AliDrawStyleTest_CSSReadWrite();
-  AliDrawStyleTest_IsSelected();
   AliDrawStyleTest_GetProperty();
-  AliDrawStyleTest_GetSelector();
-  // AliDrawStyleTest_CountObjects();
   // AliDrawStyleTest_TGraphApplyStyle();
   // AliDrawStyleTest_TH1ApplyStyle();
   // AliDrawStyleTest_TF1ApplyStyle();
   // AliDrawStyleTest_TPadApplyStyle();
   // AliDrawStyleTest_TCanvasApplyCssStyle();
-  // AliDrawStyleTest_ApplyCssStyle();
+  AliDrawStyleTest_ApplyCssStyle();
 }
 
 /// Test acces to the style indexed array
@@ -63,25 +67,24 @@ void AliDrawStyleTest_StyleArray(){
   if (result!=1){
     ::Error("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",0)==%d should be 1-FAILED\n",result);
   }else{
-     ::Info("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",0)- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",0)- IsOK");
   }
   result = AliDrawStyle::GetMarkerStyle("1;2,3;4",1);
   if (result!=2){
     ::Error("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",1)==%d should be 2-FAILED\n",result);
   }else{
-     ::Info("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",1)- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",1)- IsOK");
   }
   //
-  result = AliDrawStyle::GetMarkerColor("1;2,3;4",0);
+  result = AliDrawStyle::GetMarkerStyle("1;2,3;4",0);
   if (result!=1){
     ::Error("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",0)==%d should be 1-FAILED\n",result);
   }else{
-     ::Info("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",0)- IsOK");
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",0)- IsOK");
   }
   //
 }
 
-/// test AliDrawStyle::GetPropertyValue
 void AliDrawStyleTest_Attributes(){
   TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
   if ( AliDrawStyle::GetPropertyValue(input,"marker_color").Contains("1,2,4,5")){
@@ -99,89 +102,92 @@ void AliDrawStyleTest_Attributes(){
 /// test GetIntValues
 void AliDrawStyleTest_GetIntValues(){
   TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
-  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",0) == 1){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",0)- IsOK");
+  Bool_t status;
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",0, status) == 1){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",0, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",0)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",0, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",1) == 2){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",1)- IsOK");
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",1, status) == 2){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",1, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",1)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",1, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",2) == 4){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",2)- IsOK");
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",2, status) == 4){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",2, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",2)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",2, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",3) == 5){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",3)- IsOK");
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",3, status) == 5){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",3, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",3)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",3, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",0) == 25){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",0)- IsOK");
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",0, status) == 25){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",0, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",0)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",0, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",1) == 21){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1)- IsOK");
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",1, status) == 21){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",2) == 22){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1)- IsOK");
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",2, status) == 22){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",3) == 23){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1)- IsOK");
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",3, status) == 23){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1, \"status\")- FAILED");
   }
 }
 
 ///
 void AliDrawStyleTest_GetFloatValues(){
   TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
-  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",0) == 1){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",0)- IsOK");
+  Bool_t status;
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",0, status) == 1){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",0, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",0)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",0, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",1) == 2){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",1)- IsOK");
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",1, status) == 2){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",1, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",1)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",1, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",2) == 4){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",2)- IsOK");
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",2, status) == 4){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",2, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",2)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",2, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",3) == 5){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",3)- IsOK");
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",3, status) == 5){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",3, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",3)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",3, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",0) == 25){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",0)- IsOK");
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",0, status) == 25){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",0, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",0)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",0, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",1) == 21){
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",1, status) == 21){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",2) == 22){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- IsOK");
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",2, status) == 22){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1, \"status\")- FAILED");
   }
-  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",3) == 23){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- IsOK");
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",3, status) == 23){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1, \"status\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1, \"status\")- FAILED");
   }
 }
 
@@ -190,68 +196,31 @@ void AliDrawStyleTest_GetFloatValues(){
 ///          - diff between the files should be 0 except of the formatting
 /// TODO test - ignoring commented fields in selector and in the declaration
 // void AliDrawStyleTest_CSSReadWrite(){
-//   //TObjArray *cssArray = AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css");
-// TObjArray *cssArray = AliDrawStyle::ReadCSSFile("/Users/bdrum/Projects/alicesw/AliRoot/STAT/test/alirootTestStyle.css");
-//   AliDrawStyle::WriteCSSFile(cssArray,"test.css");
-//   TString diff = gSystem->GetFromPipe("diff -w -B    test.css  $AliRoot_SRC/STAT/test/alirootTestStyle.css");
-//   if (diff.Length()>0){
-//     ::Error("AliDrawStyleTest","AliDrawStyleTestStyle_CSSReadWrite- FAILED");
-//   }else{
-//     ::Info("AliDrawStyleTest","AliDrawStyleTestStyle_CSSReadWrite- IsOK");
+//
+//   if (gSystem->GetFromPipe(TString("[ -f ") + TString("$AliRoot_SRC/STAT/test/alirootTestStyle.css") +  TString(" ] && echo 1 || echo 0")) == "0") {
+//     std::cout << "File doesn't exist1" << std::endl;
+//     ::Info("AliDrawStyleTest","AliDrawStyleTest_CSSReadWrite()- FAILED");
+//     return;
 //   }
+//   TObjArray *cssArray = AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0);
+//   if (cssArray == NULL) {
+//     std::cout << "null-pointer error" << std::endl;
+//     ::Info("AliDrawStyleTest","AliDrawStyleTest_CSSReadWrite()- FAILED");
+//     return;
+//   }
+//   AliDrawStyle::WriteCSSFilecssArray,"$AliRoot_SRC/STAT/test/test.css");
+//   TObjArray *cssArrayFromTest = AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/test.css",0);
+//   //AliDrawStyle::WriteCSSFile
+//   //AliDrawStyle::WriteCSSFile
+//
+//   for (Int_t i = 0; i < cssArray->GetEntriesFast(); i++){
+//     if ((TString(cssArray->At(i)->GetName()).ReplaceAll("\n", "") == TString(cssArrayFromTest->At(i)->GetName()).ReplaceAll("\n", "")) && TString(cssArray->At(i)->GetTitle()).ReplaceAll("\n", "") == TString(cssArrayFromTest->At(i)->GetTitle()).ReplaceAll("\n", "")) ::Info("AliDrawStyleTest","AliDrawStyleTest_CSSReadWrite()- ");
+//     else ::Info("AliDrawStyleTest","AliDrawStyleTest_CSSReadWrite()- FAILED");
+//
+//   }
+//   gSystem->GetFromPipe("rm -f $AliRoot_SRC/STAT/test/test.css");
+//
 // }
-/// TODO - add test for IsSelected @done
-/// Add benchmark of is selected (timer, loop, print) @done if I get you right.
-/// What time do we need?
-/// Now we have
-/// bench(100) = 0.001079.s || bench(1000) = 0.01162.s || bench(10000) == 0.06675.s bench(100000) = 0.6101.s
-/// \param selector
-/// \param className
-/// \param attributeName
-/// \return
-void  AliDrawStyleTest_IsSelected(){//TString selector, TString className, TString attributeName){
-  TString selectors = "TH1.Status#obj1, TH1.Warning#obj1, TH1.Warning#obj3 \tTGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1 \tTGraph.Warning#TPC.QA.dcar_posA_2 \tTF1.Status, .Status#obj1, #obj3";
-  std::cout << selectors << std::endl;
-  if (AliDrawStyle::IsSelected(selectors, "TF1", "Status", "anyObject")){
-    ::Info("AliDrawStyleTest","AliDrawStyle::IsSelected(selectors, \"TF1\", \"Status\", \"anyObject\")- IsOK");
-  }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::IsSelected(selectors, \"TF1\", \"Status\", \"anyObject\")- FAILED");
-  }
-  if (AliDrawStyle::IsSelected(selectors, "TGraphErrors", "AnyTag", "obj3")){
-    ::Info("AliDrawStyleTest","AliDrawStyle::IsSelected(selectors, \"TGraphErrors\", \"AnyTag\", \"obj3\")- IsOK");
-  }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::IsSelected(selectors, \"TGraphErrors\", \"AnyTag\", \"obj3\")- FAILED");
-  }
-  if (AliDrawStyle::IsSelected(selectors, "TGraph", "Warning", "TPC.QA.dcar_posA_2")){
-    ::Info("AliDrawStyleTest","AliDrawStyle::IsSelected(selectors, \"TGraph\", \"Warning\", \"TPC.QA.dcar_posA_2\")- IsOK");
-  }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::IsSelected(selectors, \"TGraph\", \"Warning\", \"TPC.QA.dcar_posA_2\")- FAILED");
-  }
-  if (!AliDrawStyle::IsSelected(selectors, "TH1", "Status", "obj2")){
-    ::Info("AliDrawStyleTest","!AliDrawStyle::IsSelected(selectors, \"TH1\", \"Status\", \"obj2\")- IsOK");
-  }else{
-    ::Error("AliDrawStyleTest","!AliDrawStyle::IsSelected(selectors, \"TH1\", \"Status\", \"obj2\")- FAILED");
-  }
-  if (!AliDrawStyle::IsSelected(selectors, "Graph", "Warning", "obj1")){
-    ::Info("AliDrawStyleTest","!AliDrawStyle::IsSelected(selectors, \"Graph\", \"Warning\", \"obj1\")- IsOK");
-  }else{
-    ::Error("AliDrawStyleTest","!AliDrawStyle::IsSelected(selectors, \"Graph\", \"Warning\", \"obj1\")- FAILED");
-  }
-
-  //should I make this like separate function?
-  // Int_t n = 100000;
-  // TStopwatch timer;
-  // timer.Start();
-  // for (Int_t i=0; i<n; i++){
-  //   AliDrawStyle::IsSelected(selector, "tag123", "TGraphErrors","yyy");
-  // }
-  // timer.Stop();
-  //
-  // std::cout << "Benchmarking:" <<endl;
-  // std::cout.precision(4);
-  // std::cout << n << "calls of AliDrawStyle::IsSelected(tag*.TH*#*xxx \ttag*.*Errors#*yyy  , \"tag123\", \"TGraphErrors\",\"yyy\") tooks" << timer.RealTime() << ".s" <<endl;
-
-}
 
 void  AliDrawStyleTest_GetProperty(){
   AliDrawStyle::SetCssStyle("alirootTestStyle.css",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
@@ -270,7 +239,7 @@ void  AliDrawStyleTest_GetProperty(){
   }else{
     ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"line_color\", \"TGraphErrors\", \"Warning\", \"asdasobj56\")- FAILED");
   }
-  if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker_color", "SomeNotExistingClass", "SomeNotExistingStatus", "obj3") == "21,22,23,24"){
+  if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker_color", "SomeNotExistingClass", "SomeNotExistingStatus", "obj3") == "37,38,39,40"){
     ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_color\", \"SomeNotExistingClass\", \"SomeNotExistingStatus\", \"obj3\")- IsOK");
   }else{
     ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_color\", \"SomeNotExistingClass\", \"SomeNotExistingStatus\", \"obj3\")- FAILED");
@@ -284,51 +253,122 @@ void  AliDrawStyleTest_GetProperty(){
 }
 
 
-void AliDrawStyleTest_GetSelector(){
+/// Generate figut and apply 2 styles test1, -> test2 ->test1
+/// resulting pad has to be the same
+//SetStyle(styleName, pathToCssFile)
+//specify into AliDrawStyle::ApplyCssStyle(pad or canvas, styleName) active pad or canvas, styleName
+//for Apply a new style you should set new style and make AliDrawStyle::ApplyCssStyle() again with new styleName.
 
-  if (AliDrawStyle::GetSelector("alirootTestStyle.css") == TString("\n\n\nTGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1    \t\n\n\n\nTF1.Status, .Status#obj1, #obj3    \t\n\n.Status#obj1, #obj3, TGraphErrors.Warning    \t\n\n\nTH1.Status#obj1, TH1.Warning#obj1, TH1.Warning#obj3    \t")){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetSelector(\"alirootTestStyle.css\")- IsOK");
+void AliDrawStyleTest_ApplyCssStyle(){
+  TCanvas *canv = MakeTestPlot(3);
+  AliDrawStyle::SetCssStyle("test1",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/test1.css",0));
+  AliDrawStyle::ApplyCssStyle(canv, "test1");
+  canv->Print("test1.xml");
+  AliDrawStyle::SetCssStyle("test2",AliDrawStyle::ReadCSSFile("test2.css",0));
+  AliDrawStyle::ApplyCssStyle(canv, "test2");
+  AliDrawStyle::ApplyCssStyle(canv, "test1");
+  canv->Print("test2-1.xml");
+  Int_t nDiff = gSystem->GetFromPipe("diff  test1.xml test2-1.xml  | wc -l").Atoi()-4;
+  if (nDiff == 0) {
+    ::Info("AliDrawStyleTest","AliDrawStyle::ApplyStyle(\"canv\",\"test1\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetSelector(\"alirootTestStyle.css\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::ApplyStyle(\"canv\",\"test1\")- FAILED");
   }
-
 }
-//TODO: added generator of objects and check function
-//void AliDrawStyleTest_CountObjects(){
-  // const Int_t nHis = 10;
-  // TH1F *hisArray[nHis];
-  // TGraph *grArray[nHis];
-  // TF1  *fitArray[nHis];
-  // //TGraphErrors *grArray[nHis];
-  // //TF1  *fitArray[nHis];
-  // TList *oList = new TList();
-  //
-  // for (Int_t i=0; i<nHis; i++){
-  //   hisArray[i] = new TH1F(TString::Format("his%d.classRaw",i).Data(), "histo from a gaussian", 100, -3, 3);
-  //   fitArray[i] = new TF1(TString::Format("func%d.classRaw",i).Data(),"",0,3,6);
-  //   grArray[i] = new TGraph(10);
-  //   oList->AddLast(hisArray[i]);
-  //   oList->AddLast(fitArray[i]);
-  //   oList->AddLast(grArray[i]);
-  // }
 
-//}
 
-// void AliDrawStyleTest_TGraphApplyStyle(){
-//
-// }
-// void AliDrawStyleTest_TH1ApplyStyle(){
-//
-// }
-// void AliDrawStyleTest_TF1ApplyStyle(){
-//
-// }
-// void AliDrawStyleTest_TPadApplyStyle(){
-//
-// }
-// void AliDrawStyleTest_TCanvasApplyCssStyle(){
-//
-// }
-// void AliDrawStyleTest_ApplyCssStyle(){
-//
-// }
+///
+TCanvas *MakeTestPlot(Int_t nHis) {
+
+    TRandom r;
+    TCanvas *exampleCanvas = new TCanvas("c1", "The AliDrawStyle::ApplyCssStyle example", 200, 10, 1200, 900);
+    AliPainter::DivideTPad(exampleCanvas,"<vertical>[1l,1r]", "Pad");
+    exampleCanvas->cd(1);
+    TH1F *hisArray[nHis];
+    for (Int_t i = 0; i < nHis; i++) {
+      hisArray[i] = new TH1F(TString::Format("his[%d].class(Raw)", i).Data(),
+                             TString::Format("his[%d].class(Raw)", i).Data(), 100, -5, 5);
+      hisArray[i]->SetStats(0);
+      hisArray[i]->SetTitle("TH1");
+      hisArray[i]->SetMarkerStyle(1);
+      hisArray[i]->FillRandom("gaus", 100000 / (i + 2));
+      if (i == 0) {
+        hisArray[i]->Draw("err");
+      } else {
+        hisArray[i]->Draw("SAMEerr");
+      }
+    }
+    //
+    exampleCanvas->cd(2);
+    TLegend *legend = new TLegend(0.1, 0.1, 0.4, 0.4, "Graph");
+    const Int_t n = 100;
+    Double_t x[n], y[n];
+    TGraph *grArray[nHis];
+    for (Int_t j = 0; j < n; j++) {
+      x[j] = j * 0.6 + 5;
+      y[j] = (nHis) * log(x[j]);
+    }
+
+    for (Int_t i = 0; i < nHis; i++) {
+      for (Int_t j = 0; j < n; j++) {
+        x[j] = j * 0.6 + 5;
+        y[j] = log(x[j]) / (i + 1);
+      }
+      grArray[i] = new TGraph(n, x, y);
+      grArray[i]->SetName(TString::Format("graph[%d].class(Raw)", i).Data());
+      grArray[i]->SetTitle(TString::Format("gr[%d]", i).Data());
+      if (i == 0) {
+        grArray[i]->SetMinimum(0);
+        grArray[i]->Draw("alp");
+      } else {
+        grArray[i]->Draw("lp");
+      }
+      legend->AddEntry(grArray[i], "", "p");
+    }
+    legend->Draw();
+  return exampleCanvas;
+}
+
+/*
+void SetStyleForTest(Int_t val, TCanvas *canv) {
+    cCanvas->SetFillColor(val);
+    cCanvas->SetBorderSize(val);
+    cCanvas->SetBorderMode(val);
+    TList *oListPad = NULL;
+    TList *oListObj = NULL;
+
+    oList = pad->GetListOfPrimitives();
+    for(Int_t c = 0; c < oList->GetEntries(); c++) {
+        (TPad *) oList->At(c)->SetFillColor(val);
+        (TPad *) oList->At(c)->SetBottomMargin(val);
+        (TPad *) oList->At(c)->SetTopMargin(val);
+        (TPad *) oList->At(c)->SetLeftMargin(val);
+        (TPad *) oList->At(c)->SetRightMargin(val);
+        (TPad *) oList->At(c)->SetBorderSize(val);
+        (TPad *) oList->At(c)->SetBorderMode(val);
+        (TPad *) oList->At(c)->SetGridx(val);
+        (TPad *) oList->At(c)->SetGridy(val);
+        (TPad *) oList->At(c)->SetTickx(val);
+        (TPad *) oList->At(c)->SetTicky(val);
+        (TPad *) oList->At(c)->SetLogx(val);
+        (TPad *) oList->At(c)->SetLogy(val);
+        (TPad *) oList->At(c)->SetLogz(val);
+        for (Int_t k = 0; k < oList->GetEntries(); k++) {
+
+            cObj = oListObj->At(k);
+            if (cObj->InheritsFrom("TH1") || cObj->InheritsFrom("TGraph") || cObj->InheritsFrom("TF1")) {
+
+                cObj->SetMarkerColor(val);
+                cObj->SetMarkerSize(val);
+                cObj->SetMarkerStyle(val);
+                cObj->SetLineColor(val);
+                cObj->SetLineWidth(val);
+                cObj->SetLineStyle(val);
+                cObj->SetFillColor(val);
+                cObj->SetFillStyle(val);
+            }
+        }
+    }
+    canv->Modified();
+}
+*/

--- a/STAT/test/AliDrawStyleTest.C
+++ b/STAT/test/AliDrawStyleTest.C
@@ -184,12 +184,17 @@ void AliDrawStyleTest_CSSReadWrite(){
 /// \param className
 /// \param attributeName
 /// \return
+/// Comments:
+///      * We will use root TRegexp for the pattern matching
+///      * tab
 Bool_t  AliDrawStyleTest_IsSelected(TString selector, TString className, TString attributeName){
   TString selector= ".TH*#*xxx .TH1*#yyy  ";
-  // AliDrawStyle::IsSelected(selector, "TGraph","xxx"); //should be flase
-  // AliDrawStyle::IsSelected(selector, "TH2","xxx");   //should be true
-  // AliDrawStyle::IsSelected(selector, "TH1","xxx");   //should be false
-  // AliDrawStyle::IsSelected(selector, "TH1","yyy");   //should be true
+  // AliDrawStyle::IsSelected(selector, "TGraph","xxx");  //should be false
+  // AliDrawStyle::IsSelected(selector, "TH2","xxx");     //should be true
+  // AliDrawStyle::IsSelected(selector, "TH2","yyy");     //should be false
+  // AliDrawStyle::IsSelected(selector, "TH1","xxx");     //should be true
+  // AliDrawStyle::IsSelected(selector, "TH1","yyy");     //should be true
+  // AliDrawStyle::IsSelected(selector, "TH1","yyy");     //should be true
   // TString className="TH2";
   // TString objectName="xxx";
   // Bool_t isSelected=0;

--- a/STAT/test/AliDrawStyleTest.C
+++ b/STAT/test/AliDrawStyleTest.C
@@ -169,7 +169,7 @@ void AliDrawStyleTest_GetFloatValues(){
 ///          - diff between the files should be 0 except of the formatting
 /// TODO test - ignoring commented fields in selector and in the declaration
 void AliDrawStyleTest_CSSReadWrite(){
-  TObjArray *cssArray = AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css");
+  TObjArray *cssArray = AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0);
   AliDrawStyle::WriteCSSFile(cssArray,"test.css");
   TString diff = gSystem->GetFromPipe("diff -w -B    test.css  $AliRoot_SRC/STAT/test/alirootTestStyle.css");
   if (diff.Length()>0){
@@ -188,7 +188,7 @@ void AliDrawStyleTest_CSSReadWrite(){
 ///      * We will use root TRegexp for the pattern matching
 ///      * tab
 Bool_t  AliDrawStyleTest_IsSelected(TString selector, TString className, TString attributeName){
-  TString selector= ".TH*#*xxx .TH1*#yyy  ";
+  //TString selector= ".TH*#*xxx .TH1*#yyy  ";
   // AliDrawStyle::IsSelected(selector, "TGraph","xxx");  //should be false
   // AliDrawStyle::IsSelected(selector, "TH2","xxx");     //should be true
   // AliDrawStyle::IsSelected(selector, "TH2","yyy");     //should be false

--- a/STAT/test/AliDrawStyleTest.C
+++ b/STAT/test/AliDrawStyleTest.C
@@ -1,37 +1,39 @@
 /// \ingroup STAT/test
 /// \brief  test of AliDrawStyleTest macro
 /// Example usage
+/// Some benchmark of the performance doing parsing in loop
+///      stopwatch.Start(); (for i; i<n; i++) doSomething(); formatted(dosomething, stopwatch.Print());
 /*!
 \code
-.L $AliRoot_SRC/STAT/test/AliDrawStyleTest.C
+.L $AliRoot_SRC/STAT/test/AliDrawStyleTest.C+
 AliDrawStyleTestGetArray();
 aliroot -b -q  $AliRoot_SRC/STAT/test/AliDrawStyleTest.C+ | tee AliDrawStyleTest.log
-
 \endcode
-
-
 */
+
 #include "Rtypes.h"
 #include "TMath.h"
 #include "AliDrawStyle.h"
 #include "Riostream.h"
 #include <iostream>
+#include "TSystem.h"
 
-void AliDrawStyleTestStyleArray();
-void AliDrawStyleTestStyle_Attributes();
-void AliDrawStyleTestStyle_GetIntValues();
-void AliDrawStyleTestStyle_GetFloatValues();
-
+void AliDrawStyleTest_StyleArray();
+void AliDrawStyleTest_Attributes();
+void AliDrawStyleTest_GetIntValues();
+void AliDrawStyleTest_GetFloatValues();
+void AliDrawStyleTest_CSSReadWrite();
 
 void AliDrawStyleTest(){
-  AliDrawStyleTestStyleArray();
-  AliDrawStyleTestStyle_Attributes();
-  AliDrawStyleTestStyle_GetIntValues();
-  AliDrawStyleTestStyle_GetFloatValues();
-
+  AliDrawStyleTest_StyleArray();
+  AliDrawStyleTest_Attributes();
+  AliDrawStyleTest_GetIntValues();
+  AliDrawStyleTest_GetFloatValues();
+  AliDrawStyleTest_CSSReadWrite();
 }
 
-void AliDrawStyleTestStyleArray(){
+/// Test acces to the style indexed array
+void AliDrawStyleTest_StyleArray(){
   //
   // Standard ALICE marker/colors arrays
   // TODO - extend it with the test of all line and marker atributes
@@ -58,17 +60,8 @@ void AliDrawStyleTestStyleArray(){
   //
 }
 
-void AliDrawStyleTestStyle_PredefinedArray(){
-  //
-  // AliDrawStyle::GetMarkerStyle("figTemplate",1); //should be 20
-  // AliDrawStyle::GetMarkerStyle("figTemplate",1); //should be 21
-  // (AliDrawStyle::GetMarkerColor("figTemplate",0)==kBlack); // should be kBlack OK
-  // (AliDrawStyle::GetMarkerColor("figTemplate",1)==kRed+1)
-  // AliDrawStyle::GetMarkerColor("figTemplate",0); // should be
-}
-
-///
-void AliDrawStyleTestStyle_Attributes(){
+/// test AliDrawStyle::GetAttributeValue
+void AliDrawStyleTest_Attributes(){
   TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
   if ( AliDrawStyle::GetAttributeValue(input,"marker_color").Contains("1,2,4,5")){
     ::Info("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\")- IsOK");
@@ -82,8 +75,8 @@ void AliDrawStyleTestStyle_Attributes(){
   }
 }
 
-
-void AliDrawStyleTestStyle_GetIntValues(){
+/// test GetIntValues
+void AliDrawStyleTest_GetIntValues(){
   TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
   if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",0) == 1){
     ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",0)- IsOK");
@@ -127,9 +120,8 @@ void AliDrawStyleTestStyle_GetIntValues(){
   }
 }
 
-
-
-void AliDrawStyleTestStyle_GetFloatValues(){
+///
+void AliDrawStyleTest_GetFloatValues(){
   TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
   if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",0) == 1){
     ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",0)- IsOK");
@@ -157,7 +149,6 @@ void AliDrawStyleTestStyle_GetFloatValues(){
     ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",0)- FAILED");
   }
   if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",1) == 21){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- IsOK");
   }else{
     ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- FAILED");
   }
@@ -171,4 +162,39 @@ void AliDrawStyleTestStyle_GetFloatValues(){
   }else{
     ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- FAILED");
   }
+}
+
+
+/// To test  - input CSS file to be read and than written
+///          - diff between the files should be 0 except of the formatting
+/// TODO test - ignoring commented fields in selector and in the declaration
+void AliDrawStyleTest_CSSReadWrite(){
+  TObjArray *cssArray = AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css");
+  AliDrawStyle::WriteCSSFile(cssArray,"test.css");
+  TString diff = gSystem->GetFromPipe("diff -w -B    test.css  $AliRoot_SRC/STAT/test/alirootTestStyle.css");
+  if (diff.Length()>0){
+    ::Error("AliDrawStyleTest","AliDrawStyleTestStyle_CSSReadWrite- FAILED");
+  }else{
+    ::Info("AliDrawStyleTest","AliDrawStyleTestStyle_CSSReadWrite- IsOK");
+  }
+}
+/// TODO - add test for IsSelected
+/// Add benchnchamrk of is selected (timer, loop, print)
+/// \param selector
+/// \param className
+/// \param attributeName
+/// \return
+Bool_t  AliDrawStyleTest_IsSelected(TString selector, TString className, TString attributeName){
+  TString selector= ".TH*#*xxx .TH1*#yyy  ";
+  // AliDrawStyle::IsSelected(selector, "TGraph","xxx"); //should be flase
+  // AliDrawStyle::IsSelected(selector, "TH2","xxx");   //should be true
+  // AliDrawStyle::IsSelected(selector, "TH1","xxx");   //should be false
+  // AliDrawStyle::IsSelected(selector, "TH1","yyy");   //should be true
+  // TString className="TH2";
+  // TString objectName="xxx";
+  // Bool_t isSelected=0;
+  // TObjArray * subArray = selector.Tokenize(" \t");
+  // for (Int_t i=0; i<subArray->GetEntries(); i++){
+  //   TString subExp=subArray->At(i)->GetName();
+  // }
 }

--- a/STAT/test/AliDrawStyleTest.C
+++ b/STAT/test/AliDrawStyleTest.C
@@ -5,20 +5,30 @@
 \code
 .L $AliRoot_SRC/STAT/test/AliDrawStyleTest.C
 AliDrawStyleTestGetArray();
-aliroot -b -q  $AliRoot_SRC/STAT/test/AliDrawStyleTest.C | tee AliDrawStyleTest.log
+aliroot -b -q  $AliRoot_SRC/STAT/test/AliDrawStyleTest.C+ | tee AliDrawStyleTest.log
 
 \endcode
 
 
 */
+#include "Rtypes.h"
+#include "TMath.h"
 #include "AliDrawStyle.h"
 #include "Riostream.h"
 #include <iostream>
 
 void AliDrawStyleTestStyleArray();
+void AliDrawStyleTestStyle_Attributes();
+void AliDrawStyleTestStyle_GetIntValues();
+void AliDrawStyleTestStyle_GetFloatValues();
+
 
 void AliDrawStyleTest(){
   AliDrawStyleTestStyleArray();
+  AliDrawStyleTestStyle_Attributes();
+  AliDrawStyleTestStyle_GetIntValues();
+  AliDrawStyleTestStyle_GetFloatValues();
+
 }
 
 void AliDrawStyleTestStyleArray(){
@@ -57,3 +67,108 @@ void AliDrawStyleTestStyle_PredefinedArray(){
   // AliDrawStyle::GetMarkerColor("figTemplate",0); // should be
 }
 
+///
+void AliDrawStyleTestStyle_Attributes(){
+  TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
+  if ( AliDrawStyle::GetAttributeValue(input,"marker_color").Contains("1,2,4,5")){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\")- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\")- FAILED");
+  }
+  if ( AliDrawStyle::GetAttributeValue(input,"marker_style").Contains("25,21,22,23")){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_style\")- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_style\")- FAILED");
+  }
+}
+
+
+void AliDrawStyleTestStyle_GetIntValues(){
+  TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",0) == 1){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",0)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",0)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",1) == 2){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",1)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",1)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",2) == 4){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",2)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",2)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_color",3) == 5){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_color\",3)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",3)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",0) == 25){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",0)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",0)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",1) == 21){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",2) == 22){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedIntegerAt(input,"marker_style",3) == 23){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedIntegerAt(input,\"marker_style\",1)- FAILED");
+  }
+}
+
+
+
+void AliDrawStyleTestStyle_GetFloatValues(){
+  TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",0) == 1){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",0)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",0)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",1) == 2){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",1)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",1)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",2) == 4){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",2)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",2)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_color",3) == 5){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_color\",3)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\",3)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",0) == 25){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",0)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",0)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",1) == 21){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",2) == 22){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- FAILED");
+  }
+  if ( AliDrawStyle::GetNamedFloatAt(input,"marker_style",3) == 23){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetNamedFloatAt(input,\"marker_style\",1)- FAILED");
+  }
+}

--- a/STAT/test/AliDrawStyleTest.C
+++ b/STAT/test/AliDrawStyleTest.C
@@ -1,0 +1,59 @@
+/// \ingroup STAT/test
+/// \brief  test of AliDrawStyleTest macro
+/// Example usage
+/*!
+\code
+.L $AliRoot_SRC/STAT/test/AliDrawStyleTest.C
+AliDrawStyleTestGetArray();
+aliroot -b -q  $AliRoot_SRC/STAT/test/AliDrawStyleTest.C | tee AliDrawStyleTest.log
+
+\endcode
+
+
+*/
+#include "AliDrawStyle.h"
+#include "Riostream.h"
+#include <iostream>
+
+void AliDrawStyleTestStyleArray();
+
+void AliDrawStyleTest(){
+  AliDrawStyleTestStyleArray();
+}
+
+void AliDrawStyleTestStyleArray(){
+  //
+  // Standard ALICE marker/colors arrays
+  // TODO - extend it with the test of all line and marker atributes
+  Int_t result=0;
+  result = AliDrawStyle::GetMarkerStyle("1;2,3;4",0);
+  if (result!=1){
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",0)==%d should be 1-FAILED\n",result);
+  }else{
+     ::Info("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",0)- IsOK");
+  }
+  result = AliDrawStyle::GetMarkerStyle("1;2,3;4",1);
+  if (result!=2){
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",1)==%d should be 2-FAILED\n",result);
+  }else{
+     ::Info("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",1)- IsOK");
+  }
+  //
+  result = AliDrawStyle::GetMarkerColor("1;2,3;4",0);
+  if (result!=1){
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",0)==%d should be 1-FAILED\n",result);
+  }else{
+     ::Info("AliDrawStyleTest","AliDrawStyle::GetMarkerStyle(\"1;2,3;4\",0)- IsOK");
+  }
+  //
+}
+
+void AliDrawStyleTestStyle_PredefinedArray(){
+  //
+  // AliDrawStyle::GetMarkerStyle("figTemplate",1); //should be 20
+  // AliDrawStyle::GetMarkerStyle("figTemplate",1); //should be 21
+  // (AliDrawStyle::GetMarkerColor("figTemplate",0)==kBlack); // should be kBlack OK
+  // (AliDrawStyle::GetMarkerColor("figTemplate",1)==kRed+1)
+  // AliDrawStyle::GetMarkerColor("figTemplate",0); // should be
+}
+

--- a/STAT/test/AliDrawStyleTest.C
+++ b/STAT/test/AliDrawStyleTest.C
@@ -6,8 +6,8 @@
 /*!
 \code
 .L $AliRoot_SRC/STAT/test/AliDrawStyleTest.C+
-AliDrawStyleTestGetArray();
-aliroot -b -q  $AliRoot_SRC/STAT/test/AliDrawStyleTest.C+ | tee AliDrawStyleTest.log
+AliDrawStyleTest();
+root.exe -b -q  $AliRoot_SRC/STAT/test/AliDrawStyleTest.C+ | tee AliDrawStyleTest.log
 \endcode
 */
 
@@ -17,19 +17,22 @@ aliroot -b -q  $AliRoot_SRC/STAT/test/AliDrawStyleTest.C+ | tee AliDrawStyleTest
 #include "Riostream.h"
 #include <iostream>
 #include "TSystem.h"
+#include "TStopwatch.h"
 
 void AliDrawStyleTest_StyleArray();
 void AliDrawStyleTest_Attributes();
 void AliDrawStyleTest_GetIntValues();
 void AliDrawStyleTest_GetFloatValues();
-void AliDrawStyleTest_CSSReadWrite();
+//void AliDrawStyleTest_CSSReadWrite();
+Bool_t AliDrawStyleTest_IsSelected();
 
 void AliDrawStyleTest(){
   AliDrawStyleTest_StyleArray();
   AliDrawStyleTest_Attributes();
   AliDrawStyleTest_GetIntValues();
   AliDrawStyleTest_GetFloatValues();
-  AliDrawStyleTest_CSSReadWrite();
+//  AliDrawStyleTest_CSSReadWrite();
+  AliDrawStyleTest_IsSelected();
 }
 
 /// Test acces to the style indexed array
@@ -60,18 +63,18 @@ void AliDrawStyleTest_StyleArray(){
   //
 }
 
-/// test AliDrawStyle::GetAttributeValue
+/// test AliDrawStyle::GetPropertyValue
 void AliDrawStyleTest_Attributes(){
   TString input="{\nmarker_style:25,21,22,23; \nmarker_color:1,2,4,5; \n}";
-  if ( AliDrawStyle::GetAttributeValue(input,"marker_color").Contains("1,2,4,5")){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\")- IsOK");
+  if ( AliDrawStyle::GetPropertyValue(input,"marker_color").Contains("1,2,4,5")){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetPropertyValue(input,\"marker_color\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_color\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetPropertyValue(input,\"marker_color\")- FAILED");
   }
-  if ( AliDrawStyle::GetAttributeValue(input,"marker_style").Contains("25,21,22,23")){
-    ::Info("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_style\")- IsOK");
+  if ( AliDrawStyle::GetPropertyValue(input,"marker_style").Contains("25,21,22,23")){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetPropertyValue(input,\"marker_style\")- IsOK");
   }else{
-    ::Error("AliDrawStyleTest","AliDrawStyle::GetAttributeValue(input,\"marker_style\")- FAILED");
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetPropertyValue(input,\"marker_style\")- FAILED");
   }
 }
 
@@ -168,38 +171,78 @@ void AliDrawStyleTest_GetFloatValues(){
 /// To test  - input CSS file to be read and than written
 ///          - diff between the files should be 0 except of the formatting
 /// TODO test - ignoring commented fields in selector and in the declaration
-void AliDrawStyleTest_CSSReadWrite(){
-  TObjArray *cssArray = AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0);
-  AliDrawStyle::WriteCSSFile(cssArray,"test.css");
-  TString diff = gSystem->GetFromPipe("diff -w -B    test.css  $AliRoot_SRC/STAT/test/alirootTestStyle.css");
-  if (diff.Length()>0){
-    ::Error("AliDrawStyleTest","AliDrawStyleTestStyle_CSSReadWrite- FAILED");
-  }else{
-    ::Info("AliDrawStyleTest","AliDrawStyleTestStyle_CSSReadWrite- IsOK");
-  }
-}
-/// TODO - add test for IsSelected
-/// Add benchnchamrk of is selected (timer, loop, print)
+// void AliDrawStyleTest_CSSReadWrite(){
+//   //TObjArray *cssArray = AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css");
+// TObjArray *cssArray = AliDrawStyle::ReadCSSFile("/Users/bdrum/Projects/alicesw/AliRoot/STAT/test/alirootTestStyle.css");
+//   AliDrawStyle::WriteCSSFile(cssArray,"test.css");
+//   TString diff = gSystem->GetFromPipe("diff -w -B    test.css  $AliRoot_SRC/STAT/test/alirootTestStyle.css");
+//   if (diff.Length()>0){
+//     ::Error("AliDrawStyleTest","AliDrawStyleTestStyle_CSSReadWrite- FAILED");
+//   }else{
+//     ::Info("AliDrawStyleTest","AliDrawStyleTestStyle_CSSReadWrite- IsOK");
+//   }
+// }
+/// TODO - add test for IsSelected @done
+/// Add benchmark of is selected (timer, loop, print) @done if I get you right.
+/// What time do we need?
+/// Now we have
+/// bench(100) = 0.001079.s || bench(1000) = 0.01162.s || bench(10000) == 0.06675.s bench(100000) = 0.6101.s
 /// \param selector
 /// \param className
 /// \param attributeName
 /// \return
-/// Comments:
-///      * We will use root TRegexp for the pattern matching
-///      * tab
-Bool_t  AliDrawStyleTest_IsSelected(TString selector, TString className, TString attributeName){
-  //TString selector= ".TH*#*xxx .TH1*#yyy  ";
-  // AliDrawStyle::IsSelected(selector, "TGraph","xxx");  //should be false
-  // AliDrawStyle::IsSelected(selector, "TH2","xxx");     //should be true
-  // AliDrawStyle::IsSelected(selector, "TH2","yyy");     //should be false
-  // AliDrawStyle::IsSelected(selector, "TH1","xxx");     //should be true
-  // AliDrawStyle::IsSelected(selector, "TH1","yyy");     //should be true
-  // AliDrawStyle::IsSelected(selector, "TH1","yyy");     //should be true
-  // TString className="TH2";
-  // TString objectName="xxx";
-  // Bool_t isSelected=0;
-  // TObjArray * subArray = selector.Tokenize(" \t");
-  // for (Int_t i=0; i<subArray->GetEntries(); i++){
-  //   TString subExp=subArray->At(i)->GetName();
+Bool_t  AliDrawStyleTest_IsSelected(){//TString selector, TString className, TString attributeName){
+  TString selectors = "TH1.Status#obj1, TH1.Warning#obj1, TH1.Warning#obj3 \tTGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1 \tTGraph.Warning#TPC.QA.dcar_posA_2 \tTF1.Status, .Status#obj1, #obj3";
+  std::cout << selectors << std::endl;
+  if (AliDrawStyle::IsSelected(selectors, "TF1", "Status", "anyObject")){
+    ::Info("AliDrawStyleTest","AliDrawStyle::IsSelected(selectors, \"TF1\", \"Status\", \"anyObject\")- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::IsSelected(selectors, \"TF1\", \"Status\", \"anyObject\")- FAILED");
+  }
+  if (AliDrawStyle::IsSelected(selectors, "TGraphErrors", "AnyTag", "obj3")){
+    ::Info("AliDrawStyleTest","AliDrawStyle::IsSelected(selectors, \"TGraphErrors\", \"AnyTag\", \"obj3\")- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::IsSelected(selectors, \"TGraphErrors\", \"AnyTag\", \"obj3\")- FAILED");
+  }
+  if (AliDrawStyle::IsSelected(selectors, "TGraph", "Warning", "TPC.QA.dcar_posA_2")){
+    ::Info("AliDrawStyleTest","AliDrawStyle::IsSelected(selectors, \"TGraph\", \"Warning\", \"TPC.QA.dcar_posA_2\")- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::IsSelected(selectors, \"TGraph\", \"Warning\", \"TPC.QA.dcar_posA_2\")- FAILED");
+  }
+  if (!AliDrawStyle::IsSelected(selectors, "TH1", "Status", "obj2")){
+    ::Info("AliDrawStyleTest","!AliDrawStyle::IsSelected(selectors, \"TH1\", \"Status\", \"obj2\")- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","!AliDrawStyle::IsSelected(selectors, \"TH1\", \"Status\", \"obj2\")- FAILED");
+  }
+  if (!AliDrawStyle::IsSelected(selectors, "Graph", "Warning", "obj1")){
+    ::Info("AliDrawStyleTest","!AliDrawStyle::IsSelected(selectors, \"Graph\", \"Warning\", \"obj1\")- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","!AliDrawStyle::IsSelected(selectors, \"Graph\", \"Warning\", \"obj1\")- FAILED");
+  }
+
+  //should I make this like separate function?
+  // Int_t n = 100000;
+  // TStopwatch timer;
+  // timer.Start();
+  // for (Int_t i=0; i<n; i++){
+  //   AliDrawStyle::IsSelected(selector, "tag123", "TGraphErrors","yyy");
   // }
+  // timer.Stop();
+  //
+  // std::cout << "Benchmarking:" <<endl;
+  // std::cout.precision(4);
+  // std::cout << n << "calls of AliDrawStyle::IsSelected(tag*.TH*#*xxx \ttag*.*Errors#*yyy  , \"tag123\", \"TGraphErrors\",\"yyy\") tooks" << timer.RealTime() << ".s" <<endl;
+
+}
+
+Bool_t  AliDrawStyleTest_GetProperty(){
+  AliDrawStyle::SetCssStyle("alirootTestStyle.css",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
+  if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "Status", "TPC.QA.dcar_posA_1") == "   1,2,3,4"){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_size\", \"TGraph\", \"Status\", \"TPC.QA.dcar_posA_1\")- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_size\", \"TGraph\", \"Status\", \"TPC.QA.dcar_posA_1\")- FAILED");
+  }
+
+
+
 }

--- a/STAT/test/AliDrawStyleTest.C
+++ b/STAT/test/AliDrawStyleTest.C
@@ -24,7 +24,8 @@ void AliDrawStyleTest_Attributes();
 void AliDrawStyleTest_GetIntValues();
 void AliDrawStyleTest_GetFloatValues();
 //void AliDrawStyleTest_CSSReadWrite();
-Bool_t AliDrawStyleTest_IsSelected();
+void AliDrawStyleTest_IsSelected();
+void AliDrawStyleTest_GetProperty();
 
 void AliDrawStyleTest(){
   AliDrawStyleTest_StyleArray();
@@ -33,6 +34,7 @@ void AliDrawStyleTest(){
   AliDrawStyleTest_GetFloatValues();
 //  AliDrawStyleTest_CSSReadWrite();
   AliDrawStyleTest_IsSelected();
+  AliDrawStyleTest_GetProperty();
 }
 
 /// Test acces to the style indexed array
@@ -191,7 +193,7 @@ void AliDrawStyleTest_GetFloatValues(){
 /// \param className
 /// \param attributeName
 /// \return
-Bool_t  AliDrawStyleTest_IsSelected(){//TString selector, TString className, TString attributeName){
+void  AliDrawStyleTest_IsSelected(){//TString selector, TString className, TString attributeName){
   TString selectors = "TH1.Status#obj1, TH1.Warning#obj1, TH1.Warning#obj3 \tTGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1 \tTGraph.Warning#TPC.QA.dcar_posA_2 \tTF1.Status, .Status#obj1, #obj3";
   std::cout << selectors << std::endl;
   if (AliDrawStyle::IsSelected(selectors, "TF1", "Status", "anyObject")){
@@ -235,14 +237,32 @@ Bool_t  AliDrawStyleTest_IsSelected(){//TString selector, TString className, TSt
 
 }
 
-Bool_t  AliDrawStyleTest_GetProperty(){
+void  AliDrawStyleTest_GetProperty(){
   AliDrawStyle::SetCssStyle("alirootTestStyle.css",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
-  if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "Status", "TPC.QA.dcar_posA_1") == "   1,2,3,4"){
+  if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "Status", "TPC.QA.dcar_posA_1") == "1,2,3,4"){
     ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_size\", \"TGraph\", \"Status\", \"TPC.QA.dcar_posA_1\")- IsOK");
   }else{
     ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_size\", \"TGraph\", \"Status\", \"TPC.QA.dcar_posA_1\")- FAILED");
   }
-
-
+  if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TF1", "Status", "obj4") == "17,18,19,20"){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_size\", \"TF1\", \"Status\", \"obj4\")- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_size\", \"TF1\", \"Status\", \"obj4\")- FAILED");
+  }
+  if (AliDrawStyle::GetProperty("alirootTestStyle.css","line_color", "TGraphErrors", "Warning", "asdasobj56") == "41,42,43,44"){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"line_color\", \"TGraphErrors\", \"Warning\", \"asdasobj56\")- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"line_color\", \"TGraphErrors\", \"Warning\", \"asdasobj56\")- FAILED");
+  }
+  if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker_color", "SomeNotExistingClass", "SomeNotExistingStatus", "obj3") == "21,22,23,24"){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_color\", \"SomeNotExistingClass\", \"SomeNotExistingStatus\", \"obj3\")- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_color\", \"SomeNotExistingClass\", \"SomeNotExistingStatus\", \"obj3\")- FAILED");
+  }
+  if (AliDrawStyle::GetProperty("alirootTestStyle.css","line_color", "TH1", "Warning", "obj1") == "57,58,59,60"){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"line_color\", \"TH1\", \"Warning\", \"obj1\")- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"line_color\", \"TH1\", \"Warning\", \"obj1\")- FAILED");
+  }
 
 }

--- a/STAT/test/AliDrawStyleTest.C
+++ b/STAT/test/AliDrawStyleTest.C
@@ -23,18 +23,34 @@ void AliDrawStyleTest_StyleArray();
 void AliDrawStyleTest_Attributes();
 void AliDrawStyleTest_GetIntValues();
 void AliDrawStyleTest_GetFloatValues();
-//void AliDrawStyleTest_CSSReadWrite();
+//  void AliDrawStyleTest_CSSReadWrite();
 void AliDrawStyleTest_IsSelected();
 void AliDrawStyleTest_GetProperty();
+void AliDrawStyleTest_GetSelector();
+// void AliDrawStyleTest_CountObjects();
+// void AliDrawStyleTest_TGraphApplyStyle();
+// void AliDrawStyleTest_TH1ApplyStyle();
+// void AliDrawStyleTest_TF1ApplyStyle();
+// void AliDrawStyleTest_TPadApplyStyle();
+// void AliDrawStyleTest_TCanvasApplyCssStyle();
+// void AliDrawStyleTest_ApplyCssStyle();
 
 void AliDrawStyleTest(){
   AliDrawStyleTest_StyleArray();
   AliDrawStyleTest_Attributes();
   AliDrawStyleTest_GetIntValues();
   AliDrawStyleTest_GetFloatValues();
-//  AliDrawStyleTest_CSSReadWrite();
+  //  AliDrawStyleTest_CSSReadWrite();
   AliDrawStyleTest_IsSelected();
   AliDrawStyleTest_GetProperty();
+  AliDrawStyleTest_GetSelector();
+  // AliDrawStyleTest_CountObjects();
+  // AliDrawStyleTest_TGraphApplyStyle();
+  // AliDrawStyleTest_TH1ApplyStyle();
+  // AliDrawStyleTest_TF1ApplyStyle();
+  // AliDrawStyleTest_TPadApplyStyle();
+  // AliDrawStyleTest_TCanvasApplyCssStyle();
+  // AliDrawStyleTest_ApplyCssStyle();
 }
 
 /// Test acces to the style indexed array
@@ -266,3 +282,53 @@ void  AliDrawStyleTest_GetProperty(){
   }
 
 }
+
+
+void AliDrawStyleTest_GetSelector(){
+
+  if (AliDrawStyle::GetSelector("alirootTestStyle.css") == TString("\n\n\nTGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1    \t\n\n\n\nTF1.Status, .Status#obj1, #obj3    \t\n\n.Status#obj1, #obj3, TGraphErrors.Warning    \t\n\n\nTH1.Status#obj1, TH1.Warning#obj1, TH1.Warning#obj3    \t")){
+    ::Info("AliDrawStyleTest","AliDrawStyle::GetSelector(\"alirootTestStyle.css\")- IsOK");
+  }else{
+    ::Error("AliDrawStyleTest","AliDrawStyle::GetSelector(\"alirootTestStyle.css\")- FAILED");
+  }
+
+}
+//TODO: added generator of objects and check function
+//void AliDrawStyleTest_CountObjects(){
+  // const Int_t nHis = 10;
+  // TH1F *hisArray[nHis];
+  // TGraph *grArray[nHis];
+  // TF1  *fitArray[nHis];
+  // //TGraphErrors *grArray[nHis];
+  // //TF1  *fitArray[nHis];
+  // TList *oList = new TList();
+  //
+  // for (Int_t i=0; i<nHis; i++){
+  //   hisArray[i] = new TH1F(TString::Format("his%d.classRaw",i).Data(), "histo from a gaussian", 100, -3, 3);
+  //   fitArray[i] = new TF1(TString::Format("func%d.classRaw",i).Data(),"",0,3,6);
+  //   grArray[i] = new TGraph(10);
+  //   oList->AddLast(hisArray[i]);
+  //   oList->AddLast(fitArray[i]);
+  //   oList->AddLast(grArray[i]);
+  // }
+
+//}
+
+// void AliDrawStyleTest_TGraphApplyStyle(){
+//
+// }
+// void AliDrawStyleTest_TH1ApplyStyle(){
+//
+// }
+// void AliDrawStyleTest_TF1ApplyStyle(){
+//
+// }
+// void AliDrawStyleTest_TPadApplyStyle(){
+//
+// }
+// void AliDrawStyleTest_TCanvasApplyCssStyle(){
+//
+// }
+// void AliDrawStyleTest_ApplyCssStyle(){
+//
+// }

--- a/STAT/test/AliDrawStyleTest.C
+++ b/STAT/test/AliDrawStyleTest.C
@@ -223,7 +223,7 @@ void AliDrawStyleTest_GetFloatValues(){
 // }
 
 void  AliDrawStyleTest_GetProperty(){
-  AliDrawStyle::SetCssStyle("alirootTestStyle.css",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
+  AliDrawStyle::RegisterCssStyle("alirootTestStyle.css",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/alirootTestStyle.css",0));
   if (AliDrawStyle::GetProperty("alirootTestStyle.css","marker_size", "TGraph", "Status", "TPC.QA.dcar_posA_1") == "1,2,3,4"){
     ::Info("AliDrawStyleTest","AliDrawStyle::GetProperty(\"alirootTestStyle.css\",\"marker_size\", \"TGraph\", \"Status\", \"TPC.QA.dcar_posA_1\")- IsOK");
   }else{
@@ -261,10 +261,10 @@ void  AliDrawStyleTest_GetProperty(){
 
 void AliDrawStyleTest_ApplyCssStyle(){
   TCanvas *canv = MakeTestPlot(3);
-  AliDrawStyle::SetCssStyle("test1",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/test1.css",0));
+  AliDrawStyle::RegisterCssStyle("test1",AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/test/test1.css",0));
   AliDrawStyle::ApplyCssStyle(canv, "test1");
   canv->Print("test1.xml");
-  AliDrawStyle::SetCssStyle("test2",AliDrawStyle::ReadCSSFile("test2.css",0));
+  AliDrawStyle::RegisterCssStyle("test2",AliDrawStyle::ReadCSSFile("test2.css",0));
   AliDrawStyle::ApplyCssStyle(canv, "test2");
   AliDrawStyle::ApplyCssStyle(canv, "test1");
   canv->Print("test2-1.xml");
@@ -328,47 +328,3 @@ TCanvas *MakeTestPlot(Int_t nHis) {
     legend->Draw();
   return exampleCanvas;
 }
-
-/*
-void SetStyleForTest(Int_t val, TCanvas *canv) {
-    cCanvas->SetFillColor(val);
-    cCanvas->SetBorderSize(val);
-    cCanvas->SetBorderMode(val);
-    TList *oListPad = NULL;
-    TList *oListObj = NULL;
-
-    oList = pad->GetListOfPrimitives();
-    for(Int_t c = 0; c < oList->GetEntries(); c++) {
-        (TPad *) oList->At(c)->SetFillColor(val);
-        (TPad *) oList->At(c)->SetBottomMargin(val);
-        (TPad *) oList->At(c)->SetTopMargin(val);
-        (TPad *) oList->At(c)->SetLeftMargin(val);
-        (TPad *) oList->At(c)->SetRightMargin(val);
-        (TPad *) oList->At(c)->SetBorderSize(val);
-        (TPad *) oList->At(c)->SetBorderMode(val);
-        (TPad *) oList->At(c)->SetGridx(val);
-        (TPad *) oList->At(c)->SetGridy(val);
-        (TPad *) oList->At(c)->SetTickx(val);
-        (TPad *) oList->At(c)->SetTicky(val);
-        (TPad *) oList->At(c)->SetLogx(val);
-        (TPad *) oList->At(c)->SetLogy(val);
-        (TPad *) oList->At(c)->SetLogz(val);
-        for (Int_t k = 0; k < oList->GetEntries(); k++) {
-
-            cObj = oListObj->At(k);
-            if (cObj->InheritsFrom("TH1") || cObj->InheritsFrom("TGraph") || cObj->InheritsFrom("TF1")) {
-
-                cObj->SetMarkerColor(val);
-                cObj->SetMarkerSize(val);
-                cObj->SetMarkerStyle(val);
-                cObj->SetLineColor(val);
-                cObj->SetLineWidth(val);
-                cObj->SetLineStyle(val);
-                cObj->SetFillColor(val);
-                cObj->SetFillStyle(val);
-            }
-        }
-    }
-    canv->Modified();
-}
-*/

--- a/STAT/test/AliTreeTrending.css
+++ b/STAT/test/AliTreeTrending.css
@@ -64,13 +64,15 @@ TH1.Status#obj1, TH1.Warning#obj1, TH1.Warning#obj3   {
 }
 
 .statusPad#Top {
-    bottom_margin:   0.001;
-    right_margin:    0.05;
+    left_margin:     120px;
+    bottom_margin:   1px;
+    right_margin:    80px;
 }
 
 .statusPad#Bottom{
-    bottom_margin:   0.4;
-    right_margin:    0.05;
+    left_margin:     120px;
+    bottom_margin:   60px;
+    right_margin:    80px;
     top_margin:      0.0;  
     gridX:           3;   
     gridY:           1;

--- a/STAT/test/AliTreeTrending.css
+++ b/STAT/test/AliTreeTrending.css
@@ -15,9 +15,10 @@ TGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1   {
 
 .deadBand   {
     marker_size:   1,1,1;
-    marker_color:  400,632,416;; /* marker_color defenition */
-    line_color:    2,3,4;/* line_color defenition */
-    line_style:    2,3,4;
+    marker_color:  800,632,416; /* marker_color definition */
+    line_color:    800,632,416;/* line_color definition */
+    line_style:    1,2,6;
+    line_width:    2,2,2;
 }
 
 .multiGraph   {      /*like figTemplateTRD   markerstyles: 20,21,24,25,27,28,34,33,29,30*/

--- a/STAT/test/CMakeLists.txt
+++ b/STAT/test/CMakeLists.txt
@@ -3,3 +3,5 @@ add_test("func_STAT_AliTreePlayer"
          bash -c "ALIROOT_SOURCE=${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/STAT/test/statTest.sh testAliTreePlayer")
 add_test("func_STAT_AliTMinuitToolkitTest"
          bash -c "ALIROOT_SOURCE=${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/STAT/test/statTest.sh testAliTMinutiToolkitTestLinear")
+add_test("func_STAT_AliDrawStyleTest"
+         bash -c "ALIROOT_SOURCE=${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/STAT/test/statTest.sh testAliDrawStyleTest")

--- a/STAT/test/alirootTestStyle.css
+++ b/STAT/test/alirootTestStyle.css
@@ -1,0 +1,19 @@
+.TH*  {
+    marker_size:   1,1,1,1;
+    marker_color:  2,4,6,8;
+    line_color:    2,4,6,8;
+    line_style:    1,1,1,1;
+}
+.TGraph*  {
+    marker_size:   1,1,1,1;
+    marker_color:  2,4,6,8;
+    line_color:    2,4,6,8;
+    line_style:    1,1,1,1;
+}
+.TGraphErrors*  {
+    marker_size:   1,1,1,1;
+    marker_color:  2,4,6,8;
+    line_color:    2,4,6,8;
+    line_style:    1,1,1,1;
+}
+

--- a/STAT/test/alirootTestStyle.css
+++ b/STAT/test/alirootTestStyle.css
@@ -9,8 +9,29 @@ TGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1 - means obj1 from TGraph with any 
 TGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1   {
     marker_size:   1,2,3,4;
     marker_color:  5,6,7,8; /* marker_color defenition */
-    line_color:    9,10,11,12; /* line_color defenition */
+    line_color:    5,6,7,8; /* line_color defenition */
     line_style:    13,14,15,16;
+}
+
+.deadBand   {
+    marker_size:   1,1,1;
+    marker_color:  400,632,416; /* marker_color defenition */
+    line_color:    400,632,416; /* line_color defenition */
+    line_style:    2,3,4;
+}
+
+.multiGraph   {      /*like figTemplateTRD   markerstyles: 20,21,24,25,27,28,34,33,29,30*/
+    marker_size:   1,1, 0.9,0.9, 1.4,1.4, 1.1,1.1, 1.2,1.2;
+    marker_color:  1,2,3,4; /* kBlack, kRed+1 , kBlue+1, kGreen+3, kMagenta+1, kOrange-1,kCyan+2,kYellow+2,kGray+1,  kRed-10 */
+    line_color:    1,2,3,4; /* kBlack, kRed+1 , kBlue+1, kGreen+3, kMagenta+1, kOrange-1,kCyan+2,kYellow+2,kGray+1,  kRed-10 */
+    line_style:    1,2,3,4,5,6,7,8,9,10;
+}
+
+.multiGraphPair   {    /*like figTemplateTRDPair markerstyles: 20,21,24,25,27,28,34,33,29,30*/
+    marker_size:   1,1, 0.9,0.9, 1.4,1.4, 1.1,1.1, 1.2,1.2;
+    marker_color:  1,2,3,4,5,6,7,8,9,10; /* marker_color defenition */
+    line_color:    1,2,3,4,5,6,7,8,9,10; /* line_color defenition */
+    line_style:    1,1,1,1,1,1,1,1,1;
 }
 
 /*

--- a/STAT/test/alirootTestStyle.css
+++ b/STAT/test/alirootTestStyle.css
@@ -1,19 +1,42 @@
-.TH*  {
-    marker_size:   1,1,1,1;
-    marker_color:  2,4,6,8;
-    line_color:    2,4,6,8;
-    line_style:    1,1,1,1;
-}
-.TGraph*  {
-    marker_size:   1,1,1,1;
-    marker_color:  2,4,6,8;
-    line_color:    2,4,6,8;
-    line_style:    1,1,1,1;
-}
-.TGraphErrors*  {
-    marker_size:   1,1,1,1;
-    marker_color:  2,4,6,8;
-    line_color:    2,4,6,8;
-    line_style:    1,1,1,1;
+/*
+How to use css in aliroot.
+examples of css style in aliroot:
+*/
+
+/*
+TGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1 - means obj1 from TGraph with any tag(Status, Warnings, Errors) and TPC.QA.dcar_posA_1 from TGraph with tag Status.
+*/
+TGraph#obj1, TGraph.Status#TPC.QA.dcar_posA_1   {
+    marker_size:   1,2,3,4;
+    marker_color:  5,6,7,8; /* marker_color defenition */
+    line_color:    9,10,11,12; /* line_color defenition */
+    line_style:    13,14,15,16;
 }
 
+/*
+TF1.Status, .Status#obj1, #obj3 - means any object from TF1 class with tag Status and obj1 from any class with tag Status and obj3 from any class with any tag.
+*/
+
+TF1.Status, .Status#obj1, #obj3   {
+    marker_size:   17,18,19,20;
+    marker_color:  21,22,23,24;
+    line_color:    25,26,27,28;
+    line_style:    29,30,31,32;
+}
+
+.Status#obj1, #obj3, TGraphErrors.Warning   {
+    marker_size:   33,34,35,36;
+    marker_color:  37,38,39,40;
+    line_color:    41,42,43,44;
+    line_style:    45,46,47,48;
+}
+
+/*
+TH1.Status#obj1, TH1.Warning#obj1, TH1.Warning#obj3 - means apply the value of marker_size, marker_color, line_color, line_style for obj1 of class TH1 with tag Status and obj1 from TH1 with tag Warning and for obj3 from TH1 with tag Warning.
+*/
+TH1.Status#obj1, TH1.Warning#obj1, TH1.Warning#obj3   {
+    marker_size:   49,50,51,52;
+    marker_color:  53,54,55,56; /* marker_color defenition */
+    line_color:    57,58,59,60;
+    line_style:    61,62,63,64;
+}

--- a/STAT/test/statTest.sh
+++ b/STAT/test/statTest.sh
@@ -74,7 +74,7 @@ EOF
   N_BAD=$(grep -c "E-Ali" AliDrawStyleTest.log)
   TEST_STATUS=0
   if [[ $N_GOOD != 21 ]]; then
-    alilog_error "statTest.AliDrawStyleTest: Test OK"
+    alilog_error "statTest.AliDrawStyleTest: Test FAILED"
     ((TEST_STATUS++))
   fi
   if [[ $N_BAD != 0 ]]; then

--- a/STAT/test/statTest.sh
+++ b/STAT/test/statTest.sh
@@ -63,4 +63,32 @@ EOF
   fi
 }
 
+
+testAliDrawStyleTest() {
+  cp $ALIROOT_SOURCE/STAT/test/AliDrawStyleTest.C .
+  root -n -b -l <<\EOF 2>&1 | tee AliDrawStyleTest.log
+    gSystem->AddIncludePath("-I$ALICE_ROOT/include");
+    .x ./AliDrawStyleTest.C+
+EOF
+  N_GOOD=$(grep -cE 'Ali.*OK' AliDrawStyleTest.log)
+  N_BAD=$(grep -c "E-Ali" AliDrawStyleTest.log)
+  TEST_STATUS=0
+  if [[ $N_GOOD != 21 ]]; then
+    alilog_error "statTest.AliDrawStyleTest: Test OK"
+    ((TEST_STATUS++))
+  fi
+  if [[ $N_BAD != 0 ]]; then
+    alilog_error "statTest.AliDrawStyleTest: Test FAILED"
+    ((TEST_STATUS+=2))
+  fi
+  if [[ $TEST_STATUS == 0 ]]; then
+    alilog_success "statTest.AliDrawStyleTest: All OK"
+  else
+    alilog_error "statTest.: FAILED (code $TEST_STATUS)"
+  fi
+  exit $TEST_STATUS
+
+}
+
+
 [[ $1 ]] && $1

--- a/STAT/test/statTest.sh
+++ b/STAT/test/statTest.sh
@@ -73,7 +73,7 @@ EOF
   N_GOOD=$(grep -cE 'Ali.*OK' AliDrawStyleTest.log)
   N_BAD=$(grep -c "E-Ali" AliDrawStyleTest.log)
   TEST_STATUS=0
-  if [[ $N_GOOD != 21 ]]; then
+  if [[ $N_GOOD != 25 ]]; then
     alilog_error "statTest.AliDrawStyleTest: Test FAILED"
     ((TEST_STATUS++))
   fi

--- a/STAT/test/statTest.sh
+++ b/STAT/test/statTest.sh
@@ -70,10 +70,12 @@ testAliDrawStyleTest() {
     gSystem->AddIncludePath("-I$ALICE_ROOT/include");
     .x ./AliDrawStyleTest.C+
 EOF
+
   N_GOOD=$(grep -cE 'Ali.*OK' AliDrawStyleTest.log)
   N_BAD=$(grep -c "E-Ali" AliDrawStyleTest.log)
+
   TEST_STATUS=0
-  if [[ $N_GOOD != 31 ]]; then
+  if [[ $N_GOOD != 27 ]]; then
     alilog_error "statTest.AliDrawStyleTest: Test FAILED"
     ((TEST_STATUS++))
   fi

--- a/STAT/test/statTest.sh
+++ b/STAT/test/statTest.sh
@@ -73,7 +73,7 @@ EOF
   N_GOOD=$(grep -cE 'Ali.*OK' AliDrawStyleTest.log)
   N_BAD=$(grep -c "E-Ali" AliDrawStyleTest.log)
   TEST_STATUS=0
-  if [[ $N_GOOD != 25 ]]; then
+  if [[ $N_GOOD != 30 ]]; then
     alilog_error "statTest.AliDrawStyleTest: Test FAILED"
     ((TEST_STATUS++))
   fi

--- a/STAT/test/statTest.sh
+++ b/STAT/test/statTest.sh
@@ -73,7 +73,7 @@ EOF
   N_GOOD=$(grep -cE 'Ali.*OK' AliDrawStyleTest.log)
   N_BAD=$(grep -c "E-Ali" AliDrawStyleTest.log)
   TEST_STATUS=0
-  if [[ $N_GOOD != 30 ]]; then
+  if [[ $N_GOOD != 31 ]]; then
     alilog_error "statTest.AliDrawStyleTest: Test FAILED"
     ((TEST_STATUS++))
   fi

--- a/STAT/test/test1.css
+++ b/STAT/test/test1.css
@@ -1,0 +1,46 @@
+TGraph   {
+  marker_size:   0.3,0.6,1.2;
+  marker_color:  3,6,9;
+  marker_style:  3,4,5;
+  line_color:    1,3,6;
+  line_style:    1,2,3;
+  line_width:    0.9,1.4,1.9;
+  fill_color:    0,0,0;
+  fill_style:    0,0,0;
+}
+
+TH1F    {
+  marker_size:   0.3,0.6,1.2;
+  marker_color:  10,12,14;
+  marker_style:  3,4,5;
+  line_color:    2,4,8;
+  line_style:    1,2,3;
+  line_width:    0.9,1.4,1.9;
+  fill_color:    0,0,0;
+  fill_style:    0,0,0;
+}
+
+TPad.Raw#pad   {
+  fill_color:    2,2,2;
+  fill_style:    1,2,3;
+  bottom_margin: 0;
+  top_margin:    0;
+  left_margin:   0;
+  right_margin:  0;
+  border_size:   1;
+  border_mode:   2;
+  gridX:         1;
+  gridY:         1;
+  tickX:         1;
+  tickY:         1;
+  logX:          0;
+  logY:          0;
+  logZ:          0;
+
+}
+
+TCanvas    {
+  fill_color:    3;
+  border_size:   1;
+  border_mode:   2;
+}

--- a/STAT/test/test2.css
+++ b/STAT/test/test2.css
@@ -1,0 +1,30 @@
+TCanvas    {
+  fill_color:    2;
+  border_size:   1;
+  border_mode:   2;
+}
+
+
+TGraph   {
+  marker_size:   0.3,0.6,1.2;
+  marker_color:  2,4,6;
+  marker_style:  3,4,5;
+  line_color:    3,6,9;
+  line_style:    1,2,3;
+  line_width:    0.9,1.4,1.9;
+  fill_color:    0,0,0;
+  fill_style:    0,0,0;
+
+}
+
+
+TH1F   {
+  marker_size:   1.2,2.4,4.8;
+  marker_color:  1,3,5;
+  marker_style:  6,8,10;
+  line_color:    8,10,12;
+  line_style:    1,2,3;
+  line_width:    2.1,2.5,2.9;
+  fill_color:    0,0,0;
+  fill_style:    0,0,0;
+}

--- a/STAT/test/testDrawArrayHisto.C
+++ b/STAT/test/testDrawArrayHisto.C
@@ -16,8 +16,8 @@
 TObjArray * hisArray=NULL;
 
 void RegisterStyles(){
-  AliDrawStyle::SetCssStyle("rawStyle", AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/Macros/raw.css",0));
-  AliDrawStyle::SetCssStyle("bbStyle", AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/Macros/bb.css",0));
+  AliDrawStyle::RegisterCssStyle("rawStyle", AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/Macros/raw.css",0));
+  AliDrawStyle::RegisterCssStyle("bbStyle", AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/Macros/bb.css",0));
 }
 
 

--- a/STAT/test/testDrawArrayHisto.C
+++ b/STAT/test/testDrawArrayHisto.C
@@ -1,0 +1,57 @@
+/*
+  wget http://aliqatrkeos.web.cern.ch/aliqatrkeos/performance/alice/data/2015/LHC15o/pass1/LHC15o.pass1.B1.Bin0/performanceHisto.root -o performanceHisto.root
+
+   AliDrawStyle::SetDefaults();
+  AliDrawStyle::ApplyStyle("figTemplate");
+
+
+*/
+
+TObjArray * hisArray=NULL;
+
+void ReadInputData() {
+  // read cache file from server
+  TFile *finput=NULL;
+  TString fname = "./performanceHisto.root";
+  if (!gSystem->AccessPathName( fname )) {
+    finput = TFile::Open( fname ); // check if file in local directory exists
+  }
+  else {
+    TFile::SetCacheFileDir(".");
+    finput = TFile::Open("http://aliqatrkeos.web.cern.ch/aliqatrkeos/performance/alice/data/2015/LHC15o/pass1/LHC15o.pass1.B1.Bin0/performanceHisto.root", "CACHEREAD"); // if not: download from ROOT server
+  }
+  // get histogram array
+  hisArray = new TObjArray();
+  TList *keys = finput->GetListOfKeys();
+  for (Int_t iKey = 0; iKey < keys->GetEntries(); iKey++) {
+    TObject *o = finput->Get(
+            TString::Format("%s;%d", keys->At(iKey)->GetName(), ((TKey *) keys->At(iKey))->GetCycle()).Data());
+    hisArray->AddLast(o);
+  }
+}
+
+/// Example P4 report
+void makeP4Report(){
+  TString drawExpressionP4="";
+  drawExpressionP4="[1,1,2]:";
+  drawExpressionP4+="%Ogridx,gridy;hisDeltaP4_Allv_qPt_tgl(0,400,80,120,0,10)(0,1)(f-grms p);:";
+  drawExpressionP4+="%Ogridx,gridy;hisPullP4_Allv_qPt_tgl(0,400,80,120,0,10)(0,1)(f-grms p);:";
+  drawExpressionP4+="%Ogridx,gridy;hisDeltaP4_Allv_qPt_tgl(100,300,99,102,0,10)(0)(err);:";
+  drawExpressionP4+="%Ogridx,gridy;hisPullP4_Allv_qPt_tgl(100,300,99,102,0,10)(0)(err);:";
+  TPad * padP4 = AliTreePlayer::DrawHistograms(0,hisArray,drawExpressionP4,keepArray, 1+2+4+8);
+  padP4->SaveAs("deltaP4TPCtoFull.png");
+  padP4->SaveAs("deltaP4TPCtoFull.C");
+}
+
+/// Example P4 report
+void makeP4ReportHisto(){
+  TString drawExpressionP4="";
+  drawExpressionP4="[1,1]:";
+  drawExpressionP4+="%Ogridx,gridy;hisDeltaP4_Allv_qPt_tgl(100,300,0,40,102,0,10)(0)(err);hisDeltaP4_Allv_qPt_tgl(100,300,40,80,102,0,10)(0)(err);hisDeltaP4_Allv_qPt_tgl(100,300,80,10,102,0,10)(0)(err);:";
+  drawExpressionP4+="%Ogridx,gridy;hisPullP4_Allv_qPt_tgl(100,300,99,102,0,10)(0)(err);:";
+  TPad * padP4 = AliTreePlayer::DrawHistograms(0,hisArray,drawExpressionP4,keepArray, 1+2+4+8);
+  padP4->SaveAs("deltaP4TPCtoFull.png");
+  padP4->SaveAs("deltaP4TPCtoFull.C");
+}
+
+

--- a/STAT/test/testDrawArrayHisto.C
+++ b/STAT/test/testDrawArrayHisto.C
@@ -1,13 +1,25 @@
 /*
-  wget http://aliqatrkeos.web.cern.ch/aliqatrkeos/performance/alice/data/2015/LHC15o/pass1/LHC15o.pass1.B1.Bin0/performanceHisto.root -o performanceHisto.root
-
-   AliDrawStyle::SetDefaults();
+  AliDrawStyle::SetDefaults();
   AliDrawStyle::ApplyStyle("figTemplate");
+  //
+  .L $AliRoot_SRC/STAT/test/testDrawArrayHisto.C
+  ReadInputData();
+  RegisterStyles();
+  makeP4Report();
 
 
-*/
+  AliDrawStyle::ApplyCssStyle(gPad,"bbStyle");
+  AliDrawStyle::ApplyCssStyle(gPad,"rawStyle");
+
+ */
 
 TObjArray * hisArray=NULL;
+
+void RegisterStyles(){
+  AliDrawStyle::SetCssStyle("rawStyle", AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/Macros/raw.css",0));
+  AliDrawStyle::SetCssStyle("bbStyle", AliDrawStyle::ReadCSSFile("$AliRoot_SRC/STAT/Macros/bb.css",0));
+}
+
 
 void ReadInputData() {
   // read cache file from server
@@ -37,17 +49,6 @@ void makeP4Report(){
   drawExpressionP4+="%Ogridx,gridy;hisDeltaP4_Allv_qPt_tgl(0,400,80,120,0,10)(0,1)(f-grms p);:";
   drawExpressionP4+="%Ogridx,gridy;hisPullP4_Allv_qPt_tgl(0,400,80,120,0,10)(0,1)(f-grms p);:";
   drawExpressionP4+="%Ogridx,gridy;hisDeltaP4_Allv_qPt_tgl(100,300,99,102,0,10)(0)(err);:";
-  drawExpressionP4+="%Ogridx,gridy;hisPullP4_Allv_qPt_tgl(100,300,99,102,0,10)(0)(err);:";
-  TPad * padP4 = AliTreePlayer::DrawHistograms(0,hisArray,drawExpressionP4,keepArray, 1+2+4+8);
-  padP4->SaveAs("deltaP4TPCtoFull.png");
-  padP4->SaveAs("deltaP4TPCtoFull.C");
-}
-
-/// Example P4 report
-void makeP4ReportHisto(){
-  TString drawExpressionP4="";
-  drawExpressionP4="[1,1]:";
-  drawExpressionP4+="%Ogridx,gridy;hisDeltaP4_Allv_qPt_tgl(100,300,0,40,102,0,10)(0)(err);hisDeltaP4_Allv_qPt_tgl(100,300,40,80,102,0,10)(0)(err);hisDeltaP4_Allv_qPt_tgl(100,300,80,10,102,0,10)(0)(err);:";
   drawExpressionP4+="%Ogridx,gridy;hisPullP4_Allv_qPt_tgl(100,300,99,102,0,10)(0)(err);:";
   TPad * padP4 = AliTreePlayer::DrawHistograms(0,hisArray,drawExpressionP4,keepArray, 1+2+4+8);
   padP4->SaveAs("deltaP4TPCtoFull.png");

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -761,6 +761,7 @@ WARN_LOGFILE           =
 INPUT                  = @CMAKE_SOURCE_DIR@/doxygen \
                          @CMAKE_SOURCE_DIR@/STAT \
                          @CMAKE_SOURCE_DIR@/STAT/test \
+                         @CMAKE_SOURCE_DIR@/STAT/Macros \
                          @CMAKE_SOURCE_DIR@/TPC \
                          @CMAKE_SOURCE_DIR@/TPC/Attic \
                          @CMAKE_SOURCE_DIR@/TPC/Base/test \


### PR DESCRIPTION
## QA and perfromance parameterization development
Contributors: Marian, Boris , Sebastian

### Add CSS style for root graphics and graphics
* **AliDrawStyle (EXTENDED)**, **AliDrawStyleTest.C(EXTENDED)**  + test **test/*.css files (NEW)**
  *  implementing subset of CSS style standard as in html
  * see doxygen documentation, resp. usage in the test/AliDrawStyleTest.C
     * usage in the AliPhysics_ROOT QA macros
  * author: Boris, Marian   
* **AliPainter (NEW)** 
  * using CSS style
  * for QA and performance plots generation
  * implementing object drawing using string formatting see
  * Status: Work in progress - more painting functions to be added 
  * E.g. ND Histogram draw interface (see doxygen) as serie of functors
     ````
     AliPainter::DrawHistogram("hisK0DMassQPtTgl()(0)()(err)", hisArray);
     AliPainter::DrawHistogram("hisK0DMassQPtTgl(-0.02,0.02)(0)(1)(err)", hisArray);
     ````      
  * author: Boris, Marian
* **AliTreeTrending (EXTENDED)**
  * Update of class to create QA reports
  * Using CSS style
  * Add more function - eg. to create decomposed status plot
  * author: Marian, Sebastian
* **STAT/TStatToolkit.h(EXTENDED)**
  * Adding function for the "sparse" graphs merging/rebinning 
    * Used in AliTreeTrending or user macros 
  ````
      void RebinSparseGraph(TGraph * graph0, TGraph *graph1, Option_t * option="");
      void RebinSparseMultiGraph(TMultiGraph *multiGraph, TGraph *graphRef);
      void MakeMultiGraphSparse(TMultiGraph *multiGraph);
  ````

### ROOT tree "database" access
* **AliExternalInfo (EXTENDED)**
  * Implementing GetChain with friend trees (similar as GetTree)
    ```` 
    AliExternalInfo::GetChain(TString type, TString period, TString pass, TString friendList)
    ````
  * Used for the calibration and reconstruction  QA validation (in AliPhysics) for multi periods
*  STAT/Macros/aliExternalInfo.C
  * Example usage of the AliExternalInfo class 
  * Functions usefull also for combined root tree "DB" queries (see doxygen documentation)
  * Example usage for correlating Logbook, QA.TPC, QA.EVS:
  ````
    .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C
    drawLogbook("LHC15o","pass1","QA.TPC.meanTPCncl>0","runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:MonALISA.RCT.tpc_value");
    drawLogbook("LHC10h","pass2","totalEventsPhysics>1000&&totalNumberOfFilesMigrated>20","runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:MonALISA.RCT.tpc_value");
    drawLogbook("LHC11h","pass2","totalEventsPhysics>1000&&totalNumberOfFilesMigrated>20","runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:MonALISA.RCT.tpc_value");
  ````
### HTML table export
* **AliTreePlayer(UPDATED)** - **AliTreeFormulaF(NEW, derived from TTreeFormula)**
  * Usage of string formatted TTree queries (not possible in TTreefromula)
    * See example fromat string used in html table export to format html link
    ````
    TString pathData="<a href=\"http://aliqatpc.web.cern.ch/aliqatpc/data/%d{TPC.Anchor.year}/%s{TPC.Anchor.period.GetName()}/%{TPC.Anchor.pass.GetName()}/000%d{run}/";
    ````
### Fitting procedure    
* **STAT/AliTMinuitToolkit.h (Extended)**
  * export with formula as a latex formula - used for legends)
  * Used in the QAs plots for fits description
   
### Makefiles, tests  and doxygen
* STAT/CMakeLists.txt
  * Added new classes
* doxygen/Doxyfile.in
  * adding test and Macros to doxygen
*  STAT/test/statTest.sh
  * updated tests 
* STAT/STATLinkDef.h  
 * new classes
 * adding CINT interace for some map

