### PR TITLE
Add new event selection features: by cluster and by triggered detector

### DIFF
--- a/RAW/RAWDatarec/AliRawReader.h
+++ b/RAW/RAWDatarec/AliRawReader.h
@@ -198,7 +198,7 @@ class AliRawReader: public TObject {
     virtual AliRawReader* CloneSingleEvent() const { return NULL; }
 
   protected :
-    virtual void     SelectEvents(Int_t type,ULong64_t triggerMask=0,const char *triggerExpr=NULL,ULong64_t triggerMask50=0,const char *contExpr=NULL, const char *exclExpr=NULL);
+    virtual void     SelectEvents(Int_t type,ULong64_t triggerMask=0,const char *triggerExpr=NULL,ULong64_t triggerMask50=0,const char *contExpr=NULL, const char *exclExpr=NULL, const char *selClusterExpr=NULL, const char *exclClusterExpr=NULL, const char *selDetectorExpr=NULL, const char *exclDetectorExpr=NULL);
     Bool_t           IsSelected() const;
     Bool_t           IsEventSelected() const;
 
@@ -220,7 +220,11 @@ class AliRawReader: public TObject {
     ULong64_t        fSelectTriggerMask50;  // trigger maskNext50 for selecting events (0 = no selection)
     TString          fSelectTriggerExpr;    // trigger expression for selecting events (empty = no selection)
     TString          fContainTriggerExpr;   // string required in trigger name for selecting events (empty = no selection)
-    TString          fExcludeTriggerExpr;   // string required in trigger name for exluding events (empty = no selection)
+    TString          fExcludeTriggerExpr;   // string required in trigger name for excluding events (empty = no selection)
+    TString          fSelectClusterExpr;    // string with names of clusters for selecting events (empty = no selection)
+    TString          fExcludeClusterExpr;   // string with names of clusters for excluding events (empty = no selection)
+    UInt_t           fSelectDetectorExpr;   // mask with names of detectors for selecting events (empty = no selection)
+    UInt_t           fExcludeDetectorExpr;  // mask with names of detectors for excluding events (empty = no selection)
     Bool_t           fVeto[100];            // veto for the 50+50 trigger masks
 
     Int_t            fErrorCode;            // code of last error


### PR DESCRIPTION
This commit introduces two new ways to pre-select events to be reconstructed in AliRawReader:
1) events can be selected based on the trigger cluster, which is extracted by parsing the string of the fired trigger cluster. E.g.
rec("raw.root","?Cluster=CENT") -> reconstruct events of the CENT cluster
rec("raw.root","?Cluster=CENT || CALO") -> reconstruct events of the CENT and CALO clusters
rec("raw.root","?ExcludeCluster=CENT") -> rejects events of the CENT cluster

2) events can be selected based on the presence/absence of specific detectors in the list of triggered detectors. E.g.
rec("raw.root","?DetectorsContain=ITSSDD") -> reconstruct events in which the SDD were triggered
rec("raw.root","?DetectorsExcluded=ITSSDD") -> reject events in which the SDD were triggered

These features are needed for the reconstruction of the pp reference wun of 2017 (LHC17p and LHC17q) to treat separately the events collected with SDD (CENT and CALO clusters) from those without SDD (= those that are in the FAST and CALOFAST clusters but not in the CENT and CALO).
