### PR TITLE
ATO-46  ADD: AliExternalInfo::CacheProduction

### DIFF
--- a/STAT/AliExternalInfo.h
+++ b/STAT/AliExternalInfo.h
@@ -78,6 +78,7 @@ public:
   Bool_t CacheProdCycle()                                               {return Cache("MonALISA.ProductionCycle", "", "");}
   Bool_t CacheCPass()                                                   {return Cache("MonALISA.ProductionCPass", "", "");}
   Bool_t CacheProdCycleByID(TString ID)                                 {return Cache("MonALISA.ProductionCycleID", ID, "");}
+  static void CacheProduction(TPRegexp select, TPRegexp reject, TString sourceList);
 
   TTree* GetTree(TString type, TString period, TString pass, Int_t buildIndex=1);
   TTree* GetTree(TString type, TString period, TString pass, TString friendList);


### PR DESCRIPTION
### Cache production tree
* Used in case we need to run run over sevral rpooductions
* E.g used to make 2015-2017 QA/calibration sumaries : 
  * See e.g summary: https://indico.cern.ch/event/610359/contributions/2808318/attachments/1566741/2469481/TPCNormalizedVolumeAndFlux.pdf
```
void AliExternalInfo::CacheProduction(TPRegexp select, TPRegexp reject, TString sourceList)
```
Input production list - from MonaLisa HTM linterface 
### Parameters:
* select - selection mask 
* reject  - rejection mask
* sourceList  - list of detectors to cache

### Example usage:
* Cache all  LHC17  production data 
* Chace  tree:
  * QA.TPC;QA.EVS;QA.TRD;QA.rawTPC;QA.ITS;Logbook;QA.TOF;Logbook.detector

```       AliExternalInfo::CacheProduction(TPRegexp("LHC17.*"),TPRegexp("cpass0"),"QA.TPC;QA.EVS;QA.TRD;QA.rawTPC;QA.ITS;Logbook;QA.TOF;Logbook.detector");
```
