### PR TITLE
[EMCAL-42] Add operator== and operator<< to DCS Config objects

### DIFF
--- a/EMCAL/EMCALbase/AliEMCALTriggerDCSConfig.cxx
+++ b/EMCAL/EMCALbase/AliEMCALTriggerDCSConfig.cxx
@@ -44,3 +44,29 @@ AliEMCALTriggerDCSConfig::~AliEMCALTriggerDCSConfig()
   delete fSTUObj;
   delete fSTUDCAL;
 }
+
+bool AliEMCALTriggerDCSConfig::operator==(const AliEMCALTriggerDCSConfig & other) const {
+  bool isequal = true;
+  if(fSTUObj && other.fSTUObj) {
+    if(!(*fSTUObj == *other.fSTUObj)) isequal == false; // both EMCAL STU objects there, but not the same
+  } else if((fSTUObj && !other.fSTUObj) || (!fSTUObj && other.fSTUObj)) isequal == false; // one of the two missing
+
+  if(fSTUDCAL && other.fSTUDCAL) {
+    if(!(*fSTUDCAL == *other.fSTUDCAL)) isequal == false; // both DCAL STU objects there, but not the same
+  } else if((fSTUDCAL && !other.fSTUDCAL) || (!fSTUDCAL && other.fSTUDCAL)) isequal == false; // one of the two missing
+
+  // check TRUs
+  if(fTRUArr->GetEntries() != other.fTRUArr->GetEntries()){
+    // one object has more TRU entries than the other
+    isequal = false;
+  } else {
+    for(int itru = 0; itru < fTRUArr->GetSize(); itru++) {
+      AliEMCALTriggerTRUDCSConfig *thistru = GetTRUDCSConfig(itru),
+                                  *othertru = other.GetTRUDCSConfig(itru);
+      if(thistru && othertru){
+        if(!(*thistru == *othertru)) isequal = false;     
+      } else if((thistru && !othertru) || (!thistru && othertru)) isequal = false;    // one of the two missing
+    }
+  }
+  return isequal;
+}

--- a/EMCAL/EMCALbase/AliEMCALTriggerDCSConfig.h
+++ b/EMCAL/EMCALbase/AliEMCALTriggerDCSConfig.h
@@ -26,6 +26,14 @@ public:
   
   AliEMCALTriggerDCSConfig();
   virtual ~AliEMCALTriggerDCSConfig();
+
+  /**
+   * @brief Equalty operator
+   * 
+   * Checks if two DCS configs are the same. For equalty all both DCS configurations 
+   * and all TRU configurations must match.
+   */
+  bool operator==(const AliEMCALTriggerDCSConfig &other) const;
   
   void                         SetTRUArr(TClonesArray* const ta)             { fTRUArr    = ta; }
   inline void                  SetSTUObj(AliEMCALTriggerSTUDCSConfig* so, Bool_t isDCAL = false);

--- a/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.cxx
@@ -20,6 +20,7 @@
 #include "TVector2.h"
 
 // Standard libraries
+#include <iomanip>
 #include <iostream>
 
 /// \cond CLASSIMP
@@ -181,3 +182,22 @@ Int_t AliEMCALTriggerSTUDCSConfig::AliEMCALTriggerSTUTRUErrorCount::Compare(cons
   return 0;
 }
 
+bool AliEMCALTriggerSTUDCSConfig::operator==(const AliEMCALTriggerSTUDCSConfig &other) const {
+  return (fGetRawData == other.fGetRawData) && (fRegion == other.fRegion) &&
+         (fFw == other.fFw) && (fPatchSize == other.fPatchSize) && (fMedian == other.fMedian) &&
+         !memcmp(fPHOSScale, other.fPHOSScale, sizeof(Int_t) * 4) &&
+         !memcmp(fG, other.fG, sizeof(Int_t) * 6) &&
+         !memcmp(fJ, other.fJ, sizeof(Int_t) * 6);
+}
+
+std::ostream &operator<<(std::ostream &stream, const AliEMCALTriggerSTUDCSConfig &config){
+  stream << "Gamma High: (" << config.fG[0][0] << ", " << config.fG[1][0] << ", " << config.fG[2][0] << ")" << std::endl;
+  stream << "Gamma Low:  (" << config.fG[0][1] << ", " << config.fG[1][1] << ", " << config.fG[2][1] << ")" << std::endl;
+  stream << "Jet High:   (" << config.fJ[0][0] << ", " << config.fJ[1][0] << ", " << config.fJ[2][0] << ")" << std::endl;
+  stream << "Jet Low:    (" << config.fJ[0][1] << ", " << config.fJ[1][1] << ", " << config.fJ[2][1] << ")" << std::endl;
+  stream << "GetRawData: " << config.fGetRawData << ", Region: " << config.fRegion << ", Median: " << config.fMedian 
+         << "Firmware: " << std::hex << config.fFw << std::dec << ", PHOS Scale: ("
+         << config.fPHOSScale[0] << ", " << config.fPHOSScale[1] << ", " << config.fPHOSScale[2] << ", " << config.fPHOSScale[3]
+         << ")" << std::endl;
+  return stream;
+}

--- a/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.h
+++ b/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.h
@@ -4,6 +4,7 @@
  * See cxx source for full Copyright notice                               */
 
 #include "TObject.h"
+#include <iosfwd>
 
 class TVector2;
 class TClonesArray;
@@ -63,6 +64,22 @@ public:
 
   AliEMCALTriggerSTUDCSConfig();
   virtual ~AliEMCALTriggerSTUDCSConfig();
+
+  /**
+   * @brief Equalty operator
+   * 
+   * Checks whether the two STU DCS configurations are the same. For equalty
+   * all setting must be the same. Error counters are not considered.
+   */
+  bool operator==(const AliEMCALTriggerSTUDCSConfig &other) const;
+
+  /**
+   * @brief Streaming operator
+   * 
+   * Printing all STU DCS settings on the output stream, except for the
+   * error counters
+   */
+  friend std::ostream &operator<<(std::ostream &stream, const AliEMCALTriggerSTUDCSConfig &config);
   
   void    SetG(Int_t i, Int_t j, Int_t gv) { fG[i][j]    = gv; }
   void    SetJ(Int_t i, Int_t j, Int_t jv) { fJ[i][j]    = jv; }

--- a/EMCAL/EMCALbase/AliEMCALTriggerTRUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/AliEMCALTriggerTRUDCSConfig.cxx
@@ -14,6 +14,9 @@
  **************************************************************************/
 
 #include "AliEMCALTriggerTRUDCSConfig.h"
+#include <bitset>
+#include <iomanip>
+#include <iostream>
 
 /// \cond CLASSIMP
 ClassImp(AliEMCALTriggerTRUDCSConfig) ;
@@ -42,3 +45,18 @@ Int_t AliEMCALTriggerTRUDCSConfig::GetSegmentation()
 		return 1;
 }
 
+bool AliEMCALTriggerTRUDCSConfig::operator==(const AliEMCALTriggerTRUDCSConfig &other) const {
+	return (fSELPF == other.fSELPF) && (fL0SEL == other.fL0SEL) && (fL0COSM == other.fL0COSM)
+					&& (fGTHRL0 == other.fGTHRL0) && (fRLBKSTU == other.fRLBKSTU) && (fFw == other.fFw)
+					&& !memcmp(fMaskReg, other.fMaskReg, sizeof(UInt_t) * 6);
+}
+
+std::ostream &operator<<(std::ostream &stream, const AliEMCALTriggerTRUDCSConfig &conf){
+	stream << "SELPF: " << std::hex << conf.fSELPF << ", L0SEL: " << conf.fL0SEL << ", L0COSM: " << std::dec 
+				 << conf.fL0COSM << ", GTHRL0: " << conf.fGTHRL0 << ", RLBKSTU: " << conf.fRLBKSTU << ", FW: " << std::hex
+				 << conf.fFw << std::dec << std::endl;
+	for(int ireg = 0; ireg < 6; ireg++){
+		stream << "Reg" << ireg << ": " << std::bitset<sizeof(UInt_t) *8>(conf.fMaskReg[ireg]) << std::endl;
+	}
+	return stream;
+}

--- a/EMCAL/EMCALbase/AliEMCALTriggerTRUDCSConfig.h
+++ b/EMCAL/EMCALbase/AliEMCALTriggerTRUDCSConfig.h
@@ -15,6 +15,7 @@
 //________________________________________________
 
 #include "TObject.h"
+#include <iosfwd>
 
 class AliEMCALTriggerTRUDCSConfig : public TObject 
 {
@@ -23,6 +24,21 @@ public:
 
 	AliEMCALTriggerTRUDCSConfig();
 	virtual ~AliEMCALTriggerTRUDCSConfig() {}
+
+	/**
+ 	 * @brief equalty operator
+   * 
+	 * Checking if the two TRU DCS configurations are equal. For equalty
+	 * all settings must be the same.
+	 */ 
+	bool operator==(const AliEMCALTriggerTRUDCSConfig &other) const;
+
+	/**
+	 * @brief Streaming operator
+	 * 
+	 * Printing all settings of the given TRU on the output stream
+	 */
+	friend std::ostream &operator<<(std::ostream &stream, const AliEMCALTriggerTRUDCSConfig &other);
 
 	void    SetSELPF(  UInt_t pf)              { fSELPF  = pf;        }
 	void    SetL0SEL(  UInt_t la)              { fL0SEL  = la;        }

--- a/EMCAL/EMCALbase/CMakeLists.txt
+++ b/EMCAL/EMCALbase/CMakeLists.txt
@@ -126,6 +126,21 @@ install(TARGETS ${MODULE}
 
 install(FILES ${HDRS} DESTINATION include)
 
+# Unit tests
+# TRU DCS config unit test
+add_executable(testemcaltrudcsconfig TestsAliEMCALTriggerTRUDCSConfig.cxx)
+target_link_libraries(testemcaltrudcsconfig ${MODULE} ${LIBDEPS})
+add_test(func_EMCALbase_AliEMCALTriggerTRUDCSConfig 
+    testemcaltrudcsconfig)
+install(TARGETS testemcaltrudcsconfig RUNTIME DESTINATION bin)
+
+# STU DCS config unit test
+add_executable(testemcalstudcsconfig TestsAliEMCALTriggerSTUDCSConfig.cxx)
+target_link_libraries(testemcalstudcsconfig ${MODULE} ${LIBDEPS})
+add_test(func_EMCALbase_AliEMCALTriggerSTUDCSConfig 
+    testemcalstudcsconfig)
+install(TARGETS testemcalstudcsconfig RUNTIME DESTINATION bin)
+
 # Static version if DA enabled
 if(ALIROOT_STATIC)
     add_library(${MODULE}-static STATIC $<TARGET_OBJECTS:${MODULE}-object>)

--- a/EMCAL/EMCALbase/TestsAliEMCALTriggerSTUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/TestsAliEMCALTriggerSTUDCSConfig.cxx
@@ -1,0 +1,216 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <cstdlib>
+#include <bitset>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "AliEMCALTriggerSTUDCSConfig.h"
+
+namespace EMCAL {
+  namespace Base {
+    namespace Tests {
+      namespace TestAliEMCALTriggerSTUDCSConfig {
+
+        /**
+         * @brief Apply reference configuration
+         * 
+         * Reference configuration taken from pp 2016
+         * 
+         * @param testobject Object for test to be configured
+         */
+        void ConfigureReference(AliEMCALTriggerSTUDCSConfig &testobject){
+          testobject.SetG(0,0,0);
+          testobject.SetG(1,0,0);
+          testobject.SetG(2,0,115);
+          testobject.SetG(0,1,0);
+          testobject.SetG(1,1,0);
+          testobject.SetG(2,1,51);
+          testobject.SetJ(0,0,0);
+          testobject.SetJ(1,0,0);
+          testobject.SetJ(2,0,255);
+          testobject.SetJ(0,1,0);
+          testobject.SetJ(1,1,0);
+          testobject.SetJ(2,1,204);
+          testobject.SetPatchSize(2);
+          testobject.SetFw(0x2A012);
+          testobject.SetMedianMode(0);
+          testobject.SetRegion(0xffffffff);
+          for(int i = 0; i < 4; i++) testobject.SetPHOSScale(i, 0);
+        }
+
+        /**
+         * @brief Test for operator== on itself
+         * 
+         * Tests whether operator== returns true in case the object is tested
+         * against itself.
+         * 
+         * @return true Test passed (operator== returning true)
+         * @return false Test failed (operator== returning false)
+         */
+        bool TestEqualSelf(){
+          AliEMCALTriggerSTUDCSConfig test;
+          ConfigureReference(test);
+          return test == test;
+        }
+
+        /**
+         * @brief Test for operator== on same object
+         * 
+         * Tests whether operator== returns true in case both
+         * objects have the same content.
+         * 
+         * @return true Test passed (operator== returning true)
+         * @return false Test failed (operator== returning false)
+         */
+        bool TestEqualTrue(){
+          AliEMCALTriggerSTUDCSConfig test1, test2;
+          ConfigureReference(test1);
+          ConfigureReference(test2);
+          return test1 == test2;
+        }
+
+        /**
+         * @brief Test for operator== on different objects
+         * 
+         * Tests whether the operator== returns false if at least one setting
+         * is different. For this operator== is tested with multiple objects
+         * based on a reference setting where only one parameter is changed at
+         * the time.
+         * 
+         * @return true Test passed (operator== returns false in all cases)
+         * @return false Test failed (operator== returns true at least once)
+         */
+        bool TestEqualFalse(){
+          AliEMCALTriggerSTUDCSConfig ref, test;
+          ConfigureReference(ref);
+          std::bitset<16> testresults;
+
+          // Variation Gamma
+          ConfigureReference(test);
+          test.SetG(2, 0, 77);
+          test.SetG(2, 1, 51);
+          testresults.set(0, ref == test);
+
+          // Variation Jet
+          ConfigureReference(test);
+          test.SetJ(2, 0, 191);
+          test.SetJ(2, 1, 128);
+          testresults.set(1, ref == test);
+
+          // Variation patch size
+          ConfigureReference(test);
+          test.SetPatchSize(0);
+          testresults.set(2, ref == test);
+
+          // Variation region
+          ConfigureReference(test);
+          test.SetRegion(0xffffff7f);
+          testresults.set(3, ref == test);
+
+          // Variation fw
+          ConfigureReference(test);
+          test.SetFw(0x1A012);
+          testresults.set(4, ref == test);
+
+          // Variation median mode
+          ConfigureReference(test);
+          test.SetMedianMode(1);
+          testresults.set(5, ref == test);
+
+          // Variation PHOS scale
+          ConfigureReference(test);
+          test.SetPHOSScale(0, 1);
+          test.SetPHOSScale(1, 2);
+          test.SetPHOSScale(2, 1);
+          test.SetPHOSScale(3, 0);
+          testresults.set(6, ref == test);
+
+          return !testresults.any();
+        }
+
+        /**
+         * @brief Test for the stream operator
+         * 
+         * Test if operator<< for a reference configuration produces 
+         * the expected reference string. Test is implemented using a streaming
+         * operator.
+         * 
+         * @return true Test passed (operator<< to string produces reference string)
+         * @return false Test failed (operator<< to string produces different string)
+         */
+        bool TestStream() {
+          std::string reference = std::string("Gamma High: (0, 0, 115)\nGamma Low:  (0, 0, 51)\nJet High:   (0, 0, 255)\nJet Low:    (0, 0, 204)\n")
+                                + std::string("GetRawData: 1, Region: -1, Median: 0Firmware: 2a012, PHOS Scale: (0, 0, 0, 0)\n");
+          
+          AliEMCALTriggerSTUDCSConfig test;
+          ConfigureReference(test);
+          std::stringstream testmaker;
+          testmaker << test;
+          return testmaker.str() == reference;
+        }
+      }
+    }
+  }
+}
+
+/**
+ * @brief Test runner for tests of class AliEMCALTriggerSTUDCSConfig
+ * 
+ * Running all tests implemented for the TRU DCS Config
+ * 
+ * @param argc Number of commamnd line arguments (not handled)
+ * @param argv Array of command line arguments (not handled)
+ * @return int 0 if the test is successful, 1 if not
+ */
+int main(int argc, char **argv) {
+  int npass(0);
+  if(EMCAL::Base::Tests::TestAliEMCALTriggerSTUDCSConfig::TestEqualSelf()){
+    npass++;
+  } else {
+    std::cerr << "Failure eq_self" << std::endl;
+  }
+  if(EMCAL::Base::Tests::TestAliEMCALTriggerSTUDCSConfig::TestEqualTrue()){
+    npass++;
+  } else {
+    std::cerr << "Failure_eq_true" << std::endl;
+  }
+  if(EMCAL::Base::Tests::TestAliEMCALTriggerSTUDCSConfig::TestEqualFalse()){
+    npass++;
+  } else {
+    std::cerr << "Failure_eq_false" << std::endl;
+  }
+  if(EMCAL::Base::Tests::TestAliEMCALTriggerSTUDCSConfig::TestStream()){
+    npass++;
+  } else {
+    std::cerr << "Failure_stream" << std::endl;
+  }
+  std::cout << "Passing " << npass << "/4" << std::endl;
+  if(npass == 4) return EXIT_SUCCESS;
+  return EXIT_FAILURE;
+}

--- a/EMCAL/EMCALbase/TestsAliEMCALTriggerTRUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/TestsAliEMCALTriggerTRUDCSConfig.cxx
@@ -1,0 +1,218 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <cstdlib>
+#include <bitset>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "AliEMCALTriggerTRUDCSConfig.h"
+
+namespace EMCAL {
+  namespace Base {
+    namespace Tests {
+      namespace TestAliEMCALTriggerTRUDCSConfig {
+
+        /**
+         * @brief Apply reference configuration
+         * 
+         * Reference configuration taken from pp 2016
+         * 
+         * @param testobject Object for test to be configured
+         */
+        void ConfigureReference(AliEMCALTriggerTRUDCSConfig &testobject){
+          testobject.SetSELPF(7711);
+	        testobject.SetL0SEL(1);
+	        testobject.SetL0COSM(100);
+	        testobject.SetGTHRL0(132);
+	        testobject.SetMaskReg(1024, 0);
+	        testobject.SetMaskReg(0, 1);
+	        testobject.SetMaskReg(512, 2);
+	        testobject.SetMaskReg(31985, 3);
+	        testobject.SetMaskReg(0, 4);
+	        testobject.SetMaskReg(0, 5);
+	        testobject.SetRLBKSTU(0);
+	        testobject.SetFw(0x21);
+        }
+        
+        /**
+         * @brief Test for operator== on itself
+         * 
+         * Tests whether operator== returns true in case the object is tested
+         * against itself.
+         * 
+         * @return true Test passed (operator== returning true)
+         * @return false Test failed (operator== returning false)
+         */
+        bool TestEqualSelf(){
+          AliEMCALTriggerTRUDCSConfig testobject;
+          ConfigureReference(testobject);
+
+          // Make test          
+          return testobject == testobject;
+        }
+
+        /**
+         * @brief Test for operator== on same object
+         * 
+         * Tests whether operator== returns true in case both
+         * objects have the same content.
+         * 
+         * @return true Test passed (operator== returning true)
+         * @return false Test failed (operator== returning false)
+         */
+        bool TestEqualTrue(){
+          AliEMCALTriggerTRUDCSConfig test1, test2;
+          ConfigureReference(test1);
+          ConfigureReference(test2);
+          return test1 == test2;
+        }
+
+        /**
+         * @brief Test for operator== on different objects
+         * 
+         * Tests whether the operator== returns false if at least one setting
+         * is different. For this operator== is tested with multiple objects
+         * based on a reference setting where only one parameter is changed at
+         * the time.
+         * 
+         * @return true Test passed (operator== returns false in all cases)
+         * @return false Test failed (operator== returns true at least once)
+         */
+        bool TestEqualFalse(){
+          AliEMCALTriggerTRUDCSConfig ref, testobject;
+          std::bitset<8> testresult;      // bit set in case test fails (operator returns true)
+          testresult.reset();
+
+          // Configure reference          
+          ConfigureReference(ref);
+
+          // Variation peak finder
+          ConfigureReference(testobject);
+          testobject.SetSELPF(7000);
+          testresult.set(0, ref == testobject);
+
+          // Variation L0 Algorithm
+          ConfigureReference(testobject);
+          testobject.SetL0SEL(2);
+          testresult.set(1, ref == testobject);
+
+          // Variation cosmic threshold
+          ConfigureReference(testobject);
+          testobject.SetL0COSM(1000);
+          testresult.set(2, ref == testobject);
+
+          // Variation global threshold
+          ConfigureReference(testobject);
+          testobject.SetGTHRL0(184);
+          testresult.set(3, ref == testobject);
+
+          // Variation Rollback
+          ConfigureReference(testobject);
+          testobject.SetRLBKSTU(1);
+          testresult.set(4, ref == testobject);
+
+          // Variation Firmware
+          ConfigureReference(testobject);
+          testobject.SetFw(0x11);
+          testresult.set(5, ref == testobject);
+
+          // Variation Mask
+          ConfigureReference(testobject);
+          testobject.SetMaskReg(768,0);
+          testobject.SetMaskReg(15,1);
+          testobject.SetMaskReg(37632,2);
+          testobject.SetMaskReg(63,3);
+          testobject.SetMaskReg(0,4);
+          testobject.SetMaskReg(208,5);
+          testresult.set(5, ref == testobject);
+
+          return !testresult.any();
+        }
+
+        /**
+         * @brief Test for the stream operator
+         * 
+         * Test if operator<< for a reference configuration produces 
+         * the expected reference string. Test is implemented using a streaming
+         * operator.
+         * 
+         * @return true Test passed (operator<< to string produces reference string)
+         * @return false Test failed (operator<< to string produces different string)
+         */
+        bool TestStream(){
+          std::string reference = std::string("SELPF: 1e1f, L0SEL: 1, L0COSM: 100, GTHRL0: 132, RLBKSTU: 0, FW: 21\n")
+                                + std::string("Reg0: 00000000000000000000010000000000\nReg1: 00000000000000000000000000000000\n")
+                                + std::string("Reg2: 00000000000000000000001000000000\nReg3: 00000000000000000111110011110001\n")
+                                + std::string("Reg4: 00000000000000000000000000000000\nReg5: 00000000000000000000000000000000\n");
+          
+          AliEMCALTriggerTRUDCSConfig test;
+          ConfigureReference(test);
+          std::stringstream testmaker;
+          testmaker << test;
+          return testmaker.str() == reference;
+        }
+      }
+    }
+  }
+} 
+
+/**
+ * @brief Test runner for tests of class AliEMCALTriggerTRUDCSConfig
+ * 
+ * Running all tests implemented for the TRU DCS Config
+ * 
+ * @param argc Number of commamnd line arguments (not handled)
+ * @param argv Array of command line arguments (not handled)
+ * @return int 0 if the test is successful, 1 if not
+ */
+int main(int argc, char **argv) {
+  int npass(0);
+  if(EMCAL::Base::Tests::TestAliEMCALTriggerTRUDCSConfig::TestEqualSelf()){
+    npass++;
+  } else {
+    std::cerr << "Failure eq_self" << std::endl;
+  }
+  if(EMCAL::Base::Tests::TestAliEMCALTriggerTRUDCSConfig::TestEqualTrue()){
+    npass++;
+  } else {
+    std::cerr << "Failure_eq_true" << std::endl;
+  }
+  if(EMCAL::Base::Tests::TestAliEMCALTriggerTRUDCSConfig::TestEqualFalse()){
+    npass++;
+  } else {
+    std::cerr << "Failure_eq_false" << std::endl;
+  }
+  if(EMCAL::Base::Tests::TestAliEMCALTriggerTRUDCSConfig::TestStream()){
+    npass++;
+  } else {
+    std::cerr << "Failure_stream" << std::endl;
+  }
+  std::cout << "Passing " << npass << "/4" << std::endl;
+  if(npass == 4) return EXIT_SUCCESS;
+  return EXIT_FAILURE;
+}


### PR DESCRIPTION
Add operators << and == to trigger DCS config object to check if two configurations are the same. New operators are covered by unit tests integrated in the ALICE ctest suite.