### PR TITLE
 avoid floating point error when pz is larger than e

### DIFF
--- a/STEER/STEERBase/AliMCParticle.h
+++ b/STEER/STEERBase/AliMCParticle.h
@@ -141,7 +141,7 @@ inline Double_t AliMCParticle::Y()         const
     Double_t e  = E();
     Double_t pz = Pz();
     
-    if ( TMath::Abs(e - TMath::Abs(pz)) > FLT_EPSILON ) {
+    if ( e - TMath::Abs(pz) > FLT_EPSILON ) {
 	return 0.5*TMath::Log((e+pz)/(e-pz));
     } else { 
 	return -999.;


### PR DESCRIPTION
In the old condition, the Log((e+pz)/(e-pz)) is not evaluated when e == pz within float precision, but it is evaluated when pz > E (which is unphysical ,but can happen within float precision). By removing the outer TMath::Abs from the condition, pz > E is also caught, and will return a -999 as rapidity. Anyone who approves, please check if I didn't make a dumb mistake in logic ... thanks, Redmer