### PR TITLE
[EMCAL-45] JSON-serialize ODCB objects

### DIFF
--- a/EMCAL/EMCALbase/AliEMCALTriggerDCSConfig.cxx
+++ b/EMCAL/EMCALbase/AliEMCALTriggerDCSConfig.cxx
@@ -16,6 +16,7 @@
 #include "AliEMCALTriggerDCSConfig.h"
 #include "AliEMCALTriggerSTUDCSConfig.h"
 #include "AliEMCALTriggerTRUDCSConfig.h"
+#include <sstream>
 
 /// \cond CLASSIMP
 ClassImp(AliEMCALTriggerDCSConfig) ;
@@ -49,11 +50,11 @@ bool AliEMCALTriggerDCSConfig::operator==(const AliEMCALTriggerDCSConfig & other
   bool isequal = true;
   if(fSTUObj && other.fSTUObj) {
     if(!(*fSTUObj == *other.fSTUObj)) isequal == false; // both EMCAL STU objects there, but not the same
-  } else if((fSTUObj && !other.fSTUObj) || (!fSTUObj && other.fSTUObj)) isequal == false; // one of the two missing
+  } else if((fSTUObj && !other.fSTUObj) || (!fSTUObj && other.fSTUObj)) isequal = false; // one of the two missing
 
   if(fSTUDCAL && other.fSTUDCAL) {
     if(!(*fSTUDCAL == *other.fSTUDCAL)) isequal == false; // both DCAL STU objects there, but not the same
-  } else if((fSTUDCAL && !other.fSTUDCAL) || (!fSTUDCAL && other.fSTUDCAL)) isequal == false; // one of the two missing
+  } else if((fSTUDCAL && !other.fSTUDCAL) || (!fSTUDCAL && other.fSTUDCAL)) isequal = false; // one of the two missing
 
   // check TRUs
   if(fTRUArr->GetEntries() != other.fTRUArr->GetEntries()){
@@ -69,4 +70,18 @@ bool AliEMCALTriggerDCSConfig::operator==(const AliEMCALTriggerDCSConfig & other
     }
   }
   return isequal;
+}
+
+std::string AliEMCALTriggerDCSConfig::ToJSON() const {
+  std::stringstream jsonstring;
+  jsonstring << "{";
+  if(fSTUObj) jsonstring << "\"fSTUObj\":" << fSTUObj->ToJSON() << ",";
+  if(fSTUDCAL) jsonstring << "\"fSTUDCAL\":" << fSTUDCAL->ToJSON() << ",";
+  jsonstring << "fTRUArr:[";
+  for(int ien  = 0; ien < fTRUArr->GetEntries(); ien++){
+    jsonstring << "{\"TRU" << ien << "\":" << static_cast<AliEMCALTriggerTRUDCSConfig *>(fTRUArr->At(ien))->ToJSON() << "}";
+    if(ien != fTRUArr->GetEntries()-1) jsonstring << ",";
+  }
+  jsonstring << "]}";
+  return jsonstring.str();
 }

--- a/EMCAL/EMCALbase/AliEMCALTriggerDCSConfig.h
+++ b/EMCAL/EMCALbase/AliEMCALTriggerDCSConfig.h
@@ -15,6 +15,7 @@
 
 #include "TObject.h"
 #include "TClonesArray.h"
+#include <string>
 
 class AliEMCALTriggerSTUDCSConfig;
 class AliEMCALTriggerTRUDCSConfig;
@@ -34,6 +35,13 @@ public:
    * and all TRU configurations must match.
    */
   bool operator==(const AliEMCALTriggerDCSConfig &other) const;
+
+	/**
+	 * @brief Serialize object to JSON format
+	 * 
+	 * @return JSON-serialized trigger DCS config object 
+	 */
+  std::string ToJSON() const;
   
   void                         SetTRUArr(TClonesArray* const ta)             { fTRUArr    = ta; }
   inline void                  SetSTUObj(AliEMCALTriggerSTUDCSConfig* so, Bool_t isDCAL = false);

--- a/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.cxx
@@ -22,6 +22,7 @@
 // Standard libraries
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 
 /// \cond CLASSIMP
 ClassImp(AliEMCALTriggerSTUDCSConfig) ;
@@ -200,4 +201,19 @@ std::ostream &operator<<(std::ostream &stream, const AliEMCALTriggerSTUDCSConfig
          << config.fPHOSScale[0] << ", " << config.fPHOSScale[1] << ", " << config.fPHOSScale[2] << ", " << config.fPHOSScale[3]
          << ")" << std::endl;
   return stream;
+}
+
+std::string AliEMCALTriggerSTUDCSConfig::ToJSON() const {
+  std::stringstream jsonstring;
+  jsonstring << "{" 
+             << "\"fG\":[[" << fG[0][0] << "," << fG[1][0] << "," << fG[2][0] << "],[" << fG[0][1] << "," << fG[1][1] << "," << fG[2][1] <<"]],"
+             << "\"fJ\":[[" << fJ[0][0] << "," << fJ[1][0] << "," << fJ[2][0] << "],[" << fJ[0][1] << "," << fJ[1][1] << "," << fJ[2][1] <<"]],"
+             << "\"fRawData\":" << fGetRawData << ","
+             << "\"fRegion\":" << fRegion << ","
+             << "\"fFirmware\":" << fFw << ","
+             << "\"fMedian\":" << fMedian << ","
+             << "\"fPHOSScale\":[" << fPHOSScale[0] << "," << fPHOSScale[1] << "," << fPHOSScale[2] << "," << fPHOSScale[3] << "]"
+             << "}";
+
+  return jsonstring.str();
 }

--- a/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.h
+++ b/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.h
@@ -5,6 +5,7 @@
 
 #include "TObject.h"
 #include <iosfwd>
+#include <string>
 
 class TVector2;
 class TClonesArray;
@@ -80,6 +81,13 @@ public:
    * error counters
    */
   friend std::ostream &operator<<(std::ostream &stream, const AliEMCALTriggerSTUDCSConfig &config);
+
+  /**
+   * @brief Serialize object to JSON format
+   * 
+   * @return JSON-serialized TRU DCS config object 
+   */
+  std::string ToJSON() const;
   
   void    SetG(Int_t i, Int_t j, Int_t gv) { fG[i][j]    = gv; }
   void    SetJ(Int_t i, Int_t j, Int_t jv) { fJ[i][j]    = jv; }

--- a/EMCAL/EMCALbase/AliEMCALTriggerTRUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/AliEMCALTriggerTRUDCSConfig.cxx
@@ -17,6 +17,7 @@
 #include <bitset>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 
 /// \cond CLASSIMP
 ClassImp(AliEMCALTriggerTRUDCSConfig) ;
@@ -59,4 +60,18 @@ std::ostream &operator<<(std::ostream &stream, const AliEMCALTriggerTRUDCSConfig
 		stream << "Reg" << ireg << ": " << std::bitset<sizeof(UInt_t) *8>(conf.fMaskReg[ireg]) << std::endl;
 	}
 	return stream;
+}
+
+std::string AliEMCALTriggerTRUDCSConfig::ToJSON() const {
+	std::stringstream jsonstring;
+	jsonstring << "{"
+						 << "\"fSELPF\":" << fSELPF << ","
+						 << "\"fL0SEL\":" << fL0SEL << ","
+						 << "\"fL0COSM\":" << fL0COSM << ","
+						 << "\"fGTHRL0\":" << fGTHRL0 << ","
+						 << "\"fRLBKSTU\":" << fRLBKSTU << ","
+						 << "\"fFw\":" << fFw << ","
+						 << "\"fMaskReg\":[" << fMaskReg[0] << "," << fMaskReg[1] << "," << fMaskReg[2] << "," << fMaskReg[3] << "," << fMaskReg[4] << "," << fMaskReg[5] << "]"
+						 << "}";
+	return jsonstring.str();
 }

--- a/EMCAL/EMCALbase/AliEMCALTriggerTRUDCSConfig.h
+++ b/EMCAL/EMCALbase/AliEMCALTriggerTRUDCSConfig.h
@@ -40,6 +40,13 @@ public:
 	 */
 	friend std::ostream &operator<<(std::ostream &stream, const AliEMCALTriggerTRUDCSConfig &other);
 
+	/**
+	 * @brief Serialize object to JSON format
+	 * 
+	 * @return JSON-serialized TRU DCS config object 
+	 */
+	std::string ToJSON() const;
+
 	void    SetSELPF(  UInt_t pf)              { fSELPF  = pf;        }
 	void    SetL0SEL(  UInt_t la)              { fL0SEL  = la;        }
 	void    SetL0COSM( UInt_t lc)              { fL0COSM = lc;        }


### PR DESCRIPTION
Adding function ToJSON to AliEMCALTrigggerDCSConfig, AliEMCALTriggerSTUDCSConfig and AliEMCALTriggerTRUDCSConfig, creating a JSON-string from the ROOT object (text format). Called with the AliEMCALTriggerDCSConfig object it creates a JSON string with the whole trigger configuration.