### PR TITLE
fix weird ununderstandable problem with ROOT6 cling clashing in interpreter mode when cout is used in aliroot binary

### DIFF
--- a/ALIROOT/aliroot.cxx
+++ b/ALIROOT/aliroot.cxx
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
     
     if (argument=="--version")
     {      
-      cout << "aliroot " << ALIROOT_REVISION << " " << ALIROOT_VERSION << endl;
+      printf("aliroot %s %s\n", ALIROOT_REVISION, ALIROOT_VERSION);
       return 0;
     }    
   }


### PR DESCRIPTION
This circumvents a crash in ROOT 6 cling on some systems.
We have been trying to debug this with @pzhristov but could not find the real cause.