### PR TITLE
Revert #558 and #561 following validation results

### DIFF
--- a/STEER/STEER/AliHelix.cxx
+++ b/STEER/STEER/AliHelix.cxx
@@ -330,8 +330,8 @@ Double_t  AliHelix::GetPhase(Double_t x, Double_t y ) const
   //
   Float_t delta = TMath::Nint((phase2-fHelix[2])/(2.*TMath::Pi()));
   phase2-= 2*TMath::Pi()*delta;
-  while ( (phase2-fHelix[2])>TMath::Pi() ) phase2 -=2.*TMath::Pi();
-  while ( (phase2-fHelix[2])<-TMath::Pi() ) phase2+=2.*TMath::Pi();
+  if ( (phase2-fHelix[2])>TMath::Pi()) phase2 -=2.*TMath::Pi();
+  if ( (phase2-fHelix[2])<-TMath::Pi()) phase2+=2.*TMath::Pi();
 
   Double_t t     = (phase2-fHelix[2]);
   t/=fHelix[4];
@@ -369,10 +369,6 @@ Int_t    AliHelix::GetRPHIintersections(const AliHelix &h, Double_t phase[2][2],
   //Double_t * c2 = &(h.fHelix[6]);
   //  Double_t  c1[3] = {fHelix[5],fHelix[0],fHelix[8]};
 
-  const double maxR = 400.; // discard radii above this
-  const double maxR2 = maxR*maxR;
-  const double maxRPhi = maxR*TMath::Pi();
-  
   // PH initiaziation in case of return
   phase[0][0]=phase[0][1]=phase[1][0]=phase[1][1]=0;
   ri[0]=ri[1]=1000000;
@@ -392,11 +388,9 @@ Int_t    AliHelix::GetRPHIintersections(const AliHelix &h, Double_t phase[2][2],
     y0[0] = (d+c1[2]-c2[2])*c2[1]/(2*d)+ fHelix[0];
     //    return 0;
     phase[1][0] = phase[0][0] = GetPhase(x0[0],y0[0]);
-    if (TMath::Abs(phase[0][0])>maxRPhi) return 0;
     phase[1][1] = phase[0][1] = h.GetPhase(x0[0],y0[0]);
-    if (TMath::Abs(phase[0][1])>maxRPhi) return 0;
     ri[1] = ri[0] = x0[0]*x0[0]+y0[0]*y0[0];
-    return ri[0]<maxR2 ? 1 : 0;
+    return 1;
   }
   if ( (d+c2[2])<c1[2]){
     if ( (d+c2[2])+cut<c1[2]) return 0;
@@ -404,14 +398,12 @@ Int_t    AliHelix::GetRPHIintersections(const AliHelix &h, Double_t phase[2][2],
     Double_t xx = c2[0]+ c2[0]*c2[2]/d+ fHelix[5];
     Double_t yy = c2[1]+ c2[1]*c2[2]/d+ fHelix[0]; 
     phase[1][1] = phase[0][1] = h.GetPhase(xx,yy);
-    if (TMath::Abs(phase[0][1])>maxRPhi) return 0;
     //
     Double_t xx2 = c2[0]*c1[2]/d+ fHelix[5];
     Double_t yy2 = c2[1]*c1[2]/d+ fHelix[0]; 
     phase[1][0] = phase[0][0] = GetPhase(xx2,yy2);
-    if (TMath::Abs(phase[0][0])>maxRPhi) return 0;
     ri[1] = ri[0] = xx*xx+yy*yy;
-    return ri[0]<maxR2 ? 1 : 0;
+    return 1;
   }
 
   if ( (d+c1[2])<c2[2]){
@@ -420,14 +412,12 @@ Int_t    AliHelix::GetRPHIintersections(const AliHelix &h, Double_t phase[2][2],
     Double_t xx = -c2[0]*c1[2]/d+ fHelix[5];
     Double_t yy = -c2[1]*c1[2]/d+ fHelix[0]; 
     phase[1][1] = phase[0][1] = GetPhase(xx,yy);
-    if (TMath::Abs(phase[0][1])>maxRPhi) return 0;
     //
     Double_t xx2 = c2[0]- c2[0]*c2[2]/d+ fHelix[5];
     Double_t yy2 = c2[1]- c2[1]*c2[2]/d+ fHelix[0]; 
     phase[1][0] = phase[0][0] = h.GetPhase(xx2,yy2);
-    if (TMath::Abs(phase[0][0])>maxRPhi) return 0;
     ri[1] = ri[0] = xx*xx+yy*yy;
-    return ri[0]<maxR2 ? 1 : 0;
+    return 1;
   }
 
   Double_t d1 = (d*d+c1[2]*c1[2]-c2[2]*c2[2])/(2.*d);
@@ -441,17 +431,12 @@ Int_t    AliHelix::GetRPHIintersections(const AliHelix &h, Double_t phase[2][2],
   x0[1] = (c2[0]*d1-c2[1]*v1)/d + fHelix[5];
   y0[1] = (c2[1]*d1+c2[0]*v1)/d + fHelix[0];      
   //
-  int np = 0;
   for (Int_t i=0;i<2;i++){
-    phase[np][0] = GetPhase(x0[i],y0[i]);
-    if (TMath::Abs(phase[np][0])>maxRPhi) continue;
-    phase[np][1] = h.GetPhase(x0[i],y0[i]);
-    if (TMath::Abs(phase[np][1])>maxRPhi) continue;
-    ri[np] = x0[i]*x0[i]+y0[i]*y0[i];
-    if (ri[np]>maxR2) continue;
-    np++;
+    phase[i][0] = GetPhase(x0[i],y0[i]);
+    phase[i][1] = h.GetPhase(x0[i],y0[i]);
+    ri[i] = x0[i]*x0[i]+y0[i]*y0[i];    
   }      
-  return np;
+  return 2;
 } 
 
 
@@ -544,14 +529,6 @@ Int_t  AliHelix::ParabolicDCA(const AliHelix&h,  //helixes
     }
     
     if ((dt1*gt1+dt2*gt2)>0) {dt1=-dt1; dt2=-dt2;}
-    const double kMaxDt = 100.;
-    if (TMath::Abs(dt1)>kMaxDt) {
-      dt1 = dt1>0 ? kMaxDt : -kMaxDt;
-    }
-    if (TMath::Abs(dt2)>kMaxDt) {
-      dt2 = dt2>0 ? kMaxDt : -kMaxDt;
-    }
-    
     
     //if (TMath::Abs(dt1)/(TMath::Abs(t1)+1.e-3) < 1.e-4)
     //  if (TMath::Abs(dt2)/(TMath::Abs(t2)+1.e-3) < 1.e-4) {


### PR DESCRIPTION
* Revert "Limit helix DCA phase*r search to 100cm,"
  This reverts commit 02d7155cb24af6e758644f0bf031eb22698d8afc.

* Revert "Make sure the helix phase is in -pi:pi range"
  This reverts commit e14ba678c79924d16afd8326b393c3aaf863e26f.

See [ALIROOT-7685](https://alice.its.cern.ch/jira/browse/ALIROOT-7685)