### PR TITLE
Commenting prints and putting a protection for undefined pc in NextParticle 

### DIFF
--- a/EVGEN/AliGenReaderEMD.cxx
+++ b/EVGEN/AliGenReaderEMD.cxx
@@ -32,8 +32,8 @@ ClassImp(AliGenReaderEMD)
 
 AliGenReaderEMD::AliGenReaderEMD():
     fStartEvent(0),
-    fNcurrent(0),  
-    fNparticle(0), 
+    fNcurrent(0),
+    fNparticle(0),
     fTreeNtuple(0),
     fPcToTrack(0),
     fOffset(0),
@@ -94,7 +94,7 @@ AliGenReaderEMD::AliGenReaderEMD():
       	     fPxomegaCside[i] = fPyomegaCside[i] = fPzomegaCside[i] = 0.;
 	   }
 	 }
-       }	
+       }
     }
     if(fPcToTrack==kAll) printf("\n\t   *** AliGenReaderEMD will track all produced particles \n\n");
     else if(fPcToTrack==kNotNucleons) printf("\n\t   *** AliGenReaderEMD will track all produced particles except nucleons\n\n");
@@ -105,8 +105,8 @@ AliGenReaderEMD::AliGenReaderEMD():
 AliGenReaderEMD::AliGenReaderEMD(const AliGenReaderEMD &reader):
     AliGenReader(reader),
     fStartEvent(0),
-    fNcurrent(0),  
-    fNparticle(0), 
+    fNcurrent(0),
+    fNparticle(0),
     fTreeNtuple(0),
     fPcToTrack(0),
     fOffset(0),
@@ -167,7 +167,7 @@ AliGenReaderEMD::AliGenReaderEMD(const AliGenReaderEMD &reader):
       	     fPxomegaCside[i] = fPyomegaCside[i] = fPzomegaCside[i] = 0.;
 	   }
 	 }
-       }	
+       }
     }
     reader.Copy(*this);
 }
@@ -189,24 +189,28 @@ AliGenReaderEMD& AliGenReaderEMD::operator=(const  AliGenReaderEMD& rhs)
 void AliGenReaderEMD::Copy(TObject&) const
 {
     //
-    // Copy 
+    // Copy
     //
     Fatal("Copy","Not implemented!\n");
 }
 
 // -----------------------------------------------------------------------------------
-void AliGenReaderEMD::Init() 
+void AliGenReaderEMD::Init()
 {
 //
 // Reset the existing file environment and open a new root file
-    
+
     TFile *pFile=0;
     if (!pFile) {
-	pFile = new TFile(fFileName);
-	pFile->cd();
-	printf("\n %s file opened to read RELDIS EMD events\n\n", fFileName);
+	     pFile = new TFile(fFileName);
+	      pFile->cd();
+	       printf("\n %s file opened to read RELDIS EMD events\n\n", fFileName);
     }
     fTreeNtuple = (TTree*)gDirectory->Get("h2032");
+    if(!fTreeNtuple){
+      Warning("Init", "No ntuple found!!!!");
+      return;
+    }
     fNcurrent = fStartEvent;
 
     TTree *Ntu=fTreeNtuple;
@@ -299,76 +303,79 @@ void AliGenReaderEMD::Init()
 }
 
 // -----------------------------------------------------------------------------------
-Int_t AliGenReaderEMD::NextEvent() 
+Int_t AliGenReaderEMD::NextEvent()
 {
-    // Read the next event  
+    // Read the next event
     Int_t nTracks=0;
     fNparticle = 0; fOffset=0;
-    
+
     TFile* pFile = fTreeNtuple->GetCurrentFile();
     pFile->cd();
-    
+
 
     Int_t nentries = (Int_t) fTreeNtuple->GetEntries();
     if(fNcurrent < nentries) {
-	fTreeNtuple->GetEvent(fNcurrent);
-	if(fNcurrent%100 == 0) printf("\n *** Reading event %d ***\n",fNcurrent);
-	//
-	if(fPcToTrack==kAll || fPcToTrack==kOnlyNucleons){ // nucleons
-	   nTracks = fNnCside+fNnAside+fNpCside+fNpAside;
-	}
-	if(fPcToTrack==kAll || fPcToTrack==kNotNucleons){ //pions,eta,omega
-	    nTracks += fNppCside+fNpmCside+fNppAside+fNpmAside+fNp0Aside+fNp0Cside+
-	    	fNetaAside+fNetaCside+fNomegaAside+fNomegaCside;
-	}
-	fNcurrent++;
-	printf("\t #### Putting %d particles in the stack\n", nTracks);
-	/*if(fPcToTrack==kAll || fPcToTrack==kOnlyNucleons) printf("\t\t  %d+%d neutrons, %d+%d protons\n", 
-		fNnAside,fNnCside, fNpAside,fNpCside);
-	if(fPcToTrack==kAll || fPcToTrack==kNotNucleons) printf("\t %d+%d pi+, %d+%d pi-, %d+%d pi0, %d+%d eta, %d+%d omega\n",
-	        fNppAside,fNppCside,fNpmAside,fNpmCside, 
-		fNp0Aside,fNp0Cside,fNetaAside,fNetaCside, fNomegaAside,fNomegaCside);*/
-	return nTracks;
+	     fTreeNtuple->GetEvent(fNcurrent);
+	      if(fNcurrent%100 == 0) printf("\n *** Reading event %d ***\n",fNcurrent);
+	       //
+	       if(fPcToTrack==kAll || fPcToTrack==kOnlyNucleons){ // nucleons
+	           nTracks = fNnCside+fNnAside+fNpCside+fNpAside;
+	       }
+	       if(fPcToTrack==kAll || fPcToTrack==kNotNucleons){ //pions,eta,omega
+	           nTracks += fNppCside+fNpmCside+fNppAside+fNpmAside+fNp0Aside+fNp0Cside+
+	    	       fNetaAside+fNetaCside+fNomegaAside+fNomegaCside;
+	       }
+	       fNcurrent++;
+	       printf("\t #### Putting %d particles in the stack\n", nTracks);
+	       /*if(fPcToTrack==kAll || fPcToTrack==kOnlyNucleons) printf("\t\t  %d+%d neutrons, %d+%d protons\n",
+		       fNnAside,fNnCside, fNpAside,fNpCside);
+	       if(fPcToTrack==kAll || fPcToTrack==kNotNucleons) printf("\t %d+%d pi+, %d+%d pi-, %d+%d pi0, %d+%d eta, %d+%d omega\n",
+	        fNppAside,fNppCside,fNpmAside,fNpmCside,fNp0Aside,fNp0Cside,fNetaAside,fNetaCside, fNomegaAside,fNomegaCside);*/
+	       return nTracks;
+    }
+    else{
+      Warning("NextEvent", "No more entries found in external file!!!!");
+      return 0;
     }
 
     return 0;
 }
 
 // -----------------------------------------------------------------------------------
-TParticle* AliGenReaderEMD::NextParticle() 
+TParticle* AliGenReaderEMD::NextParticle()
 {
     // Read the next particle
     Float_t p[4]={0.,0.,0.,0.};
-    int pdgCode=0;
-    
+    int pdgCode=1234567;
+
     if(fPcToTrack==kAll || fPcToTrack==kOnlyNucleons){//***********************************************
       if(fNparticle<fNnAside){
         p[0] = fPxnAside[fNparticle];
         p[1] = fPynAside[fNparticle];
-        p[2] = fPznAside[fNparticle];  
+        p[2] = fPznAside[fNparticle];
 	pdgCode = fnPDGCode;
-//    printf(" pc%d n sideA: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
+    //printf(" pc%d n sideA: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
       else if(fNparticle>=fNnAside && fNparticle<(fNnAside+fNnCside)){
         p[0] = fPxnCside[fNparticle];
         p[1] = fPynCside[fNparticle];
         p[2] = fPznCside[fNparticle];
 	pdgCode = fnPDGCode;
-//    printf(" pc%d n sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
+    //printf(" pc%d n sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
       else if(fNparticle>=fNnAside+fNnCside && fNparticle<(fNnAside+fNnCside+fNpAside)){
         p[0] = fPxpAside[fNparticle];
         p[1] = fPypAside[fNparticle];
         p[2] = fPzpAside[fNparticle];
 	pdgCode = fpPDGCode;
-//    printf(" pc%d p sideA: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
+    //printf(" pc%d p sideA: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
       else if(fNparticle>=fNnAside+fNnCside+fNpAside && fNparticle<(fNnAside+fNnCside+fNpCside+fNpAside)){
         p[0] = fPxpCside[fNparticle];
         p[1] = fPypCside[fNparticle];
         p[2] = fPzpCside[fNparticle];
 	pdgCode = fpPDGCode;
-//    printf(" pc%d p sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
+    //printf(" pc%d p sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
       fOffset = fNnAside+fNnCside+fNpCside+fNpAside;
     } //**********************************************************************************************
@@ -376,32 +383,32 @@ TParticle* AliGenReaderEMD::NextParticle()
       if(fNparticle>=fOffset && fNparticle<fOffset+fNppAside){ // *** pi +
         p[0] = fPxppAside[fNparticle];
         p[1] = fPyppAside[fNparticle];
-        p[2] = fPzppAside[fNparticle];  
+        p[2] = fPzppAside[fNparticle];
 	pdgCode = fppPDGCode;
-//    printf(" pc%d pi+ sideA: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
+    //printf(" pc%d pi+ sideA: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
       if(fNparticle>=fOffset+fNppAside && fNparticle<fOffset+fNppAside+fNppCside){
         p[0] = fPxppCside[fNparticle];
         p[1] = fPyppCside[fNparticle];
         p[2] = fPzppCside[fNparticle];
 	pdgCode = fppPDGCode;
-//    printf(" pc%d pi+ sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
+    //printf(" pc%d pi+ sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
       if(fNparticle>=fOffset+fNppAside+fNppCside && fNparticle<fOffset+fNppAside+fNppCside+fNpmAside){ // *** pi -
         p[0] = fPxpmAside[fNparticle];
         p[1] = fPypmAside[fNparticle];
         p[2] = fPzpmAside[fNparticle];
 	pdgCode = fpmPDGCode;
-//    printf(" pc%d pi- sideA: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
+    //printf(" pc%d pi- sideA: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
       if(fNparticle>=fOffset+fNppAside+fNppCside+fNpmAside && fNparticle<fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside){
         p[0] = fPxpmCside[fNparticle];
         p[1] = fPypmCside[fNparticle];
         p[2] = fPzpmCside[fNparticle];
 	pdgCode = fpmPDGCode;
-//    printf(" pc%d pi- sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
+    //printf(" pc%d pi- sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
-      if(fNparticle>=fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside && 
+      if(fNparticle>=fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside &&
          fNparticle<fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside){ // *** pi 0
         p[0] = fPxp0Aside[fNparticle];
         p[1] = fPyp0Aside[fNparticle];
@@ -409,37 +416,37 @@ TParticle* AliGenReaderEMD::NextParticle()
 	pdgCode = fp0PDGCode;
 //    printf(" pc%d pi0 sideA: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
-      if(fNparticle>=fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside && 
+      if(fNparticle>=fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside &&
         fNparticle<fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside+fNp0Cside){
         p[0] = fPxp0Cside[fNparticle];
         p[1] = fPyp0Cside[fNparticle];
         p[2] = fPzp0Cside[fNparticle];
 	pdgCode = fp0PDGCode;
-//    printf(" pc%d pi0 sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
+    //printf(" pc%d pi0 sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
-      if(fNparticle>=fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside+fNp0Cside && 
+      if(fNparticle>=fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside+fNp0Cside &&
          fNparticle<fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside+fNp0Cside+fNetaAside){ // *** eta
         p[0] = fPxetaAside[fNparticle];
         p[1] = fPyetaAside[fNparticle];
         p[2] = fPzetaAside[fNparticle];
 	pdgCode = fetaPDGCode;
-//    printf(" pc%d eta sideA: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
+    //printf(" pc%d eta sideA: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
-      if(fNparticle>=fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside+fNp0Cside+fNetaAside && 
+      if(fNparticle>=fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside+fNp0Cside+fNetaAside &&
          fNparticle<fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside+fNp0Cside+fNetaAside+fNetaCside){
         p[0] = fPxetaCside[fNparticle];
         p[1] = fPyetaCside[fNparticle];
         p[2] = fPzetaCside[fNparticle];
 	pdgCode = fetaPDGCode;
-//    printf(" pc%d eta sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
+    //printf(" pc%d eta sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
-      if(fNparticle>=fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside+fNp0Cside+fNetaAside+fNetaCside && 
+      if(fNparticle>=fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside+fNp0Cside+fNetaAside+fNetaCside &&
          fNparticle<fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside+fNp0Cside+fNetaAside+fNetaCside+fNomegaAside){ // *** omega
         p[0] = fPxomegaAside[fNparticle];
         p[1] = fPyomegaAside[fNparticle];
         p[2] = fPzomegaAside[fNparticle];
 	pdgCode = fomegaPDGCode;
-//    printf(" pc%d omega sideA: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
+    //printf(" pc%d omega sideA: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
       if(fNparticle>=fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside+fNp0Cside+fNetaAside+fNetaCside+fNomegaAside
       && fNparticle<fOffset+fNppAside+fNppCside+fNpmAside+fNpmCside+fNp0Aside+fNp0Cside+fNetaAside+fNetaCside+fNomegaAside+fNomegaCside){
@@ -447,27 +454,28 @@ TParticle* AliGenReaderEMD::NextParticle()
         p[1] = fPyomegaCside[fNparticle];
         p[2] = fPzomegaCside[fNparticle];
 	pdgCode = fomegaPDGCode;
-//    printf(" pc%d omega sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
+    //printf(" pc%d omega sideC: PDG code %d,  momentum (%f, %f, %f) \n", fNparticle, pdgCode, p[0],p[1],p[2]);
       }
-      
-    } 
-   
+
+    }
+
+   if(pdgCode!=1234567){
     Float_t ptot = TMath::Sqrt(p[0]*p[0]+p[1]*p[1]+p[2]*p[2]);
     Double_t amass = TDatabasePDG::Instance()->GetParticle(pdgCode)->Mass();
     p[3] = TMath::Sqrt(ptot*ptot+amass*amass);
-    
-    if(p[3]<=amass){ 
-       Warning("Generate","Particle %d  E = %f GeV mass = %f GeV ",pdgCode,p[3],amass);
-    }
-    
-    //printf("  Pc %d:  PDGcode %d  p(%1.2f, %1.2f, %1.2f, %1.3f)\n",
-    //	fNparticle,pdgCode,p[0], p[1], p[2], p[3]);
-    
-    TParticle* particle = new TParticle(pdgCode, 0, -1, -1, -1, -1, 
+
+    //if(p[3]<=amass){
+       //Warning("Generate","Particle %d  E = %f GeV p = %f GeV/c mass = %f GeV/c2 ",pdgCode,p[3],ptot,amass);
+    //}
+
+    //printf("  Pc %d:  PDGcode %d  p(%1.2f, %1.2f, %1.2f, %1.3f)\n",	fNparticle,pdgCode,p[0], p[1], p[2], p[3]);
+
+    TParticle* particle = new TParticle(pdgCode, 0, -1, -1, -1, -1,
     	p[0], p[1], p[2], p[3], 0., 0., 0., 0.);
     if((p[0]*p[0]+p[1]*p[1]+p[2]*p[2])>1e-5) particle->SetBit(kTransportBit);
     fNparticle++;
     return particle;
+  }
 }
 
 //___________________________________________________________


### PR DESCRIPTION
Despite the large number of lines tagged as changed, in this commit I simply:
1) commented a warning print that was useless (but annoying)
2) most importantly, put a protection in NextParticle() method that forbid not well defined particle to be propagated to the stack for tracking.

I also would like to explain that this external reader generator reads ntuples from RELDIS generator (dedicated to EM dissociation events) and that it is NOT used if not by myself for local productions since the RELDIS ntuples are not widely distributed.

I thank in advance whoever will allow this changes to be ported to the release.
Regards, ch.