### PR TITLE
Possibility to use multiple contain selections on trigger class

### DIFF
--- a/RAW/RAWDatarec/AliRawReader.cxx
+++ b/RAW/RAWDatarec/AliRawReader.cxx
@@ -338,12 +338,9 @@ AliRawReader* AliRawReader::Create(const char *uri)
 	continue;
       }
       else if((option.BeginsWith("Contain=",TString::kIgnoreCase))){
-	if(contExpr.IsNull()){
-	  option.ReplaceAll("Contain=","");
-	  contExpr=option.Data();
-	}else{
-	  AliWarningClass(Form("Ingnoring multiple Contain requests: %s",option.Data()));
-	}
+	option.ReplaceAll("Contain=","");
+	option.ReplaceAll("||"," ");
+	contExpr += Form("%s ",option.Data());
 	continue;
       }
       else if((option.BeginsWith("Exclude=",TString::kIgnoreCase))){
@@ -536,10 +533,17 @@ void AliRawReader::LoadTriggerClass(const char* name, Int_t index)
   if (TPRegexp(Form("%s%s%s",kMyWordBond,name,kMyWordBond)).Substitute(fSelectTriggerExpr,incrInd.Data(),"g")) {
     selTrigger=kTRUE;
   }else if(!fContainTriggerExpr.IsNull()) {
-    if (names.Contains(fContainTriggerExpr.Data())){
-      fSelectTriggerExpr += incrInd;
-      selTrigger=kTRUE;
+    TObjArray* arrc=fContainTriggerExpr.Tokenize(" ");
+    Int_t nSelTri=arrc->GetEntries();
+    for(Int_t jtri=0; jtri<nSelTri; jtri++){
+      TObjString* seltri=(TObjString*)arrc->At(jtri);
+      TString seltris=seltri->GetString();
+      if (names.Contains(seltris.Data())){
+	fSelectTriggerExpr += incrInd;
+	selTrigger=kTRUE;
+      }
     }
+    delete arrc;
   }
   if(!fExcludeTriggerExpr.IsNull()){
     if(index>=0 && names.Contains(fExcludeTriggerExpr.Data())){


### PR DESCRIPTION
This commit allows to select trigger classes using multiple selection of type "contain", which are treated in OR. 
For example one can run the rec.C with the option "?Contain=CCUP || CTRUE" to reconstruct the events of all the trigger classes CTRUE* and CCUP*.
With this feature, in the future, reconstructions of specific triggers should be easier to configure.
For example, the LHC15o reprocessing of ALIROOT-7611, which required 2 separate cycles, can be done in one cycle with the modified code.
