### PR TITLE
Add the possibility of injecting single particle species via macro configuration

### DIFF
--- a/EVGEN/AliGenParam.h
+++ b/EVGEN/AliGenParam.h
@@ -32,6 +32,10 @@ public:
               Double_t (*YPara )(const Double_t*, const Double_t*),
               Double_t (*V2Para)(const Double_t*, const Double_t*),
               Int_t    (*IpPara)(TRandom*)           );
+  AliGenParam(const char* name, Int_t npart, int pdg,
+              Double_t (*PtPara)(const Double_t*, const Double_t*) = 0x0,
+              Double_t (*YPara )(const Double_t*, const Double_t*) = 0x0,
+              Double_t (*V2Para)(const Double_t*, const Double_t*) = 0x0);
 
   virtual ~AliGenParam();
   virtual void GenerateN(Int_t ntimes);
@@ -100,6 +104,8 @@ protected:
   Bool_t      fKeepParent;   //  Store parent even if it does not have childs within cuts
   Bool_t      fKeepIfOneChildSelected; //Accept parent and child even if other children are not within cut.
   Bool_t      fPreserveFullDecayChain; //Prevent flagging(/skipping) of decay daughter particles; preserves complete forced decay chain
+
+  Int_t       fPDGcode;                // PDG code in case of single particle injector
 
 private:
   AliGenParam(const AliGenParam &Param);


### PR DESCRIPTION
This PR adds a simple way to configure AliGenParam to inject a particular particle species directly from an interpreted macro.
Due to a limitation of CINT it is not possible to pass an interpreted function to a library function, meaning that any new injection scheme would require adding a piece of code in AliRoot/AliPhysics instead of simply hacking the AliDPG repository.
This makes easier to replace AliGenBox with AliGenParam since now the functionality is the same with this new constructor.

@akalweit