### PR TITLE
In events w/o TPC we want to get only complementary ITS_SA tracks

### DIFF
--- a/STEER/ESD/AliESDEvent.h
+++ b/STEER/ESD/AliESDEvent.h
@@ -607,6 +607,7 @@ protected:
 
   void AddMuonTrack(const AliESDMuonTrack *t);
   void AddMuonGlobalTrack(const AliESDMuonGlobalTrack *t);     // AU
+  void FixITSSAFlags();
   
   TList *fESDObjects;             // List of esd Objects
 


### PR DESCRIPTION
Between 2015 and 2017 in absence of TPC only ITS pureSA tracks were reconstructed.
This created some problem in filtering/analysis, therefer we reverted this behaviour to reconstruct
only complementarySA in absence of TPC (they will be physically equivalent to pureSA in this case).
For already reconstructed data we redefine the pureSA flag on the fly in the AliESDEvent::ConnectTracks