### PR TITLE
TPC chi2 set in AliESDtrack(AliVTrack*) constructor

### DIFF
--- a/STEER/AOD/AliAODTrack.h
+++ b/STEER/AOD/AliAODTrack.h
@@ -144,6 +144,11 @@ class AliAODTrack : public AliVTrack {
   }
   
   UShort_t GetTPCNcls()  const { return GetTPCncls(); }
+  Double_t GetTPCchi2() const {
+    Int_t nTPCclus=GetNcls(1);
+    if(fChi2perNDF>0. && nTPCclus > 5) return fChi2perNDF*(nTPCclus-5);
+    else return 999.;
+  }
 
   Int_t GetNcls(Int_t idet) const;
 

--- a/STEER/ESD/AliESDtrack.cxx
+++ b/STEER/ESD/AliESDtrack.cxx
@@ -636,6 +636,8 @@ AliESDtrack::AliESDtrack(const AliVTrack *track) :
   if (bmap) SetTPCFitMap(*bmap);
   bmap = GetTPCSharedMapPtr();
   if (bmap) SetTPCSharedMap(*bmap);
+  // Set TPC chi2
+  fTPCchi2 = track->GetTPCchi2();
   //
   // Set the combined PID
   const Double_t *pid = track->PID();


### PR DESCRIPTION
This commit is aimed at properly setting the TPC chi2 when converting an AOD track into and ESD track using the constructor AliESDtrack(const AliVTrack *track). 

It is a modification in two classes:
1) AliAODTrack to add an helper method to compute the TPC chi2 from the chi2perNDF, by reversing what done in AliAnalysisTaskESDfilter::Chi2perNDF
2) AliESDtrack to set the TPC chi2 in the constructor that creates the track from an AliVTrack

