### PR TITLE
Set impact parameter in conversion from AOD to ESD tracks

### DIFF
--- a/STEER/AOD/AliAODTrack.h
+++ b/STEER/AOD/AliAODTrack.h
@@ -261,6 +261,9 @@ class AliAODTrack : public AliVTrack {
   Double_t PAtDCA() const { return TMath::Sqrt(PxAtDCA()*PxAtDCA() + PyAtDCA()*PyAtDCA() + PzAtDCA()*PzAtDCA()); }
   Bool_t   PxPyPzAtDCA(Double_t p[3]) const { p[0] = PxAtDCA(); p[1] = PyAtDCA(); p[2] = PzAtDCA(); return kTRUE; }
   
+  virtual void GetImpactParameters(Float_t &xy,Float_t &z) const;
+  void GetImpactParameters(Float_t p[2], Float_t cov[3]) const;
+
   Double_t GetRAtAbsorberEnd() const { return fRAtAbsorberEnd; }
   
   Double_t GetITSchi2()       const       {return fITSchi2;}

--- a/STEER/ESD/AliESDtrack.cxx
+++ b/STEER/ESD/AliESDtrack.cxx
@@ -638,6 +638,18 @@ AliESDtrack::AliESDtrack(const AliVTrack *track) :
   if (bmap) SetTPCSharedMap(*bmap);
   // Set TPC chi2
   fTPCchi2 = track->GetTPCchi2();
+
+  // Impact parameters
+  if (track->InheritsFrom("AliAODTrack")) {
+    Float_t ip[2], ipCov[3];
+    track->GetImpactParameters(ip,ipCov);
+    fD = ip[0];
+    fZ = ip[1];
+    fCdd = ipCov[0];
+    fCdz = ipCov[1];
+    fCzz = ipCov[2];
+  }
+
   //
   // Set the combined PID
   const Double_t *pid = track->PID();


### PR DESCRIPTION
This commit is aimed at properly setting the track impact parameter when converting an AOD track into and ESD track using the constructor AliESDtrack(const AliVTrack *track).

It is a modification in two classes:

1) AliAODTrack to add the methods to compute the impact parameter and its uncertainty (following advices and suggestions from Ruben)
2) AliESDtrack to call the calculation and to set the impact parameter in case the track passed to the AliESDtrack(const AliVTrack *track) constructor is an AliAODTrack.

