### PR TITLE
In events w/o TPC filter ITS_pureSA tracks as complementary ITS_SA 

### DIFF
--- a/ANALYSIS/ANALYSISalice/AliESDtrackCuts.h
+++ b/ANALYSIS/ANALYSISalice/AliESDtrackCuts.h
@@ -154,6 +154,7 @@ public:
   Bool_t  GetRequireTPCStandAlone()  const   { return fCutRequireTPCStandAlone;}
   Bool_t  GetRequireITSRefit()       const   { return fCutRequireITSRefit;}
   Bool_t  GetRequireITSStandAlone()  const   { return fCutRequireITSStandAlone; }
+  Bool_t  GetRequireITSpureSA()      const   { return fCutRequireITSpureSA; }
   Bool_t  GetAcceptKinkDaughters()   const   { return fCutAcceptKinkDaughters;}
   Bool_t  GetAcceptSharedTPCClusters()        const   {return fCutAcceptSharedTPCClusters;}
   Float_t GetMaxFractionSharedTPCClusters()   const   {return fCutMaxFractionSharedTPCClusters;}

--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.h
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.h
@@ -36,6 +36,7 @@ class AliAnalysisTaskESDfilter : public AliAnalysisTaskSE
   virtual void   UserExec(Option_t *option);
   virtual void   Terminate(Option_t *option);
   virtual void   ConvertESDtoAOD();
+  void AdjustCutsForEvent(const AliESDEvent& esd, TList& modifiedCuts, bool revert);
 
   // Setters
   virtual void SetTrackFilter   (AliAnalysisFilter*   trackF)                {fTrackFilter                 = trackF;}
@@ -81,7 +82,9 @@ class AliAnalysisTaskESDfilter : public AliAnalysisTaskSE
   
   void SetMuonCaloPass();
   void SetAddPCMv0s(Bool_t addPCMv0s) {fAddPCMv0s=addPCMv0s;}
-  
+
+  AliAnalysisFilter* GetTrackFilter() const { return fTrackFilter;}
+
 private:
   AliAnalysisTaskESDfilter(const AliAnalysisTaskESDfilter&);
   AliAnalysisTaskESDfilter& operator=(const AliAnalysisTaskESDfilter&);

--- a/ITS/ITSbase/AliITStrackerSA.cxx
+++ b/ITS/ITSbase/AliITStrackerSA.cxx
@@ -141,23 +141,18 @@ Int_t AliITStrackerSA::Clusters2Tracks(AliESDEvent *event){
   else {
     AliDebug(1,"Stand Alone flag set: doing tracking in ITS alone\n");
   }
-  if(!rc){
-    bool isTPC = event->GetNumberOfTPCClusters();
-    bool canUseAllCl = event->GetPrimaryVertexSPD()->GetNContributors()
-      < AliITSReconstructor::GetRecoParam()->GetMaxSPDcontrForSAToUseAllClusters();
-
-    //RS: do complementary reco. If TPC is absent, the complementary is equivalent to pureSA, do it only
-    // if the SPD mult does not exceed requested threshold
-    if (isTPC || canUseAllCl) { 
+  if(!rc){ 
+    if (event->GetNumberOfTPCClusters()) {
       sw.Start();
-      rc=FindTracks(event,kFALSE); 
+      rc=FindTracks(event,kFALSE); //RS: do complementary reco if there are TPC clusters
       sw.Stop();
       AliInfoF("timingSAcompl: %e/%e real/cpu",sw.RealTime(),sw.CpuTime());
     }
-
-    //RS: do pureSA reco only if TPC is present, otherwise the complementary one will play the role of
-    // pureSA
-    if (isTPC && AliITSReconstructor::GetRecoParam()->GetSAUseAllClusters()==kTRUE &&  canUseAllCl) {
+    Int_t nSPDcontr=0;
+    const AliESDVertex *spdv = event->GetPrimaryVertexSPD();
+    if(spdv) nSPDcontr = spdv->GetNContributors();
+    if(AliITSReconstructor::GetRecoParam()->GetSAUseAllClusters()==kTRUE && 
+       nSPDcontr<=AliITSReconstructor::GetRecoParam()->GetMaxSPDcontrForSAToUseAllClusters()) {
       sw.Start();
       rc=FindTracks(event,kTRUE);
       sw.Stop();

--- a/STEER/ESD/AliESDEvent.cxx
+++ b/STEER/ESD/AliESDEvent.cxx
@@ -2543,10 +2543,6 @@ void AliESDEvent::ConnectTracks() {
     TIter nextTOF(fESDTOFClusters);
     while ((clus=(AliESDTOFCluster*)nextTOF())) clus->SetEvent((AliVEvent *) this);
   }
-
-  // If relevant, conver ITSpureSA tracks to complementarySA tracks in events w/o TPC
-  FixITSSAFlags();
-  
   fTracksConnected = kTRUE;
   //
 }
@@ -2722,35 +2718,4 @@ void AliESDEvent::AdjustMCLabels(const AliVEvent *mcTruth)
   }
   
   
-}
-
-void AliESDEvent::FixITSSAFlags()
-{
-  // between 2015 and 2017 in absence of TPC only ITS pureSA tracks were reconstructed.
-  // This created some problem in filtering, therefer we reverted this behaviour to reconstruct
-  // only complementarySA in absence of TPC (they will be physically equivalent to pureSA in this case)
-  // For emulate this behavoiur, we need to override the pureSA flag for TPC-less events in old ESDs
-
-  // this is relevant only events w/o TPC
-  if (GetNumberOfTPCClusters()>0) return;
-  
-  int nPureSA = 0;
-  // check if this event is affected, i.e. it has no ITScomplementary tracks but has SA tracks
-  for (int i=GetNumberOfTracks();i--;) {
-    AliESDtrack* tr = GetTrack(i);
-    ULong_t flags = tr->GetStatus();
-    if ( flags & AliESDtrack::kTPCin ) continue;
-    if ( flags & AliESDtrack::kITSpureSA ) {
-      nPureSA++;
-      continue;
-    }
-    if ( flags & AliESDtrack::kITSin ) return; // if there is at least 1 complementary SA track, do nothing 
-  }
-  if (!nPureSA) return;
-  // change all pureSA tracks to complementarySA
-  for (int i=GetNumberOfTracks();i--;) {
-    AliESDtrack* tr = GetTrack(i);
-    if (tr->IsOn(AliESDtrack::kITSpureSA)) tr->ResetStatus(AliESDtrack::kITSpureSA);
-  }
-   
 }

--- a/STEER/ESD/AliESDEvent.h
+++ b/STEER/ESD/AliESDEvent.h
@@ -607,7 +607,6 @@ protected:
 
   void AddMuonTrack(const AliESDMuonTrack *t);
   void AddMuonGlobalTrack(const AliESDMuonGlobalTrack *t);     // AU
-  void FixITSSAFlags();
   
   TList *fESDObjects;             // List of esd Objects
 


### PR DESCRIPTION
In absence of TPC only ITS pureSA tracks are reconstructed, while the ESD->AOD filtering usually accepts only complementary ITS_SA track. This patch detects such events and redefines all cuts requesting compl. ITS_SA tracks to accept ITS_pureSA track. In the end of the event the cuts are restored.