### PR TITLE
 Improved conversion from AOD to ESD track for track selection

### DIFF
--- a/STEER/ESD/AliESDtrack.cxx
+++ b/STEER/ESD/AliESDtrack.cxx
@@ -620,7 +620,7 @@ AliESDtrack::AliESDtrack(const AliVTrack *track) :
   // Set ITS cluster map
   fITSClusterMap=track->GetITSClusterMap();
   fITSSharedMap=0;
-
+  fITSchi2=track->GetITSchi2();
   fITSncls=0;
   for(i=0; i<6; i++) {
     if(HasPointOnITSLayer(i)) fITSncls++;


### PR DESCRIPTION
These commits allow to apply the "full" set of cuts of AliESDtrackCuts::AcceptTrack on AOD tracks after converting the to AlIESDtrack.

Two classes are modified:
1. AliESDtrack: to copy the ITS chi2 from the AOD to the ESD track in the constructor AliESDtrack(const AliVTrack *track)
2. AliESDtrackCuts: to do in AcceptVTrack the conversion from AOD to ESD track setting all the variables used in the track selection

NOTES:
* the kink daughter rejection is applied directly on the AOD track  before converting it to ESD track
* the golden chi2 is retrieved from the value stored in the AOD track instead of recomputing it on the fly as for the ESD tracks
* the geometrical length cut is applied using the track parameterization at the vertex because the one at the inner radius of teh TPC is not available for TPC tracks: this makes a small difference in the trracks that are rejected/selected by this cut in AOD and ESD
