### PR TITLE
Bug fix: particle UniqueID was not retrieved before writing stack!

### DIFF
--- a/THijing/AliGenHijing.cxx
+++ b/THijing/AliGenHijing.cxx
@@ -423,6 +423,7 @@ void AliGenHijing::Generate()
 	  if (pSelected[i]) {
 	      kf   = iparticle->GetPdgCode();
 	      ks   = iparticle->GetStatusCode();
+	      ksp  = iparticle->GetUniqueID();
 	      p[0] = iparticle->Px();
 	      p[1] = iparticle->Py();
 	      p[2] = iparticle->Pz() * sign;


### PR DESCRIPTION
As stated in the commit message, the UniqueID was not retrieved in the loop where particles are written in the stack, but in the case where the data driven spectator fragmentation is applied, this would imply that all the spectators are written in the stack as coming from the target (the last value of the previous loop being used).
This change is therefore important and need to be pulled asap!
Thanks a lot, 
ch/