### PR TITLE
Fix: update AliTPCcalibAlignInterpolation::Process argument to AliVEvent

### DIFF
--- a/TPC/TPCcalib/AliTPCcalibAlignInterpolation.cxx
+++ b/TPC/TPCcalib/AliTPCcalibAlignInterpolation.cxx
@@ -389,7 +389,7 @@ void AliTPCcalibAlignInterpolation::ProcessStandalone(const char * inputList){
 
 
 
-void  AliTPCcalibAlignInterpolation::Process(AliESDEvent *esdEvent){
+void  AliTPCcalibAlignInterpolation::Process(AliVEvent *eventV) {
   //
   // Create distortion maps out of residual histograms of ITS-TRD interpolation and TPC space points
   // JIRA ticket: https://alice.its.cern.ch/jira/browse/ATO-108
@@ -399,6 +399,10 @@ void  AliTPCcalibAlignInterpolation::Process(AliESDEvent *esdEvent){
   const Double_t kMaxSNP = 0.8; // max snp tolerated
   //
   static Bool_t firstCall = kTRUE;
+
+  AliESDEvent* esdEvent = dynamic_cast<AliESDEvent*>(eventV);
+  if (!esdEvent) return;
+  
   if (firstCall) {
     firstCall = kFALSE;
     ExtractTPCGasData();

--- a/TPC/TPCcalib/AliTPCcalibAlignInterpolation.h
+++ b/TPC/TPCcalib/AliTPCcalibAlignInterpolation.h
@@ -41,7 +41,7 @@ public :
   AliTPCcalibAlignInterpolation(const Text_t *name, const Text_t *title, Bool_t onTheFlyFill);
   virtual ~AliTPCcalibAlignInterpolation();
   void ProcessStandalone(const char * inputList);
-  virtual void     Process(AliESDEvent *event);
+  virtual void     Process(AliVEvent *event);
   virtual void     Terminate();
   void   SetStreamLevelTrack(Int_t streamLevelTrack){fStreamLevelTrack=streamLevelTrack;}
   Bool_t RefitITStrack(AliESDfriendTrack *friendTrack, Double_t mass, AliExternalTrackParam &trackITS, Double_t &chi2, Double_t &npoints, Int_t* sortInd=0);


### PR DESCRIPTION
The AliTPCcalibBase::Process(AliESDEvent*) was changed to Process(AliVEvent*) during adaptation of calib framework
to flat containers/HLT, but the derived AliTPCcalibAlignInterpolation::Process was not modified. As a result, the
derived method is not called and the residual trees are not produced.
At the moment fixing just by dynamic_cast from AliVEvent to AliESDEvent, so the task will do nothing on the HLT.