### PR TITLE
[EMCAL-135] Fix deep copy in pass names

### DIFF
--- a/STEER/STEERBase/AliOADBContainer.cxx
+++ b/STEER/STEERBase/AliOADBContainer.cxx
@@ -411,7 +411,7 @@ Int_t AliOADBContainer::InitFromFile(const char* fname, const char* key)
     fUpperLimits[i] = cont->UpperLimit(i);
     fArray->AddAt(cont->GetObjectByIndex(i), i);
     TObject* passName = cont->GetPassNameByIndex(i);
-    fPassNames->AddAt(passName ? passName : new TObjString(""), i);
+    fPassNames->AddAt(new TObjString(passName ? passName->GetName() : ""), i);
   }
 
   if (!fDefaultList) 


### PR DESCRIPTION
Since InitFromFile sets ownership over pass name
container (#622) when setting the target object a
deep copy of the pass name has to be performed in
any case, otherwise the container will crash when
accessing the pass name while retrieving the
corresponding object from the container.