### PR TITLE
Fix in STEER/STEERBase/AliTRDPIDParams.cxx

### DIFF
--- a/STEER/STEERBase/AliTRDPIDParams.cxx
+++ b/STEER/STEERBase/AliTRDPIDParams.cxx
@@ -25,7 +25,6 @@
 
 #include "AliTRDPIDParams.h"
 
-#include <iostream>
 
 ClassImp(AliTRDPIDParams)
 //ClassImp(AliTRDPIDParams::AliTRDPIDThresholds)

--- a/STEER/STEERBase/AliTRDPIDParams.h
+++ b/STEER/STEERBase/AliTRDPIDParams.h
@@ -45,6 +45,7 @@ public:
         AliTRDPIDThresholds(Int_t nTracklets, Double_t eff, Double_t *params, Int_t charge);
         AliTRDPIDThresholds(Int_t nTracklets, Double_t effMin, Double_t effMax, Double_t *params = NULL);
         AliTRDPIDThresholds(Int_t nTracklets, Double_t eff, Double_t *params = NULL);
+	AliTRDPIDThresholds(Int_t nTracklets, Double_t eff, Int_t charge);
         AliTRDPIDThresholds(const AliTRDPIDThresholds &);
         AliTRDPIDThresholds &operator=(const AliTRDPIDThresholds &);
         virtual ~AliTRDPIDThresholds() {}


### PR DESCRIPTION
A constructor had to be added to AliTRDPIDParams.cxx. Otherwise the 'test' object in the GetThresholdParameters() function is not initialized correctly and thus the function does not return the correct threshold parameters for the PID.
Additionally, an output of the threshold parameters was added to the Print() function, to simplify debugging and analysis.