### PR TITLE
Fix STU region in stream operator

### DIFF
--- a/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.cxx
@@ -20,6 +20,7 @@
 #include "TVector2.h"
 
 // Standard libraries
+#include <bitset>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -196,9 +197,11 @@ std::ostream &operator<<(std::ostream &stream, const AliEMCALTriggerSTUDCSConfig
   stream << "Gamma Low:  (" << config.fG[0][1] << ", " << config.fG[1][1] << ", " << config.fG[2][1] << ")" << std::endl;
   stream << "Jet High:   (" << config.fJ[0][0] << ", " << config.fJ[1][0] << ", " << config.fJ[2][0] << ")" << std::endl;
   stream << "Jet Low:    (" << config.fJ[0][1] << ", " << config.fJ[1][1] << ", " << config.fJ[2][1] << ")" << std::endl;
-  stream << "GetRawData: " << config.fGetRawData << ", Region: " << config.fRegion << ", Median: " << config.fMedian 
-         << "Firmware: " << std::hex << config.fFw << std::dec << ", PHOS Scale: ("
-         << config.fPHOSScale[0] << ", " << config.fPHOSScale[1] << ", " << config.fPHOSScale[2] << ", " << config.fPHOSScale[3]
+  stream << "GetRawData: " << config.fGetRawData 
+         << ", Region: " << std::hex << config.fRegion << std::dec << "(" << std::bitset<sizeof(config.fRegion) * 8>(config.fRegion) << ")"
+         << ", Median: " << config.fMedian 
+         << ", Firmware: " << std::hex << config.fFw << std::dec 
+         << ", PHOS Scale: (" << config.fPHOSScale[0] << ", " << config.fPHOSScale[1] << ", " << config.fPHOSScale[2] << ", " << config.fPHOSScale[3]
          << ")" << std::endl;
   return stream;
 }


### PR DESCRIPTION
STU region should be displayed in two ways
- hex number for comparison with DCS settings
- bitset in order to easily read of masked regions