### PR TITLE
fix CTP TimeStamp: triggers may be ahead of 1st scaler

### DIFF
--- a/STEER/ESD/AliESDEvent.h
+++ b/STEER/ESD/AliESDEvent.h
@@ -218,6 +218,7 @@ public:
   UInt_t    GetTimeStamp()  const { return fHeader?fHeader->GetTimeStamp():0;}
   UInt_t    GetTimeStampCTP() const;
   UInt_t    GetTimeStampCTPBCCorr() const;
+  AliTimeStamp GetAliTimeStamp() const;
   UInt_t    GetEventType()  const { return fHeader?fHeader->GetEventType():0;}
   UInt_t    GetEventSpecie()  const { return fHeader?fHeader->GetEventSpecie():0;}
   Int_t     GetEventNumberInFile() const {return fHeader?fHeader->GetEventNumberInFile():-1;}


### PR DESCRIPTION
The trigger time stamp uses 1st scaler record as a reference and assumed that no trigger
may appear before this scaler. This apperars not to be true.
Added extra method AliTimeStamp AliESDEvent::GetAliTimeStamp() to extract precise
timestamp with ms precision