### PR TITLE
Add possibility to require ITS match for TRD tracking seeds

### DIFF
--- a/HLT/TRD/tracking/AliHLTTRDTrack.cxx
+++ b/HLT/TRD/tracking/AliHLTTRDTrack.cxx
@@ -9,6 +9,7 @@ AliHLTTRDTrack::AliHLTTRDTrack() :
   fNtracklets(0),
   fNmissingConsecLayers(0),
   fNtrackletsOffline(0),
+  fLabelOffline(0),
   fIsStopped(false)
 {
   //------------------------------------------------------------------
@@ -27,6 +28,7 @@ AliHLTTRDTrack::AliHLTTRDTrack(const AliHLTTRDTrack& t) :
   fNtracklets( t.fNtracklets),
   fNmissingConsecLayers( t.fNmissingConsecLayers),
   fNtrackletsOffline( t.fNtrackletsOffline),
+  fLabelOffline( t.fLabelOffline),
   fIsStopped( t.fIsStopped)
 {
   //------------------------------------------------------------------
@@ -50,6 +52,7 @@ AliHLTTRDTrack &AliHLTTRDTrack::operator=(const AliHLTTRDTrack& t)
   fNtracklets = t.fNtracklets;
   fNmissingConsecLayers = t.fNmissingConsecLayers;
   fNtrackletsOffline = t.fNtrackletsOffline;
+  fLabelOffline = t.fLabelOffline;
   fIsStopped = t.fIsStopped;
   for (Int_t i=0; i<=5; ++i) {
     fAttachedTracklets[i] = t.fAttachedTracklets[i];
@@ -65,6 +68,7 @@ AliHLTTRDTrack::AliHLTTRDTrack(AliESDtrack& t,Bool_t c) throw (const Char_t *) :
   fNtracklets(0),
   fNmissingConsecLayers(0),
   fNtrackletsOffline(0),
+  fLabelOffline(-1),
   fIsStopped(false)
 {
   //------------------------------------------------------------------
@@ -89,6 +93,7 @@ AliHLTTRDTrack::AliHLTTRDTrack(AliExternalTrackParam& t ) throw (const Char_t *)
   fNtracklets(0),
   fNmissingConsecLayers(0),
   fNtrackletsOffline(0),
+  fLabelOffline(-1),
   fIsStopped(false)
 {
   //------------------------------------------------------------------
@@ -162,6 +167,7 @@ void AliHLTTRDTrack::ConvertFrom( const AliHLTTRDTrackDataRecord &t )
   SetTPCtrackId( t.fTPCTrackID );
   fNtracklets = 0;
   fNmissingConsecLayers = 0;
+  fLabelOffline = -1;
   fNtrackletsOffline = 0;
   fIsStopped = false;
   for ( int iLayer=0; iLayer <6; iLayer++ ){

--- a/HLT/TRD/tracking/AliHLTTRDTrack.h
+++ b/HLT/TRD/tracking/AliHLTTRDTrack.h
@@ -25,6 +25,7 @@ class AliHLTTRDTrack : public AliKalmanTrack
   Int_t GetNlayers() const;
   Bool_t GetIsFindable(Int_t iLayer) const { return fIsFindable[iLayer]; }
   Int_t GetNtrackletsOffline() const { return fNtrackletsOffline; }
+  Int_t GetLabelOffline() const { return fLabelOffline; }
   Int_t GetTracklet(Int_t iLayer) const;
   Int_t GetNmissingConsecLayers(Int_t iLayer) const;
   Bool_t GetIsStopped() const { return fIsStopped; }
@@ -34,6 +35,7 @@ class AliHLTTRDTrack : public AliKalmanTrack
   void SetNtracklets( Int_t nTrklts) { fNtracklets = nTrklts; }
   void SetIsFindable(Int_t iLayer) { fIsFindable[iLayer] = kTRUE; }
   void SetNtrackletsOffline(Int_t nTrklts) { fNtrackletsOffline = nTrklts; }
+  void SetLabelOffline(Int_t lab) { fLabelOffline = lab; }
   void SetIsStopped() { fIsStopped = kTRUE; }
 
   using AliExternalTrackParam::GetPredictedChi2;
@@ -64,6 +66,7 @@ class AliHLTTRDTrack : public AliKalmanTrack
   Int_t fNtracklets;            // number of attached TRD tracklets
   Int_t fNmissingConsecLayers;  // number of missing consecutive layers
   Int_t fNtrackletsOffline;     // number of attached offline TRD tracklets for debugging only
+  Int_t fLabelOffline;          // offline TRD MC label of this track
   Int_t fAttachedTracklets[6];  // IDs for attached tracklets sorted by layer
   Bool_t fIsFindable[6];        // number of layers where tracklet should exist
   Bool_t fIsStopped;            // track ends in TRD

--- a/HLT/TRD/tracking/AliHLTTRDTracker.cxx
+++ b/HLT/TRD/tracking/AliHLTTRDTracker.cxx
@@ -7,8 +7,8 @@
 
 #include "AliMCParticle.h"
 
-//#define ENABLE_HLTTRDDEBUG
-#define ENABLE_WARNING 0
+#define ENABLE_HLTTRDDEBUG
+#define ENABLE_WARNING 1
 #include "AliHLTTRDTrackerDebug.h"
 
 ClassImp(AliHLTTRDTracker)
@@ -243,7 +243,7 @@ void AliHLTTRDTracker::LoadTracklet(const AliHLTTRDTrackletWord &tracklet)
   fNtrackletsInChamber[tracklet.GetDetector()]++;
 }
 
-void AliHLTTRDTracker::DoTracking( AliExternalTrackParam *tracksTPC, int *tracksTPClab, int nTPCtracks, int *tracksTPCnTrklts )
+void AliHLTTRDTracker::DoTracking( AliExternalTrackParam *tracksTPC, int *tracksTPClab, int nTPCtracks, int *tracksTPCnTrklts, int *tracksTRDlabel )
 {
   //--------------------------------------------------------------------
   // Steering function for the tracking
@@ -276,6 +276,9 @@ void AliHLTTRDTracker::DoTracking( AliExternalTrackParam *tracksTPC, int *tracks
     t->SetLabel(tracksTPClab[i]);
     if (tracksTPCnTrklts != 0x0) {
       t->SetNtrackletsOffline(tracksTPCnTrklts[i]);
+    }
+    if (tracksTRDlabel != 0x0) {
+      t->SetLabelOffline(tracksTRDlabel[i]);
     }
 
     //FIXME can this be deleted? Or can it happen that a track has no mass assigned?

--- a/HLT/TRD/tracking/AliHLTTRDTracker.cxx
+++ b/HLT/TRD/tracking/AliHLTTRDTracker.cxx
@@ -7,8 +7,8 @@
 
 #include "AliMCParticle.h"
 
-#define ENABLE_HLTTRDDEBUG
-#define ENABLE_WARNING 1
+//#define ENABLE_HLTTRDDEBUG
+#define ENABLE_WARNING 0
 #include "AliHLTTRDTrackerDebug.h"
 
 ClassImp(AliHLTTRDTracker)

--- a/HLT/TRD/tracking/AliHLTTRDTracker.cxx
+++ b/HLT/TRD/tracking/AliHLTTRDTracker.cxx
@@ -597,7 +597,7 @@ bool AliHLTTRDTracker::FollowProlongation(AliHLTTRDTrack *t, int nTPCtracks)
         fDebug->SetChi2Real(fCandidates[currIdx].GetPredictedChi2(yzPosReal, fSpacePoints[realTrkltId].fCov), iLayer);
         fDebug->SetRawTrackletPositionReal(fSpacePoints[realTrkltId].fR, fSpacePoints[realTrkltId].fX, iLayer);
         fDebug->SetCorrectedTrackletPositionReal(yzPosReal, iLayer);
-        fDebug->SetTrackletPropertiesReal(fTracklets[realTrkltId].GetDetector(), fGeo->GetSector(fTracklets[realTrkltId].GetDetector()), iLayer);
+        fDebug->SetTrackletPropertiesReal(fGeo->GetSector(fTracklets[realTrkltId].GetDetector()), fTracklets[realTrkltId].GetDetector(), iLayer);
       }
     }
     //

--- a/HLT/TRD/tracking/AliHLTTRDTracker.h
+++ b/HLT/TRD/tracking/AliHLTTRDTracker.h
@@ -60,7 +60,7 @@ public:
   void Reset();
   void StartLoadTracklets(const int nTrklts);
   void LoadTracklet(const AliHLTTRDTrackletWord &tracklet);
-  void DoTracking(AliExternalTrackParam *tracksTPC, int *tracksTPClab, int nTPCtracks, int *tracksTPCnTrklts = 0x0);
+  void DoTracking(AliExternalTrackParam *tracksTPC, int *tracksTPClab, int nTPCtracks, int *tracksTPCnTrklts = 0x0, int *tracksTRDlabel = 0x0);
   bool CalculateSpacePoints();
   bool FollowProlongation(AliHLTTRDTrack *t, int nTPCtracks);
   int GetDetectorNumber(const float zPos, const float alpha, const int layer) const;

--- a/HLT/TRD/tracking/AliHLTTRDTrackerDebug.h
+++ b/HLT/TRD/tracking/AliHLTTRDTrackerDebug.h
@@ -31,7 +31,7 @@ class AliHLTTRDTrackerDebug
                     fRoadY.Zero(); fRoadZ.Zero(); fTrackletXReal.Zero(); fTrackletYReal.Zero(); fTrackletZReal.Zero(); ; fTrackletYcorrReal.Zero(); fTrackletZcorrReal.Zero();
                     fTrackletSecReal.Zero(); fTrackletDetReal.Zero(); fTrackXReal.Zero(); fTrackYReal.Zero(); fTrackZReal.Zero(); fTrackSecReal.Zero();
                     fChi2Update.Zero(); fChi2Real.Zero(); fNmatchesAvail.Zero(); fFindable.Zero(); fFindableMC.Zero(); fUpdates.Zero();
-                    fEv = 0; fNTPCtracks = 0; fTrk = 0; fTrackId = 0; fNtrklts = 0; fNtrkltsRef = 0; fNlayers = 0; fChi2 = 0; fNmatch = 0; fNfake = 0; fNrelated = 0;
+                    fEv = 0; fNTPCtracks = 0; fTrk = 0; fTrackId = 0; fNtrklts = 0; fNtrkltsRef = 0; fTrackIDref = -1; fNlayers = 0; fChi2 = 0; fNmatch = 0; fNfake = 0; fNrelated = 0;
                     fXvMC = 0; fYvMC = 0; fZvMC = 0; fPdgCode = 0; fParam.Reset(); fParamNoUp.Reset();
                  }
 
@@ -49,7 +49,7 @@ class AliHLTTRDTrackerDebug
             { fTrackNoUpX(ly) = trk.GetX(); fTrackNoUpY(ly) = trk.GetY(); fTrackNoUpZ(ly) = trk.GetZ(); fTrackNoUpPhi(ly) = trk.GetSnp(); fTrackNoUpLambda(ly) = trk.GetTgl();
               fTrackNoUpPt(ly) = trk.Pt(); fTrackNoUpSector(ly) = GetSector(trk.GetAlpha()); fTrackNoUpYerr(ly) = trk.GetSigmaY2(); fTrackNoUpZerr(ly) = trk.GetSigmaZ2(); }
     void SetTrackParameterReal(const AliHLTTRDTrack &trk, int ly) { fTrackXReal(ly) = trk.GetX(); fTrackYReal(ly) = trk.GetY(); fTrackZReal(ly) = trk.GetZ(); fTrackSecReal(ly) = GetSector(trk.GetAlpha()); }
-    void SetTrack(const AliHLTTRDTrack &trk) { fParam = trk; fChi2 = trk.GetChi2(); fNlayers = trk.GetNlayers(); fNtrklts = trk.GetNtracklets(); fNtrkltsRef = trk.GetNtrackletsOffline();
+    void SetTrack(const AliHLTTRDTrack &trk) { fParam = trk; fChi2 = trk.GetChi2(); fNlayers = trk.GetNlayers(); fNtrklts = trk.GetNtracklets(); fNtrkltsRef = trk.GetNtrackletsOffline(); fTrackIDref = trk.GetLabelOffline();
                                                 for (int iLy=0; iLy<6; iLy++) { if (trk.GetIsFindable(iLy)) fFindable(iLy) = 1; } }
     void SetTrackNoUp(const AliHLTTRDTrack &trk) { fParamNoUp = trk; }
 
@@ -123,6 +123,8 @@ class AliHLTTRDTrackerDebug
         "chi2Total=" << fChi2 <<
         "nLayers=" << fNlayers <<
         "nTracklets=" << fNtrklts <<
+        "nTrackletsOffline=" << fNtrkltsRef <<
+        "labelRef=" << fTrackIDref <<
         "track.=" << &fParam <<
         "trackNoUp.=" << &fParamNoUp <<
         "roadY.=" << &fRoadY <<
@@ -148,6 +150,7 @@ class AliHLTTRDTrackerDebug
     int fTrackId;
     int fNtrklts;
     int fNtrkltsRef;
+    int fTrackIDref;
     int fNlayers;
     float fChi2;
     int fNmatch;


### PR DESCRIPTION
Only TPC tracks with ITS hits can be considered for HLT TRD tracking without the usage of std::vector::erase() to make it faster. Small typos for the debug output were fixed.