### PR TITLE
[EMCAL-172, ALIROOT-7718, ALIROOT-7649] Disable trigger simulation vi…

### DIFF
--- a/EMCAL/EMCALbase/AliEMCALRecParam.cxx
+++ b/EMCAL/EMCALbase/AliEMCALRecParam.cxx
@@ -60,6 +60,7 @@ fUseFALTRO(kTRUE),
 fFitLEDEvents(kFALSE),
 fUseL1Phase(kTRUE),// Run1 setting //raw signal
 fRejectBelowThreshold(0),
+fSimulateTriggerElectronics(true),
 fTrkInITS(kFALSE) // Run1 setting 
 {  
   InitPIDParametersForHighFlux();
@@ -102,6 +103,7 @@ fUseFALTRO(rp.fUseFALTRO),
 fFitLEDEvents(rp.fFitLEDEvents), 
 fUseL1Phase(rp.fUseL1Phase),//raw signal
 fRejectBelowThreshold(rp.fRejectBelowThreshold),
+fSimulateTriggerElectronics(rp.fSimulateTriggerElectronics),
 fTrkInITS(rp.fTrkInITS)
 {  
   // PID values
@@ -209,6 +211,9 @@ AliEMCALRecParam& AliEMCALRecParam::operator = (const AliEMCALRecParam& rp)
       fPar5[i] = rp.fPar5[i];
       fPar6[i] = rp.fPar6[i];
     }
+
+    // trigger electronics
+    fSimulateTriggerElectronics = rp.fSimulateTriggerElectronics;
   }    
   
   return *this;

--- a/EMCAL/EMCALbase/AliEMCALRecParam.h
+++ b/EMCAL/EMCALbase/AliEMCALRecParam.h
@@ -122,6 +122,7 @@ class AliEMCALRecParam : public AliDetectorRecoParam
   void SetFALTROUsage(Bool_t val)           {fUseFALTRO=val; }
   void SetLEDFit(Bool_t val)                {fFitLEDEvents=val; }
   void SetL1PhaseUse(Bool_t val)            {fUseL1Phase=val; }
+  void SetSimulateTriggerElectronics(Bool_t doSim) {fSimulateTriggerElectronics = doSim; }
 
 	
   /* raw signal getters */
@@ -135,6 +136,7 @@ class AliEMCALRecParam : public AliDetectorRecoParam
   Bool_t   UseFALTRO()            const {return fUseFALTRO; }
   Bool_t   FitLEDEvents()         const {return fFitLEDEvents; }
   Bool_t   UseL1Phase()           const {return fUseL1Phase;}     
+  Bool_t   IsSimulateTriggerElectronics() const { return fSimulateTriggerElectronics; }
   
   //Unfolding (Adam)
   void InitUnfoldingParameters();  
@@ -212,12 +214,15 @@ class AliEMCALRecParam : public AliDetectorRecoParam
   Double_t fPar5[3];               ///< UF SSPar nr 5
   Double_t fPar6[3];               ///< UF SSPar nr 6
 
+  // Trigger electronics
+  Bool_t   fSimulateTriggerElectronics; ///< Steer simulating trigger electronics
+
   static TObjArray* fgkMaps;       ///< ALTRO mappings for RCU0..RCUX
 
   Bool_t   fTrkInITS;              ///< Select tracks with AliVTrack::kITSout
 
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecParam,20) ;
+  ClassDef(AliEMCALRecParam,21) ;
   /// \endcond
  
 };

--- a/EMCAL/EMCALrec/AliEMCALReconstructor.h
+++ b/EMCAL/EMCALrec/AliEMCALReconstructor.h
@@ -115,7 +115,9 @@ class AliEMCALReconstructor : public AliReconstructor {
   };
   
   Bool_t CalculateResidual(AliESDtrack *track, AliESDCaloCluster *cluster, Float_t &dEta, Float_t &dPhi) const;
-  
+
+ protected:
+  void InitTriggerElectronics() const;
  private:
   
   AliEMCALReconstructor              (const AliEMCALReconstructor &); /// Not implemented

--- a/EMCAL/EMCALsim/AliEMCALTriggerElectronics.cxx
+++ b/EMCAL/EMCALsim/AliEMCALTriggerElectronics.cxx
@@ -109,21 +109,37 @@ fGeometry(0)
     }
   } else fSTUDCAL = 0;
 
+  // active status for STUs
+  if(!stuConf->GetRegion()) fSTU->SetActive(false);
+  if(stuConfDCal && fSTUDCAL && !stuConfDCal->GetRegion()) fSTUDCAL->SetActive(false);
+
   // Checking if the L1 thresholds are missing
   for (int ithr = 0; ithr < 2; ithr++) {
     if (stuConf->GetG(2,ithr) == 0) {
-      AliError(Form("EMCAL DCS STU has 0 threshold for EGA %d.  This trigger will not be properly simulated.  Check OCDB!!!",ithr));
+      if(stuConf->GetRegion())
+        AliError(Form("EMCAL DCS STU has 0 threshold for EGA %d.  This trigger will not be properly simulated.  Check OCDB!!!",ithr));
+      else
+        AliWarning(Form("EMCAL DCS STU has 0 threshold for EGA %d. EMCAL STU inactive - this trigger will not be simulated.", ithr));
     }
     if (stuConf->GetJ(2,ithr) == 0) {
-      AliError(Form("EMCAL DCS STU has 0 threshold for EJE %d.  This trigger will not be properly simulated.  Check OCDB!!!",ithr));
+      if(stuConf->GetRegion())
+        AliError(Form("EMCAL DCS STU has 0 threshold for EJE %d.  This trigger will not be properly simulated.  Check OCDB!!!",ithr));
+      else
+        AliWarning(Form("EMCAL DCS STU has 0 threshold for EJE %d. EMCAL STU inactive - this trigger will not be simulated.", ithr));
     }
 
     if (stuConfDCal) {
       if (stuConfDCal->GetG(2,ithr) == 0) {
-        AliError(Form("DCAL DCS STU has 0 threshold for EGA %d.  This trigger will not be properly simulated.  Check OCDB!!!",ithr));
+        if(stuConfDCal->GetRegion())
+          AliError(Form("DCAL DCS STU has 0 threshold for EGA %d.  This trigger will not be properly simulated.  Check OCDB!!!",ithr));
+        else
+          AliWarning(Form("DCAL DCS STU has 0 threshold for EGA %d. DCAL STU inactive - this trigger will not be simulated.", ithr));
       }
       if (stuConfDCal->GetG(2,ithr) == 0) {
-        AliError(Form("DCAL DCS STU has 0 threshold for EJE %d.  This trigger will not be properly simulated.  Check OCDB!!!",ithr));
+        if(stuConfDCal->GetRegion())
+          AliError(Form("DCAL DCS STU has 0 threshold for EJE %d.  This trigger will not be properly simulated.  Check OCDB!!!",ithr));
+        else
+          AliWarning(Form("DCAL DCS STU has 0 threshold for EJE %d. DCAL STU inactive - this trigger will not be simulated.", ithr));
       }
     }
   }

--- a/EMCAL/EMCALsim/AliEMCALTriggerSTU.cxx
+++ b/EMCAL/EMCALsim/AliEMCALTriggerSTU.cxx
@@ -42,6 +42,7 @@ ClassImp(AliEMCALTriggerSTU) ;
 //_______________
 AliEMCALTriggerSTU::AliEMCALTriggerSTU() : AliEMCALTriggerBoard()
 ,fDCSConfig(0x0)
+,fActive(true)
 {
   fGammaTh[0] = fGammaTh[1] = 0;
   fJetTh[0] = fJetTh[1] = 0;
@@ -53,6 +54,7 @@ AliEMCALTriggerSTU::AliEMCALTriggerSTU() : AliEMCALTriggerBoard()
 //_______________
 AliEMCALTriggerSTU::AliEMCALTriggerSTU(AliEMCALTriggerSTUDCSConfig *dcsConf, const TVector2& RS) : AliEMCALTriggerBoard(RS)
 ,fDCSConfig(dcsConf)
+,fActive(true)
 {
   fGammaTh[0] = fGammaTh[1] = 0;
   fJetTh[0] = fJetTh[1] = 0;	
@@ -136,6 +138,7 @@ void AliEMCALTriggerSTU::Build( TString& str, Int_t iTRU, Int_t** M, const TVect
 //_______________
 void AliEMCALTriggerSTU::L1(int type)
 {	
+  if(!fActive) return;      // Don't simulate L1 for inactive STUs
   TVector2 s1, s2, s3, s4;
   fDCSConfig->GetSegmentation(s1, s2, s3, s4);
   Int_t fBkg = 0;

--- a/EMCAL/EMCALsim/AliEMCALTriggerSTU.h
+++ b/EMCAL/EMCALsim/AliEMCALTriggerSTU.h
@@ -34,8 +34,10 @@ public:
   
   virtual void  SetThreshold(int type, Int_t v);
   virtual Int_t GetThreshold(int type);
+  void SetActive(Bool_t active) { fActive = active; }
   
   virtual Int_t GetMedianEnergy();
+  bool IsActive() const { return fActive; }
   virtual void  SetBkgRho(Int_t fRho) { fBkgRho = fRho; }
 
   virtual void  Reset();
@@ -51,7 +53,8 @@ private:
   
   Int_t   fGammaTh[2]; ///< Gamma threshold
   Int_t   fJetTh[2];   ///< Jet threshold
-  Int_t   fBkgRho; // BkgRho for L1 calculation.  Calculated from the other STU. 
+  Int_t   fBkgRho;     ///< BkgRho for L1 calculation.  Calculated from the other STU. 
+  Bool_t  fActive;      ///< Active status for STU, if inactive the L1 trigger will not be simulated
   
   AliEMCALTriggerSTUDCSConfig *fDCSConfig; // DCS config
   


### PR DESCRIPTION
…a reco params

Trigger electronics only createed in case it is enabled
in the EMCAL reco params (new field in reco params with
default value true). In case the trigger electronics is a
nullptr (not constructed in the constructor) the trigger
simulation will not be processed.

Off-status for STU is handled via the DCS region: For OFF
STUs the DCS sends  null values for all entries of the
STU configuration. The off-status can therefor be deduced
from a 0 value in the STU region. In this case the active
status of the STU is set to 0, and for inactive STUs the
function L1 processing the L1 trigger simulation will be
skipped.