### PR TITLE
fix L0 time array overflow due to null L0 threshold from OCDB EMCAL-39

### DIFF
--- a/EMCAL/EMCALbase/AliEMCALTriggerRawDigit.cxx
+++ b/EMCAL/EMCALbase/AliEMCALTriggerRawDigit.cxx
@@ -61,7 +61,13 @@ AliEMCALTriggerRawDigit::~AliEMCALTriggerRawDigit()
 /// Set L0 times
 //____________________________________________________________________________
 Bool_t AliEMCALTriggerRawDigit::SetL0Time(const Int_t i)
-{	
+{  
+  if (fNL0Times > 9)
+  {
+    AliError("More than 10 L0 times!");
+    return kFALSE;
+  }
+
   for (Int_t j = 0; j < fNL0Times; j++)
   {
     if (i == fL0Times[j]) 
@@ -72,13 +78,7 @@ Bool_t AliEMCALTriggerRawDigit::SetL0Time(const Int_t i)
   }
   
   fNL0Times++;
-  
-  if (fNL0Times > 9)
-  {
-    AliError("More than 10 L0 times!");
-    return kFALSE;
-  }
-  
+
   fL0Times[fNL0Times - 1] = i;
   
   return kTRUE;


### PR DESCRIPTION
everything is in the title, should fix the old standing EMCAL-39 ticket.
@mfasDa  should be enough to remove the Fatal (to be turned into an Error?) in the TriggerElectroncis constructor, do you think we should include that in the same PR?