### PR TITLE
TRD PID Parameters: adapt response of code when threshold parameters not available

### DIFF
--- a/STEER/STEERBase/AliTRDPIDParams.cxx
+++ b/STEER/STEERBase/AliTRDPIDParams.cxx
@@ -382,6 +382,14 @@ Bool_t AliTRDPIDParams::AliTRDPIDCentrality::GetThresholdParameters(Int_t ntrack
     AliDebug(1, Form("Threshold params found: NTracklets %d, Electron Efficiency %f, Charge %d", parResult->GetNTracklets(), parResult->GetElectronEfficiency(), parResult->GetCharge()));
     
     memcpy(params, parResult->GetThresholdParams(), sizeof(Double_t) * 4);
+
+
+    Double_t epsilon=0.0001;
+    if(((params[0]+999)<epsilon)&&((params[1]+999)<epsilon)&&((params[2]+999)<epsilon)&&((params[3]+999)<epsilon)){
+      AliError("Threshold Parameters set to -999: Parameters not available for this configuration.");
+      return kFALSE;
+    }
+
     return kTRUE;
 }
 

--- a/STEER/STEERBase/AliTRDPIDParams.cxx
+++ b/STEER/STEERBase/AliTRDPIDParams.cxx
@@ -116,8 +116,7 @@ Bool_t AliTRDPIDParams::GetThresholdParameters(Int_t ntracklets, Double_t effici
         return kFALSE;
     }
 
-    cent->GetThresholdParameters(ntracklets, efficiency, params, charge);
-    return kTRUE;
+    return cent->GetThresholdParameters(ntracklets, efficiency, params, charge);
 }
 
 //____________________________________________________________

--- a/STEER/STEERBase/AliTRDPIDResponse.cxx
+++ b/STEER/STEERBase/AliTRDPIDResponse.cxx
@@ -859,11 +859,12 @@ Bool_t AliTRDPIDResponse::IdentifiedAsElectron(Int_t nTracklets, const Double_t 
         AliError("Using Parameters for both charges");
         if((iCharge!=AliPID::kNoCharge)&&(!fkPIDResponseObject->GetThresholdParameters(nTracklets, level, params,centrality,PIDmethod,AliPID::kNoCharge))){
             AliError("No Params found for the given configuration with charge 0");
+            return kTRUE;
         }
-        return kTRUE;
+        if(iCharge==AliPID::kNoCharge){
+            return kTRUE;
+        }
     }
-
-
 
     Double_t threshold = 1. - params[0] - params[1] * p - params[2] * TMath::Exp(-params[3] * p);
     AliDebug(3,Form("is ident details %i %f %f %i %f %f %f %f \n",nTracklets, level, centrality,PIDmethod,probEle, threshold,TMath::Min(threshold, 0.99),TMath::Max(TMath::Min(threshold, 0.99), 0.2)));


### PR DESCRIPTION
- add output in AliTRDPIDParams::AliTRDPIDCentrality::GetThresholdParameters() that gives error message when threshold parameters are set to default values  (-999) as necessary for LHC17n
- ensure that return value of AliTRDPIDParams::AliTRDPIDCentrality::GetThresholdParameters() is passed over correctly to AliTRDPIDResponseObject::GetThresholdParameters()
- ensure that AliTRDPIDResponse::IdentifiedAsElectron() only returns default kTRUE if no parameters are available