### PR TITLE
Changes needed to work with Decayers other than AliDecayerPythia like…

### DIFF
--- a/EVGEN/AliGenITSULib.cxx
+++ b/EVGEN/AliGenITSULib.cxx
@@ -81,7 +81,6 @@ GenFunc AliGenITSULib::GetPt(Int_t iPID, const char * sForm) const
   AliError(Form("Unknown Pt distribution %s. Pt distribution is set to 0 ",sForm));
   func=0;
  }
- printf("returning function pointer %p \n", func);
  return func;
 }
 

--- a/EVGEN/AliGenITSULib.cxx
+++ b/EVGEN/AliGenITSULib.cxx
@@ -74,13 +74,14 @@ GenFunc AliGenITSULib::GetPt(Int_t iPID, const char * sForm) const
    case kBzero :    func=PtLbDist; break;
    case kDs    :    func=PtLcDist; break;
    case kDplus :    func=PtLcDist; break;
+   case kOmega_ccc: func=PtLbDist;   break;    
    default : AliError(Form("Unknown particle type: %i, Pt dist is 0",iPID));      func=0;
   } 
  }else {
   AliError(Form("Unknown Pt distribution %s. Pt distribution is set to 0 ",sForm));
   func=0;
  }
-
+ printf("returning function pointer %p \n", func);
  return func;
 }
 
@@ -88,7 +89,7 @@ GenFunc AliGenITSULib::GetY(Int_t iPID, const char *sForm) const
 {
  GenFunc func;
 
- if(TMath::Abs(iPID) != kLc && TMath::Abs(iPID) != kLb && TMath::Abs(iPID) != kXi_c && TMath::Abs(iPID) != kBplus && TMath::Abs(iPID) != kBzero && TMath::Abs(iPID)!=kDplus && TMath::Abs(iPID)!=kDs) {
+ if(TMath::Abs(iPID) != kLc && TMath::Abs(iPID) != kLb && TMath::Abs(iPID) != kXi_c && TMath::Abs(iPID) != kBplus && TMath::Abs(iPID) != kBzero && TMath::Abs(iPID)!=kDplus && TMath::Abs(iPID)!=kDs  && TMath::Abs(iPID) != kOmega_ccc) {
   AliError(Form("Unknown PID: %i, form: %s, returning 0",iPID,sForm));   //////////	
   func=0;
  } else { 
@@ -103,7 +104,7 @@ GenFuncIp AliGenITSULib::GetIp(Int_t iPID, const char *sForm) const
  // Return pointer to particle type parameterisation
  GenFuncIp id;
 
- if(TMath::Abs(iPID) != kLc && TMath::Abs(iPID) != kLb && TMath::Abs(iPID) != kXi_c && TMath::Abs(iPID) != kBplus && TMath::Abs(iPID) != kBzero && TMath::Abs(iPID)!=kDplus && TMath::Abs(iPID)!=kDs) {
+ if(TMath::Abs(iPID) != kLc && TMath::Abs(iPID) != kLb && TMath::Abs(iPID) != kXi_c && TMath::Abs(iPID) != kBplus && TMath::Abs(iPID) != kBzero && TMath::Abs(iPID)!=kDplus && TMath::Abs(iPID)!=kDs && TMath::Abs(iPID)!=kOmega_ccc) {
   AliError(Form("Unknown PID: %i, form: %s, return 0",iPID,sForm));   //////////	
   id = 0;
  } else {
@@ -122,6 +123,7 @@ GenFuncIp AliGenITSULib::GetIp(Int_t iPID, const char *sForm) const
    case -kDs   :                                  return id=IpDsMinus;
    case kDplus :                                  return id=IpDPlus;
    case -kDplus:                                  return id=IpDMinus;
+   case  kOmega_ccc:                              return id=IpOmegaccc;
    default  : AliFatal(Form("Unknown particle type: %i",iPID));  id=0;
   }
 
@@ -129,3 +131,12 @@ GenFuncIp AliGenITSULib::GetIp(Int_t iPID, const char *sForm) const
 
  return id;
 }
+
+Int_t AliGenITSULib::IpOmegaccc(TRandom* ran)
+{
+  Int_t ip = 4444;
+  if (ran->Rndm() < 0.5) ip = -ip;
+  return ip;
+}
+
+

--- a/EVGEN/AliGenITSULib.h
+++ b/EVGEN/AliGenITSULib.h
@@ -17,7 +17,7 @@ class AliGenITSULib :public AliGenLib {
 
  public:
 
-  enum EPartId {kLb=5122,kLc=4122,kXi_c = 4232,kBplus = 521,kBzero = 511,kDs=431,kDplus=411};
+  enum EPartId {kLb=5122,kLc=4122,kXi_c = 4232,kBplus = 521,kBzero = 511,kDs=431,kDplus=411, kOmega_ccc=4444};
 
   //Getters
     
@@ -40,8 +40,10 @@ class AliGenITSULib :public AliGenLib {
   static Int_t IpDsPlus(TRandom * /*ran*/)  {return     (int)kDs;}
   static Int_t IpDsMinus(TRandom * /*ran*/) {return    -(int)kDs;}
   static Int_t IpDPlus(TRandom * /*ran*/)   {return  (int)kDplus;}
-  static Int_t IpDMinus(TRandom * /*ran*/)  {return -(int)kDplus;}
+  static Int_t IpDMinus(TRandom * /*ran*/)  {return  -(int)kDplus;}
 
+  static Int_t IpOmegaccc(TRandom * /*ran*/);
+  
   static Double_t PtFlat(const Double_t * /*px*/, const Double_t * /*dummy*/) {return 1;}
   static Double_t YFlat (const Double_t * /*py*/, const Double_t * /*dummy*/) {return 1;}
 

--- a/EVGEN/AliGenParam.cxx
+++ b/EVGEN/AliGenParam.cxx
@@ -110,7 +110,6 @@ AliGenParam::AliGenParam(Int_t npart, const AliGenLib * Library,  Int_t param, c
   fTitle    = "Particle Generator using pT and y parameterisation";
   fAnalog   = kAnalog;
   SetForceDecay();
-  printf("have pointer %p \n", fPtParaFunc);
 }
 //____________________________________________________________
 AliGenParam::AliGenParam(Int_t npart, Int_t param, const char* tname, const char* name):
@@ -517,7 +516,6 @@ void AliGenParam::Init()
   gROOT->GetListOfFunctions()->Remove(fPtPara);
   //  Set representation precision to 10 MeV
   Int_t npx= Int_t((fPtMax - fPtMin) / fDeltaPt);
-  printf("and now it is %p \n", fPtPara);
   fPtPara->SetNpx(npx);
 
   snprintf(name, 256, "y-parameterisation  for %s", GetName());

--- a/EVGEN/AliGenParam.cxx
+++ b/EVGEN/AliGenParam.cxx
@@ -73,7 +73,8 @@ AliGenParam::AliGenParam()
   fKeepParent(kFALSE),
   fKeepIfOneChildSelected(kFALSE),
   fPreserveFullDecayChain(kFALSE),
-  fPDGcode(0)
+  fPDGcode(0),
+  fIncFortran(-1)
 {
   // Default constructor
 }
@@ -101,13 +102,15 @@ AliGenParam::AliGenParam(Int_t npart, const AliGenLib * Library,  Int_t param, c
    fKeepParent(kFALSE),
    fKeepIfOneChildSelected(kFALSE),
    fPreserveFullDecayChain(kFALSE),
-   fPDGcode(0)
+   fPDGcode(0),
+   fIncFortran(-1)
 {
   // Constructor using number of particles parameterisation id and library
   fName     = "Param";
   fTitle    = "Particle Generator using pT and y parameterisation";
   fAnalog   = kAnalog;
   SetForceDecay();
+  printf("have pointer %p \n", fPtParaFunc);
 }
 //____________________________________________________________
 AliGenParam::AliGenParam(Int_t npart, Int_t param, const char* tname, const char* name):
@@ -133,7 +136,8 @@ AliGenParam::AliGenParam(Int_t npart, Int_t param, const char* tname, const char
   fKeepParent(kFALSE),
   fKeepIfOneChildSelected(kFALSE),
   fPreserveFullDecayChain(kFALSE),
-  fPDGcode(0)
+  fPDGcode(0),
+  fIncFortran(-1)
 {
   // Constructor using parameterisation id and number of particles
   //
@@ -494,7 +498,12 @@ void AliGenParam::Init()
 	Fatal("AliGenParam",
               "No decayer attached");
   }
-
+  // For AliDecayerPythia based on FORTRAN there is a known inconsitency between the index returned by
+  // GetFirstDaughter(), GetLastDaughter(), GetMother() ... and the actual position in the C++ particle list.
+  // That's the reason whe the offset fIncFortran = -1 is needed in this case but not for decayers based on
+  // C++
+  
+  if (fDecayer->ClassName() != "AliDecayerPythia") fIncFortran=0;
   //Begin_Html
   /*
     <img src="picts/AliGenParam.gif">
@@ -508,7 +517,7 @@ void AliGenParam::Init()
   gROOT->GetListOfFunctions()->Remove(fPtPara);
   //  Set representation precision to 10 MeV
   Int_t npx= Int_t((fPtMax - fPtMin) / fDeltaPt);
-
+  printf("and now it is %p \n", fPtPara);
   fPtPara->SetNpx(npx);
 
   snprintf(name, 256, "y-parameterisation  for %s", GetName());
@@ -770,9 +779,9 @@ void AliGenParam::GenerateN(Int_t ntimes)
 
             if(!fPreserveFullDecayChain){
               if (pFlag[i] == 1) {
-                ipF = iparticle->GetFirstDaughter();
-                ipL = iparticle->GetLastDaughter();
-                if (ipF > 0) for (j=ipF-1; j<ipL; j++) pFlag[j]=1;
+                ipF = iparticle->GetFirstDaughter() + fIncFortran;
+                ipL = iparticle->GetLastDaughter()  + fIncFortran;
+                if (ipF > 0) for (j=ipF; j<=ipL; j++) pFlag[j]=1;
                 continue;
               }
             }
@@ -785,9 +794,9 @@ void AliGenParam::GenerateN(Int_t ntimes)
               //  Double_t mass     = particle->Mass();
               //  Double_t width    = particle->Width();
               if (lifeTime > (Double_t) fMaxLifeTime) {
-                ipF = iparticle->GetFirstDaughter();
-                ipL = iparticle->GetLastDaughter();
-                if (ipF > 0) for (j=ipF-1; j<ipL; j++) pFlag[j]=1;
+                ipF = iparticle->GetFirstDaughter() + fIncFortran;
+                ipL = iparticle->GetLastDaughter()  + fIncFortran;
+                if (ipF > 0) for (j=ipF; j<=ipL; j++) pFlag[j]=1;
                     } else{
                 trackIt[i]     = 0;
                 pSelected[i]   = 1;

--- a/EVGEN/AliGenParam.h
+++ b/EVGEN/AliGenParam.h
@@ -104,8 +104,8 @@ protected:
   Bool_t      fKeepParent;   //  Store parent even if it does not have childs within cuts
   Bool_t      fKeepIfOneChildSelected; //Accept parent and child even if other children are not within cut.
   Bool_t      fPreserveFullDecayChain; //Prevent flagging(/skipping) of decay daughter particles; preserves complete forced decay chain
-
   Int_t       fPDGcode;                // PDG code in case of single particle injector
+  Int_t       fIncFortran;   // respect fortran counting in particle list (Pythia6)
 
 private:
   AliGenParam(const AliGenParam &Param);


### PR DESCRIPTION
… AliDecayerPythia8

For AliDecayerPythia based on FORTRAN there is a known inconsistency between the index returned by GetFirstDaughter(), GetLastDaughter(), GetMother() ... and the actual position in the C++ particle list. That's the reason whe the offset fIncFortran = -1 is needed in this case. This offset was already present in the original version. The new version sets the offset to zero for other decayers like AliDecayerPythia8.