### PR TITLE
[EMCAL-179] Display dec representation of reg mask

### DIFF
--- a/EMCAL/EMCALbase/AliEMCALTriggerTRUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/AliEMCALTriggerTRUDCSConfig.cxx
@@ -57,7 +57,7 @@ std::ostream &operator<<(std::ostream &stream, const AliEMCALTriggerTRUDCSConfig
 				 << conf.fL0COSM << ", GTHRL0: " << conf.fGTHRL0 << ", RLBKSTU: " << conf.fRLBKSTU << ", FW: " << std::hex
 				 << conf.fFw << std::dec << std::endl;
 	for(int ireg = 0; ireg < 6; ireg++){
-		stream << "Reg" << ireg << ": " << std::bitset<sizeof(UInt_t) *8>(conf.fMaskReg[ireg]) << std::endl;
+		stream << "Reg" << ireg << ": " << std::bitset<sizeof(UInt_t) *8>(conf.fMaskReg[ireg]) << " (" << conf.fMaskReg[ireg] << ")" << std::endl;
 	}
 	return stream;
 }


### PR DESCRIPTION
In order to compare to original files the bitwise
representation is not of help as the original values exist
only in decimal represenation. Therefore both decimal
and bitwise representation are displayed.