### PR TITLE
Fix iterator, which fails in GCC 8 static assertion.

### DIFF
--- a/MUON/MUONcalib/AliMUONBusPatchEvolution.cxx
+++ b/MUON/MUONcalib/AliMUONBusPatchEvolution.cxx
@@ -745,7 +745,7 @@ void AliMUONBusPatchEvolution::ShrinkTimeAxis()
     histos[timeResolution].push_back(h);
   }
 
-  std::set<int, int>::const_iterator it;
+  std::set<int>::const_iterator it;
 
   TH1::AddDirectory(kFALSE);
 


### PR DESCRIPTION
WIthout checking the code in detail: apparaently this iterator should be std::set<int> iterator, instead of <int, int>.
No idea why it worked before, probably by chance.