### PR TITLE
Propagate DetectorStatus to AODs

### DIFF
--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
@@ -473,6 +473,9 @@ AliAODHeader* AliAnalysisTaskESDfilter::ConvertHeader(const AliESDEvent& esd)
 
   header->SetIRInt2InteractionMap(esd.GetHeader()->GetIRInt2InteractionMap());
   header->SetIRInt1InteractionMap(esd.GetHeader()->GetIRInt1InteractionMap());
+
+  // Detector status
+  header->SetDetectorStatusMask(esd.GetDetectorStatus());
   
   // ITS Cluster Multiplicty
   const AliMultiplicity *mult = esd.GetMultiplicity();

--- a/STEER/AOD/AliAODEvent.h
+++ b/STEER/AOD/AliAODEvent.h
@@ -109,6 +109,7 @@ class AliAODEvent : public AliVEvent {
   UInt_t GetDAQAttributes() const            {return fHeader ? fHeader->GetDAQAttributes() : 0;}
   Bool_t IsIncompleteDAQ();
 
+  virtual Bool_t IsDetectorOn(ULong_t detMask) const { return fHeader ? fHeader->IsDetectorOn(UInt_t(detMask)) : kTRUE; }
 
   // setters and getters for header information
   void     SetRunNumber(Int_t n) {if (fHeader) fHeader->SetRunNumber(n);}

--- a/STEER/AOD/AliAODHeader.cxx
+++ b/STEER/AOD/AliAODHeader.cxx
@@ -57,6 +57,7 @@ AliAODHeader::AliAODHeader() :
   fNDimuons(0),
   fNGlobalMuons(0),               // AU
   fNGlobalDimuons(0),             // AU
+  fDetectorStatus(0xFFFFFFFF),
   fDAQAttributes(0),
   fEventType(0),
   fOrbitNumber(0),
@@ -130,6 +131,7 @@ AliAODHeader::AliAODHeader(Int_t nRun,
   fNDimuons(0),
   fNGlobalMuons(0),               // AU
   fNGlobalDimuons(0),             // AU
+  fDetectorStatus(0xFFFFFFFF),
   fDAQAttributes(0),
   fEventType(0),
   fOrbitNumber(nOrbit),
@@ -228,6 +230,7 @@ AliAODHeader::AliAODHeader(Int_t nRun,
   fNDimuons(nDimuons),
   fNGlobalMuons(nGlobalMuons),               // AU
   fNGlobalDimuons(nGlobalDimuons),           // AU
+  fDetectorStatus(0xFFFFFFFF),
   fDAQAttributes(daqAttrib),
   fEventType(evttype),
   fOrbitNumber(nOrbit),
@@ -306,6 +309,8 @@ AliAODHeader::AliAODHeader(const AliAODHeader& hdr) :
   fNDimuons(hdr.fNDimuons),
   fNGlobalMuons(hdr.fNGlobalMuons),           // AU
   fNGlobalDimuons(hdr.fNGlobalDimuons),       // AU
+  fDetectorStatus(hdr.fDetectorStatus),
+  fDAQAttributes(hdr.fDAQAttributes),
   fEventType(hdr.fEventType),
   fOrbitNumber(hdr.fOrbitNumber),
   fPeriodNumber(hdr.fPeriodNumber),
@@ -401,6 +406,7 @@ AliAODHeader& AliAODHeader::operator=(const AliAODHeader& hdr)
     fNDimuons         = hdr.fNDimuons;
     fNGlobalMuons     = hdr.fNGlobalMuons;           // AU
     fNGlobalDimuons   = hdr.fNGlobalDimuons;         // AU
+    fDetectorStatus   = hdr.fDetectorStatus;
     fDAQAttributes    = hdr.fDAQAttributes;
     fDiamondZ         = hdr.fDiamondZ;
     fDiamondSig2Z     = hdr.fDiamondSig2Z;
@@ -559,6 +565,7 @@ void AliAODHeader::Print(Option_t* /*option*/) const
   printf("ref. Mult.Comb |eta|<1. : %d\n", fRefMultComb10);
   printf("number of muons         : %d\n", fNMuons);
   printf("number of dimuons       : %d\n", fNDimuons);
+  printf("DetectorStatus          : %u\n", fDetectorStatus);
   printf("offline trigger         : %u\n", fOfflineTrigger);
 
   if (fQTheta) {

--- a/STEER/AOD/AliAODHeader.h
+++ b/STEER/AOD/AliAODHeader.h
@@ -107,6 +107,13 @@ class AliAODHeader : public AliVAODHeader {
   Int_t     GetRefMultiplicityComb08() const { return fRefMultComb08; }
   Int_t     GetRefMultiplicityComb10() const { return fRefMultComb10; }
 
+  void SetDetectorStatusMask(UInt_t detStatus) { fDetectorStatus=detStatus;          }
+  void SetDetectorStatus(UInt_t detMask)       { fDetectorStatus|=detMask;           }
+  void ResetDetectorStatus(UInt_t detMask)     { fDetectorStatus&=~detMask;          }
+  UInt_t GetDetectorStatus() const             { return fDetectorStatus;             }
+  Bool_t IsDetectorOn(ULong_t detMask) const    { return (fDetectorStatus&detMask)>0; }
+
+
   UInt_t    GetDAQAttributes()         const {return fDAQAttributes;}
   void      SetDAQAttributes(UInt_t v)       {fDAQAttributes = v;}
 
@@ -253,6 +260,7 @@ class AliAODHeader : public AliVAODHeader {
   Int_t       fNDimuons;            // number of dimuons in the forward spectrometer
   Int_t       fNGlobalMuons;        // number of muons in the forward spectrometer + MFT       // AU
   Int_t       fNGlobalDimuons;      // number of dimuons in the forward spectrometer + MFT     // AU
+  UInt_t      fDetectorStatus;      // set detector event status bit for good event selection
   UInt_t      fDAQAttributes;       // DAQ attibutes
   UInt_t      fEventType;           // Type of Event
   UInt_t      fOrbitNumber;         // Orbit Number
@@ -286,7 +294,7 @@ class AliAODHeader : public AliVAODHeader {
   Float_t     fT0spread[kT0SpreadSize]; // spread of time distributions: (TOA+T0C/2), T0A, T0C, (T0A-T0C)/2
   TBits   fIRInt2InteractionsMap;  // map of the Int2 events (normally 0TVX) near the event, that's Int2Id-EventId in a -90 to 90 window
   TBits   fIRInt1InteractionsMap;  // map of the Int1 events (normally V0A&V0C) near the event, that's Int1Id-EventId in a -90 to 90 window
-  ClassDef(AliAODHeader, 30);
+  ClassDef(AliAODHeader, 31);
 };
 inline
 void AliAODHeader::SetCentrality(const AliCentrality* cent)      { 

--- a/STEER/AOD/AliNanoAODHeader.h
+++ b/STEER/AOD/AliNanoAODHeader.h
@@ -128,6 +128,9 @@ public:
 
   Int_t GetVarIndex(TString varName); 
   
+  // assume event filtering is done before and that nano AOD don't need the detector staus bits
+  virtual Bool_t IsDetectorOn(ULong_t /*detMask*/) const { return kTRUE; }
+
   ClassDef(AliNanoAODHeader, 4)
 private:
   void NotImplemented() const;

--- a/STEER/STEERBase/AliVAODHeader.h
+++ b/STEER/STEERBase/AliVAODHeader.h
@@ -89,6 +89,9 @@ class AliVAODHeader : public AliVHeader {
   virtual UInt_t  GetDAQAttributes()             const;
   virtual void    SetDAQAttributes(UInt_t);
 
+  virtual Bool_t IsDetectorOn(ULong_t detMask) const = 0;
+
+
 
 };
 

--- a/STEER/STEERBase/AliVEvent.h
+++ b/STEER/STEERBase/AliVEvent.h
@@ -256,6 +256,7 @@ public:
   // event status
   virtual Bool_t IsIncompleteDAQ() {return kFALSE;}
 
+  virtual Bool_t IsDetectorOn(ULong_t /*detMask*/) const { return kTRUE; }
 
   virtual void ConnectTracks() {}
   virtual EDataLayoutType GetDataLayoutType() const = 0;


### PR DESCRIPTION
In order to filter for HV dip events in the TPC, the Detector status
flags need to be propagated to AODs.
This also unifies the treatment of the detector flag testing between the
different event types. A virtual function was added in AliVEvnet which
retruns 'true' by default in the detector on check. It is then
overridden by the ESD and AOD implementation