### PR TITLE
ATO-83, ATO-46  - AliExternalInfo modifications (MC/Anchor guess)+ more examples

### DIFF
--- a/STAT/Macros/aliExternalInfo.C
+++ b/STAT/Macros/aliExternalInfo.C
@@ -18,7 +18,10 @@
 /// ## Example usage
 /// ###   Load library and define some example variables
 /*!
-    .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C
+     AliDrawStyle::SetDefaults();
+     AliDrawStyle::ApplyStyle("figTemplate");
+
+    .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C+
     // define some example selection and copy past the code below
     TString  period="LHC15o", pass="pass1", runSelection="QA.TPC.meanTPCncl>0", varSelection="run:runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:QA.TPC.meanMIP";
     TString source="Logbook;QA.TPC;QA.TRD;QA.ITS;MonALISA.RCT;QA.EVS";
@@ -46,7 +49,7 @@ TLatex latex;
 /*!
  * ### Example usage:
 \code
-    .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C
+    .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C+
     drawLogbook("LHC15o","pass1","QA.TPC.meanTPCncl>0","runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:MonALISA.RCT.tpc_value");
     drawLogbook("LHC10h","pass2","totalEventsPhysics>1000&&totalNumberOfFilesMigrated>20","runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:MonALISA.RCT.tpc_value");
     drawLogbook("LHC11h","pass2","totalEventsPhysics>1000&&totalNumberOfFilesMigrated>20","runDuration:totalEventsPhysics:totalNumberOfFilesMigrated:MonALISA.RCT.tpc_value");
@@ -92,7 +95,7 @@ void drawLogbook(TString period, TString pass,TString runSelection="", TString v
 /*!
  * ## Example usage:
  \code
-   .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C
+   .L $AliRoot_SRC/STAT/Macros/aliExternalInfo.C+
   drawLogbookMultiExpr("LHC15o","pass1", "totalNumberOfFilesMigrated>2000", "runDuration;totalEventsPhysics/1000;totalNumberOfFilesMigrated:run");
   drawLogbookMultiExpr("LHC15o","pass1", "totalNumberOfFilesMigrated>2000&&QA.TPC.meanMIP>40", "runDuration;totalEventsPhysics/1000;totalNumberOfFilesMigrated:run");
 \endcode
@@ -174,6 +177,8 @@ void CacheTestMCProductions(TString dataType, const char *fileList=NULL){
     delete tree;
   }
   for (Int_t iPeriod=0; iPeriod<periodList->GetEntriesFast(); iPeriod++){
+    TObjString * pName= (TObjString*)periodList->At(iPeriod);
+    if (pName==NULL) continue;
     TTree* tree = info.GetTree(dataType.Data(),periodList->At(iPeriod)->GetName(),"passMC");
     if (tree){
       Int_t entries=tree->Draw("run","1","goff");
@@ -220,6 +225,8 @@ void CacheTrendingProductions(TString dataType){
   delete tree;
   //
   for (Int_t iPeriod=0; iPeriod<periodList->GetEntriesFast(); iPeriod++) {
+    TObjString * pName= (TObjString*)idList->At(iPeriod);
+    if (pName==NULL) continue;
     TTree* treeP = info.GetTreeProdCycleByID(idList->At(iPeriod)->GetName());
     if (treeP==NULL) continue;
     TLeaf *leafOutput = treeP->GetLeaf("outputdir");
@@ -268,5 +275,8 @@ void CheckProductions(){
   treeRaw->SetAlias("isTRD","type==\"QA.TRD\"");
   // black list for production
   treeRaw->SetAlias("isBlack","strstr(pass,\"clean\")!=0||strstr(pass,\"rec\")!=0||strstr(pass,\"its\")!=0||strstr(pass,\"cpass\")!=0||strstr(pass,\"vpass\")!=0||strstr(pass,\"muon\")!=0||strstr(pass,\"cosmic\")!=0||strstr(pass,\"align\")!=0||strstr(pass,\"FAST\")!=0||strstr(pass,\"scan\")!=0||strstr(pass,\"test\")!=0");
+
+  /// export production in json format
+  AliTreePlayer::selectWhatWhereOrderBy(treeRaw,"period:pass:type:nRuns:nRunsProd:runList","nRuns>0","",0,1000,"json","rawProduction.json");
 
 }

--- a/STAT/Macros/aliExternalInfo.sh
+++ b/STAT/Macros/aliExternalInfo.sh
@@ -7,8 +7,8 @@
 #    mcPeriodQATrending.root    - MC detectorQA+production per period
 #    realDataRunTrending.root   - Real data QA+production per run
 #    realDataPeriodTrending.root- Real data QA+production per period
-# ( source $AliRoot_SRC/STAT/Macros/aliExternalInfo.sh; cacheMCInfo; cacheRealDataInfo )
-
+# ( source $AliRoot_SRC/STAT/Macros/aliExternalInfo.sh; cacheMCInfo;  )
+#  ( source $AliRoot_SRC/STAT/Macros/aliExternalInfo.sh; cacheRealDataInfo )
 # cache MC trending trees and create summary trees with run statistic
 cacheMCInfo(){
     aliroot -n -b -l <<\EOF 2>&1 | tee cacheMC.log


### PR DESCRIPTION
###  ATO-83 - AliExternalInfo - modification of local caching 
* STAT/Macros/aliExternalInfo.C, STAT/Macros/aliExternalInfo.sh
* Use compiled macro instead of normal in extended interface example
* protection against empty data
  * agregated  information to be automatically posted on the web page http://aliqamodafs.web.cern.ch/aliqamodafs

````
QA.MCRun.location http://aliqamodafs.web.cern.ch/aliqamodafs
QA.MCPeriod.location http://aliqamodafs.web.cern.ch/aliqamodafs
QA.Run.location http://aliqamodafs.web.cern.ch/aliqamodafs
QA.Period.location http://aliqamodafs.web.cern.ch/aliqamodafs
````
     * TODO - run cronjob at afs

### ATO-83 - AliExternalInfo -speed-up and protections ￼…
* protection against NULL file pointer TFile:Open
* disable loading of metadata in case of "production caching"
* use Info only in case of verbose mode
* Speed up - minimizing calls for the fLogCache->GetEntry
  * before call was done in inner looop of double loop
* Bug fixes:
  * close the files in production loops
    * before memory leak and error too many files open
  * initialize all variables to 0 before SetBranch
    * random error before
