### PR TITLE
ATO-83, ATO-373 - proper JSON format in the TTree->JSON export

### DIFF
--- a/STAT/AliTreePlayer.cxx
+++ b/STAT/AliTreePlayer.cxx
@@ -698,6 +698,9 @@ Int_t  AliTreePlayer::selectWhatWhereOrderBy(TTree * tree, TString what, TString
       }
     }
   }
+  if (isJSON&&!isElastic){
+    fprintf(default_fp,"{\n\t \"tree\": [\n "); // add metadata info
+  }
 
   Int_t selected=0;
   for (Int_t ientry=firstentry; ientry<firstentry+nentries; ientry++){
@@ -732,7 +735,7 @@ Int_t  AliTreePlayer::selectWhatWhereOrderBy(TTree * tree, TString what, TString
         if (isElastic){
           fprintf(default_fp,"{\"index\":{\"_id\": \"");
         }else{
-          fprintf(default_fp,"{{\n");
+          fprintf(default_fp,"{\n");
         }
       }
       for (Int_t icol=0; icol<nCols; icol++){
@@ -750,13 +753,15 @@ Int_t  AliTreePlayer::selectWhatWhereOrderBy(TTree * tree, TString what, TString
         }
         if (rFormulaList[icol]->GetTree()==NULL) continue;
         Int_t nData=rFormulaList[icol]->GetNdata();
-        if (isElastic==kFALSE){
+        if (isJSON==kFALSE){
           fprintf(default_fp,"\t\"%s\":",rFormulaList[icol]->GetName());
         }else{
           if (isIndex[icol]==kFALSE && isParent[icol]==kFALSE){
             TString fieldName(rFormulaList[icol]->GetName());
-            if (isClass[icol]) fieldName.Remove(fieldName.Length()-1);
-            fieldName.ReplaceAll(".","%_");
+            if (isElastic) {
+              if (isClass[icol]) fieldName.Remove(fieldName.Length() - 1);
+              fieldName.ReplaceAll(".", "%_");
+            }
             if (icol>0 && isIndex[icol-1]==kFALSE && isParent[icol-1]==kFALSE ){
               fprintf(default_fp,"\t,\"%s\":",fieldName.Data());
             }else{
@@ -769,7 +774,7 @@ Int_t  AliTreePlayer::selectWhatWhereOrderBy(TTree * tree, TString what, TString
             if (isClass[icol]!=NULL){
               fprintf(default_fp,"%s",obuffer.Data());
             }else {
-              if (isElastic && rFormulaList[icol]->IsString()) {
+              if ( (isElastic || isJSON)  && rFormulaList[icol]->IsString()) {
                 fprintf(default_fp, "\t\"%s\"",
                         rFormulaList[icol]->PrintValue(0, 0, printFormatList[icol]->GetName()));
               } else {
@@ -848,7 +853,7 @@ Int_t  AliTreePlayer::selectWhatWhereOrderBy(TTree * tree, TString what, TString
       fprintf(default_fp,"\n");
     }
   }
-  if (isJSON) fprintf(default_fp,"}\n");
+  if (isJSON) fprintf(default_fp,"}\t]\n}\n");
   if (isHTML){
     fprintf(default_fp,"\t</tbody>"); // add metadata info
     fprintf(default_fp,"</table>"); // add metadata info

--- a/STAT/Macros/aliExternalInfo.C
+++ b/STAT/Macros/aliExternalInfo.C
@@ -266,6 +266,16 @@ void CacheTrendingProductions(TString dataType){
   }
 }
 
+/// Cache MC production information
+/// TODO - reset cache timeout before
+void CacheMCProductionInfo(){
+  AliExternalInfo info;
+  tree = info.GetTreeMCPassGuess();
+  delete tree;
+}
+
+
+/// This is example function
 void CheckProductions(){
   AliExternalInfo info;
   //to add there production yer
@@ -275,8 +285,20 @@ void CheckProductions(){
   treeRaw->SetAlias("isTRD","type==\"QA.TRD\"");
   // black list for production
   treeRaw->SetAlias("isBlack","strstr(pass,\"clean\")!=0||strstr(pass,\"rec\")!=0||strstr(pass,\"its\")!=0||strstr(pass,\"cpass\")!=0||strstr(pass,\"vpass\")!=0||strstr(pass,\"muon\")!=0||strstr(pass,\"cosmic\")!=0||strstr(pass,\"align\")!=0||strstr(pass,\"FAST\")!=0||strstr(pass,\"scan\")!=0||strstr(pass,\"test\")!=0");
-
   /// export production in json format
   AliTreePlayer::selectWhatWhereOrderBy(treeRaw,"period:pass:type:nRuns:nRunsProd:runList","nRuns>0","",0,1000,"json","rawProduction.json");
+}
+
+/// Export MC Anchor Guess + derived information in JSON format
+/// To be used for the web browsing
+void ExportMCAnchorJSON(){
+  AliExternalInfo info;
+  tree = info.GetTreeMCPassGuess();
+  TString toExport="";
+  toExport+="MCProdName.fString:MCAliphysics.fString:MCAliroot.fString";
+  toExport+="AnchorProdTag.fString:AnchorPassName.fString:Anchoraliroot.fString:Anchoraliphys.fString:";
+  toExport+="rankGuess:runNMatches:runNMC:runNAnchor";
+  AliTreePlayer::selectWhatWhereOrderBy(tree,toExport,"","",0,1000,"json","MCAnchor.json");
 
 }
+


### PR DESCRIPTION
##  Function AliTreePlayer::selectWhatWhereOrderBy fixed for JSON export
* Fixed proper JSON format
  * previous version working only for elastic json format  

### Example usage in aliExternalInfo.C::ExportMCAnchorJSON()
* Code to export summary MCAnchor json file using selected (toExport)  information form the tree:
````
TString toExport="";
  toExport+="MCProdName.fString:MCAliphysics.fString:MCAliroot.fString";
  toExport+="AnchorProdTag.fString:AnchorPassName.fString:Anchoraliroot.fString:Anchoraliphys.fString:";
  toExport+="rankGuess:runNMatches:runNMC:runNAnchor";
  AliTreePlayer::selectWhatWhereOrderBy(tree,toExport,"","",0,1000,"json","MCAnchor.json");
````
### Example Output (first 2 elements as selected  by jq query)
* jq query
````
  cat  MCAnchor.json |  jq .tree[0,1]
`````
* output
`````
{
  "MCProdName.fString": "LHC18b9b2",
  "MCAliphysics.fString": "v5-08-13zj-01-cookdedx-1",
  "MCAliroot.fStringAnchorProdTag.fString": "v5-08-13zj-cookdedx-1",
  "AnchorPassName.fString": "pass1_CENT_wSDD",
  "Anchoraliroot.fString": "v5-08-13w-cookdedx-1",
  "Anchoraliphys.fString": "v5-08-13w-01-cookdedx-1",
  "rankGuess": 1,
  "runNMatches": 1,
  "runNMC": 1,
  "runNAnchor": 72
}
{
  "MCProdName.fString": "LHC18b9b2",
  "MCAliphysics.fString": "v5-08-13zj-01-cookdedx-1",
  "MCAliroot.fStringAnchorProdTag.fString": "v5-08-13zj-cookdedx-1",
  "AnchorPassName.fString": "pass1_CENT_woSDD",
  "Anchoraliroot.fString": "v5-08-13w-cookdedx-1",
  "Anchoraliphys.fString": "v5-08-13w-01-cookdedx-1",
  "rankGuess": 2,
  "runNMatches": 1,
  "runNMC": 1,
  "runNAnchor": 72
}
````