### PR TITLE
Fix trivial bug introduced in #683

### DIFF
--- a/ITSMFT/ITS/ITSUpgradeRec/AliITSUTrackerGlo.cxx
+++ b/ITSMFT/ITS/ITSUpgradeRec/AliITSUTrackerGlo.cxx
@@ -433,10 +433,11 @@ Int_t AliITSUTrackerGlo::LoadClusters(TTree * treeRP)
 {
   // read from tree (if pointer provided) or directly from the ITS reco interface
   //
-  return fReconstructor->LoadClusters(treeRP);
-  //
+  int ncl = fReconstructor->LoadClusters(treeRP);
   fITS->SortClusters(AliITSUClusterPix::SortModeIdTrkYZ());
   fITS->ProcessClusters();
+  return ncl;
+  //
 } 
 
 //_________________________________________________________________________


### PR DESCRIPTION
Hi @shahor02,

I introduced a trivial bug with the previous PR, in principle now the cluster sorting will be performed once for both CA and Global Tracker (as it was intended to be in the first PR, but the return was before the sorting of the clusters).

Can you please check if this works for you?
Cheers,
Max