### PR TITLE
Set new AliVTrack::kTRDupdate in AliESDtrack::fFlags if TRD was used …

### DIFF
--- a/HLT/global/AliFlatESDTrack.h
+++ b/HLT/global/AliFlatESDTrack.h
@@ -165,7 +165,7 @@ class AliFlatESDTrack :public AliVTrack {
   // ---------------------------------------------------------------------------------
   // AliVParticle interface
   ULong_t  GetStatus() const ;
-  Bool_t IsOn(Int_t mask) const;
+  Bool_t IsOn(ULong_t mask) const;
   virtual Double_t Pt() const {const AliFlatExternalTrackParam* p=GetFlatTrackParam(); return (p)?p->GetPt():kVeryBig;}
   virtual Double_t GetTgl()  const {const AliFlatExternalTrackParam* p=GetFlatTrackParam(); return (p)?p->GetTgl():kVeryBig;}
   using AliVTrack::GetImpactParameters;
@@ -312,7 +312,7 @@ inline ULong_t  AliFlatESDTrack::GetStatus() const {
   return x;
 }
 
-inline Bool_t AliFlatESDTrack::IsOn(Int_t mask) const {
+inline Bool_t AliFlatESDTrack::IsOn(ULong_t mask) const {
   return (GetStatus()&mask)>0;
 }
 

--- a/STEER/AOD/AliAODTrack.h
+++ b/STEER/AOD/AliAODTrack.h
@@ -189,7 +189,7 @@ class AliAODTrack : public AliVTrack {
     else {delete[] fPID; fPID = 0;}
   }
   
-  Bool_t IsOn(Int_t mask) const {return (fFlags&mask)>0;}
+  Bool_t IsOn(ULong_t mask) const {return (fFlags&mask)>0;}
   ULong_t GetStatus() const { return GetFlags(); }
   ULong_t GetFlags() const { return fFlags; }
 

--- a/STEER/ESD/AliESDtrack.h
+++ b/STEER/ESD/AliESDtrack.h
@@ -78,7 +78,7 @@ public:
   void GetESDpid(Double_t *p) const;
   virtual const Double_t *PID() const { return fR; }
 
-  Bool_t IsOn(Int_t mask) const {return (fFlags&mask)>0;}
+  Bool_t IsOn(ULong_t mask) const {return (fFlags&mask)>0;}
   ULong_t GetStatus() const {return fFlags;}
   Int_t GetLabel() const {return fLabel;}
   void SetLabel(Int_t label) {fLabel = label;}

--- a/STEER/STEERBase/AliVTrack.cxx
+++ b/STEER/STEERBase/AliVTrack.cxx
@@ -26,6 +26,8 @@
 
 ClassImp(AliVTrack)
 
+const ULong64_t AliVTrack::kTRDupdate = 0x100000000; // Flag TRD updating the ESD kinematics
+
 AliVTrack::AliVTrack(const AliVTrack& vTrack) :
   AliVParticle(vTrack) { } // Copy constructor
 

--- a/STEER/STEERBase/AliVTrack.h
+++ b/STEER/STEERBase/AliVTrack.h
@@ -27,7 +27,7 @@ class AliTOFHeader;
 class AliVTrack: public AliVParticle {
 
 public:
-  enum {
+  enum  {
     kITSin        = 0x1
     ,kITSout      = 0x2
     ,kITSrefit    = 0x4
@@ -64,6 +64,9 @@ public:
     ,kESDpid      = 0x40000000
     ,kTIME        = 0x80000000
   };
+  // since with enum we cannot go above 32 bits, we have to define static constants here
+  static const ULong64_t kTRDupdate; // Flag TRD updating the ESD kinematics
+  
   enum {
     kTRDnPlanes = 6,
     kEMCALNoMatch = -4096,
@@ -231,7 +234,7 @@ public:
 
   virtual Int_t             GetKinkIndex(Int_t /*i*/) const { return 0;}
   virtual Double_t          GetSigned1Pt()         const { return 0;}
-  virtual Bool_t            IsOn(Int_t /*mask*/) const {return 0;}
+  virtual Bool_t            IsOn(ULong_t /*mask*/) const {return 0;}
   virtual Double_t          GetX()    const {return 0;}
   virtual Double_t          GetY()    const {return 0;}
   virtual Double_t          GetZ()    const {return 0;}

--- a/TPC/TPCrec/AliTPCtrack.h
+++ b/TPC/TPCrec/AliTPCtrack.h
@@ -88,6 +88,7 @@ public:
   Int_t GetRemoval() const {return fRemoval;}
   Int_t GetLab2() const {return fLab2;}
   Bool_t GetBConstrain() const {return fBConstrain;}
+  Bool_t GetTRDUpdate() const {return fTRDUpdate;}
   Int_t GetNShared() const {return fNShared;}
   Int_t GetNFoundable() const {return fNFoundable;}
   //
@@ -103,6 +104,7 @@ protected:
   //
   Int_t   fNFoundable;      //number of foundable clusters - dead zone taken to the account
   Bool_t  fBConstrain;   // indicate seeding with vertex constrain
+  Bool_t  fTRDUpdate;    // indicate that the TRD was used in the fit
   Int_t   fLastPoint;     // last  cluster position     
   Int_t   fFirstPoint;    // first cluster position
   Int_t fRemoval;         // removal factor
@@ -114,7 +116,7 @@ protected:
   Int_t    fKinkIndexes[3];     // kink indexes - minus = mother + daughter
   Int_t    fV0Indexes[3];     // kink indexes - minus = mother + daughter
   static double fgMatLarge[16]; // large initial cov. matrix (0-14) + optional additive term for p[4] error
-  ClassDef(AliTPCtrack,5)   // Time Projection Chamber reconstructed tracks
+  ClassDef(AliTPCtrack,6)   // Time Projection Chamber reconstructed tracks
 };
 
 #endif

--- a/TPC/TPCrec/AliTPCtracker.cxx
+++ b/TPC/TPCrec/AliTPCtracker.cxx
@@ -3907,7 +3907,9 @@ Int_t AliTPCtracker::RefitInward(AliESDEvent *event)
     AliTPCseed * seed = (AliTPCseed*) fSeeds->UncheckedAt(i);
     if (!seed) continue;
     if (seed->GetKinkIndex(0)>0)  UpdateKinkQualityD(seed);  // update quality informations for kinks
-    AliESDtrack *esd=event->GetTrack(i);
+    AliESDtrack *esd = seed->GetESD();
+    if (!esd) esd = event->GetTrack(i); // just in case the esd track pointer was not set in the seed
+    if (seed->GetTRDUpdate()) esd->SetStatus(AliESDtrack::kTRDupdate);
     //
     //RS: if needed, attach temporary cluster array
     const AliTPCclusterMI** seedClustersSave = seed->GetClusters();


### PR DESCRIPTION
…in update

Note: we already had 32 flags, the enum in the AliVTrack could not accomodate more.
Therefor the kTRDupdate is defined as bit 33. 