### PR TITLE
New correct fix for memory leaks in AliTPCDigitizer

### DIFF
--- a/TPC/TPCsim/AliTPCDigitizer.cxx
+++ b/TPC/TPCsim/AliTPCDigitizer.cxx
@@ -799,9 +799,7 @@ void AliTPCDigitizer::DigitizeWithTailAndCrossTalk(Option_t* option)
     for (Int_t ires = 0;ires<20;ires++) timeResArr->AddAt(graphRes[ires],ires);
     timeResFunc.AddAt(timeResArr,isec); // Fill all trfs into a single TObjArray 
     nIonTailBins = graphRes[3]->GetN();
-    delete [] graphRes;
     delete trfIndexArr;
-    delete timeResArr;
   }
 
   //
@@ -1178,6 +1176,13 @@ void AliTPCDigitizer::DigitizeWithTailAndCrossTalk(Option_t* option)
   delete []active;
   delete []digarr;
   for (Int_t sector=0; sector<nROCs; sector++){
+    TObjArray *timeResArr = (TObjArray*)timeResFunc.At(sector);
+    for (Int_t ires = 0;ires<20;ires++) {
+      TGraphErrors  *graphRes = (TGraphErrors*)timeResArr->At(ires);
+      delete graphRes;
+    }
+//    delete timeResArr;
+
     TMatrixD *crossTalkSignal = (TMatrixD*)crossTalkSignalArray.At(sector);
     delete crossTalkSignal;
   }


### PR DESCRIPTION
Previous fix (#711) was not correct, since it failed when simulating common mode corrections. This better fix should solve the memory leaks without introducing any flaw.
Essentially, all 'delete' were moved to the end of the method (the TOBjArray itself is not explicitly deleted since doing so causes a crash). Valgrind tests prove the absence of memory leaks.