### PR TITLE
PWGPP-429- Extend functionality to calculate numerical derivative of V0

### DIFF
--- a/STAT/Macros/AliExternalInfo.cfg
+++ b/STAT/Macros/AliExternalInfo.cfg
@@ -100,7 +100,7 @@ Logbook.timeout 86400
 Logbook.filename logbook.root
 Logbook.treename logbook
 Logbook.nopass   true
-Logbook.metadataMacro $ALICE_ROOT/STAT/Macros/logbookAddMetadata.C
+Logbook.metadataMacro $ALICE_ROOT/STAT/Macros/logbookAddMetadata.C+
 
 Logbook.detector.location http://aliqamod.web.cern.ch
 Logbook.detector.timeout 86400

--- a/STAT/Macros/AliNDFunctionInterface.cxx
+++ b/STAT/Macros/AliNDFunctionInterface.cxx
@@ -160,7 +160,7 @@ Int_t  AliNDFunctionInterface::FitMVA(TTree *tree, const char *varFit, TCut cut,
   loader.AddTarget(varFit);
   /// 3.) Setup DataSet
   loader.AddRegressionTree(tree, 1.0);   // link the TTree to the loader, weight for each event  = 1
-  Int_t entries = tree->Draw("1","cut","goff");
+  Int_t entries = tree->Draw("1",cut,"goff");
   loader.PrepareTrainingAndTestTree(cut, TString::Format("nTrain_Regression=%d:nTest_Regression=%d:SplitMode=Random:NormMode=NumEvents:!V",entries/2,entries/2));
   /// 4.) Book regression methods from the methods list
   TObjArray *methodList = TString(methods).Tokenize(":");

--- a/STAT/Macros/logbookAddMetadata.C
+++ b/STAT/Macros/logbookAddMetadata.C
@@ -1,21 +1,34 @@
 /*
-  Append logbook metadata decribing tree structure,  and annotating varaibles
+  Append logbook metadata describing tree structure,  and annotating variables
   
   Usage:
-     1.) Metadata can be setup infoking macro:
+     1.) Metadata can be setup invoking macro:
          AliExternalInfo info;
          TTree * tree = info.GetTree("Logbook","LHC15o","cpass1_pass1","QA.TRD;QA.TOF;QA.TPC;Logbook.detector");     
          //
          metadataMacro="$ALICE_ROOT/STAT/Macros/logbookAddMetadata.C";
          gROOT->ProcessLine(TString::Format(".x %s((TTree*)%p,0);",metadataMacro,tree).Data());
-     2.) Macro can be executed automatically if proper configuation file leaded AliExternalInfo.cfg
-     
-
+         tree->GetUserInfo()->ls()
+         // Example print class metadata
+         AliTreePlayer::selectMetadata(tree, "[class==\"\"]",0)->Print();
+         // Example print axis description metadata
+         AliTreePlayer::selectMetadata(tree, "[Axis==\"\"]",0)->Print();
+     2.) Macro can be executed automatically if configuration file loaded in AliExternalInfo.cfg
+         (see line in default AliRoot_SRC/STAT/Macros/AliExternalInfo.cfg)
+         Logbook.metadataMacro $ALICE_ROOT/STAT/Macros/logbookAddMetadata.C+
 */
+
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include "TTree.h"
+#include "TPRegexp.h"
+#include "TList.h"
+#include "AliTreePlayer.h"
+#include "TStatToolkit.h"
+#endif
 
 void logbookAddMetadata(TTree*tree, Int_t verbose=0){
   //
-  // Set metadata infomation 
+  // Set metadata information
   //
   if (tree==NULL) {
     ::Error("logbookAddMetadata","Start processing. Emtpy tree");
@@ -92,7 +105,7 @@ void logbookAddMetadata(TTree*tree, Int_t verbose=0){
     mlist->Print();
   }
   if (verbose==2){
-    // AliTreeToolkit::printMetadata(treeLogbook, "[class]",0);  // not yet comitted
+     AliTreePlayer::selectMetadata(tree, "[class==\"\"]",0)->Print();
   }
   ::Info("logbookAddMetadata","End");
 

--- a/STEER/ESD/AliESDv0.h
+++ b/STEER/ESD/AliESDv0.h
@@ -143,7 +143,7 @@ public:
   //virtual Bool_t   GetPxPyPz(Double_t */*p*/) const { return kFALSE; }
   virtual void     SetID(Short_t /*id*/) {;}
   Double_t GetKFInfo(UInt_t p1, UInt_t p2, Int_t type) const;
-  Double_t GetKFInfoScale(UInt_t p1, UInt_t p2, Int_t type, Double_t d1pt, Double_t s1pt) const;
+  Double_t GetKFInfoScale(UInt_t p1, UInt_t p2, Int_t type, Double_t d1pt, Double_t s1pt, Double_t eLoss=0, Int_t flag=0x3) const;
   //
   void SetUsedByCascade(Bool_t v) {SetBit(kUsedByCascadeBit,v);}
   Bool_t GetUsedByCascade() const {return TestBit(kUsedByCascadeBit);}


### PR DESCRIPTION
### PWGPP-429 - Extend functionality to calculate numerical derivative of V0￼…
* Code of general interest - (PWGPP_429)  used to benchmark data with/without TRD
* delta of qpt shift, scaling, eloss (NEW)
*  delta of energy loss correction
  * AliExternalTrackParam::BetheBlochGeant()
  * Unit - fraction of energy loss - MIP normalized to 1
* possibility to specify separately delta for particle 1 and particle 2
  * enabling position dependent fits

### ATO-445- FitMVA proper cut in entries estimator
* Bug fix

### ATO-46 - make logbookAddMetadata.C compiled 
* fix for ROOT6 tutorials
* ROOT5 working well also with non compiled version