### PR TITLE
TimeStamp precise up to the BC

### DIFF
--- a/STEER/ESD/AliESDEvent.cxx
+++ b/STEER/ESD/AliESDEvent.cxx
@@ -2662,12 +2662,12 @@ UInt_t AliESDEvent::GetTimeStampCTP() const
 }
 
 //______________________________________________________________________________
-UInt_t AliESDEvent::GetTimeStampCTPBCCorr() const
+Double_t AliESDEvent::GetTimeStampCTPBCCorr() const
 {
   // calculate/return CTP time stamp in the approximation of BC=25ns
   const AliTimeStamp* ctp0 = GetCTPStart();
   const double kBCLHC = 1./40.079;
-  UInt_t tCTP = 0;
+  double tCTP = 0;
   if ( !(tCTP=ctp0->GetSeconds()) ) return GetTimeStamp(); // N/A
   Long64_t span= Long64_t(GetOrbitNumber())-Long64_t(ctp0->GetOrbit());
   // sometimes the ctp0 points to time after the triggers start
@@ -2677,7 +2677,9 @@ UInt_t AliESDEvent::GetTimeStampCTPBCCorr() const
   }
   // subtract from current orbit the orbit at CTP SOR
   span += Long64_t(GetPeriodNumber()<<24);
-  tCTP += (span*3564*kBCLHC+ctp0->GetMicroSecs())/1000000;
+  span *= 3564;
+  span += int(GetBunchCrossNumber())-int(ctp0->GetBunchCross()%3564);
+  tCTP += (span*kBCLHC+ctp0->GetMicroSecs())/1000000;
   return tCTP;
 }
 
@@ -2690,22 +2692,28 @@ AliTimeStamp AliESDEvent::GetAliTimeStamp() const
   UInt_t sec = ctp0->GetSeconds();
   UInt_t msec = ctp0->GetMicroSecs();
   Long64_t span= Long64_t(GetOrbitNumber())-Long64_t(ctp0->GetOrbit());
+  Bool_t fail = kFALSE;
   if ( !sec ) {
     AliWarning("CTP start not available, building from GetTimeStamp()");
     sec = GetTimeStamp();
+    fail = kTRUE;
   }
   else if (span<-10000 && GetPeriodNumber()==ctp0->GetPeriod()) {
     AliWarningF("The triggered orbit is too much ahead (%lld) of 1st scaler, fall back to GetTimeStamp",span);
     sec = GetTimeStamp();
+    fail = kTRUE;
   }
   else {
     span += Long64_t(GetPeriodNumber()<<24);
-    span *= 3564*kBCLHC;
+    span *= 3564;
+    span += int(GetBunchCrossNumber())-int(ctp0->GetBunchCross()%3564);
+    span *= kBCLHC;
     span += msec;
     sec += span/1000000;
     msec = span%1000000;
   }
   AliTimeStamp evSt(GetOrbitNumber(),GetPeriodNumber(),sec,msec);
+  evSt.SetUniqueID(fail);
   return evSt;
 }
   

--- a/STEER/ESD/AliESDEvent.h
+++ b/STEER/ESD/AliESDEvent.h
@@ -217,7 +217,7 @@ public:
   UInt_t    GetOrbitNumber() const {return fHeader?fHeader->GetOrbitNumber():0;}
   UInt_t    GetTimeStamp()  const { return fHeader?fHeader->GetTimeStamp():0;}
   UInt_t    GetTimeStampCTP() const;
-  UInt_t    GetTimeStampCTPBCCorr() const;
+  Double_t  GetTimeStampCTPBCCorr() const;
   AliTimeStamp GetAliTimeStamp() const;
   UInt_t    GetEventType()  const { return fHeader?fHeader->GetEventType():0;}
   UInt_t    GetEventSpecie()  const { return fHeader?fHeader->GetEventSpecie():0;}


### PR DESCRIPTION
The GetAliTimeStamp and GetTimeStampCTPBCCorr (changed to double) will return the time-stamp
precise up to the BC. Note that rarely the 1st CTP scaled is not in sync with the actual CTP start,
in this case the CTP time stamp may be wrong. If it cannot be calculated, the GetTimeStamp (event building time)
will be assigned and the AliTimeStamp (from GetAliTimeStamp) will have GetUniqueID() == 1 (in case of success it is 0)