### PR TITLE
All track types status getters/setters use ULong64_t

### DIFF
--- a/ANALYSIS/ANALYSISalice/AliAODITSsaTrackCuts.cxx
+++ b/ANALYSIS/ANALYSISalice/AliAODITSsaTrackCuts.cxx
@@ -56,7 +56,7 @@ Bool_t AliAODITSsaTrackCuts::AcceptTrack(const AliAODTrack* aodTrack)
 
   if ( !( aodTrack->HasPointOnITSLayer(AliESDtrackCuts::kSPD*2) || aodTrack->HasPointOnITSLayer(AliESDtrackCuts::kSPD*2+1) ) ) return kFALSE; //at least one point in the SPD
 
-  UInt_t status = aodTrack->GetStatus();
+  ULong64_t status = aodTrack->GetStatus();
   if ((status&AliESDtrack::kITSrefit)==0) return kFALSE;
 
   if ((status & AliESDtrack::kITSin) == 0 || (status & AliESDtrack::kTPCin)) return kFALSE;  else if(!(status & AliESDtrack::kITSpureSA)) return kFALSE;

--- a/ANALYSIS/ANALYSISalice/AliAODv0KineCuts.cxx
+++ b/ANALYSIS/ANALYSISalice/AliAODv0KineCuts.cxx
@@ -332,7 +332,7 @@ Bool_t  AliAODv0KineCuts::SingleTrackCuts(AliAODv0 * const v0) const
     if(!d[i]) return kFALSE;
     
     // status word
-    ULong_t status = d[i]->GetStatus();
+    ULong64_t status = d[i]->GetStatus();
 
     // No. of TPC clusters leave to the users
     if(d[i]->GetTPCNcls() < 1) return kFALSE;

--- a/ANALYSIS/ANALYSISalice/AliAnalysisTaskPIDqa.cxx
+++ b/ANALYSIS/ANALYSISalice/AliAnalysisTaskPIDqa.cxx
@@ -411,7 +411,7 @@ void AliAnalysisTaskPIDqa::FillITSqa()
   Int_t ntracks=event->GetNumberOfTracks();
   for(Int_t itrack = 0; itrack < ntracks; itrack++){
     AliVTrack *track=(AliVTrack*)event->GetTrack(itrack);
-    ULong_t status=track->GetStatus();
+    ULong64_t status=track->GetStatus();
     // not that nice. status bits not in virtual interface
     // ITS refit + ITS pid selection
     if (!( ( (status & AliVTrack::kITSrefit)==AliVTrack::kITSrefit ) ||
@@ -1039,7 +1039,7 @@ void AliAnalysisTaskPIDqa::FillTPCqa()
     //
     //basic track cuts
     //
-    ULong_t status=track->GetStatus();
+    ULong64_t status=track->GetStatus();
     // not that nice. status bits not in virtual interface
     // TPC refit + ITS refit + TPC pid
     if (!( (status & AliVTrack::kTPCrefit) == AliVTrack::kTPCrefit) ||
@@ -1097,7 +1097,7 @@ void AliAnalysisTaskPIDqa::FillTPCqa()
       //
       //basic track cuts
       //
-      ULong_t status=track->GetStatus();
+      ULong64_t status=track->GetStatus();
       // not that nice. status bits not in virtual interface
       // TPC refit + ITS refit + TPC pid
       if (!( (status & AliVTrack::kTPCrefit) == AliVTrack::kTPCrefit) ||
@@ -1130,7 +1130,7 @@ void AliAnalysisTaskPIDqa::FillTPCqa()
       //
       //basic track cuts
       //
-      ULong_t status=track->GetStatus();
+      ULong64_t status=track->GetStatus();
       // not that nice. status bits not in virtual interface
       // TPC refit + ITS refit + TPC pid
       if (!( (status & AliVTrack::kTPCrefit) == AliVTrack::kTPCrefit) ||
@@ -1164,7 +1164,7 @@ void AliAnalysisTaskPIDqa::FillTPCqa()
       //
       //basic track cuts
       //
-      ULong_t status=track->GetStatus();
+      ULong64_t status=track->GetStatus();
       // not that nice. status bits not in virtual interface
       // TPC refit + ITS refit + TPC pid
       if (!( (status & AliVTrack::kTPCrefit) == AliVTrack::kTPCrefit) ||
@@ -1197,7 +1197,7 @@ void AliAnalysisTaskPIDqa::FillTPCqa()
       //
       //basic track cuts
       //
-      ULong_t status=track->GetStatus();
+      ULong64_t status=track->GetStatus();
       // not that nice. status bits not in virtual interface
       // TPC refit + ITS refit + TPC pid
       if (!( (status & AliVTrack::kTPCrefit) == AliVTrack::kTPCrefit) ||
@@ -1240,7 +1240,7 @@ Bool_t TrackIsAccepted(AliVTrack* track)
     //
     //basic track cuts
     //
-    ULong_t status=track->GetStatus();
+    ULong64_t status=track->GetStatus();
     // not that nice. status bits not in virtual interface
     // TPC refit + ITS refit + TPC pid + TRD out
     if (!( (status & AliVTrack::kTPCrefit) == AliVTrack::kTPCrefit) ||
@@ -1892,7 +1892,7 @@ void AliAnalysisTaskPIDqa::FillTOFqa()
     //
     //basic track cuts
     //
-    ULong_t status=track->GetStatus();
+    ULong64_t status=track->GetStatus();
     // TPC refit + ITS refit +
     // TOF out + kTIME
     // kTIME
@@ -1986,7 +1986,7 @@ void AliAnalysisTaskPIDqa::FillT0qa()
     //
     //basic track cuts
     //
-    ULong_t status=track->GetStatus();
+    ULong64_t status=track->GetStatus();
     // TPC refit + ITS refit +
     if (!((status & AliVTrack::kTPCrefit) == AliVTrack::kTPCrefit) ||
         !((status & AliVTrack::kITSrefit) == AliVTrack::kITSrefit) ) continue;
@@ -2044,7 +2044,7 @@ void AliAnalysisTaskPIDqa::FillEMCALqa()
     //
     //basic track cuts
     //
-    ULong_t status=track->GetStatus();
+    ULong64_t status=track->GetStatus();
     // not that nice. status bits not in virtual interface
     if (!( (status & AliVTrack::kEMCALmatch) == AliVTrack::kEMCALmatch) ) continue;
 
@@ -2065,7 +2065,7 @@ void AliAnalysisTaskPIDqa::FillEMCALqa()
     //
     //basic track cuts
     //
-    ULong_t status=track->GetStatus();
+    ULong64_t status=track->GetStatus();
     // not that nice. status bits not in virtual interface
     if (!( (status & AliVTrack::kEMCALmatch) == AliVTrack::kEMCALmatch) ) continue;
 
@@ -2105,7 +2105,7 @@ void AliAnalysisTaskPIDqa::FillEMCALqa()
     //
     //basic track cuts
     //
-    ULong_t status=track->GetStatus();
+    ULong64_t status=track->GetStatus();
     // not that nice. status bits not in virtual interface
     if (!( (status & AliVTrack::kEMCALmatch) == AliVTrack::kEMCALmatch) ) continue;
 
@@ -2145,7 +2145,7 @@ void AliAnalysisTaskPIDqa::FillEMCALqa()
     //
     //basic track cuts
     //
-    ULong_t status=track->GetStatus();
+    ULong64_t status=track->GetStatus();
     // not that nice. status bits not in virtual interface
     if (!( (status & AliVTrack::kEMCALmatch) == AliVTrack::kEMCALmatch) ) continue;
 
@@ -2200,7 +2200,7 @@ void AliAnalysisTaskPIDqa::FillHMPIDqa()
     //
     //basic track cuts
     //
-    const ULong_t status=track->GetStatus();
+    const ULong64_t status=track->GetStatus();
     // not that nice. status bits not in virtual interface
     // TPC refit + ITS refit +
     // TOF out + TOFpid +
@@ -2251,7 +2251,7 @@ void AliAnalysisTaskPIDqa::FillTOFHMPIDqa()
     //
     //basic track cuts
     //
-    ULong_t status=track->GetStatus();
+    ULong64_t status=track->GetStatus();
     // not that nice. status bits not in virtual interface
     // TPC refit + ITS refit +
     // TOF out + TOFpid +
@@ -2308,7 +2308,7 @@ void AliAnalysisTaskPIDqa::FillTPCTOFqa()
     //
     //basic track cuts
     //
-    ULong_t status=track->GetStatus();
+    ULong64_t status=track->GetStatus();
     // not that nice. status bits not in virtual interface
     // TPC refit + ITS refit +
     // TOF out + TOFpid +

--- a/ANALYSIS/ANALYSISalice/AliESDtrackCuts.cxx
+++ b/ANALYSIS/ANALYSISalice/AliESDtrackCuts.cxx
@@ -1267,7 +1267,7 @@ Bool_t AliESDtrackCuts::AcceptTrack(const AliESDtrack* esdTrack)
   //
   // esdEvent is only required for the MaxChi2TPCConstrainedVsGlobal
 
-  UInt_t status = esdTrack->GetStatus();
+  ULong64_t status = esdTrack->GetStatus();
 
   // getting quality parameters from the ESD track
   Int_t nClustersITS = esdTrack->GetITSclusters(0);
@@ -1778,7 +1778,7 @@ Bool_t AliESDtrackCuts::AcceptVTrack(const AliVTrack* vTrack)
   //The track is not an AliESDtrack.  Perform a more limited
   //set of cuts
 
-  UInt_t status = vTrack->GetStatus();
+  ULong64_t status = vTrack->GetStatus();
 
   // getting quality parameters from the ESD track
   // Int_t nClustersITS = vTrack->GetITSclusters(0);

--- a/ANALYSIS/ANALYSISalice/AliESDv0KineCuts.cxx
+++ b/ANALYSIS/ANALYSISalice/AliESDv0KineCuts.cxx
@@ -330,7 +330,7 @@ Bool_t  AliESDv0KineCuts::SingleTrackCuts(AliESDv0 * const v0) const
     if(!d[i]) return kFALSE;
     
     // status word
-    ULong_t status = d[i]->GetStatus();
+    ULong64_t status = d[i]->GetStatus();
 
     // No. of TPC clusters leave to the users
     if(d[i]->GetTPCNcls() < 1) return kFALSE;

--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
@@ -2776,7 +2776,7 @@ void AliAnalysisTaskESDfilter::AdjustCutsForEvent(const AliESDEvent& esd, TList&
   // check if this event is affected, i.e. it has no ITScomplementary tracks but has SA tracks
   for (int i=esd.GetNumberOfTracks();i--;) {
     AliESDtrack* tr = esd.GetTrack(i);
-    ULong_t flags = tr->GetStatus();
+    ULong64_t flags = tr->GetStatus();
     if ( flags & AliESDtrack::kTPCin ) continue;
     if ( flags & AliESDtrack::kITSpureSA ) {
       nPureSA++;

--- a/EMCAL/EMCALrec/AliEMCALTracker.cxx
+++ b/EMCAL/EMCALrec/AliEMCALTracker.cxx
@@ -291,7 +291,7 @@ Int_t AliEMCALTracker::LoadTracks(AliESDEvent *esd)
       Int_t nClustersITS = esdTrack->GetITSclusters(0);
       Int_t nClustersTPC = esdTrack->GetTPCclusters(0);
 
-      ULong_t status = esdTrack->GetStatus();
+      ULong64_t status = esdTrack->GetStatus();
 
       //Bool_t  tpcIn  = (status&AliESDtrack::kTPCin )==AliESDtrack::kTPCin ;
       //Bool_t  itsIn  = (status&AliESDtrack::kITSin )==AliESDtrack::kITSin ;

--- a/EVE/EveDet/AliEveTRDData.h
+++ b/EVE/EveDet/AliEveTRDData.h
@@ -134,13 +134,13 @@ public:
   void    Print(Option_t *opt="a") const; // *MENU*
   void    Load(const Char_t *what="all") const; // *MENU*
   void    SetStatus(UChar_t s=0);         // *MENU*
-  void    SetESDstatus(ULong_t stat) {fESDStatus = stat;} 
+  void    SetESDstatus(ULong64_t stat) {fESDStatus = stat;} 
 private:
   AliEveTRDTrack(const AliEveTRDTrack&);            // Not implemented
   AliEveTRDTrack& operator=(const AliEveTRDTrack&); // Not implemented
 
   UChar_t        fTrackState;   // bit map for the track drawing state
-  ULong_t        fESDStatus;    // ESD status bit for this track
+  ULong64_t      fESDStatus;    // ESD status bit for this track
   Float_t        fAlpha;        // sector angle for this track  
   AliTrackPoint *fPoints;       // track crossing points
   AliRieman     *fRim;          // rieman fitter

--- a/HLT/global/AliFlatESDTrack.h
+++ b/HLT/global/AliFlatESDTrack.h
@@ -164,8 +164,8 @@ class AliFlatESDTrack :public AliVTrack {
 
   // ---------------------------------------------------------------------------------
   // AliVParticle interface
-  ULong_t  GetStatus() const ;
-  Bool_t IsOn(ULong_t mask) const;
+  ULong64_t  GetStatus() const ;
+  Bool_t IsOn(ULong64_t mask) const;
   virtual Double_t Pt() const {const AliFlatExternalTrackParam* p=GetFlatTrackParam(); return (p)?p->GetPt():kVeryBig;}
   virtual Double_t GetTgl()  const {const AliFlatExternalTrackParam* p=GetFlatTrackParam(); return (p)?p->GetTgl():kVeryBig;}
   using AliVTrack::GetImpactParameters;
@@ -301,8 +301,8 @@ inline Int_t AliFlatESDTrack::GetExternalTrackParam( AliExternalTrackParam &p, U
   return 0;
 }
 
-inline ULong_t  AliFlatESDTrack::GetStatus() const {
-  ULong_t x=0;
+inline ULong64_t  AliFlatESDTrack::GetStatus() const {
+  ULong64_t x=0;
   if( fNTPCClusters>0 ){
     x|= kTPCrefit | kTPCin| kTPCout;    
   } else x|= kITSpureSA;
@@ -312,7 +312,7 @@ inline ULong_t  AliFlatESDTrack::GetStatus() const {
   return x;
 }
 
-inline Bool_t AliFlatESDTrack::IsOn(ULong_t mask) const {
+inline Bool_t AliFlatESDTrack::IsOn(ULong64_t mask) const {
   return (GetStatus()&mask)>0;
 }
 

--- a/HLT/rec/AliHLTOnlineESDtrack.h
+++ b/HLT/rec/AliHLTOnlineESDtrack.h
@@ -61,7 +61,7 @@ class AliHLTOnlineESDtrack : public AliExternalTrackParam {
   const AliExternalTrackParam * GetTPCInnerParam() const {return fTPCInner;}
   const AliExternalTrackParam * GetOuterParam() const { return fOp;}
 
-  ULong_t   GetStatus() const {return fFlags;}
+  ULong64_t GetStatus() const {return fFlags;}
   Int_t     GetID() const { return fID;}
   Int_t     GetLabel() const {return fLabel;}
   Int_t     GetTPCLabel() const {return fTPCLabel;}
@@ -95,7 +95,7 @@ private:
   AliExternalTrackParam *fTPCInner; // Track parameters estimated at the inner wall of TPC using the TPC stand-alone 
   AliExternalTrackParam *fOp; // Track parameters estimated at the point of maximal radial coordinate reached during the tracking
 
-  ULong_t   fFlags;          // Reconstruction status flags 
+  ULong64_t fFlags;          // Reconstruction status flags 
   Int_t     fID;             // Unique ID of the track
   Int_t     fLabel;          // Track label
   Int_t     fITSLabel;       // label according ITS
@@ -128,7 +128,7 @@ private:
   UChar_t   fTRDncls;        // number of clusters assigned in the TRD
   UChar_t   fTRDncls0;       // number of clusters assigned in the TRD before first material cross
 
-  ClassDef(AliHLTOnlineESDtrack, 1); // AliESDtrack instance optimized for HLT
+  ClassDef(AliHLTOnlineESDtrack, 2); // AliESDtrack instance optimized for HLT
 };
 
 #endif

--- a/ITS/AliITSComparisonV2.C
+++ b/ITS/AliITSComparisonV2.C
@@ -189,7 +189,7 @@ Int_t AliITSComparisonV2
         Int_t cnt=0;
         for (Int_t i=0; i<nentr; i++) {
            AliESDtrack *t=event->GetTrack(i);
-	   UInt_t status=t->GetStatus();
+	   ULong64_t status=t->GetStatus();
 
            if ((status&AliESDtrack::kITSrefit)==0) continue;
 

--- a/ITS/ITSbase/AliITStrackV2.h
+++ b/ITS/ITSbase/AliITStrackV2.h
@@ -62,7 +62,7 @@ public:
   void UpdateESDtrack(ULong_t flags) const;
   
   AliESDtrack *GetESDtrack() const {return fESDtrack;}
-  virtual ULong_t  GetStatus() const {
+  virtual ULong64_t  GetStatus() const {
     if(fESDtrack){return fESDtrack->GetStatus();} 
     else { AliWarning("null ESD track pointer - status 0"); return 0;} }
 

--- a/ITS/ITSbase/AliITStrackerMI.cxx
+++ b/ITS/ITSbase/AliITStrackerMI.cxx
@@ -2545,7 +2545,7 @@ Bool_t AliITStrackerMI::RefitAt(Double_t xx,AliITStrackMI *track,
     }
   }
   Int_t evsp=repa->GetEventSpecie();
-  ULong_t trStatus=0;
+  ULong64_t trStatus=0;
   if(track->GetESDtrack()) trStatus=track->GetStatus();
   Int_t innermostlayer=0;
   if((evsp&AliRecoParam::kCosmic) || (trStatus&AliESDtrack::kTPCin))  {
@@ -4113,7 +4113,7 @@ void AliITStrackerMI::CookLabel(AliITStrackMI *track,Float_t wrong) const {
      
   if (track->GetESDtrack()){
     tpcLabel = track->GetESDtrack()->GetTPCLabel();
-    ULong_t trStatus=track->GetESDtrack()->GetStatus();
+    ULong64_t trStatus=track->GetESDtrack()->GetStatus();
     if(!(trStatus&AliESDtrack::kTPCin)) tpcLabel=track->GetLabel(); // for ITSsa tracks
   }
    track->SetChi2MIP(9,0);

--- a/ITS/ITSbase/AliITStrackerMI.h
+++ b/ITS/ITSbase/AliITStrackerMI.h
@@ -244,7 +244,7 @@ public:
   void CookdEdx(AliITStrackMI* track);
 
   Int_t GetParticleId(const AliESDtrack* track) const{
-    ULong_t trStatus=track->GetStatus();  
+    ULong64_t trStatus=track->GetStatus();  
     Bool_t isSA=kTRUE; if(trStatus&AliESDtrack::kTPCin) isSA=kFALSE;
     return fITSPid->GetParticleIdFromdEdxVsP(track->P(),track->GetITSsignal(),isSA);
   }

--- a/ITS/macrosSDD/CheckSDDInESD.C
+++ b/ITS/macrosSDD/CheckSDDInESD.C
@@ -106,7 +106,7 @@ void CheckSDDInESD(TString filename="AliESDs.root", Int_t optTracks=kAll){
       }
       //      track->PropagateTo(4.,5.);
       htpccl->Fill(track->GetNcls(1));
-      Int_t status=track->GetStatus();
+      ULong64_t status=track->GetStatus();
       Bool_t tpcin=0;
       hStatus->Fill(-1.);
       if(status & AliESDtrack::kTPCin){

--- a/ITSMFT/ITS/ITSUpgradeRec/AliITSUTrackerGlo.cxx
+++ b/ITSMFT/ITS/ITSUpgradeRec/AliITSUTrackerGlo.cxx
@@ -394,7 +394,7 @@ Int_t AliITSUTrackerGlo::RefitInward(AliESDEvent *esdEv)
     fCurrESDtrack = esdEv->GetTrack(itr);
     fCurrESDtrMClb = fCurrESDtrack->GetLabel();
     // Start time integral and add distance from current position to vertex 
-    UInt_t trStat = fCurrESDtrack->GetStatus();
+    ULong64_t trStat = fCurrESDtrack->GetStatus();
     if ( !(trStat & AliESDtrack::kITSout) ) continue;
     if (   trStat & AliESDtrack::kITSrefit ) continue; // already done
     if ( !(trStat & AliESDtrack::kTPCin)   ) continue; // skip ITS s.a.

--- a/ITSMFT/ITS/macros/QA/AliITSUComparison.C
+++ b/ITSMFT/ITS/macros/QA/AliITSUComparison.C
@@ -193,7 +193,7 @@ Int_t AliITSUComparison
         Int_t cnt=0;
         for (Int_t i=0; i<nentr; i++) {
            AliESDtrack *t=event->GetTrack(i);
-	   UInt_t status=t->GetStatus();
+	   ULong64_t status=t->GetStatus();
 
            if ((status&AliESDtrack::kITSrefit)==0) continue;
 

--- a/ITSMFT/ITS/macros/QA/AliITSUComparisonCooked.C
+++ b/ITSMFT/ITS/macros/QA/AliITSUComparisonCooked.C
@@ -219,7 +219,7 @@ Int_t AliITSUComparisonCooked
         Int_t cnt=0;
         for (Int_t i=0; i<nentr; i++) {
            AliESDtrack *t=event->GetTrack(i);
-	   UInt_t status=t->GetStatus();
+	   ULong64_t status=t->GetStatus();
 
            if ((status&AliESDtrack::kITSrefit)==0) continue;
            if (t->GetITSclusters(0)<4) continue;

--- a/ITSMFT/ITS/macros/QA/CompareESD.C
+++ b/ITSMFT/ITS/macros/QA/CompareESD.C
@@ -43,8 +43,8 @@ void CompareESD() {
       for (Int_t j=0; j<ntnew; j++) {
 	  AliESDtrack *to=eold->GetTrack(j);
 	  AliESDtrack *tn=enew->GetTrack(j);
-          UInt_t so=to->GetStatus();
-          UInt_t sn=tn->GetStatus();
+          ULong64_t so=to->GetStatus();
+          ULong64_t sn=tn->GetStatus();
           if (so != sn) {
 	     cout<<"Track status is different !"<<endl;
 	     return;

--- a/PHOS/PHOSbase/AliPHOSTrackSegmentMakerv1.cxx
+++ b/PHOS/PHOSbase/AliPHOSTrackSegmentMakerv1.cxx
@@ -292,7 +292,7 @@ void  AliPHOSTrackSegmentMakerv1::GetDistanceInPHOSPlane(AliPHOSEmcRecPoint * em
       AliESDtrack *esdTrack=fESD->GetTrack(i);
 
       // Skip the tracks having "wrong" status (has to be checked/tuned)
-      ULong_t status = esdTrack->GetStatus();
+      ULong64_t status = esdTrack->GetStatus();
       if ((status & AliESDtrack::kTPCout)   == 0) continue;
 //     if ((status & AliESDtrack::kTRDout)   == 0) continue;
 //     if ((status & AliESDtrack::kTRDrefit) == 1) continue;

--- a/PHOS/PHOSbase/AliPHOSTracker.cxx
+++ b/PHOS/PHOSbase/AliPHOSTracker.cxx
@@ -162,7 +162,7 @@ Int_t AliPHOSTracker::PropagateBack(AliESDEvent *esd) {
      AliESDtrack *esdTrack=esd->GetTrack(index[i]);
 
      // Skip the tracks having "wrong" status (has to be checked/tuned)
-     ULong_t status = esdTrack->GetStatus();
+     ULong64_t status = esdTrack->GetStatus();
      if ((status & AliESDtrack::kTPCout)   == 0) continue;
 //     if ((status & AliESDtrack::kTRDout)   == 0) continue;
 //     if ((status & AliESDtrack::kTRDrefit) == 1) continue;

--- a/STEER/AOD/AliAODMCParticle.cxx
+++ b/STEER/AOD/AliAODMCParticle.cxx
@@ -162,7 +162,7 @@ void AliAODMCParticle::Print(const Option_t */*opt*/) const {
     Printf(">>> PDG (%d) : %s",fPdgCode,"Unknown");
   }
   Printf(">>  P(%3.3f,%3.3f,%3.3f) V((%3.3f,%3.3f,%3.3f,%3.3f)",fPx,fPy,fPz,fVx,fVy,fVz,fVt);  
-  Printf(">   Mother %d, First Daughter %d Last Daughter %d , Status %d, PhysicalPrimary %d",
+  Printf(">   Mother %d, First Daughter %d Last Daughter %d , Status %llu, PhysicalPrimary %d",
 	 fMother,fDaughter[0],fDaughter[1],GetStatus(),
 	 IsPhysicalPrimary());
 }

--- a/STEER/AOD/AliAODMCParticle.h
+++ b/STEER/AOD/AliAODMCParticle.h
@@ -95,9 +95,9 @@ class AliAODMCParticle: public AliVParticle {
       fFlag &= 0xffff;    // reset the upper bins keep the lower bins
       fFlag |= (((UInt_t)status)<<16); // bit shift by 16
     }
-    virtual UInt_t GetStatus() const {
+    virtual ULong64_t GetStatus() const {
       // bit shift by 16
-      return fFlag>>16;
+      return ULong64_t(fFlag>>16);
     }
 
     void        SetMCStatusCode(Int_t status) { SetStatus(status)  ; }

--- a/STEER/AOD/AliAODRecoDecay.cxx
+++ b/STEER/AOD/AliAODRecoDecay.cxx
@@ -416,11 +416,11 @@ UChar_t  AliAODRecoDecay::GetITSClusterMap() const {
   return map;
 }
 //--------------------------------------------------------------------------
-ULong_t AliAODRecoDecay::GetStatus() const {
+ULong64_t AliAODRecoDecay::GetStatus() const {
   // 
   // Same as for ITSClusterMap
   //
-  ULong_t status=0;
+  ULong64_t status=0;
 
   if(!GetNDaughters()) {
     AliError("No daughters available");

--- a/STEER/AOD/AliAODRecoDecay.h
+++ b/STEER/AOD/AliAODRecoDecay.h
@@ -71,7 +71,7 @@ class AliAODRecoDecay : public AliVTrack {
   // methods of AliVTrack
   virtual Int_t    GetID() const { return -1; }
   virtual UChar_t  GetITSClusterMap() const;
-  virtual ULong_t  GetStatus() const;
+  virtual ULong64_t  GetStatus() const;
   virtual Bool_t   GetXYZ(Double_t *p) const { return XvYvZv(p); }
   using AliVTrack::GetXYZ;
   virtual Bool_t   GetCovarianceXYZPxPyPz(Double_t cv[21]) const;

--- a/STEER/AOD/AliAODTrack.h
+++ b/STEER/AOD/AliAODTrack.h
@@ -189,9 +189,9 @@ class AliAODTrack : public AliVTrack {
     else {delete[] fPID; fPID = 0;}
   }
   
-  Bool_t IsOn(ULong_t mask) const {return (fFlags&mask)>0;}
-  ULong_t GetStatus() const { return GetFlags(); }
-  ULong_t GetFlags() const { return fFlags; }
+  Bool_t IsOn(ULong64_t mask) const {return (fFlags&mask)>0;}
+  ULong64_t GetStatus() const { return GetFlags(); }
+  ULong64_t GetFlags() const { return fFlags; }
 
   Int_t   GetID() const { return (Int_t)fID; }
   Int_t   GetLabel() const { return fLabel; } 
@@ -374,9 +374,9 @@ class AliAODTrack : public AliVTrack {
   void  Print(const Option_t *opt = "") const;
 
   // setters
-  void SetFlags(ULong_t flags) { fFlags = flags; }
-  void SetStatus(ULong_t flags) { fFlags|=flags; }
-  void ResetStatus(ULong_t flags) { fFlags&=~flags; }
+  void SetFlags(ULong64_t flags) { fFlags = flags; }
+  void SetStatus(ULong64_t flags) { fFlags|=flags; }
+  void ResetStatus(ULong64_t flags) { fFlags&=~flags; }
 
   void SetID(Short_t id) { fID = id; }
   void SetLabel(Int_t label) { fLabel = label; }
@@ -474,7 +474,7 @@ class AliAODTrack : public AliVTrack {
   Double32_t    fChi2TPCConstrainedVsGlobal; // chi2 of constrained TPC vs global track (Golden chi2)
   Double32_t    fITSchi2;           // ITS chi2
 
-  ULong_t       fFlags;             // reconstruction status flags 
+  ULong64_t     fFlags;             // reconstruction status flags 
   Int_t         fLabel;             // track label, points back to MC track
   Int_t         fTOFLabel[3];       // TOF label
   Double32_t    fTrackLength;       // Track length
@@ -536,7 +536,7 @@ class AliAODTrack : public AliVTrack {
   Int_t GetNumberOfTPCClusters() const { return GetTPCncls();}  
   Int_t GetNumberOfTRDClusters() const { return GetTRDncls();}  
 
-  ClassDef(AliAODTrack, 26);
+  ClassDef(AliAODTrack, 27);
 };
 
 inline Bool_t  AliAODTrack::IsPrimaryCandidate() const

--- a/STEER/ESD/AliCascadeVertexer.cxx
+++ b/STEER/ESD/AliCascadeVertexer.cxx
@@ -79,7 +79,7 @@ Int_t AliCascadeVertexer::V0sTracks2CascadeVertices(AliESDEvent *event) {
    int trk[nentr], ntr=0;
    for (i=0; i<nentr; i++) {
      AliESDtrack *esdtr=event->GetTrack(i);
-     ULong_t status=esdtr->GetStatus();
+     ULong64_t status=esdtr->GetStatus();
      if (status&AliESDtrack::kITSpureSA) continue;
      if ((status&AliESDtrack::kITSrefit)==0)
        if ((status&AliESDtrack::kTPCrefit)==0) continue;

--- a/STEER/ESD/AliESDpid.cxx
+++ b/STEER/ESD/AliESDpid.cxx
@@ -132,7 +132,7 @@ void AliESDpid::MakeITSPID(AliESDtrack *track) const
     Double_t dedx=track->GetITSsignal();
     Bool_t isSA=kTRUE;
     Double_t momITS=mom;
-    ULong_t trStatus=track->GetStatus();
+    ULong64_t trStatus=track->GetStatus();
     if(trStatus&AliESDtrack::kTPCin) isSA=kFALSE;
     UChar_t clumap=track->GetITSClusterMap();
     Int_t nPointsForPid=0;

--- a/STEER/ESD/AliESDtrack.cxx
+++ b/STEER/ESD/AliESDtrack.cxx
@@ -1588,7 +1588,7 @@ Double_t AliESDtrack::Y() const
 }
 
 //_______________________________________________________________________
-Bool_t AliESDtrack::UpdateTrackParams(const AliKalmanTrack *t, ULong_t flags){
+Bool_t AliESDtrack::UpdateTrackParams(const AliKalmanTrack *t, ULong64_t flags){
   //
   // This function updates track's running parameters 
   //

--- a/STEER/ESD/AliESDtrack.h
+++ b/STEER/ESD/AliESDtrack.h
@@ -69,17 +69,17 @@ public:
   Int_t GetID() const { return fID;}
   void SetVertexID(Char_t id) { fVertexID=id;}
   Char_t GetVertexID() const { return fVertexID;}
-  void SetStatus(ULong_t flags) {fFlags|=flags;}
-  void ResetStatus(ULong_t flags) {fFlags&=~flags;}
-  Bool_t UpdateTrackParams(const AliKalmanTrack *t, ULong_t flags);
+  void SetStatus(ULong64_t flags) {fFlags|=flags;}
+  void ResetStatus(ULong64_t flags) {fFlags&=~flags;}
+  Bool_t UpdateTrackParams(const AliKalmanTrack *t, ULong64_t flags);
   void SetIntegratedLength(Double_t l) {fTrackLength=l;}
   void SetIntegratedTimes(const Double_t *times);
   void SetESDpid(const Double_t *p);
   void GetESDpid(Double_t *p) const;
   virtual const Double_t *PID() const { return fR; }
 
-  Bool_t IsOn(ULong_t mask) const {return (fFlags&mask)>0;}
-  ULong_t GetStatus() const {return fFlags;}
+  Bool_t IsOn(ULong64_t mask) const {return (fFlags&mask)>0;}
+  ULong64_t GetStatus() const {return fFlags;}
   Int_t GetLabel() const {return fLabel;}
   void SetLabel(Int_t label) {fLabel = label;}
 
@@ -563,7 +563,7 @@ protected:
 
   UShort_t fFrTrackID;             // id of friend in the ESDfriend
 
-  ULong_t   fFlags;          // Reconstruction status flags 
+  ULong64_t   fFlags;        // Reconstruction status flags 
   Int_t     fID;             // Unique ID of the track
   Int_t     fLabel;          // Track label
   Int_t     fITSLabel;       // label according ITS
@@ -694,7 +694,7 @@ protected:
   static bool fgkOnlineMode; //! indicate the online mode to skip some of the functionality
   static Bool_t fgTrackEMuAsPi; // when true, track mu and e with pion mass (run 2)
   AliESDtrack & operator=(const AliESDtrack & );
-  ClassDef(AliESDtrack,73)  //ESDtrack 
+  ClassDef(AliESDtrack,74)  //ESDtrack 
 };
 
 

--- a/STEER/ESD/AliESDv0.h
+++ b/STEER/ESD/AliESDv0.h
@@ -116,7 +116,7 @@ public:
   void SetParamP(const AliExternalTrackParam & paramP) {fParamP = paramP;}
   void SetParamN(const AliExternalTrackParam & paramN) {fParamN = paramN;}
   void SetStatus(Int_t status){fStatus=status;}
-  Int_t GetStatus() const {return Int_t(fStatus);}
+  ULong64_t GetStatus() const {return ULong64_t(fStatus);}
   Int_t GetIndex(Int_t i) const {return (i==0) ? fNidx : fPidx;}
   void SetIndex(Int_t i, Int_t ind);
   const Double_t *GetAnglep() const {return fAngle;}

--- a/STEER/ESD/AliV0vertexer.cxx
+++ b/STEER/ESD/AliV0vertexer.cxx
@@ -66,7 +66,7 @@ Int_t AliV0vertexer::Tracks2V0vertices(AliESDEvent *event) {
    Int_t i;
    for (i=0; i<nentr; i++) {
      AliESDtrack *esdTrack=event->GetTrack(i);
-     ULong_t status=esdTrack->GetStatus();
+     ULong64_t status=esdTrack->GetStatus();
 
      //if ((status&AliESDtrack::kITSrefit)==0)//not to accept the ITS SA tracks
         if ((status&AliESDtrack::kTPCrefit)==0) continue;

--- a/STEER/STEER/AliESDTagCreator.cxx
+++ b/STEER/STEER/AliESDTagCreator.cxx
@@ -1053,7 +1053,7 @@ void AliESDTagCreator::FillEventTag(TTree *chain, AliEventTag *evTag, Int_t iEve
     AliESDtrack * esdTrack = esd->GetTrack(iTrackNumber);
     if(esdTrack->GetLabel() != 0) fIsSim = kTRUE;
     else if(esdTrack->GetLabel() == 0) fIsSim = kFALSE;
-    UInt_t status = esdTrack->GetStatus();
+    ULong64_t status = esdTrack->GetStatus();
     
     //select only tracks with ITS refit
     if ((status&AliESDtrack::kITSrefit)==0) continue;

--- a/STEER/STEER/AliReconstruction.cxx
+++ b/STEER/STEER/AliReconstruction.cxx
@@ -5127,7 +5127,7 @@ Bool_t AliReconstruction::DecideFriendsStorage()
   for (Int_t itrk=0; itrk<ntrk; ++itrk) {
     //	  
     AliESDtrack * trk = fesd->GetTrack(itrk);
-    ULong_t status = trk->GetStatus();
+    ULong64_t status = trk->GetStatus();
     //
     // tag high pt tracks
     Bool_t isHighPt = kFALSE;

--- a/STEER/STEERBase/AliExternalTrackParam.h
+++ b/STEER/STEERBase/AliExternalTrackParam.h
@@ -137,7 +137,7 @@ class AliExternalTrackParam: public AliVTrack {
   // additional functions from AliVTrack
   virtual Int_t    GetID() const { return -999; }
   virtual UChar_t  GetITSClusterMap() const {return 0; }
-  virtual ULong_t  GetStatus() const { return 0; }
+  virtual ULong64_t GetStatus() const { return 0; }
 
   Double_t GetSign() const {return (fP[4]>0) ? 1 : -1;}
   Double_t GetP() const;

--- a/STEER/STEERBase/AliVParticle.h
+++ b/STEER/STEERBase/AliVParticle.h
@@ -73,7 +73,7 @@ public:
   virtual const Double_t *PID() const = 0; // return PID object (to be defined, still)
 
   // Not possible GetStatus(), Long in AliVTrack, Int in AliMCParticle  
-//virtual UInt_t  GetStatus()    const { return 0  ; }
+  virtual ULong64_t  GetStatus()    const { return 0  ; }
   virtual UInt_t  MCStatusCode() const { return 0  ; }
   
   virtual TParticle *Particle()  const { return NULL ; }

--- a/STEER/STEERBase/AliVTrack.h
+++ b/STEER/STEERBase/AliVTrack.h
@@ -156,8 +156,8 @@ public:
   virtual Int_t  GetPIDForTracking() const {return -999;}
   
   //pid info
-  virtual void     SetStatus(ULong_t /*flags*/) {;}
-  virtual void     ResetStatus(ULong_t /*flags*/) {;}
+  virtual void     SetStatus(ULong64_t /*flags*/) {;}
+  virtual void     ResetStatus(ULong64_t /*flags*/) {;}
 
   virtual Double_t  GetITSsignal()       const {return 0.;}
   virtual Double_t  GetITSsignalTunedOnData() const {return 0.;}
@@ -197,7 +197,7 @@ public:
   virtual void      GetHMPIDpid(Double_t */*p*/) const {;}
   virtual Double_t  GetIntegratedLength() const { return 0.;}
   
-  virtual ULong_t  GetStatus() const = 0;
+  virtual ULong64_t  GetStatus() const = 0;
   virtual Bool_t   GetXYZ(Double_t *p) const = 0;
   virtual Bool_t   GetXYZAt(Double_t /*x*/, Double_t /*b*/, Double_t* /*r*/ ) const;
   virtual Double_t GetBz() const;
@@ -234,7 +234,7 @@ public:
 
   virtual Int_t             GetKinkIndex(Int_t /*i*/) const { return 0;}
   virtual Double_t          GetSigned1Pt()         const { return 0;}
-  virtual Bool_t            IsOn(ULong_t /*mask*/) const {return 0;}
+  virtual Bool_t            IsOn(ULong64_t /*mask*/) const {return 0;}
   virtual Double_t          GetX()    const {return 0;}
   virtual Double_t          GetY()    const {return 0;}
   virtual Double_t          GetZ()    const {return 0;}

--- a/STEER/macros/AliESDanalysis.C
+++ b/STEER/macros/AliESDanalysis.C
@@ -56,7 +56,7 @@ Int_t AliESDanalysis() {
      Int_t nk=0;
      while (ntrk--) {
         AliESDtrack *track=event->GetTrack(ntrk);
-        UInt_t status=track->GetStatus();
+        ULong64_t status=track->GetStatus();
 
 	//select only tracks with the "combined PID"
         if ((status&AliESDtrack::kESDpid)==0) continue;

--- a/STEER/macros/AliVertexerTracksTest.C
+++ b/STEER/macros/AliVertexerTracksTest.C
@@ -217,7 +217,7 @@ void AliVertexerTracksTest(TString outname="AliVertexerTracksTest.root",
     // count ITS tracks
     for(Int_t itrk=0; itrk<ntracks; itrk++) {
       AliESDtrack *esdtrack = (AliESDtrack*)esd->GetTrack(itrk);
-      UInt_t status = esdtrack->GetStatus();
+      ULong64_t status = esdtrack->GetStatus();
       // only tracks found also in ITS
       if(! (status&AliESDtrack::kITSin) ) continue;      
       nitstracks++;
@@ -397,7 +397,7 @@ void VertexForOneEvent(Int_t iev=0,
   // count ITS tracks
   for(Int_t itrk=0; itrk<ntracks; itrk++) {
     AliESDtrack *esdtrack = (AliESDtrack*)esd->GetTrack(itrk);
-    UInt_t status = esdtrack->GetStatus();
+    ULong64_t status = esdtrack->GetStatus();
     // only tracks found also in ITS
     if(! (status&AliESDtrack::kITSrefit) ) continue;      
     nitstracks++;

--- a/TOF/AliTOFQADataMaker.cxx
+++ b/TOF/AliTOFQADataMaker.cxx
@@ -611,7 +611,7 @@ void AliTOFQADataMaker::MakeESDs(AliESDEvent * esd)
     FillESDsData(2,tofTimeRaw); 
     FillESDsData(3,tofToT);
     //check how many tracks where ESD PID is ok 
-    UInt_t status=track->GetStatus();
+    ULong64_t status=track->GetStatus();
     if (((status&AliESDtrack::kESDpid)==0) || 
 	((status&AliESDtrack::kTOFpid)==0)) continue;
     ntofpid++;

--- a/TOF/TOFrec/AliTOFQADataMakerRec.cxx
+++ b/TOF/TOFrec/AliTOFQADataMakerRec.cxx
@@ -971,7 +971,7 @@ void AliTOFQADataMakerRec::MakeESDs(AliESDEvent * esd)
       Double_t tofTimeRaw=track->GetTOFsignalRaw();//in ps
       Double_t tofToT=track->GetTOFsignalToT(); //in ps
       
-      UInt_t status=track->GetStatus();
+      ULong64_t status=track->GetStatus();
       if (track->IsOn(AliESDtrack::kTPCrefit)) {
 	ntpc++;
 	Double_t y=track->Eta();

--- a/TPC/TPCcalib/AliTPCcalibGainMult.cxx
+++ b/TPC/TPCcalib/AliTPCcalibGainMult.cxx
@@ -424,7 +424,7 @@ void AliTPCcalibGainMult::Process(AliVEvent *event) {
     // exclude tracks which do not look like primaries or are simply too short or on wrong sectors
     if (TMath::Abs(trackIn->Eta()) > fCutEtaWindow) continue;
 
-    UInt_t status = track->GetStatus();
+    ULong64_t status = track->GetStatus();
     if ((status&AliVTrack::kTPCrefit)==0) continue;
     if ((status&AliVTrack::kITSrefit)==0 && fCutRequireITSrefit) continue; // ITS cluster
     //
@@ -1852,7 +1852,7 @@ void AliTPCcalibGainMult::DumpHPT(const AliVEvent *event){
     AliVTrack *track = event->GetVTrack(i);
     if (!track) continue;
     if (track->Pt()<4) continue; 
-    UInt_t status = track->GetStatus();
+    ULong64_t status = track->GetStatus();
     //   
 
     AliExternalTrackParam trckIn;

--- a/TPC/TPCcalib/AliTPCcalibTimeGain.cxx
+++ b/TPC/TPCcalib/AliTPCcalibTimeGain.cxx
@@ -468,7 +468,7 @@ void AliTPCcalibTimeGain::ProcessBeamEvent(AliVEvent *event) {
     if (nCrossedRows < fCutCrossRows) continue;     
     if (TMath::Abs(trackIn->Eta()) > fCutEtaWindow) continue;
     //
-    UInt_t status = track->GetStatus();
+    ULong64_t status = track->GetStatus();
     if ((status&AliVTrack::kTPCrefit)==0) continue;
     if ((status&AliVTrack::kITSrefit)==0 && fCutRequireITSrefit) continue; // ITS cluster
     //

--- a/TPC/TPCrec/AliTPCtracker.cxx
+++ b/TPC/TPCrec/AliTPCtracker.cxx
@@ -4191,7 +4191,7 @@ void AliTPCtracker::ReadSeeds(const AliESDEvent *const event, Int_t direction)
   TTreeSRedirector * pcstreamF=(AliTPCReconstructor::StreamLevel()&kStreamOuterDet) ? fDebugStreamer:NULL;
   for (Int_t i=0; i<nentr; i++) {
     AliESDtrack *esd=event->GetTrack(i);
-    ULong_t status=esd->GetStatus();
+    ULong64_t status=esd->GetStatus();
     if (!(status&AliESDtrack::kTPCin)) continue;
     AliTPCtrack t(*esd,pcstreamF);
     t.SetNumberOfClusters(0);

--- a/TRD/AliTRDQADataMaker.cxx
+++ b/TRD/AliTRDQADataMaker.cxx
@@ -384,7 +384,7 @@ void AliTRDQADataMaker::MakeESDs(AliESDEvent * const esd)
     Int_t sector = GetSector(paramOut->GetAlpha());
 
     UInt_t u = 1;
-    UInt_t status = track->GetStatus();
+    ULong64_t status = track->GetStatus();
     for(Int_t bit=0; bit<32; bit++) 
       if (u<<bit & status) FillESDsData(2,bit);
 

--- a/TRD/TRDbase/AliTRDonlineTrackMatching.cxx
+++ b/TRD/TRDbase/AliTRDonlineTrackMatching.cxx
@@ -247,7 +247,7 @@ Bool_t AliTRDonlineTrackMatching::AcceptTrack(const AliESDtrack* esdTrack, const
   if (!esdTrack)
     return kFALSE;
 
-  UInt_t status = esdTrack->GetStatus();
+  ULong64_t status = esdTrack->GetStatus();
 
   if (fEsdTrackCutMinimal){
     return ((status & AliESDtrack::kTPCout) > 0);

--- a/TRD/TRDbase/AliTRDtrackerV1.cxx
+++ b/TRD/TRDbase/AliTRDtrackerV1.cxx
@@ -321,7 +321,7 @@ Int_t AliTRDtrackerV1::PropagateBack(AliESDEvent *event)
     Float_t p4  = seed->GetC(seed->GetBz());
   
     // Check the seed status
-    ULong_t status = seed->GetStatus();
+    ULong64_t status = seed->GetStatus();
     if ((status & AliESDtrack::kTRDout) != 0) continue;
     if ((status & AliESDtrack::kTPCout)){
       AliDebug(3, Form("Prolongate seed[%2d] which is TPC.", iSeed));
@@ -502,7 +502,7 @@ Int_t AliTRDtrackerV1::RefitInward(AliESDEvent *event)
   AliTRDtrackV1 track;
   for (Int_t itrack = 0; itrack < event->GetNumberOfTracks(); itrack++) {
     AliESDtrack *seed = event->GetTrack(itrack);
-    ULong_t status = seed->GetStatus();
+    ULong64_t status = seed->GetStatus();
 
     new(&track) AliTRDtrackV1(*seed);
     if (track.GetX() < 270.0) {

--- a/TRD/TRDcalib/AliTRDCalibTask.cxx
+++ b/TRD/TRDcalib/AliTRDCalibTask.cxx
@@ -783,7 +783,7 @@ void AliTRDCalibTask::UserExec(Option_t *)
     // Get ESD track
     fkEsdTrack = fESD->GetTrack(itrk);
     if(!fkEsdTrack) continue;
-    ULong_t status = fkEsdTrack->GetStatus(); 
+    ULong64_t status = fkEsdTrack->GetStatus(); 
     if(status&(AliESDtrack::kTPCout)) ++nbtrackTPC;
     
     // Fix suggested by Alex
@@ -800,7 +800,7 @@ void AliTRDCalibTask::UserExec(Option_t *)
     Bool_t good = kTRUE;
     Bool_t standalonetrack = kFALSE;
     Bool_t offlinetrack = kFALSE;
-    //ULong_t status = fkEsdTrack->GetStatus();
+    //ULong64_t status = fkEsdTrack->GetStatus();
     
     //////////////////////////////////////
     // Loop on calibration objects
@@ -850,7 +850,7 @@ void AliTRDCalibTask::UserExec(Option_t *)
 
     // ITS or TOF
     if(fRejectPileUpWithTOFOrITS) {
-      ULong_t statusits = fkEsdTrack->GetStatus();
+      ULong64_t statusits = fkEsdTrack->GetStatus();
       UChar_t itsPixel = fkEsdTrack->GetITSClusterMap();
       Bool_t itskany = kFALSE;
       if(((statusits & AliVTrack::kITSrefit) == AliVTrack::kITSrefit) && ((TESTBIT(itsPixel, 0) || TESTBIT(itsPixel, 1)))) itskany = kTRUE;

--- a/TRD/TRDqaAnalysis/AliTRDqaBasic.cxx
+++ b/TRD/TRDqaAnalysis/AliTRDqaBasic.cxx
@@ -200,7 +200,7 @@ void AliTRDqaBasic::Exec(Option_t *)
     if (!paramIn) continue;
     if (!paramOut) continue;
     
-    UInt_t status = track->GetStatus();
+    ULong64_t status = track->GetStatus();
     if (!(status & AliESDtrack::kTPCrefit)) continue;
 
     //if (!fTrackCuts->AcceptTrack(track)) continue;

--- a/TRD/TRDqaAnalysis/AliTRDqaESDFriends.cxx
+++ b/TRD/TRDqaAnalysis/AliTRDqaESDFriends.cxx
@@ -147,7 +147,7 @@ void AliTRDqaESDFriends::Exec(Option_t *)
     if (!paramIn) continue;
     if (!paramOut) continue;
     
-    UInt_t status = track->GetStatus();
+    ULong64_t status = track->GetStatus();
     if (!(status & AliESDtrack::kTRDrefit)) continue;
     if (!(status & AliESDtrack::kTRDpid)) continue;
     if (track->GetTRDntrackletsPID() < 6) continue;

--- a/TRD/TRDqaAnalysis/AliTRDqaElectronSpectra.cxx
+++ b/TRD/TRDqaAnalysis/AliTRDqaElectronSpectra.cxx
@@ -221,7 +221,7 @@ void AliTRDqaElectronSpectra::Exec(Option_t *)
     if (!paramIn) continue;
     if (!paramOut) continue;
     
-    UInt_t status = track->GetStatus();
+    ULong64_t status = track->GetStatus();
     if (!(status & AliESDtrack::kTRDrefit)) continue;
     if (!(status & AliESDtrack::kTRDpid)) continue;
     if (track->GetTRDntrackletsPID() < 6) continue;

--- a/TRD/TRDqaAnalysis/AliTRDqaEnergyDeposit.cxx
+++ b/TRD/TRDqaAnalysis/AliTRDqaEnergyDeposit.cxx
@@ -214,7 +214,7 @@ void AliTRDqaEnergyDeposit::Exec(Option_t *)
     if (!paramIn) continue;
     if (!paramOut) continue;
     
-    UInt_t status = track->GetStatus();
+    ULong64_t status = track->GetStatus();
     if (!(status & AliESDtrack::kTRDrefit)) continue;
     if (!(status & AliESDtrack::kTRDpid)) continue;
     if (track->GetTRDntrackletsPID() < 6) continue;

--- a/TRD/TRDqaAnalysis/AliTRDqaJPsi.cxx
+++ b/TRD/TRDqaAnalysis/AliTRDqaJPsi.cxx
@@ -268,7 +268,7 @@ void AliTRDqaJPsi::Exec(Option_t *)
 
     Int_t step    = 0;
     Int_t charge  = (track->Charge() > 0) ? 1 : 0;
-    UInt_t status = track->GetStatus();
+    ULong64_t status = track->GetStatus();
     Double_t pt   = track->Pt();
     Double_t pid  = track->GetTRDpid(AliPID::kElectron);
     
@@ -369,7 +369,7 @@ void AliTRDqaJPsi::FillHist(AliESDtrack *track, Int_t step) {
   //
 
   Int_t charge  = (track->Charge() > 0) ? 1 : 0;
-  UInt_t status = track->GetStatus();
+  ULong64_t status = track->GetStatus();
   Double_t pt   = track->Pt();
   Double_t pid  = track->GetTRDpid(AliPID::kElectron);
   

--- a/TRD/TRDrec/AliTRDQADataMakerRec.cxx
+++ b/TRD/TRDrec/AliTRDQADataMakerRec.cxx
@@ -537,7 +537,7 @@ void AliTRDQADataMakerRec::MakeESDs(AliESDEvent * esd)
     Int_t stack = GetStack(paramOut);
 
     UInt_t u = 1;
-    UInt_t status = track->GetStatus();
+    ULong64_t status = track->GetStatus();
     for(Int_t bit=0; bit<32; bit++) 
       if (u<<bit & status) FillESDsData(2,bit);
 

--- a/TRD/macros/AliTRDComparisonV2.C
+++ b/TRD/macros/AliTRDComparisonV2.C
@@ -199,7 +199,7 @@ Int_t AliTRDComparisonV2
         Int_t cnt=0;
         for (Int_t i=0; i<nentr; i++) {
            AliESDtrack *t=event->GetTrack(i);
-	   UInt_t status=t->GetStatus();
+	   ULong64_t status=t->GetStatus();
 
            if ((status&AliESDtrack::kTRDout)==0) continue;
 

--- a/macros/mcminiesd.C
+++ b/macros/mcminiesd.C
@@ -111,7 +111,7 @@ void selectMiniESD(AliESD* esdIn, AliESD* &esdOut) {
   for (Int_t itrk=0; itrk<ntrk; itrk++) {
     
     AliESDtrack * trackIn = esdIn->GetTrack(itrk);
-    UInt_t status=trackIn->GetStatus();
+    ULong64_t status=trackIn->GetStatus();
 
     //select only tracks with TPC or ITS refit
     if ((status&AliESDtrack::kTPCrefit)==0


### PR DESCRIPTION
Since the bit mask of AliESDtrack needs to use >32 bits, all getters and setters of Alice track type
(starting from AliVParticle) status (GetStatus, SetStatus) are returning/acceptring ULong64_t instead
of ULong_t