### PR TITLE
Rename GPU CMAKE build options

### DIFF
--- a/HLT/CMakeLists.txt
+++ b/HLT/CMakeLists.txt
@@ -13,8 +13,8 @@
 # * provided "as is" without express or implied warranty.                  *
 # **************************************************************************
 
-option(HLT_CUDA   "Build HLT GPU tracker using CUDA"   OFF)
-option(HLT_OPENCL "Build HLT GPU tracker using OpenCL" OFF)
+option(ENABLE_CUDA   "Build HLT GPU tracker using CUDA"   OFF)
+option(ENABLE_OPENCL "Build HLT GPU tracker using OpenCL" OFF)
 
 add_definitions(-Duse_aliroot -DUSE_ROOT -DROWHOUGHPARAMS)
 


### PR DESCRIPTION
Rename cmake option as discussed with Max and Dario (use same common name for AliRoot / O2; TPC / ITS)