### PR TITLE
Adding ZEM TDC flags (2) in AOD

### DIFF
--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
@@ -2138,6 +2138,8 @@ void AliAnalysisTaskESDfilter::ConvertZDC(const AliESDEvent& esd)
   zdcAOD->ResetZNCfired();
   zdcAOD->ResetZPAfired();
   zdcAOD->ResetZPCfired();
+  zdcAOD->ResetZEM1fired();
+  zdcAOD->ResetZEM2fired();
   
   const Float_t kNoEntry = -999.;
   //Taking into account all the 4 hits
@@ -2185,6 +2187,8 @@ void AliAnalysisTaskESDfilter::ConvertZDC(const AliESDEvent& esd)
     }
   }
   else for(int i=0; i<4; i++)  zdcAOD->SetZPATDCm(i, kNoEntry);
+  if(esdZDC->IsZEM1hit()) zdcAOD->SetZEM1fired();
+  if(esdZDC->IsZEM2hit()) zdcAOD->SetZEM2fired();
 }
 //______________________________________________________________________________
 void AliAnalysisTaskESDfilter::ConvertAD(const AliESDEvent& esd)

--- a/STEER/AOD/AliAODZDC.cxx
+++ b/STEER/AOD/AliAODZDC.cxx
@@ -47,7 +47,9 @@ AliAODZDC::AliAODZDC() :
   fIsZNAfired(kFALSE),
   fIsZNCfired(kFALSE),
   fIsZPAfired(kFALSE),
-  fIsZPCfired(kFALSE)
+  fIsZPCfired(kFALSE),
+  fIsZEM1fired(kFALSE),
+  fIsZEM2fired(kFALSE)
 {
 // Default constructor
   for(Int_t i=0; i<5; i++){
@@ -85,8 +87,9 @@ AliAODZDC::AliAODZDC(const AliAODZDC &zdcAOD) :
   fIsZNAfired(zdcAOD.fIsZNAfired),
   fIsZNCfired(zdcAOD.fIsZNCfired),
   fIsZPAfired(zdcAOD.fIsZPAfired),
-  fIsZPCfired(zdcAOD.fIsZPCfired)
-
+  fIsZPCfired(zdcAOD.fIsZPCfired),
+  fIsZEM1fired(zdcAOD.fIsZEM1fired),
+  fIsZEM2fired(zdcAOD.fIsZEM2fired)
 {
 // Constructor
   for(Int_t i=0; i<5; i++){
@@ -154,6 +157,8 @@ AliAODZDC& AliAODZDC::operator=(const AliAODZDC& zdcAOD)
     fIsZNCfired = zdcAOD.fIsZNCfired;
     fIsZPAfired = zdcAOD.fIsZPAfired;
     fIsZPCfired = zdcAOD.fIsZPCfired;
+    fIsZEM1fired = zdcAOD.fIsZEM1fired;
+    fIsZEM2fired = zdcAOD.fIsZEM2fired;
   } 
   return *this;
 }

--- a/STEER/AOD/AliAODZDC.h
+++ b/STEER/AOD/AliAODZDC.h
@@ -102,11 +102,15 @@ public:
   void  SetZNCfired() {fIsZNCfired = kTRUE;}
   void  SetZPAfired() {fIsZPAfired = kTRUE;}
   void  SetZPCfired() {fIsZPCfired = kTRUE;}
+  void  SetZEM1fired() {fIsZEM1fired = kTRUE;}
+  void  SetZEM2fired() {fIsZEM2fired = kTRUE;}
   //
   void  ResetZNAfired() {fIsZNAfired = kFALSE;}
   void  ResetZNCfired() {fIsZNCfired = kFALSE;}
   void  ResetZPAfired() {fIsZPAfired = kFALSE;}
   void  ResetZPCfired() {fIsZPCfired = kFALSE;}
+  void  ResetZEM1fired() {fIsZEM1fired = kFALSE;}
+  void  ResetZEM2fired() {fIsZEM2fired = kFALSE;}
 
 protected:
 
@@ -142,18 +146,19 @@ protected:
   Float_t   fZPATDC;     	   // ZNA TDC in ns corrected 4 phase shift;
   //
   // Jan.2016: propagating multi-hit structure of TDC hits to AODs
-  Float_t   fZNCTDCm[4];	// true if ZNC TDC has at least 1 hit
-  Float_t   fZNATDCm[4];	// true if ZNA TDC has at least 1 hit
-  Float_t   fZPCTDCm[4];	// true if ZPC TDC has at least 1 hit
-  Float_t   fZPATDCm[4];	// true if ZPA TDC has at least 1 hit
+  Float_t   fZNCTDCm[4];	// ZNC TDC 4 hit
+  Float_t   fZNATDCm[4];	// ZNA TDC 4 hit
+  Float_t   fZPCTDCm[4];	// ZPC TDC 4 hit
+  Float_t   fZPATDCm[4];	// ZPA TDC 4 hit
   //
   Bool_t    fIsZNAfired;	// if true ZNA is fired in the event
   Bool_t    fIsZNCfired;	// if true ZNC is fired in the event
   Bool_t    fIsZPAfired;	// if true ZPA is fired in the event
   Bool_t    fIsZPCfired;	// if true ZPC is fired in the event
+  Bool_t    fIsZEM1fired;	// if true ZEM1 is fired in the event
+  Bool_t    fIsZEM2fired;	// if true ZEM2 is fired in the event
 
-
-  ClassDef(AliAODZDC,4)
+  ClassDef(AliAODZDC,5)
 };
 
 #endif


### PR DESCRIPTION
In AOD we have the info about the hadronic calorimeters but also knowing whether the two EM ZDCs have been hit can be useful (for example for EMD analyses). This option has been added with this commit.
Chiara