### PR TITLE
Fix deletion order issue in SSD geometry

### DIFF
--- a/ITS/ITSsim/AliITSv11GeometrySSD.cxx
+++ b/ITS/ITSsim/AliITSv11GeometrySSD.cxx
@@ -4687,11 +4687,11 @@ void AliITSv11GeometrySSD::Layer6(TGeoVolume* moth){
   // Deallocating memory
   /////////////////////////////////////////////////////////////
   for(Int_t i=0; i<fgklayernumber; i++){
+	delete vertexlist[i];
 	for(Int_t j=0; j<nedges+1; j++)
 		delete vertex[i][j];
 	delete mountingsupportedgevector[i];
 	delete [] vertex[i];
-	delete vertexlist[i];
 	delete [] xsidevertex[i];
 	delete [] ysidevertex[i];
 	delete [] xcentervertex[i];


### PR DESCRIPTION
This fixes an issue with deletion order in the SSD geometry: the objects in a TList were deleted before the TList was deleted; this causes a problem because the TList accesses the objects to read a deletion flag when the TList itself is deleted. This was mostly a formal problem, but best to fix it anyways.