### PR TITLE
Fix: AODtracks added via ConvertTRD should have fDetPid filled

### DIFF
--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
@@ -2278,6 +2278,7 @@ void AliAnalysisTaskESDfilter::ConvertTRD(const AliESDEvent& esd)
 
     // add the reference to the matched global track
     AliAODTrack *aodTrkMatch = 0x0;
+    AliAODPid* detpid(0x0);
     AliESDtrack *esdTrkMatch = (AliESDtrack*) esdTrdTrk->GetTrackMatch();
     if (esdTrkMatch) {
       Int_t idx = esdTrkMatch->GetID();
@@ -2351,7 +2352,7 @@ void AliAnalysisTaskESDfilter::ConvertTRD(const AliESDEvent& esd)
 	  if (esdTrkMatch->GetSign() > 0) ++fNumberOfPositiveTracks;
 	  aodTrkMatch->ConvertAliPIDtoAODPID();
 	  aodTrkMatch->SetFlags(esdTrkMatch->GetStatus());
-
+	  SetAODPID(esdTrkMatch,aodTrkMatch,detpid);
 
 
 	}

--- a/STEER/AOD/AliAODTrack.h
+++ b/STEER/AOD/AliAODTrack.h
@@ -331,8 +331,8 @@ class AliAODTrack : public AliVTrack {
   void      SetTPCsignalTunedOnData(Double_t signal) {fTPCsignalTuned = signal;}
   UShort_t  GetTPCsignalN()      const { return fDetPid?fDetPid->GetTPCsignalN():0;    }
   virtual Bool_t GetTPCdEdxInfo( AliTPCdEdxInfo &v) const {return fDetPid?fDetPid->GetTPCdEdxInfo(v):0;}
-  Double_t  GetTPCmomentum()     const { return fDetPid?fDetPid->GetTPCmomentum():0.;  }
-  Double_t  GetTPCTgl()          const { return fDetPid?fDetPid->GetTPCTgl():0.;  }
+  Double_t  GetTPCmomentum()     const { return fDetPid?fDetPid->GetTPCmomentum() : P();  }
+  Double_t  GetTPCTgl()          const { return fDetPid?fDetPid->GetTPCTgl() : GetTgl();  }
   Double_t  GetTOFsignal()       const { return fDetPid?fDetPid->GetTOFsignal():0.;    }
   Double_t  GetIntegratedLength() const { return fTrackLength;}
   void      SetIntegratedLength(Double_t l) {fTrackLength = l;}


### PR DESCRIPTION
Details in https://alice.its.cern.ch/jira/browse/ALIROOT-7874?focusedCommentId=217574&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-217574

Also, AliAODTrack methods like GetTPCmomentum() which extract the info from the fDetPid will fall
back to the track momentum in absence of the fDetPid (like it is done in the AliESDtrack)