### PR TITLE
install missing include file

### DIFF
--- a/HLT/BASE/CMakeLists.txt
+++ b/HLT/BASE/CMakeLists.txt
@@ -142,6 +142,7 @@ set(HDRS ${HDRS}
     AliHLTLoggingVariadicFree.h
     AliHLTStdIncludes.h
     AliHLTCDHWrapper.h
+    AliHLTArray.h
    )
 
 # Generate the dictionary


### PR DESCRIPTION
@dberzano : The file you mention in the mail was indeed missing (a different issue than the include path issue you are solving).
This PR should fix it, no guarantuee that there aren't more files missing.