### PR TITLE
Fix for ROOT 6 hardcoded paths error

### DIFF
--- a/HLT/BASE/CMakeLists.txt
+++ b/HLT/BASE/CMakeLists.txt
@@ -148,7 +148,7 @@ set(HDRS ${HDRS}
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 set(ROOT_DEPENDENCIES Core Thread Geom Graf Hist MathCore Net RIO Tree XMLParser)
 

--- a/HLT/BASE/HOMER/CMakeLists.txt
+++ b/HLT/BASE/HOMER/CMakeLists.txt
@@ -37,7 +37,7 @@ set( HDRS ${HDRS}
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/BASE/interface/CMakeLists.txt
+++ b/HLT/BASE/interface/CMakeLists.txt
@@ -37,7 +37,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "HLTinterface-LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "HLTinterface-LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependencies

--- a/HLT/BASE/util/CMakeLists.txt
+++ b/HLT/BASE/util/CMakeLists.txt
@@ -88,7 +88,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/CALO/CMakeLists.txt
+++ b/HLT/CALO/CMakeLists.txt
@@ -84,7 +84,7 @@ set(HDRS ${HDRS}
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/EMCAL/CMakeLists.txt
+++ b/HLT/EMCAL/CMakeLists.txt
@@ -75,7 +75,7 @@ set(HDRS ${HDRS}
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/EVE/CMakeLists.txt
+++ b/HLT/EVE/CMakeLists.txt
@@ -70,7 +70,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/FJWrapper/CMakeLists.txt
+++ b/HLT/FJWrapper/CMakeLists.txt
@@ -43,7 +43,7 @@ endif(FASTJET_FOUND)
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 set(ROOT_DEPENDENCIES Core)
 set(ALIROOT_DEPENDENCIES STEERBase)

--- a/HLT/FMD/CMakeLists.txt
+++ b/HLT/FMD/CMakeLists.txt
@@ -44,7 +44,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/ITS/CMakeLists.txt
+++ b/HLT/ITS/CMakeLists.txt
@@ -75,7 +75,7 @@ set(HDRS ${HDRS}
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/MUON/CMakeLists.txt
+++ b/HLT/MUON/CMakeLists.txt
@@ -102,7 +102,7 @@ set(HDRS ${HDRS}
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/PHOS/CMakeLists.txt
+++ b/HLT/PHOS/CMakeLists.txt
@@ -62,7 +62,7 @@ set(HDRS ${HDRS}
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/QA/CMakeLists.txt
+++ b/HLT/QA/CMakeLists.txt
@@ -43,7 +43,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/RCU/CMakeLists.txt
+++ b/HLT/RCU/CMakeLists.txt
@@ -43,7 +43,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/SampleLib/CMakeLists.txt
+++ b/HLT/SampleLib/CMakeLists.txt
@@ -48,7 +48,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/T0/CMakeLists.txt
+++ b/HLT/T0/CMakeLists.txt
@@ -44,7 +44,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/TOF/CMakeLists.txt
+++ b/HLT/TOF/CMakeLists.txt
@@ -47,7 +47,7 @@ set(HDRS ${HDRS}
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/TPCLib/CMakeLists.txt
+++ b/HLT/TPCLib/CMakeLists.txt
@@ -155,7 +155,7 @@ set(HDRS ${HDRS}
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/TPCLib/EVE/CMakeLists.txt
+++ b/HLT/TPCLib/EVE/CMakeLists.txt
@@ -39,7 +39,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/TRD/CMakeLists.txt
+++ b/HLT/TRD/CMakeLists.txt
@@ -63,7 +63,7 @@ set(HDRS ${HDRS}
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/VZERO/CMakeLists.txt
+++ b/HLT/VZERO/CMakeLists.txt
@@ -43,7 +43,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/ZDC/CMakeLists.txt
+++ b/HLT/ZDC/CMakeLists.txt
@@ -43,7 +43,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/ZMQ/CMakeLists.txt
+++ b/HLT/ZMQ/CMakeLists.txt
@@ -44,7 +44,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/comp/CMakeLists.txt
+++ b/HLT/comp/CMakeLists.txt
@@ -35,7 +35,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/createGRP/lib/CMakeLists.txt
+++ b/HLT/createGRP/lib/CMakeLists.txt
@@ -53,7 +53,7 @@ set(HDRS
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "" "${CINTHDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "" "${CINTHDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/global/CMakeLists.txt
+++ b/HLT/global/CMakeLists.txt
@@ -132,7 +132,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/pendolino/CMakeLists.txt
+++ b/HLT/pendolino/CMakeLists.txt
@@ -53,7 +53,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/rec/CMakeLists.txt
+++ b/HLT/rec/CMakeLists.txt
@@ -53,7 +53,7 @@ set(SRCS ${SRCS}
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/shuttle/CMakeLists.txt
+++ b/HLT/shuttle/CMakeLists.txt
@@ -36,7 +36,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/sim/CMakeLists.txt
+++ b/HLT/sim/CMakeLists.txt
@@ -42,7 +42,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/HLT/trigger/CMakeLists.txt
+++ b/HLT/trigger/CMakeLists.txt
@@ -95,7 +95,7 @@ string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
 # Generate the dictionary
 # It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
 get_directory_property(incdirs INCLUDE_DIRECTORIES)
-generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+generate_dictionary_flat("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies

--- a/cmake/CMakeALICE.cmake
+++ b/cmake/CMakeALICE.cmake
@@ -23,14 +23,15 @@
 # @DNAME  Dictionary name
 # @LDNAME LinkDef file name, ex: LinkDef.h
 # @DHDRS  Dictionary headers
+# @DHDRS_DEPS  Dictionary header files used as dependencies to the rootmap target
 # @DINCDIR Include folders that need to be passed to cint/cling
 # @EXTRADEFINITIONS - optional, extra compile flags specific to library
-#       - used as ${ARGV4}
-macro(generate_dictionary DNAME LDNAME DHDRS DINCDIRS)
+#       - used as ${ARGV5}
+macro(_generate_dictionary DNAME LDNAME DHDRS DHDRS_DEPS DINCDIRS)
 
     # Creating the INCLUDE path for cint/cling
-    foreach( dir ${DINCDIRS})
-        set(INCLUDE_PATH -I${dir} ${INCLUDE_PATH})
+    foreach(_dir ${DINCDIRS})
+        set(INCLUDE_PATH -I${_dir} ${INCLUDE_PATH})
     endforeach()
 
     # Get the list of definitions from the directory to be sent to CINT
@@ -42,7 +43,7 @@ macro(generate_dictionary DNAME LDNAME DHDRS DINCDIRS)
 
     # Custom definitions specific to library
     # Received as the forth optional argument
-    separate_arguments(EXTRADEFINITIONS UNIX_COMMAND "${ARGV4}")
+    separate_arguments(EXTRADEFINITIONS UNIX_COMMAND "${ARGV5}")
 
     if (ROOT_VERSION_MAJOR LESS 6)
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/G__${DNAME}.cxx ${CMAKE_CURRENT_BINARY_DIR}/G__${DNAME}.h
@@ -50,7 +51,7 @@ macro(generate_dictionary DNAME LDNAME DHDRS DINCDIRS)
                        ARGS -f ${CMAKE_CURRENT_BINARY_DIR}/G__${DNAME}.cxx -c -p
                        ${GLOBALDEFINITIONS} ${EXTRADEFINITIONS} ${INCLUDE_PATH}
                        ${DHDRS} ${LDNAME}
-                       DEPENDS ${DHDRS} ${LDNAME} ${ROOT_CINT}
+                       DEPENDS ${DHDRS_DEPS} ${LDNAME} ${ROOT_CINT}
                        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                       )
     else (ROOT_VERSION_MAJOR LESS 6)
@@ -62,7 +63,7 @@ macro(generate_dictionary DNAME LDNAME DHDRS DINCDIRS)
                          -rmf ${CMAKE_CURRENT_BINARY_DIR}/lib${DNAME}.rootmap -rml lib${DNAME}
                          ${GLOBALDEFINITIONS} ${EXTRADEFINITIONS} ${INCLUDE_PATH} ${DHDRS} ${LDNAME}
                        DEPENDS
-                         ${DHDRS} ${LDNAME} ${ROOT_CINT}
+                         ${DHDRS_DEPS} ${LDNAME} ${ROOT_CINT}
                        WORKING_DIRECTORY
                          ${CMAKE_CURRENT_BINARY_DIR}
                       )
@@ -72,7 +73,44 @@ macro(generate_dictionary DNAME LDNAME DHDRS DINCDIRS)
 
     endif (ROOT_VERSION_MAJOR LESS 6)
 
+endmacro(_generate_dictionary)
+
+
+# Standard generate_dictionary function for non-flattened header files
+macro(generate_dictionary DNAME LDNAME DHDRS DINCDIRS)
+  _generate_dictionary("${DNAME}" "${LDNAME}" "${DHDRS}" "${DHDRS}" "${DINCDIRS}" "${ARGV4}")
 endmacro(generate_dictionary)
+
+
+# Same as generate_dictionary, but flattens the list of headers and sets additional include paths
+# with include_directories
+macro(generate_dictionary_flat DNAME LDNAME DHDRS DINCDIRS)
+
+    set(_dhdrs "")
+    set(_daddincdirs "")
+    foreach(_itm ${DHDRS})
+      string(FIND "${_itm}" "/" _idx)
+      if(_idx GREATER -1)
+        # Has a subdirectory specified
+        get_filename_component(_itmdir "${_itm}" DIRECTORY)
+        get_filename_component(_itmbase "${_itm}" NAME)
+        list(APPEND _dhdrs "${_itmbase}")
+        list(APPEND _daddincdirs "${CMAKE_CURRENT_SOURCE_DIR}/${_itmdir}")
+      else()
+        # No subdirectory specified
+        list(APPEND _dhdrs "${_itm}")
+      endif()
+    endforeach()
+    list(REMOVE_DUPLICATES _daddincdirs)
+    if(NOT "${_daddincdirs}" STREQUAL "")
+      foreach(_dir "${_daddincdirs}")
+        include_directories("${_dir}")
+      endforeach()
+    endif()
+    _generate_dictionary("${DNAME}" "${LDNAME}" "${_dhdrs}" "${DHDRS}" "${DINCDIRS};${_daddincdirs}" "${ARGV4}")
+
+endmacro(generate_dictionary_flat)
+
 
 # Generate the ROOTmap files
 # @LIBNAME - library name: libAnalysis.so -> Analysis.rootmap


### PR DESCRIPTION
We introduce a new `generate_dictionary_flat` CMake function to be used when
header files are in a subdirectory. The new function strips paths when passing
them to `rootcint`, hardcoding just the base header names into the libraries.
At runtime, when neither the source and the build directories are available,
basenames will be searched into the ROOT_INCLUDE_PATH environment variable and
since we install our header files in a flat directory it will finally work.

Note that the problem we are addressing does not show up in local installations
as ROOT hardcodes the full original path first, so the header files will be
always (wrongly) found in the source directory.

With @davidrohr.