### PR TITLE
[EMCAL-214] Adding range check for invalid digit coordinate

### DIFF
--- a/HLT/EMCAL/AliHLTEMCALTriggerMaker.cxx
+++ b/HLT/EMCAL/AliHLTEMCALTriggerMaker.cxx
@@ -94,7 +94,13 @@ void AliHLTEMCALTriggerMaker::AddDigit(const AliHLTCaloDigitDataStruct *digit){
    * TODO Crosscheck
    */
   Int_t fastorIndex;
-  fkGeometryPtr->GetGeometryPtr()->GetTriggerMapping()->GetFastORIndexFromCellIndex(fkGeometryPtr->GetGeometryPtr()->GetAbsCellIdFromCellIndexes(digit->fModule, digit->fX, digit->fZ), fastorIndex);
+  // check validity of the of the digit
+  int digitCellID = fkGeometryPtr->GetGeometryPtr()->GetAbsCellIdFromCellIndexes(digit->fModule, digit->fX, digit->fZ);
+  if(digitCellID < 0){
+    HLTError("Digit out of range: mod(%d), x(%d), z(%d) -> %d", digit->fModule, digit->fX, digit->fZ, digitCellID);
+    return;
+  }
+  fkGeometryPtr->GetGeometryPtr()->GetTriggerMapping()->GetFastORIndexFromCellIndex(digitCellID, fastorIndex);
   int globCol, globRow;
   fkGeometryPtr->GetGeometryPtr()->GetTriggerMapping()->GetPositionInEMCALFromAbsFastORIndex(fastorIndex, globCol, globRow);
   (*fADCOfflineValues)(globCol, globRow) += digit->fEnergy/EMCALTrigger::kEMCL1ADCtoGeV;


### PR DESCRIPTION
As discussed in the ticket digits with coordinates out-
of-range will be ignored as they are coming from
corrupted data. Instead an HLTError will be raised.

For the range check the internal boundary check of
function GetAbsCellIdFromCellIndexes is used and its
return value -1 is handled in the function AddDigit.