### PR TITLE
ATO-382 - AliTreePlayer::LoadTrees

### DIFF
--- a/STAT/AliTreePlayer.h
+++ b/STAT/AliTreePlayer.h
@@ -109,6 +109,7 @@ public:
   static void AddStatInfo(TTree* treeLeft,  TTree * treeRight , const TString refQuery, Double_t deltaT,
 		   const TString statString="median:medianLeft:medianRight:RMS:Mean:LTM0.60:LTMRMS0.60:Max:Min",
 		   Int_t maxEntries=100000000);
+  static TTree *  LoadTrees(const char *inputDataList, const char *  chRegExp, const char * chNotReg,  TString  inputFileSelection, TString axisAlias,  TString axisTitle);
   /// TODO -
   /// Metadata query from the TStatToolkit (GetMetadata, AddMetadata)
   /// TH1* DrawSorted(const char * expression, const char weights, Bool_t down, Int_t cut);  // draw sorted version of histogram


### PR DESCRIPTION
###  ATO-382 - AliTreePlayer::LoadTrees
*  Load tree and append friend trees
  * functionality used previously in macros  to compare performance map parameterization
````
TTree* AliTreePlayer::LoadTrees(const char *inputDataList, const char *chRegExp, const char *chNotReg, TString inputFileSelection, TString axisAlias, TString axisTitle)
 ````
  *  inputDataList          - command returning input data list - line with #tag:value for the metadata definition
  *  chRegExp               - regular expression  - trees to include
  *  chNotReg               - regular expression  - trees to exclude
  *  inputFileSelection     - : separated input file selection
  *  axisAlias              - axis names
  *  axisTitle              - axis titles
  * return                  - resulting tree
### Example usage in the pt resolution paramterization
* Load trees with parameterization  projections 0_1_3   - covar:pt:deltaQ
* Load trees with parameterization  projections 0_1   - covar:pt
  * Make relation  - using qPtBin as an index
````
void LoadTrees(){
  tree0 = AliTreePlayer::LoadTrees("cat map.list","his.*_proj_0_1Dist","XXX",".*","","");
  tree3 = AliTreePlayer::LoadTrees("cat map.list","his.*_proj_0_1_3Dist","XXX",".*","","");
  tree0->BuildIndex("qPtBin");
  tree3->BuildIndex("qPtBin");
  tree3->AddFriend(tree0, "T");
  tree0->SetMarkerStyle(21);
  tree3->SetMarkerStyle(21);
}
````
