### PR TITLE
fix double delete in HLT TPC code

### DIFF
--- a/HLT/TPCLib/AliHLTTPCLog.cxx
+++ b/HLT/TPCLib/AliHLTTPCLog.cxx
@@ -16,7 +16,7 @@ const char* AliHLTTPCLog::kPrec = "";
 const char* AliHLTTPCLog::kHex = "";
 const char* AliHLTTPCLog::kDec = "";
 
-stringstream AliHLTTPCLog::fgStream;
+stringstream* AliHLTTPCLog::fgStream = new stringstream;
 
 AliHLTLogging AliHLTTPCLog::fgHLTLogging;
 
@@ -29,9 +29,9 @@ const char* AliHLTTPCLog::Flush()
   string iter;
   string message("");
   int scanStatus=0;
-  fgStream >> severity;
-  while (!fgStream.eof()) {
-    fgStream >> iter;
+  *fgStream >> severity;
+  while (!fgStream->eof()) {
+    *fgStream >> iter;
     if (scanStatus==0 && iter.compare(AliHLTTPCLogKeyOrigin)==0) {
       // idicate scan of origin message
       scanStatus=1;
@@ -81,9 +81,8 @@ const char* AliHLTTPCLog::Flush()
     fgHLTLogging.Logging(kHLTLogFatal, origin.c_str(), keyword.c_str(), message.c_str());
     break;
   }
-  fgStream.clear();
+  fgStream->clear();
   string empty("");
-  fgStream.str(empty);
+  fgStream->str(empty);
   return "";
 }
-

--- a/HLT/TPCLib/AliHLTTPCLog.h
+++ b/HLT/TPCLib/AliHLTTPCLog.h
@@ -60,7 +60,7 @@ class AliHLTTPCLog  {
   /**
    * Get the stream.
    */
-  static stringstream& GetStream() {return fgStream;}
+  static stringstream& GetStream() {return *fgStream;}
 
   /**
    * Get the logging level.
@@ -69,7 +69,7 @@ class AliHLTTPCLog  {
 
  private:
   /** a stringstream to receive the output */
-  static stringstream fgStream;                                    // see above
+  static stringstream* fgStream;                                   // see above
 
   /** the logging filter */
   static TLogLevel fgLevel;                                        // see above


### PR DESCRIPTION
the legacy class uses a singleton of a singleton which does not clean up correctly, and it cannot be moved to the modern method since it is used in static class members. Just tried to fix it properly for an hour but failed... So we just leak the std::stringstream of the singleton...