### PR TITLE
[EMCAL-369] Speedup of raw fitter for HLT

### DIFF
--- a/EMCAL/EMCALUtils/AliCaloConstants.h
+++ b/EMCAL/EMCALUtils/AliCaloConstants.h
@@ -103,7 +103,7 @@ namespace CaloConstants
   namespace FitAlgorithm
   {
     ///< fitting alorithms tag numbers
-    enum fitAlgorithm { kStandard = 0, kCrude = 1, kPeakFinder = 2, kNeuralNet = 3, kFastFit= 4, kFakeAltro = 9, kNONE = 8 } ; 
+    enum fitAlgorithm { kStandard = 0, kCrude = 1, kPeakFinder = 2, kNeuralNet = 3, kFastFit= 4, kStandardFast = 5, kFakeAltro = 9, kNONE = 8 } ; 
   }
   
   namespace ReturnCodes

--- a/EMCAL/EMCALraw/AliCaloRawAnalyzerFactory.cxx
+++ b/EMCAL/EMCALraw/AliCaloRawAnalyzerFactory.cxx
@@ -24,6 +24,7 @@
 #include "AliCaloRawAnalyzerPeakFinder.h"
 #include "AliCaloRawAnalyzerCrude.h"
 #include "AliCaloRawAnalyzerKStandard.h"
+#include "AliCaloRawAnalyzerKStandardFast.h"
 #include "AliCaloRawAnalyzerFakeALTRO.h"
 
 ///
@@ -54,6 +55,9 @@ AliCaloRawAnalyzerFactory::CreateAnalyzer( const int algo )
       break;
     case kStandard:
       return new AliCaloRawAnalyzerKStandard();
+      break;
+    case kStandardFast:
+      return new AliCaloRawAnalyzerKStandardFast();
       break;
     case kFakeAltro:
       return  new AliCaloRawAnalyzerFakeALTRO();

--- a/EMCAL/EMCALraw/AliCaloRawAnalyzerKStandardFast.cxx
+++ b/EMCAL/EMCALraw/AliCaloRawAnalyzerKStandardFast.cxx
@@ -1,0 +1,202 @@
+/**************************************************************************
+//* This file is property of and copyright by the ALICE HLT Project        *
+//* ALICE Experiment at CERN, All rights reserved.                         *
+//*                                                                        *
+//* Primary Authors: Rudiger Haake <ruediger.haake@cern.ch>, Yale          *
+//*                  for The ALICE HLT Project.                            *
+//*                                                                        *
+//* Permission to use, copy, modify and distribute this software and its   *
+//* documentation strictly for non-commercial purposes is hereby granted   *
+//* without fee, provided that the above copyright notice appears in all   *
+//* copies and that both the copyright notice and this permission notice   *
+//* appear in the supporting documentation. The authors make no claims     *
+//* about the suitability of this software for any purpose. It is          *
+//* provided "as is" without express or implied warranty.                  *
+//**************************************************************************/
+
+
+// AliRoot/EMCal system
+#include "AliCaloRawAnalyzerKStandardFast.h"
+#include "AliCaloBunchInfo.h"
+#include "AliCaloFitResults.h"
+#include "AliLog.h"
+
+// Standard libraries
+#include <stdexcept>
+#include <Math/MinimizerOptions.h>
+
+
+// Root system
+#include "TF1.h"
+#include "TGraph.h"
+#include "TRandom.h"
+#include "TMath.h"
+
+#include "AliEMCALRawResponse.h"
+
+using namespace std;
+
+/// \cond CLASSIMP
+ClassImp( AliCaloRawAnalyzerKStandardFast ) ;
+/// \endcond
+
+///
+/// Constructor
+//_______________________________________________________________________
+AliCaloRawAnalyzerKStandardFast::AliCaloRawAnalyzerKStandardFast() : AliCaloRawAnalyzerFitter("Chi Square ( kStandardFast )", "KStandardFast")
+{
+  fAlgo = Algo::kStandardFast;
+
+  // Define fitter function
+  fTf1 = new TF1("signalFit", RawResponseFunction, 0, TIMEBINS , 2);
+  fTf1->SetParameters(10.,5.); //set all defaults once, just to be safe
+  fTf1->SetParNames("amp","t0");
+  ROOT::Math::MinimizerOptions::SetDefaultStrategy(0);
+
+  fSignal =  new TGraph(TIMEBINS); 
+}
+
+///
+/// Destructor
+//_______________________________________________________________________
+AliCaloRawAnalyzerKStandardFast::~AliCaloRawAnalyzerKStandardFast()
+{
+  //delete fTf1; // already done in base class
+  if(fSignal)
+    delete fSignal;
+}
+
+///
+/// Evaluation Amplitude and TOF
+//_______________________________________________________________________
+AliCaloFitResults
+AliCaloRawAnalyzerKStandardFast::Evaluate( const vector<AliCaloBunchInfo>  &bunchlist,
+                                       UInt_t altrocfg1, UInt_t altrocfg2 )
+{
+  Float_t pedEstimate  = 0;
+  short maxADC = 0;
+  Int_t first = 0;
+  Int_t last = 0;
+  Int_t bunchIndex = 0;
+  Float_t ampEstimate = 0;
+  short timeEstimate  = 0;
+  Float_t time = 0;
+  Float_t amp=0;
+  Float_t chi2 = 0;
+  Int_t ndf = 0;
+  Bool_t fitDone = kFALSE;
+
+  int nsamples = PreFitEvaluateSamples( bunchlist, altrocfg1, altrocfg2, bunchIndex, ampEstimate, 
+                                       maxADC, timeEstimate, pedEstimate, first, last,   (int)fAmpCut ); 
+  
+  
+  if (ampEstimate >= fAmpCut  ) 
+  { 
+    time = timeEstimate; 
+    Int_t timebinOffset = bunchlist.at(bunchIndex).GetStartBin() - (bunchlist.at(bunchIndex).GetLength()-1); 
+    amp = ampEstimate; 
+    
+    if ( nsamples > 1 && maxADC< OVERFLOWCUT ) 
+    { 
+      FitRaw(first, last, amp, time, chi2, fitDone);
+      time += timebinOffset;
+      timeEstimate += timebinOffset;
+      ndf = nsamples - 2;
+    }
+  } 
+  if ( fitDone ) 
+  { 
+    Float_t ampAsymm = (amp - ampEstimate)/(amp + ampEstimate);
+    Float_t timeDiff = time - timeEstimate;
+    
+    if ( (TMath::Abs(ampAsymm) > 0.1) || (TMath::Abs(timeDiff) > 2) ) 
+    {
+      amp     = ampEstimate;
+      time    = timeEstimate; 
+      fitDone = kFALSE;
+    } 
+  }  
+
+  if (amp >= fAmpCut ) 
+  { 
+    if ( ! fitDone) 
+    { 
+      amp += (0.5 - gRandom->Rndm()); 
+    }
+    time = time * TIMEBINWITH; 
+    time -= fL1Phase;
+    
+    return AliCaloFitResults( -99, -99, fAlgo , amp, time,
+                             (int)time, chi2, ndf, Ret::kDummy );
+  }
+  return AliCaloFitResults( Ret::kInvalid, Ret::kInvalid );
+}
+
+
+///
+/// Fits the raw signal time distribution
+//_______________________________________________________________________
+void
+ AliCaloRawAnalyzerKStandardFast::FitRaw( Int_t firstTimeBin, Int_t lastTimeBin,
+                                      Float_t & amp, Float_t & time, Float_t & chi2, Bool_t & fitDone) const
+{ 
+  // Changes wrt to kStandard fitter:
+  // * Fit function not created in each FitRaw() call
+  // * Signal histogram fSignal not created in each FitRaw() call
+  // * Adjusted fit range to datapoints
+  // * Fit function simplification
+  // * Use fit option N0
+  // * Minimizer strategy adjusted
+
+  Int_t nsamples = lastTimeBin - firstTimeBin + 1;
+  fitDone = kFALSE;
+  if ( nsamples < 3 )  return;  
+
+  fSignal->Set(nsamples);
+  for (int i=0; i<nsamples; i++) 
+  {
+    Int_t timebin = firstTimeBin + i;    
+    fSignal->SetPoint(i, timebin, GetReversed(timebin)); 
+  }
+
+  // Initial fit function
+  fTf1->SetRange(lastTimeBin, firstTimeBin);
+  fTf1->SetParameter(1, time);
+  fTf1->SetParameter(0, amp);
+  fTf1->SetParLimits(0, 0.5*amp, 2*amp );
+  fTf1->SetParLimits(1, time - 4, time + 4); 
+  
+  try 
+  {
+    fSignal->Fit(fTf1, "QROW N0"); // Note option 'W': equal errors on all points, 'R': Use range we set earlier, N0: Do not plot result, Q: quite mode
+    amp  = fTf1->GetParameter(0);
+    time = fTf1->GetParameter(1);
+    chi2 = fTf1->GetChisquare();
+
+    fitDone = kTRUE;
+  }
+  catch (const std::exception & e) 
+  {
+    AliError( Form("TH1 Fit exception %s", e.what()) ); 
+    // stay with default amp and time in case of exception, i.e. no special action required
+    fitDone = kFALSE;
+  }
+
+  return;
+}
+
+///
+/// Approximate response function of the EMCal electronics.
+/// Simplified version, adapted from AliEMCALRawResponse
+//_______________________________________________________________________
+Double_t AliCaloRawAnalyzerKStandardFast::RawResponseFunction(Double_t *x, Double_t *par)
+{
+  Double_t signal = 0.;
+  Double_t xx     = ( x[0] - par[1] + TAU ) / TAU;
+  
+  if(xx > 0)
+    signal = par[0] * TMath::Power(xx , ORDER) * TMath::Exp(ORDER * (1 - xx )) ;
+
+  return signal;
+}
+

--- a/EMCAL/EMCALraw/AliCaloRawAnalyzerKStandardFast.h
+++ b/EMCAL/EMCALraw/AliCaloRawAnalyzerKStandardFast.h
@@ -1,0 +1,61 @@
+#ifndef ALICALORAWANALYZERKSTANDARDFAST_H
+#define ALICALORAWANALYZERKSTANDARDFAST_H
+
+/* Copyright(c) 1998-2010, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice     */
+
+//_________________________________________________________________________
+/// \class AliCaloRawAnalyzerKStandardFast
+/// \ingroup EMCALraw
+/// \brief  Raw data fitting: standard TMinuit fit
+///
+/// Extraction of amplitude and peak position
+/// from CALO raw data using
+/// least square fit for the
+/// Moment assuming identical and 
+/// independent errors (equivalent with chi square)
+///
+/// Extracted from AliEMCALRawUtils
+///
+/// \author Per Thomas Hille <p.t.hille@fys.uio.no>, Yale. 
+/// \author David Silvermyr <David.Silvermyr@cern.ch>, ORNL
+/// \author Rudiger Haake <ruediger.haake@cern.ch>, Yale
+
+//_________________________________________________________________________
+
+#include "AliCaloRawAnalyzerFitter.h"
+
+class TH1;
+
+class  AliCaloRawAnalyzerKStandardFast : public AliCaloRawAnalyzerFitter
+{
+  friend class AliCaloRawAnalyzerFactory; // Factory for creation of raw analyzer (rule checker request)
+  
+ public:
+  
+  virtual ~AliCaloRawAnalyzerKStandardFast();
+  
+  virtual AliCaloFitResults  Evaluate( const std::vector<AliCaloBunchInfo> &bunchvector,
+                                       UInt_t altrocfg1,
+                                       UInt_t altrocfg2 );
+  
+  void FitRaw( Int_t firstTimeBin, Int_t lastTimeBin,
+               Float_t & amp,  Float_t & time,
+               Float_t & chi2, Bool_t & fitDone) const ;
+ 
+ private:
+ 
+  TGraph*                     fSignal; ///< histogram for signal that will be fit
+  static Double_t             RawResponseFunction(Double_t *x, Double_t *par); 
+
+  AliCaloRawAnalyzerKStandardFast();
+  AliCaloRawAnalyzerKStandardFast(               const AliCaloRawAnalyzerKStandardFast & );
+  AliCaloRawAnalyzerKStandardFast  & operator = (const AliCaloRawAnalyzerKStandardFast & );
+  
+  /// \cond CLASSIMP
+  ClassDef(AliCaloRawAnalyzerKStandardFast, 1);
+  /// \endcond
+
+};
+
+#endif //ALICALORAWANALYZERKSTANDARDFAST_H

--- a/EMCAL/EMCALraw/CMakeLists.txt
+++ b/EMCAL/EMCALraw/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SRCS
     AliCaloRawAnalyzerFastFit.cxx
     AliCaloRawAnalyzerFitter.cxx
     AliCaloRawAnalyzerKStandard.cxx
+    AliCaloRawAnalyzerKStandardFast.cxx
     AliCaloRawAnalyzerNN.cxx
     AliCaloRawAnalyzerPeakFinder.cxx
     AliEMCALCCUSBRawStream.cxx

--- a/EMCAL/EMCALraw/EMCALrawLinkDef.h
+++ b/EMCAL/EMCALraw/EMCALrawLinkDef.h
@@ -8,6 +8,7 @@
 #pragma link C++ class AliCaloRawAnalyzerFastFit+;
 #pragma link C++ class AliCaloRawAnalyzerPeakFinder+;
 #pragma link C++ class AliCaloRawAnalyzerKStandard+;
+#pragma link C++ class AliCaloRawAnalyzerKStandardFast+;
 #pragma link C++ class AliCaloRawAnalyzerFakeALTRO+;
 #pragma link C++ class AliCaloRawAnalyzerCrude+;
 #pragma link C++ class AliCaloNeuralFit+;

--- a/HLT/CALO/AliHLTCaloRawAnalyzerComponentv3.h
+++ b/HLT/CALO/AliHLTCaloRawAnalyzerComponentv3.h
@@ -36,7 +36,7 @@
 // or
 // visit http://web.ift.uib.no/~kjeks/doc/alice-hlt
 
-
+class AliAltroMapping;
 class AliCaloRawAnalyzer;
 class AliHLTCaloRcuCellEnergyDataStruct;
 class AliHLTCaloMapper;
@@ -146,6 +146,7 @@ class AliHLTCaloRawAnalyzerComponentv3 :  public AliHLTCaloProcessor, protected 
   
  protected:
   virtual void InitMapping(const int specification ) = 0;
+  void InitAltroMapping();
   void PrintDebugInfo();
   AliCaloRawAnalyzer *fAnalyzerPtr;   //COMMENT
   AliHLTCaloMapper *fMapperPtr;          //COMMENT
@@ -166,6 +167,9 @@ class AliHLTCaloRawAnalyzerComponentv3 :  public AliHLTCaloProcessor, protected 
 
   /** detector */
   TString fDetector;                                  // detector string id
+
+  /** cache for alto mapping, copied from AliCaloRawStreamV3 */
+  AliAltroMapping **fAltroMappingCache;
 
   /** Describing which algorithm we are using */
   Short_t fAlgorithm;                                 //COMMENT
@@ -190,7 +194,7 @@ class AliHLTCaloRawAnalyzerComponentv3 :  public AliHLTCaloProcessor, protected 
 
   /** Switch on L1 phase subtraction */ 
   Bool_t fDoL1PhaseSubtraction;                         // COMMENT             
-  
+
   class RawDataWriter  
   {
   public:

--- a/HLT/EMCAL/AliHLTEMCALAgent.cxx
+++ b/HLT/EMCAL/AliHLTEMCALAgent.cxx
@@ -51,6 +51,7 @@ AliHLTEMCALAgent gAliHLTEMCALAgent;
 //#include "AliHLTEMCALMonitorTriggerComponent.h"
 #include "AliHLTEMCALRawAnalyzerComponent.h"
 #include "AliHLTEMCALRawAnalyzerStandardComponent.h"
+#include "AliHLTEMCALRawAnalyzerStandardFastComponent.h"
 #include "AliHLTEMCALRawAnalyzerPeakFinderComponent.h"
 #include "AliHLTEMCALRawAnalyzerComponentTRU.h"
 #include "AliHLTEMCALRawAnalyzerComponentSTU.h"
@@ -217,6 +218,7 @@ int AliHLTEMCALAgent::RegisterComponents(AliHLTComponentHandler* pHandler) const
     if (!pHandler) return -EINVAL;
     
     pHandler->AddComponent(new AliHLTEMCALRawAnalyzerStandardComponent);
+    pHandler->AddComponent(new AliHLTEMCALRawAnalyzerStandardFastComponent);
     pHandler->AddComponent(new AliHLTEMCALRawAnalyzerCrudeComponent);
     pHandler->AddComponent(new AliHLTEMCALRawAnalyzerLMSComponent);
     pHandler->AddComponent(new AliHLTEMCALRawAnalyzerPeakFinderComponent);

--- a/HLT/EMCAL/AliHLTEMCALDigitsMonitorComponent.cxx
+++ b/HLT/EMCAL/AliHLTEMCALDigitsMonitorComponent.cxx
@@ -150,6 +150,7 @@ int AliHLTEMCALDigitsMonitorComponent::DoInit(int argc, const char** argv)
   fDigitsMonitor = new AliHLTEMCALDigitsMonitor;
   fDigitsMonitor->Init();
   fDigitsMonitor->SetGeometry(fGeometry);
+  return 0;
 }
 
 int AliHLTEMCALDigitsMonitorComponent::Deinit()

--- a/HLT/EMCAL/AliHLTEMCALLinkDef.h
+++ b/HLT/EMCAL/AliHLTEMCALLinkDef.h
@@ -8,6 +8,7 @@
 #pragma link C++ class AliHLTEMCALRawAnalyzerComponent+;
 #pragma link C++ class AliHLTEMCALMapper+;
 #pragma link C++ class AliHLTEMCALRawAnalyzerStandardComponent+;
+#pragma link C++ class AliHLTEMCALRawAnalyzerStandardFastComponent+;
 #pragma link C++ class AliHLTEMCALRawAnalyzerCrudeComponent+;
 #pragma link C++ class AliHLTEMCALRawAnalyzerLMSComponent+;
 #pragma link C++ class AliHLTEMCALRawAnalyzerPeakFinderComponent+;

--- a/HLT/EMCAL/AliHLTEMCALRawAnalyzerStandardFastComponent.cxx
+++ b/HLT/EMCAL/AliHLTEMCALRawAnalyzerStandardFastComponent.cxx
@@ -1,0 +1,61 @@
+/**************************************************************************
+//* This file is property of and copyright by the ALICE HLT Project        *
+//* ALICE Experiment at CERN, All rights reserved.                         *
+//*                                                                        *
+//* Primary Authors: Rudiger Haake <ruediger.haake@cern.ch>, Yale          *
+//*                  for The ALICE HLT Project.                            *
+//*                                                                        *
+//* Permission to use, copy, modify and distribute this software and its   *
+//* documentation strictly for non-commercial purposes is hereby granted   *
+//* without fee, provided that the above copyright notice appears in all   *
+//* copies and that both the copyright notice and this permission notice   *
+//* appear in the supporting documentation. The authors make no claims     *
+//* about the suitability of this software for any purpose. It is          *
+//* provided "as is" without express or implied warranty.                  *
+//**************************************************************************/
+
+// Component structure copied from AliHLTEMCALRawAnalyzerStandardComponent
+
+#include "AliHLTEMCALRawAnalyzerStandardFastComponent.h"
+#include "AliCaloRawAnalyzerKStandardFast.h"
+
+
+//AliHLTEMCALRawAnalyzerStandardFastComponent::AliHLTEMCALRawAnalyzerStandardFastComponent : AliHLTEMCALRawAnalyzerComponent()
+AliHLTEMCALRawAnalyzerStandardFastComponent::AliHLTEMCALRawAnalyzerStandardFastComponent() : AliHLTEMCALRawAnalyzerComponent( kStandardFast )
+{
+}
+
+
+AliHLTEMCALRawAnalyzerStandardFastComponent::~AliHLTEMCALRawAnalyzerStandardFastComponent()
+{
+  // destructor
+}
+
+int 
+AliHLTEMCALRawAnalyzerStandardFastComponent::DoDeinit()
+{
+  //comment
+  if (0 != fAnalyzerPtr)
+    {
+      delete fAnalyzerPtr;
+      fAnalyzerPtr = 0;
+    }
+
+  return AliHLTEMCALRawAnalyzerComponent::DoDeinit();
+}
+
+const char* 
+AliHLTEMCALRawAnalyzerStandardFastComponent::GetComponentID()
+{
+  // component id
+  return "EmcalRawStandardFast";
+}
+
+
+AliHLTComponent* 
+AliHLTEMCALRawAnalyzerStandardFastComponent::Spawn()
+{
+  // spawn component
+  return new AliHLTEMCALRawAnalyzerStandardFastComponent();
+}
+ 

--- a/HLT/EMCAL/AliHLTEMCALRawAnalyzerStandardFastComponent.h
+++ b/HLT/EMCAL/AliHLTEMCALRawAnalyzerStandardFastComponent.h
@@ -1,0 +1,30 @@
+#ifndef AliHLTEMCALRawAnalyzerStandardFastComponent_H
+#define AliHLTEMCALRawAnalyzerStandardFastComponent_H
+
+// Component structure copied from AliHLTEMCALRawAnalyzerStandardComponent
+
+#include  "AliHLTEMCALRawAnalyzerComponent.h"
+
+//AliHLTCALORawAnalyzerCrudeComponent
+
+class  AliHLTEMCALRawAnalyzerStandardFastComponent : public AliHLTEMCALRawAnalyzerComponent
+//class  AliHLTEMCALRawAnalyzerStandardFastComponent : public AliHLTCALORawAnalyzerComponent
+{
+public:
+  AliHLTEMCALRawAnalyzerStandardFastComponent();
+  virtual ~AliHLTEMCALRawAnalyzerStandardFastComponent();
+  virtual int DoDeinit();
+  virtual const char* GetComponentID();
+  virtual AliHLTComponent* Spawn(); 
+  //  virtual void GetInputDataTypes( vector <AliHLTComponentDataType>& list);
+ private:
+  AliHLTEMCALRawAnalyzerStandardFastComponent( const AliHLTEMCALRawAnalyzerStandardFastComponent  & );
+  AliHLTEMCALRawAnalyzerStandardFastComponent & operator = (const AliHLTEMCALRawAnalyzerStandardFastComponent  &);
+  // bool TestBoolConst() { return false; };
+  //  bool TestBool()  {return  false; };
+
+    
+
+};
+
+#endif

--- a/HLT/EMCAL/CMakeLists.txt
+++ b/HLT/EMCAL/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SRCS
     AliHLTEMCALMapper.cxx
     AliHLTEMCALRawAnalyzerComponent.cxx
     AliHLTEMCALRawAnalyzerStandardComponent.cxx
+    AliHLTEMCALRawAnalyzerStandardFastComponent.cxx
     AliHLTEMCALRawAnalyzerCrudeComponent.cxx
     AliHLTEMCALRawAnalyzerFastFitComponent.cxx
     AliHLTEMCALRawAnalyzerLMSComponent.cxx


### PR DESCRIPTION
Two steps found to speed up the EMCAL raw analyzer / raw fitter

- Replace in-loop dynamic allocations of memory in raw fitter by class member objects 
- Cache ALTRO mapping in raw analyzer component and pass it over to the calo raw stream in order to have the expensive read operation of the ALTRO mapping from disk only once

Now profilers show that the performance of the raw analyzer is dominated by the least square fit.