### PR TITLE
[EMCAL-402] Cache ALTRO mapping in the TRU raw analyzer

### DIFF
--- a/HLT/EMCAL/AliHLTEMCALRawAnalyzerComponentTRU.h
+++ b/HLT/EMCAL/AliHLTEMCALRawAnalyzerComponentTRU.h
@@ -45,7 +45,7 @@ class AliHLTCaloDigitMaker;
 class AliHLTCaloDigitContainerDataStruct;
 class AliRawReaderMemory;
 class AliCaloRawStreamV3;
-
+class AliAltroMapping;
 
 
 #include "AliHLTCaloConstantsHandler.h"
@@ -80,6 +80,7 @@ class AliHLTEMCALRawAnalyzerComponentTRU :  public AliHLTCaloProcessor, protecte
   virtual int DoEvent( const AliHLTComponentEventData& evtData, const AliHLTComponentBlockData* blocks,
            AliHLTComponentTriggerData& trigData, AliHLTUInt8_t* outputPtr,
            AliHLTUInt32_t& size, vector<AliHLTComponentBlockData>& outputBlocks );
+  void InitAltroMapping();
 
   /**
    * Do the real processing in the component
@@ -102,6 +103,9 @@ class AliHLTEMCALRawAnalyzerComponentTRU :  public AliHLTCaloProcessor, protecte
  private:
   AliHLTEMCALRawAnalyzerComponentTRU(const AliHLTEMCALRawAnalyzerComponentTRU & );
   AliHLTEMCALRawAnalyzerComponentTRU & operator = (const AliHLTEMCALRawAnalyzerComponentTRU &);
+
+  /** cache for alto mapping, copied from AliCaloRawStreamV3 */
+  AliAltroMapping **fAltroMappingCache;
 
   /** Pointer to the raw data reader which reads from memory */
   //AliRawReaderMemory* fRawReaderMemoryPtr;            //!transient


### PR DESCRIPTION
The ALTRO raw stream is constructed for every event and
therefore always reads the same ALTRO mapping from a text
file from disk. As the altro mapping doesn't change it is
can be cached in memory and passed to the raw analyzer
from cache, which is a significantly faster operation than
reading it from disk.