### PR TITLE
Work around TGeoHMatrix bug in ROOT v6-14-04

### DIFF
--- a/TOF/TOFrec/AliTOFtracker.cxx
+++ b/TOF/TOFrec/AliTOFtracker.cxx
@@ -554,7 +554,7 @@ void AliTOFtracker::MatchTracks( Int_t mLastStep){
     fTOFtrackPoints->Delete();
 
     for (Int_t ii=0; ii<kNclusterMax; ii++)
-      global[ii] = 0x0;
+      global[ii].Clear();
     AliTOFtrack *track =(AliTOFtrack*)fTracks->UncheckedAt(iseed);
     AliESDtrack *t =(AliESDtrack*)fSeeds->At(track->GetSeedIndex());
     //if ( t->GetTOFsignal()>0. ) continue;


### PR DESCRIPTION
`operator=()` does not work properly any longer if a null pointer is passed as
value. The intended behaviour is to invoke `Clear()` to the given instance of
`TGeoHMatrix`. This fix in AliRoot makes it work as intended without waiting for
a fix in ROOT.