### PR TITLE
Fix processing with ROOT6

### DIFF
--- a/HLT/BASE/HOMER/AliHLTHOMERReader.cxx
+++ b/HLT/BASE/HOMER/AliHLTHOMERReader.cxx
@@ -43,6 +43,7 @@
 // visit http://web.ift.uib.no/~kjeks/doc/alice-hlt
 
 #include "AliHLTHOMERReader.h"
+#include <sys/ipc.h>
 //#include <stdio.h>
 #ifdef __SUNPRO_CC
 #include <string.h>

--- a/HLT/BASE/HOMER/AliHLTHOMERReader.h
+++ b/HLT/BASE/HOMER/AliHLTHOMERReader.h
@@ -18,12 +18,10 @@
 // visit http://web.ift.uib.no/~kjeks/doc/alice-hlt
 
 #include <limits.h>
-#include <sys/ipc.h>
+//#include <sys/ipc.h>
 #include <sys/shm.h>
 #include "AliHLTHOMERData.h"
 #include <TObject.h>
-
-
 
 /**
  * @class AliHLTMonitoringReader


### PR DESCRIPTION
Move rpc.h to .cxx, since on the GRID we might compile on a
different OS than we run, and ROOT will face compatibiltiy
issues parsing the header otherwise.