### PR TITLE
Rename conflicting AliT0AnalysisTaskQA to *Legacy

### DIFF
--- a/T0/T0calib/AliT0AnalysisTaskQALegacy.cxx
+++ b/T0/T0calib/AliT0AnalysisTaskQALegacy.cxx
@@ -12,7 +12,7 @@
 #include "AliESDEvent.h"
 #include "AliESDInputHandler.h"
 
-#include "AliT0AnalysisTaskQA.h"
+#include "AliT0AnalysisTaskQALegacy.h"
 
 //#include "AliCDBMetaData.h"
 //#include "AliCDBId.h"
@@ -23,9 +23,9 @@
 // Task should calculate channels offset 
 // Authors: Alla 
 
-ClassImp(AliT0AnalysisTaskQA)
+ClassImp(AliT0AnalysisTaskQALegacy)
 //________________________________________________________________________
-AliT0AnalysisTaskQA::AliT0AnalysisTaskQA() 
+AliT0AnalysisTaskQALegacy::AliT0AnalysisTaskQALegacy() 
   : AliAnalysisTaskSE(),  fESD(0x0), fTzeroObject(0x0),
   fTzeroORA(0x0), fTzeroORC(0x0), fResolution(0x0), fTzeroORAplusORC(0x0),
     fRunNumber(0),fTimeVSAmplitude(0x0),fCFDVSPmtId(0x0),fSPDVertexVST0Vertex(0x0),
@@ -43,7 +43,7 @@ AliT0AnalysisTaskQA::AliT0AnalysisTaskQA()
 
 
 //________________________________________________________________________
-AliT0AnalysisTaskQA::AliT0AnalysisTaskQA(const char *name) 
+AliT0AnalysisTaskQALegacy::AliT0AnalysisTaskQALegacy(const char *name) 
   : AliAnalysisTaskSE(name),  fESD(0x0), fTzeroObject(0x0),
   fTzeroORA(0x0), fTzeroORC(0x0), fResolution(0x0), fTzeroORAplusORC(0x0),
     fRunNumber(0),fTimeVSAmplitude(0x0),fCFDVSPmtId(0x0),fSPDVertexVST0Vertex(0x0),
@@ -59,7 +59,7 @@ AliT0AnalysisTaskQA::AliT0AnalysisTaskQA(const char *name)
 }
 
 //________________________________________________________________________
-AliT0AnalysisTaskQA::~AliT0AnalysisTaskQA() 
+AliT0AnalysisTaskQALegacy::~AliT0AnalysisTaskQALegacy() 
 {
   // Destructor
   // printf("AliT0CalibOffsetChannels~AliT0CalibOffsetChannels() ");
@@ -78,7 +78,7 @@ AliT0AnalysisTaskQA::~AliT0AnalysisTaskQA()
 }
 
 //------------------------------------------------------------------
-void AliT0AnalysisTaskQA::UserCreateOutputObjects()
+void AliT0AnalysisTaskQALegacy::UserCreateOutputObjects()
 {
   // Create histograms
  fTimeVSAmplitude = new TH2F*[NPMT0];
@@ -118,7 +118,7 @@ void AliT0AnalysisTaskQA::UserCreateOutputObjects()
 }
 
 //________________________________________________________________________
-void AliT0AnalysisTaskQA::UserExec(Option_t *) 
+void AliT0AnalysisTaskQALegacy::UserExec(Option_t *) 
 {
   // Main loop
   // Called for each event
@@ -183,7 +183,7 @@ void AliT0AnalysisTaskQA::UserExec(Option_t *)
   PostData(1, fTzeroObject);
 }      
  //________________________________________________________________________
-void AliT0AnalysisTaskQA::Terminate(Option_t *) 
+void AliT0AnalysisTaskQALegacy::Terminate(Option_t *) 
 {
   
    // Called once at the end of the query

--- a/T0/T0calib/AliT0AnalysisTaskQALegacy.h
+++ b/T0/T0calib/AliT0AnalysisTaskQALegacy.h
@@ -1,5 +1,5 @@
-#ifndef AliT0AnalysisTaskQA_cxx
-#define AliT0AnalysisTaskQA_cxx
+#ifndef AliT0AnalysisTaskQALegacyLegacy_cxx
+#define AliT0AnalysisTaskQALegacy_cxx
 
 // task determines mean and sigma of T0 signals  ORA, ORC, ORA-ORC, ORA+ORC/2  
 // Authors: FK  
@@ -13,11 +13,11 @@ class TH2F;
 
 #include "AliAnalysisTaskSE.h"
 
-class AliT0AnalysisTaskQA : public AliAnalysisTaskSE {
+class AliT0AnalysisTaskQALegacy : public AliAnalysisTaskSE {
  public:
-  AliT0AnalysisTaskQA();
-  AliT0AnalysisTaskQA(const char *name);
-  virtual ~AliT0AnalysisTaskQA(); 
+  AliT0AnalysisTaskQALegacy();
+  AliT0AnalysisTaskQALegacy(const char *name);
+  virtual ~AliT0AnalysisTaskQALegacy(); 
   
   virtual void   UserCreateOutputObjects();
   virtual void   UserExec(Option_t *option);
@@ -40,10 +40,10 @@ class AliT0AnalysisTaskQA : public AliAnalysisTaskSE {
   TH2F        *fT0vsNtracks; //! T0A vs Ntracks
   
  
-  AliT0AnalysisTaskQA(const AliT0AnalysisTaskQA&); // not implemented
-  AliT0AnalysisTaskQA& operator=(const AliT0AnalysisTaskQA&); // not implemented
+  AliT0AnalysisTaskQALegacy(const AliT0AnalysisTaskQALegacy&); // not implemented
+  AliT0AnalysisTaskQALegacy& operator=(const AliT0AnalysisTaskQALegacy&); // not implemented
   
-  ClassDef(AliT0AnalysisTaskQA, 1); // example of analysis
+  ClassDef(AliT0AnalysisTaskQALegacy, 1); // example of analysis
 };
 
 #endif

--- a/T0/T0calib/CMakeLists.txt
+++ b/T0/T0calib/CMakeLists.txt
@@ -33,7 +33,7 @@ include_directories(${ROOT_INCLUDE_DIR}
 
 # Sources in alphabetical order
 set(SRCS
-    AliT0AnalysisTaskQA.cxx
+    AliT0AnalysisTaskQALegacy.cxx
     AliT0CalibAnalysisTask.cxx
     AliT0CalibOffsetChannelsTask.cxx
     AliT0PreprocessorOffline.cxx

--- a/T0/T0calib/T0calibLinkDef.h
+++ b/T0/T0calib/T0calibLinkDef.h
@@ -10,7 +10,7 @@
  
 #pragma link C++ class AliT0PreprocessorOffline+;
 #pragma link C++ class AliT0CalibOffsetChannelsTask+;
-#pragma link C++ class AliT0AnalysisTaskQA+;
+#pragma link C++ class AliT0AnalysisTaskQALegacy+;
 #pragma link C++ class AliT0CalibAnalysisTask+;
 #pragma link C++ class AliT0TimeAmplCorr+;
 


### PR DESCRIPTION
Task with the same name exists in AliPhysics and creates conflicts, see errors
in alisw/AliPhysics#6635