### PR TITLE
Allow skipping TOF match update when copy to new ESDEvent

### DIFF
--- a/STEER/ESD/AliESDEvent.cxx
+++ b/STEER/ESD/AliESDEvent.cxx
@@ -1215,8 +1215,8 @@ Int_t  AliESDEvent::AddTrack(const AliESDtrack *t)
     // Add track
     TClonesArray &ftr = *fTracks;
     AliESDtrack * track = new(ftr[fTracks->GetEntriesFast()])AliESDtrack(*t);
-    track->SetID(fTracks->GetEntriesFast()-1);
     track->SetESDEvent(this);
+    track->SetID(fTracks->GetEntriesFast()-1);
     return  track->GetID();    
 }
 

--- a/STEER/ESD/AliESDtrack.cxx
+++ b/STEER/ESD/AliESDtrack.cxx
@@ -3367,6 +3367,7 @@ void  AliESDtrack::ReplaceTOFTrackID(int oldID, int newID)
   // replace the ID in TOF clusters references to this track
   if (!fNtofClusters || !GetESDEvent()) return;
   TClonesArray *tofclArray = GetESDEvent()->GetESDTOFClusters();
+  if (!tofclArray || tofclArray->GetEntries()<1) return;
   for (int it=fNtofClusters;it--;) {
     AliESDTOFCluster* clTOF = (AliESDTOFCluster*)tofclArray->At(fTOFcluster[it]);
     clTOF->ReplaceMatchedTrackID(oldID,newID);


### PR DESCRIPTION
Modification needs for transfer of ESDtrack from one event to another during
filtering of the event from MC embedding