### PR TITLE
[WIP] fix gROOT->ProcessLine("AliAnalysisTaskSE::Class()") ROOT6 problem properly

### DIFF
--- a/ANALYSIS/ANALYSIS/AliAnalysisManager.cxx
+++ b/ANALYSIS/ANALYSIS/AliAnalysisManager.cxx
@@ -52,6 +52,7 @@ using std::cout;
 using std::endl;
 ClassImp(AliAnalysisManager)
 
+const TClass* (*AliAnalysisManager::fgGetBadPtr)() = NULL;
 AliAnalysisManager *AliAnalysisManager::fgAnalysisManager = NULL;
 TString AliAnalysisManager::fgCommonFileName = "";
 TString AliAnalysisManager::fgMacroNames = "";
@@ -1728,25 +1729,28 @@ void AliAnalysisManager::CheckBranches(Bool_t load)
 Bool_t AliAnalysisManager::CheckTasks() const
 {
    /// Check consistency of tasks.
-   #if ROOT_VERSION_CODE < ROOT_VERSION(5, 99, 0)
    Int_t ntasks = fTasks->GetEntries();
    if (!ntasks) {
       Error("CheckTasks", "No tasks connected to the manager. This may be due to forgetting to compile the task or to load their library.");
       return kFALSE;
    }
+   if (fgGetBadPtr == NULL)
+   {
+      Fatal("CheckTasks", "Bad ptr not initialized");
+      return kFALSE;
+   }
    // Get the pointer to AliAnalysisTaskSE::Class()
-   TClass *badptr = (TClass*)gROOT->ProcessLine("AliAnalysisTaskSE::Class()");
+   const TClass* badPtr = fgGetBadPtr();
    // Loop all tasks to check if their corresponding library was loaded
    TIter next(fTasks);
    TObject *obj;
    while ((obj=next())) {
-      if (obj->IsA() == badptr) {
+      if (obj->IsA() == badPtr) {
          Error("CheckTasks", "##################\n \
          Class for task %s NOT loaded. You probably forgot to load the library for this task (or compile it dynamically).\n###########################\n",obj->GetName());
          return kFALSE;
       }
-   }
-   #endif
+    }
    return kTRUE;
 }
 

--- a/ANALYSIS/ANALYSIS/AliAnalysisManager.h
+++ b/ANALYSIS/ANALYSIS/AliAnalysisManager.h
@@ -170,7 +170,7 @@ enum EAliAnalysisFlags {
    static void         SetGlobalStr(const char *key, const char *value);
    static void         SetGlobalInt(const char *key, Int_t value);
    static void         SetGlobalDbl(const char *key, Double_t value);
-   
+   static void         SetBadPtr(const TClass* (*ptr)()) {fgGetBadPtr = ptr;}
 
    // Container handling
    AliAnalysisDataContainer *CreateContainer(const char *name, TClass *datatype, 
@@ -290,6 +290,7 @@ private:
    static TString          fgCommonFileName;     //!<! Common output file name (not streamed)
    static TString          fgMacroNames;         //!<! Loaded macro names
    static AliAnalysisManager *fgAnalysisManager; //!<! static pointer to object instance
+   static const TClass* (*fgGetBadPtr)();        //! Bad ptr for check of AliAnalysisTaskSW
    ClassDef(AliAnalysisManager, 21)  // Analysis manager class
 };   
 #endif

--- a/ANALYSIS/ANALYSISalice/AliAnalysisTaskSE.cxx
+++ b/ANALYSIS/ANALYSISalice/AliAnalysisTaskSE.cxx
@@ -57,6 +57,19 @@
 
 ClassImp(AliAnalysisTaskSE)
 
+namespace
+{
+   const TClass* GetBadPtr()
+   {
+       return AliAnalysisTaskSE::Class();
+   }
+   const void* AliAnalysisManager_InitBadPtr()
+   {
+       AliAnalysisManager::SetBadPtr(GetBadPtr);
+       return NULL;
+   }
+}
+
 /// \file AliAnalysisTaskSE.cxx
 
 AliAODHeader*    AliAnalysisTaskSE::fgAODHeader         = NULL;
@@ -77,6 +90,7 @@ AliAODCaloTrigger* AliAnalysisTaskSE::fgAODEMCALTrigger = NULL;
 AliAODCaloTrigger* AliAnalysisTaskSE::fgAODPHOSTrigger  = NULL;
 TClonesArray*    AliAnalysisTaskSE::fgAODDimuons        = NULL;
 TClonesArray*    AliAnalysisTaskSE::fgAODHmpidRings     = NULL;
+const void*      AliAnalysisTaskSE::fgBadPtrDummy       = AliAnalysisManager_InitBadPtr();
 
 AliAnalysisTaskSE::AliAnalysisTaskSE():
     AliAnalysisTask(),

--- a/ANALYSIS/ANALYSISalice/AliAnalysisTaskSE.h
+++ b/ANALYSIS/ANALYSISalice/AliAnalysisTaskSE.h
@@ -123,6 +123,7 @@ class AliAnalysisTaskSE : public AliAnalysisTask
     AliInputEventHandler      *fMCEventHandler;     //!<! pointer to MCEventHandler
     AliTrackSelectionFactory  *fTrackSelectionFactory; ///< track selection factory
     AliVTrackSelection        *fTrackSelection;        ///< track selection
+    static const void         *fgBadPtrDummy;       //! static variable to force to load and export the badPtr to AliAnalysisManager
     ClassDef(AliAnalysisTaskSE, 5); // Analysis task for standard jet analysis
 };
  


### PR DESCRIPTION
This works around the gROOT->ProcessLine command, by registering a static callback function from AliAnalysisTaskSE into AliAnalysisManager, which allows to obtain the class pointer without macro invocation and without cyclic library dependencies.