### PR TITLE
Return dummy track for query of ebm.bd. label in absence of subsidiary event

### DIFF
--- a/STEER/STEERBase/AliMCEvent.h
+++ b/STEER/STEERBase/AliMCEvent.h
@@ -167,6 +167,8 @@ public:
   Bool_t IsFromSubsidiaryEvent(int id) const;
   void   SetTopEvent(const AliMCEvent* ev) {fTopEvent = ev;}
   const AliMCEvent* GetTopEvent() const {return fTopEvent;}
+
+  static AliMCParticle *GetDummyTrack();
   
 private:
     virtual void      ReorderAndExpandTreeTR();

--- a/STEER/STEERBase/AliStack.cxx
+++ b/STEER/STEERBase/AliStack.cxx
@@ -44,7 +44,6 @@
 ClassImp(AliStack)
 
 
-TParticle* AliStack::fgDummyParticle = 0;
 const Char_t* AliStack::fgkEmbedPathsKey = "embeddingBKGPaths";
 
 //_______________________________________________________________________
@@ -693,8 +692,7 @@ TParticle* AliStack::Particle(Int_t i, Bool_t useInEmbedding)
   // Return particle with specified ID
   if (GetMCEmbeddingFlag() && !useInEmbedding) {
     AliError("Method should not be called by user in embedding mode, returning dummy particle");
-    if (!fgDummyParticle) fgDummyParticle = new TParticle(21,999,-1,-1,-1,-1,1,1,999,999,0,0,0,0);
-    return fgDummyParticle;
+    return GetDummyParticle();
   }
   if (i==gkDummyLabel) return 0;
   
@@ -729,8 +727,7 @@ TParticle* AliStack::ParticleFromTreeK(Int_t id, Bool_t useInEmbedding) const
 //
   if (GetMCEmbeddingFlag() && !useInEmbedding) {
     AliError("Method should not be called by user in embedding mode, returning dummy particle");
-    if (!fgDummyParticle) fgDummyParticle = new TParticle(21,999,-1,-1,-1,-1,1,1,999,999,0,0,0,0);
-    return (TParticle*)fgDummyParticle;
+    return GetDummyParticle();
   }
   Int_t entry;
   if ((entry = TreeKEntry(id,useInEmbedding)) < 0) return 0;
@@ -1168,4 +1165,11 @@ Bool_t AliStack::IsSecondaryFromMaterial(Int_t index, Bool_t useInEmbedding) {
   if(indexMoth < 0) return kFALSE; // if index mother < 0 and not a physical primary, is a non-stable product or one of the beams
   return kTRUE;
 
+}
+
+//__________________________________________
+TParticle* AliStack::GetDummyParticle()
+{
+  static TParticle dummy(21,999,-1,-1,-1,-1,1,1,999,999,0,0,0,0);
+  return &dummy;
 }

--- a/STEER/STEERBase/AliStack.h
+++ b/STEER/STEERBase/AliStack.h
@@ -91,7 +91,8 @@ class AliStack : public TVirtualMCStack
     void        SetMCEmbeddingFlag(Bool_t v=kTRUE)        {fMCEmbeddingFlag = v;}
     Bool_t      GetMCEmbeddingFlag()                const {return fMCEmbeddingFlag;}
     static const char*   GetEmbeddingBKGPathsKey() {return fgkEmbedPathsKey;}
-
+    static TParticle* GetDummyParticle();
+    
   protected:
     // methods
     void  CleanParents();
@@ -120,7 +121,6 @@ class AliStack : public TVirtualMCStack
     TArrayI        fTrackLabelMap;     //! Map of track labels
     Bool_t         fMCEmbeddingFlag;   //! Flag that this is a top stack of embedded MC
 
-    static TParticle* fgDummyParticle;     // dummy particle returned in Stack::Particle call in embedding mode
     static const Char_t *fgkEmbedPathsKey;       // keyword for embedding paths
 
     ClassDef(AliStack,6) //Particles stack


### PR DESCRIPTION
If the ESD is obtained by filtering embedded signal from the MC-2-MC production
it may contain some labels belonging to the underlaying event tracks (i.e. offsetted
by 10M). The result of the query of AliMCEvent::GetTrack(label) on such a label depends on:

1) if the galice.root of the embedding production was also distilled (the reference on the
bg. event path is removed), then a dummy AliMCParticle will be returned, made from
TParticle dummy(21,999,-1,-1,-1,-1,1,1,999,999,0,0,0,0).
Also, calls to IsPhysicalPrimary, IsSecondaryFromWeakDecay, IsSecondaryFromMaterial will return FALSE,
while IsFromBGEvent will return TRUE.
The call to GetGenerator will return TString("suppressed")

2) the galice.root refers to valid directory with the underlying event: proper MCParticle is retrieved