### PR TITLE
Adding mirror SE for OCDB uploads.

### DIFF
--- a/TPC/TPCcalib/AliTPCDcalibRes.cxx
+++ b/TPC/TPCcalib/AliTPCDcalibRes.cxx
@@ -719,7 +719,7 @@ void AliTPCDcalibRes::Init()
   // adding mirroring for OCDB files that will be uploaded (Vdrift)
   TString mirrorsStr(gSystem->Getenv("MIRRORSE") ? gSystem->Getenv("MIRRORSE") : "ALICE::CERN::OCDB,ALICE::FZK::SE,ALICE::CNAF::SE");
   AliCDBManager::Instance()->SetMirrorSEs(mirrorsStr.Data());
-  printf("List of mirror SEs set to: \"%s\"\n",mirrorsStr.Data());
+  AliInfoF("List of mirror SEs set to: \"%s\"\n",mirrorsStr.Data());
   //
   // memorize GRP time
   AliGRPObject* grp = (AliGRPObject*)man->Get(AliCDBPath("GRP/GRP/Data"))->GetObject();

--- a/TPC/TPCcalib/AliTPCDcalibRes.cxx
+++ b/TPC/TPCcalib/AliTPCDcalibRes.cxx
@@ -713,7 +713,7 @@ void AliTPCDcalibRes::Init()
   //
   AliCDBManager* man = AliCDBManager::Instance();
   // adding mirroring for OCDB files that will be uploaded (Vdrift)
-  TString mirrorsStr("ALICE::CERN::OCDB,ALICE::FZK::SE,ALICE::LLNL::SE");
+  TString mirrorsStr(gSystem->Getenv("MIRRORSE") ? gSystem->Getenv("MIRRORSE") : "ALICE::CERN::OCDB,ALICE::FZK::SE,ALICE::CNAF::SE");
   AliCDBManager::Instance()->SetMirrorSEs(mirrorsStr.Data());
   printf("List of mirror SEs set to: \"%s\"\n",mirrorsStr.Data());
 

--- a/TPC/TPCcalib/AliTPCDcalibRes.cxx
+++ b/TPC/TPCcalib/AliTPCDcalibRes.cxx
@@ -712,6 +712,11 @@ void AliTPCDcalibRes::Init()
   }
   //
   AliCDBManager* man = AliCDBManager::Instance();
+  // adding mirroring for OCDB files that will be uploaded (Vdrift)
+  TString mirrorsStr("ALICE::CERN::OCDB,ALICE::FZK::SE,ALICE::LLNL::SE");
+  AliCDBManager::Instance()->SetMirrorSEs(mirrorsStr.Data());
+  printf("List of mirror SEs set to: \"%s\"\n",mirrorsStr.Data());
+
   if (fOCDBPath.IsNull()) fOCDBPath = "raw://";
   if (!man->IsDefaultStorageSet()) man->SetDefaultStorage(fOCDBPath);
   if (man->GetRun()!=fRun) man->SetRun(fRun); 

--- a/TPC/TPCcalib/AliTPCDcalibRes.cxx
+++ b/TPC/TPCcalib/AliTPCDcalibRes.cxx
@@ -712,14 +712,14 @@ void AliTPCDcalibRes::Init()
   }
   //
   AliCDBManager* man = AliCDBManager::Instance();
-  // adding mirroring for OCDB files that will be uploaded (Vdrift)
-  TString mirrorsStr(gSystem->Getenv("MIRRORSE") ? gSystem->Getenv("MIRRORSE") : "ALICE::CERN::OCDB,ALICE::FZK::SE,ALICE::CNAF::SE");
-  AliCDBManager::Instance()->SetMirrorSEs(mirrorsStr.Data());
-  printf("List of mirror SEs set to: \"%s\"\n",mirrorsStr.Data());
 
   if (fOCDBPath.IsNull()) fOCDBPath = "raw://";
   if (!man->IsDefaultStorageSet()) man->SetDefaultStorage(fOCDBPath);
   if (man->GetRun()!=fRun) man->SetRun(fRun); 
+  // adding mirroring for OCDB files that will be uploaded (Vdrift)
+  TString mirrorsStr(gSystem->Getenv("MIRRORSE") ? gSystem->Getenv("MIRRORSE") : "ALICE::CERN::OCDB,ALICE::FZK::SE,ALICE::CNAF::SE");
+  AliCDBManager::Instance()->SetMirrorSEs(mirrorsStr.Data());
+  printf("List of mirror SEs set to: \"%s\"\n",mirrorsStr.Data());
   //
   // memorize GRP time
   AliGRPObject* grp = (AliGRPObject*)man->Get(AliCDBPath("GRP/GRP/Data"))->GetObject();


### PR DESCRIPTION
This makes it safer when we upload the vdrift OCDB during processing.