### PR TITLE
Place member TH1 to top root directory

### DIFF
--- a/HLT/VZERO/AliHLTVZEROOnlineCalibComponent.cxx
+++ b/HLT/VZERO/AliHLTVZEROOnlineCalibComponent.cxx
@@ -69,6 +69,7 @@ AliHLTVZEROOnlineCalibComponent::AliHLTVZEROOnlineCalibComponent() :
   // visit http://web.ift.uib.no/~kjeks/doc/alice-hlt
   //
   // NOTE: all helper classes should be instantiated in DoInit()
+  fHistMult.SetDirectory(0);
 }
 
 // #################################################################################


### PR DESCRIPTION
Histograms created in some directory is destroyed when the directory is deleted. To avoid
invalid pointers the histos should be placed in the top ROOT dir.