### PR TITLE
Fix for usage of on-fly V0s in AOD cascades

### DIFF
--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
@@ -900,7 +900,7 @@ void AliAnalysisTaskESDfilter::ConvertCascades(const AliESDEvent& esd)
 								       dcaBachToPrimVertexXY,
 								       momBachAtCascadeVtx,
 								       *aodV0);
-    aodCascade->SetBit(AliAODEvent::kCascadesFixed);
+    aodCascade->SetBit(AliAODcascade::kOnFlyCascadesFixed);
     if (fDebug > 10) {
       printf("---- Cascade / AOD cascade : \n\n");
       aodCascade->PrintXi(fPrimaryVertex->GetX(), fPrimaryVertex->GetY(), fPrimaryVertex->GetZ());

--- a/STEER/AOD/AliAODEvent.cxx
+++ b/STEER/AOD/AliAODEvent.cxx
@@ -1191,7 +1191,7 @@ void AliAODEvent::FixCascades(){
   if(nCasc==0) return;
 
   AliAODcascade* cascForCheck=(AliAODcascade*)fCascades->UncheckedAt(0);
-  if(cascForCheck->TestBit(AliAODEvent::kCascadesFixed)){
+  if(cascForCheck->TestBit(AliAODcascade::kOnFlyCascadesFixed)){
     // Cascades already fixed -> do nothing
     // AliInfo("Cascades already fixed -> do nothing");
     return;
@@ -1256,6 +1256,6 @@ void AliAODEvent::FixCascades(){
 	}
       }
     }
-    cc->SetBit(AliAODEvent::kCascadesFixed);
+    cc->SetBit(AliAODcascade::kOnFlyCascadesFixed);
   }
 }

--- a/STEER/AOD/AliAODEvent.h
+++ b/STEER/AOD/AliAODEvent.h
@@ -73,7 +73,6 @@ class AliAODEvent : public AliVEvent {
 		       kAODListN
   };
 
-  enum statusCasc {kCascadesFixed=BIT(14)};
 
   AliAODEvent();
   virtual ~AliAODEvent();

--- a/STEER/AOD/AliAODcascade.h
+++ b/STEER/AOD/AliAODcascade.h
@@ -132,6 +132,8 @@ public:
   Double_t RapXi()          const;
   Double_t RapOmega()       const;
 
+  enum statusCasc {kOnFlyCascadesFixed=BIT(14)};
+
 protected:
 
   TRef          fDecayVertexXi;           ///< ref to decay vertex of the cascade (Xi vertex)


### PR DESCRIPTION
These 5 commits are needed to fix an issue with the AOD cascades discussed in ALIROOT-7980.
For V0s reconstructed both on-the-fly and offline, the on-fly V0 were wrongly used in the conversion of ESD cascades (done only with offline V0s) to AOD cascades.
These commits implement:
- a fix in AliAnalysisTaskESDfilter::ConvertCascade, so that in future AODs the on-fly V0s will not be used in the conversion of cascades
- a method AliAODEvent::FixCascades that fixes current AODs by re-attach the correct (offline) V0 to the cascade. This method is executed at the first call of one of the GetCascade methods of AliAODEvent
- a flagging of fixed cascades via the fBits of AliAODcascade.