### PR TITLE
ATO-445-TMVA regression (NON BACK COMP. CHANGE) + classification (ADD)

### DIFF
--- a/STAT/Macros/AliNDFunctionInterface.cxx
+++ b/STAT/Macros/AliNDFunctionInterface.cxx
@@ -126,90 +126,96 @@ Double_t AliNDFunctionInterface::GetDeltaInterpolationLinear(THn * his, Double_t
   }
   return value;
 }
-Int_t  AliNDFunctionInterface::FitMVAClassification(const char * output, const char *input_trees, const char *cuts, const char * variables, const char *methods, const char * factory_string){
-   TObjArray *dirFile=TString(output).Tokenize("#");
-   if(dirFile->GetEntries()<=1){
-	 ::Error("AliNDFunctionInterface::FitMVAClassification","Empty directory list");
-	 return -1;
-   }
-   auto outputFile = TFile::Open(dirFile->At(0)->GetName(), "update");
-   if(outputFile->GetListOfKeys()->Contains(dirFile->At(1)->GetName())){
+
+/// FitMVAClassification - TODO add documentation and test
+/// \param output
+/// \param inputTrees
+/// \param cuts
+/// \param variables
+/// \param methods
+/// \param factoryString
+/// \return
+Int_t  AliNDFunctionInterface::FitMVAClassification(const char * output, const char *inputTrees, const char *cuts, const char * variables, const char *methods, const char * factoryString){
+  TObjArray *dirFile=TString(output).Tokenize("#");
+  if(dirFile->GetEntries()<=1){
+    ::Error("AliNDFunctionInterface::FitMVAClassification","Empty directory list");
+    return -1;
+  }
+  auto outputFile = TFile::Open(dirFile->At(0)->GetName(), "update");
+  if(outputFile->GetListOfKeys()->Contains(dirFile->At(1)->GetName())){
     ::Error("AliNDFunctionInterface::FitMVAClassification","Output directory already exists");
     return -1;
-   } 
-   TString directory=TString(dirFile->At(1)->GetName());
-	TMVA::Factory factory("TMVAMultiClass", outputFile, "!V:!Silent:Color:DrawProgressBar:AnalysisType=multiclass" );
-	// Declare DataLoader 
-	TMVA::DataLoader loader(directory);
-	TObjArray *variableList = TString(variables).Tokenize(":");
-  	if (variableList->GetEntries()<=0){
-    		::Error("AliNDFunctionInterface::FitMVAClassification","Empty variable list");
-    		return -1;
-  	}
-  	for (Int_t i=0; i<variableList->GetEntries(); i++){
-    		loader.AddVariable(variableList->At(i)->GetName());
-  	}
-  	delete variableList;
+  }
+  TString directory=TString(dirFile->At(1)->GetName());
+  TMVA::Factory factory("TMVAMultiClass", outputFile, "!V:!Silent:Color:DrawProgressBar:AnalysisType=multiclass" );
+  // Declare DataLoader
+  TMVA::DataLoader loader(directory);
+  TObjArray *variableList = TString(variables).Tokenize(":");
+  if (variableList->GetEntries()<=0){
+    ::Error("AliNDFunctionInterface::FitMVAClassification","Empty variable list");
+    return -1;
+  }
+  for (Int_t i=0; i<variableList->GetEntries(); i++){
+    loader.AddVariable(variableList->At(i)->GetName());
+  }
+  delete variableList;
 
-	TObjArray *treeList = TString(input_trees).Tokenize(":");
-	TObjArray *cutList = TString(cuts).Tokenize(":");
-  	if (treeList->GetEntries()<=1){
-    		::Error("AliNDFunctionInterface::FitMVAClassification","More than one input tree required.");
-    		return -1;
-  	}
-	if (treeList->GetEntries()<cutList->GetEntries()){
-    		::Error("AliNDFunctionInterface::FitMVAClassification","Entries in cut list exceed number of trees.");
-    		return -1;
-  	}
-	
-	TTree * tree_in[treeList->GetEntries()];
-	TFile * input[treeList->GetEntries()];
-	TCut cut[treeList->GetEntries()];
-  	for (Int_t i=0; i<treeList->GetEntries(); i++) cut[i]="";
-	for (Int_t i=0; i<cutList->GetEntries(); i++) cut[i]=cutList->At(i)->GetName();
-  	for (Int_t i=0; i<treeList->GetEntries(); i++){
-		TObjArray * inTree = TString(treeList->At(i)->GetName()).Tokenize("#");
-		input[i] = TFile::Open( TString(inTree->At(0)->GetName() ));
-		tree_in[i] = (TTree*) input[i]->Get(inTree->At(1)->GetName());	
-    	loader.AddTree(tree_in[i],inTree->At(1)->GetName(),1.0,cut[i]);
-		delete inTree;
-  	}
-   
-	loader.PrepareTrainingAndTestTree("", FactorySetting[factory_string]);
-	
-	TObjArray *methodList = TString(methods).Tokenize(":");
-	if (methodList->GetEntries()<=0){
-    		::Error("AliNDFunctionInterface::FitMVAClassification","Empty method list");
-    		return -1;
-  	}
-	for (Int_t i=0; i<methodList->GetEntries(); i++){
-    		std::string methodName=methodList->At(i)->GetName();
-    		printf("Booking method %s\t%d\t%s\n",methodName.data(), regressionMethodID[methodName], regressionMethodSetting[methodName].data());
-		factory.BookMethod(&loader,regressionMethodID[methodName], methodName.data(), regressionMethodSetting[methodName].data());
-	}
-	factory.TrainAllMethods();
+  TObjArray *treeList = TString(inputTrees).Tokenize(":");
+  TObjArray *cutList = TString(cuts).Tokenize(":");
+  if (treeList->GetEntries()<=1){
+    ::Error("AliNDFunctionInterface::FitMVAClassification","More than one input tree required.");
+    return -1;
+  }
+  if (treeList->GetEntries()<cutList->GetEntries()){
+    ::Error("AliNDFunctionInterface::FitMVAClassification","Entries in cut list exceed number of trees.");
+    return -1;
+  }
 
-	/// Write ascii weight files to root file
-	outputFile->cd(directory);
-	for (Int_t i=0; i<methodList->GetEntries(); i++) {
-	        std::string methodName = methodList->At(i)->GetName();
-	        TString weightFile = TString::Format(directory+"/weights/TMVAMultiClass_%s.weights.xml",methodName.data());
-	        printf("Weight file\t%s\n", weightFile.Data());
-	        TObjString weight(gSystem->GetFromPipe(TString::Format("cat %s",weightFile.Data())));
-	        weight.Write(methodName.data());
-	}
-   TObjString varList(variables);
-   varList.Write("variables");
-	delete methodList;
-	factory.TestAllMethods();
-	factory.EvaluateAllMethods();
-	outputFile->Close();
-		
-	return 0;
+  TTree * tree_in[treeList->GetEntries()];
+  TFile * input[treeList->GetEntries()];
+  TCut cut[treeList->GetEntries()];
+  for (Int_t i=0; i<treeList->GetEntries(); i++) cut[i]="";
+  for (Int_t i=0; i<cutList->GetEntries(); i++) cut[i]=cutList->At(i)->GetName();
+  for (Int_t i=0; i<treeList->GetEntries(); i++){
+    TObjArray * inTree = TString(treeList->At(i)->GetName()).Tokenize("#");
+    input[i] = TFile::Open( TString(inTree->At(0)->GetName() ));
+    tree_in[i] = (TTree*) input[i]->Get(inTree->At(1)->GetName());
+    loader.AddTree(tree_in[i],inTree->At(1)->GetName(),1.0,cut[i]);
+    delete inTree;
+  }
+
+  loader.PrepareTrainingAndTestTree("", FactorySetting[factoryString]);
+
+  TObjArray *methodList = TString(methods).Tokenize(":");
+  if (methodList->GetEntries()<=0){
+    ::Error("AliNDFunctionInterface::FitMVAClassification","Empty method list");
+    return -1;
+  }
+  for (Int_t i=0; i<methodList->GetEntries(); i++){
+    std::string methodName=methodList->At(i)->GetName();
+    printf("Booking method %s\t%d\t%s\n",methodName.data(), regressionMethodID[methodName], regressionMethodSetting[methodName].data());
+    factory.BookMethod(&loader,regressionMethodID[methodName], methodName.data(), regressionMethodSetting[methodName].data());
+  }
+  factory.TrainAllMethods();
+
+  /// Write ascii weight files to root file
+  outputFile->cd(directory);
+  for (Int_t i=0; i<methodList->GetEntries(); i++) {
+    std::string methodName = methodList->At(i)->GetName();
+    TString weightFile = TString::Format(directory+"/weights/TMVAMultiClass_%s.weights.xml",methodName.data());
+    printf("Weight file\t%s\n", weightFile.Data());
+    TObjString weight(gSystem->GetFromPipe(TString::Format("cat %s",weightFile.Data())));
+    weight.Write(methodName.data());
+  }
+  TObjString varList(variables);
+  varList.Write("variables");
+  delete methodList;
+  factory.TestAllMethods();
+  factory.EvaluateAllMethods();
+  outputFile->Close();
+
+  return 0;
 }
-
-
-
 
 ///  FitMVARegression wrapper = Do TMVA regression and save weights into output root file
 /// \param output              - output path <file>#directory/
@@ -219,11 +225,23 @@ Int_t  AliNDFunctionInterface::FitMVAClassification(const char * output, const c
 /// \param cut                 - cut formula
 /// \param variables           - : separated list of explanatory variables
 /// \param methods             - : separated list of the regression methods (have to be registered before)
-/// \param factory_string      - factory string (e.g specifying number of training and test samples). Factory string to be registered before. If empty default used
+/// \param factoryString      - factory string (e.g specifying number of training and test samples). Factory string to be registered before. If empty default used
 /// \return                    - Fit parameters will be saved in the output destination - return value 0 in case of success
-Int_t  AliNDFunctionInterface::FitMVARegression(const char * output, TTree *tree, const char *varFit, TCut cut, const char * variables, const char *methods,const char * factory_string){
-  ///  0. Declare Factory
 
+/// Example usage in test macro ( QAtrendingFitExample.C function makeMVAFits() and  makeMVABootstrapMI() ), e.g:
+/// -----------
+/// \code
+/// TString output="TMVA_RegressionOutput.root#";
+///  for (Int_t iBoot=0; iBoot<nRegression; iBoot++) {
+///    AliNDFunctionInterface::FitMVARegression(output+"resolutionMIP"+iBoot,treeCache, "resolutionMIP", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN", "");
+///    AliNDFunctionInterface::FitMVARegression(output+"meanMIPeleR"+iBoot,treeCache, "meanMIPeleR", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN","");
+///    AliNDFunctionInterface::FitMVARegression(output+"tpcItsMatchA"+iBoot,treeCache, "tpcItsMatchA", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN","");
+///  }
+/// \endcode
+/// Algorithm:
+/// ---------
+Int_t  AliNDFunctionInterface::FitMVARegression(const char * output, TTree *tree, const char *varFit, TCut cut, const char * variables, const char *methods,const char * factoryString){
+  /// * 0. Declare Factory
   TObjArray *dirFile=TString(output).Tokenize("#");
   if(dirFile->GetEntries()<=1){
 	 ::Error("AliNDFunctionInterface::FitMVARegression","Empty directory list");
@@ -237,9 +255,9 @@ Int_t  AliNDFunctionInterface::FitMVARegression(const char * output, TTree *tree
   TString directory=TString(dirFile->At(1)->GetName());
   TMVA::Factory factory("TMVARegression", outputFile, "!V:!Silent:Color:DrawProgressBar:AnalysisType=Regression" );
   TString varNameFit=varFit;
-  /// 1.) Declare DataLoader
+  /// * 1.) Declare DataLoader
   TMVA::DataLoader loader(directory);
-  //  2.) Add the feature variables from the variables list
+  //  * 2.) Add the feature variables from the variables list
   TObjArray *weight_split = TString(variables).Tokenize(";");
   TObjArray *variableList = TString(weight_split->At(0)->GetName()).Tokenize(":");
   TString weights = "";
@@ -256,13 +274,13 @@ Int_t  AliNDFunctionInterface::FitMVARegression(const char * output, TTree *tree
   }
   delete variableList;
   loader.AddTarget(varFit);
-  /// 3.) Setup DataSet
+  /// * 3.) Setup DataSet
   loader.AddRegressionTree(tree, 1.0);   // link the TTree to the loader, weight for each event  = 1
   
   Int_t entries = tree->Draw("1",cut,"goff");
-  loader.PrepareTrainingAndTestTree(cut, FactorySetting[factory_string]);
+  loader.PrepareTrainingAndTestTree(cut, FactorySetting[factoryString]);
   if (weights!="") loader.SetWeightExpression(weights,"Regression");
-  /// 4.) Book regression methods from the methods list
+  /// * 4.) Book regression methods from the methods list
   TObjArray *methodList = TString(methods).Tokenize(":");
   if (methodList->GetEntries()<=0){
     ::Error("AliNDFunctionInterface::FitMVARegression","Empty method list");
@@ -273,9 +291,9 @@ Int_t  AliNDFunctionInterface::FitMVARegression(const char * output, TTree *tree
     printf("Booking method %s\t%d\t%s\n",methodName.data(), regressionMethodID[methodName], regressionMethodSetting[methodName].data());
     factory.BookMethod(&loader,regressionMethodID[methodName], methodName.data(), regressionMethodSetting[methodName].data());
   }
-  /// 5.) Train all methods
+  /// * 5.) Train all methods
   factory.TrainAllMethods();
-  /// 6.) Write ascii weight files to root file
+  /// * 6.) Write ascii weight files to root file
   outputFile->cd(directory);
   for (Int_t i=0; i<methodList->GetEntries(); i++) {
     std::string methodName = methodList->At(i)->GetName();
@@ -288,100 +306,16 @@ Int_t  AliNDFunctionInterface::FitMVARegression(const char * output, TTree *tree
   TObjString varList(weight_split->At(0)->GetName());
   varList.Write("variables");
   delete methodList;
-  // 7.) Evaluate all MVAs using the set of test events             /// TODO - make an option
+  /// * 7.) Evaluate all MVAs using the set of test events             /// TODO - make an option
   factory.TestAllMethods();
-  // 8.) Evaluate and compare performance of all configured MVAs    /// TODO - make an option
+  /// * 8.) Evaluate and compare performance of all configured MVAs    /// TODO - make an option
   factory.EvaluateAllMethods();
-  // Save the output
+  /// * Save the output
   outputFile->Close();
   return 0;
 }
 
-/// Fit MVA regression
-/// \param tree            - input tree (or chain)
-/// \param varFit          - colon separated variable string
-/// \param cut             - selection (TTree cut)
-/// \param variables       - colon separated explanatory variable list
-/// \param methods         - colon separated method list - only registered methods can be used (using registerMethod(std::string method,  std::string content, TMVA::Types::EMVA id))
-/// \return                - status
-/// weights are saved in the root file
-///
-///###Example usage in test macro ( QAtrendingFitExample.C function makeMVAFits() and  makeMVABootstrapMI() ), e.g: ###
-///==================================================================================================================
-///\code
-/// for (Int_t iBoot=0; iBoot<10; iBoot++) {
-///    AliNDFunctionInterface::FitMVA(treeCache, "resolutionMIP", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN", 0, iBoot);
-/// }
-///\endcode
-/// TODOs:
-///==============
-/// * TODO - user defined splitting training/test
-/// * TODO  - Error handling: file output  currently in UPDATE mode - in case of existing entries - regression fail
-/// Algorithm:
-///==============
-///  * 1.) Declare DataLoader
-///  * 2.) Add the feature variables from the variables list and target variable(s)
-///  * 4.) Book regression methods from the methods list
-///  * 5.) Train all methods
-///  * 6.) Write ascii weight files to root file
-Int_t  AliNDFunctionInterface::FitMVA(TTree *tree, const char *varFit, TCut cut, const char * variables, const char *methods, const char *weights, Int_t index){
-  ///  0. Declare Factory
-  auto outputFile = TFile::Open("TMVA_RegressionOutput.root", "UPDATE");
-  TMVA::Factory factory("TMVARegression", outputFile, "!V:!Silent:Color:DrawProgressBar:AnalysisType=Regression" );
-  TString varNameFit=varFit;
-  if (index>=0) varNameFit=TString::Format("%s[%d]",varFit,index);
-  /// 1.) Declare DataLoader
-  TMVA::DataLoader loader(TString::Format("dir_%s",varNameFit.Data()).Data());
-  //  2.) Add the feature variables from the variables list
-  TObjArray *variableList = TString(variables).Tokenize(":");
-  if (variableList->GetEntries()<=0){
-    ::Error("AliNDFunctionInterface::FitMVA","Empty variable list");
-    return -1;
-  }
-  for (Int_t i=0; i<variableList->GetEntries(); i++){
-    loader.AddVariable(variableList->At(i)->GetName());
-    /// TODO check existence - validity of variable - in case of error - exit with error message
-  }
-  delete variableList;
-  loader.AddTarget(varFit);
-  /// 3.) Setup DataSet
-  loader.AddRegressionTree(tree, 1.0);   // link the TTree to the loader, weight for each event  = 1
-  Int_t entries = tree->Draw("1",cut,"goff");
-  loader.PrepareTrainingAndTestTree(cut, TString::Format("nTrain_Regression=%d:nTest_Regression=%d:SplitMode=Random:NormMode=NumEvents:!V",entries/2,entries/2));
-  if (weights!=NULL) loader.SetWeightExpression(weights);
-  /// 4.) Book regression methods from the methods list
-  TObjArray *methodList = TString(methods).Tokenize(":");
-  if (methodList->GetEntries()<=0){
-    ::Error("AliNDFunctionInterface::FitMVA","Empty method list");
-    return -1;
-  }
-  for (Int_t i=0; i<methodList->GetEntries(); i++){
-    std::string methodName=methodList->At(i)->GetName();
-    printf("Booking method %s\t%d\t%s\n",methodName.data(), regressionMethodID[methodName], regressionMethodSetting[methodName].data());
-    factory.BookMethod(&loader,regressionMethodID[methodName], methodName.data(), regressionMethodSetting[methodName].data());
-  }
-  /// 5.) Train all methods
-  factory.TrainAllMethods();
-  /// 6.) Write ascii weight files to root file
-  for (Int_t i=0; i<methodList->GetEntries(); i++) {
-    std::string methodName = methodList->At(i)->GetName();
-    TString weightFile = TString::Format("dir_%s/weights/TMVARegression_%s.weights.xml", varNameFit.Data(),methodName.data());
-    printf("Weight file\t%s\n", weightFile.Data());
-    TObjString weight(gSystem->GetFromPipe(TString::Format("cat %s",weightFile.Data())));
-    outputFile->cd(TString::Format("dir_%s", varNameFit.Data()).Data());
-    weight.Write(methodName.data());
-  }
-  delete methodList;
-  // 7.) Evaluate all MVAs using the set of test events             /// TODO - make an option
-  factory.TestAllMethods();
-  // 8.) Evaluate and compare performance of all configured MVAs    /// TODO - make an option
-  factory.EvaluateAllMethods();
-  // Save the output
-  outputFile->Close();
-  return 0;
-}
-
-// Load MVA regression object and register it in the map of available readers fr evaluation in TFormula
+/// Load MVA regression object and register it in the map of available readers fr evaluation in TFormula
 /// Current ION of TMVA does not allow standard persistence in root file
 ///       Way around:
 ///          Writing -  ASCII files are stored as TSting in the root file
@@ -391,70 +325,21 @@ Int_t  AliNDFunctionInterface::FitMVA(TTree *tree, const char *varFit, TCut cut,
 /// \param method        - method name (e.g MLP)
 /// \param dir           - directory usually coding regression variable with dir_ prefix (e.g. dir_meanMIPele)
 /// \return              - error code
-///
 /// TODOs:
 /// -----------------------------------------------------------------------------------------------------------
 /// * TODO - ASK TMVA team to implement standard IO
 /// * TODO - ASK TMVA team to disable requirement to set variable addresses or find switch to make it
 ///
-/// Example parameters (see also QAtrendingFitExample.C loadMVAReaders())
-///==================================================================================================================
+/// Example usage (see also QAtrendingFitExample.C loadMVAReaders()):
+/// -----------------------------------------------------------------------------------------------------------
 /// \code
-///  AliNDFunctionInterface::LoadMVAReader(0,"TMVA_RegressionOutput.root","MLP","dir_resolutionMIP");
-///  AliNDFunctionInterface::LoadMVAReader(1,"TMVA_RegressionOutput.root","KNN","dir_resolutionMIP");
-///  AliNDFunctionInterface::LoadMVAReader(2,"TMVA_RegressionOutput.root","BDTRF25_8","dir_resolutionMIP");
-///  AliNDFunctionInterface::LoadMVAReader(3,"TMVA_RegressionOutput.root","BDTRF12_16","dir_resolutionMIP");
-///
-/// Int_t id=0;  const char * inputFile="TMVA_RegressionOutput.root"; const char *method="MLP"; const char *dir="dir_resolutionMIP"
+/// void loadMVAReaders(){
+///  AliNDFunctionInterface::LoadMVAReader(0,"TMVA_RegressionOutput.root","BDTRF25_8","resolutionMIP0");
+///  AliNDFunctionInterface::LoadMVAReader(1,"TMVA_RegressionOutput.root","BDTRF12_16","resolutionMIP0");
+///  AliNDFunctionInterface::LoadMVAReader(2,"TMVA_RegressionOutput.root","KNN","resolutionMIP0");
+///}
 /// \endcode
 TMVA::MethodBase * AliNDFunctionInterface::LoadMVAReader(Int_t id/*=0*/, const char * inputFile/*="TMVA_RegressionOutput.root"*/, const char *method/*="MLP"*/, const char *dir/*="dir_resolutionMIP"*/){
-  TMVA::Reader *reader;
-  reader = new TMVA::Reader( "!Color:!Silent" );
-  auto fin = TFile::Open(inputFile);
-  if (fin==NULL){
-    ::Error("LoadMVAReader","Invalid input file\t%s", inputFile);
-    return NULL;
-  }
-  TDirectoryFile *dir0 = 0,*dirVar=0;
-  fin->GetObject(dir,dir0);
-  if (dir0==NULL) {
-    ::Error("LoadMVAReader","Invalid input directory\t%s\t%s", dir, inputFile);
-    return NULL;
-  }
-  dir0->GetObject("InputVariables_Id",dirVar);
-  for (Int_t i=0; i<dirVar->GetNkeys()-2; i++){
-    TString varHis = dirVar->GetListOfKeys()->At(i)->GetName();
-    TString var(varHis(0,varHis.First("__")));
-    printf("%s\n",var.Data());
-    Float_t value;
-    reader->AddVariable(var.Data(),&value);   /// dummy booking  it is not used - TODO - ask TMVA to remove requirement
-  }
-  /// write weight from the root file to txt files as it is expected by reader
-  FILE * pFile;
-  pFile = fopen ("weights.xml","w");
-  TObjString *methodWeights= NULL;
-
-  if (dir0==NULL) {
-    ::Error("LoadMVAReader","Object %s not present in  input directory\t%s/%s",  method, inputFile,dir);
-    delete pFile;
-    return NULL;
-  }
-  dir0->GetObject(method,methodWeights);
-  if (methodWeights==NULL){
-    ::Error("LoadMVAReader","Object %s not present in  input directory\t%s/%s",  method, inputFile,dir);
-    delete pFile;
-    return NULL;
-  }
-  fprintf (pFile, "%s",methodWeights->GetName());
-  fclose (pFile);
-  reader->BookMVA( method, "weights.xml");
-  if (id>=0) AliNDFunctionInterface::readerMethodBase[id]=dynamic_cast<TMVA::MethodBase *>(reader->FindMVA(method));
-  return dynamic_cast<TMVA::MethodBase *>(reader->FindMVA(method));
-}
-
-
-
-TMVA::MethodBase * AliNDFunctionInterface::LoadMVAReaderNew(Int_t id/*=0*/, const char * inputFile/*="TMVA_RegressionOutput.root"*/, const char *method/*="MLP"*/, const char *dir/*="dir_resolutionMIP"*/){
   TMVA::Reader *reader;
   reader = new TMVA::Reader( "!Color:!Silent" );
   auto fin = TFile::Open(inputFile);
@@ -511,13 +396,13 @@ TMVA::MethodBase * AliNDFunctionInterface::LoadMVAReaderNew(Int_t id/*=0*/, cons
 /// \return  error code - 0 mean OK
 ///
 /// Example usage in  (see also QAtrendingFitExample.C loadMVAReadersBootstrap())
-///==================================================================================================================
+/// -----------------------------------------------------------------------------------------------------------
 /// \code
 /// void loadMVAReadersBootstrap() {
 ///  AliNDFunctionInterface::LoadMVAReaderArray(0,"TMVA_RegressionOutput.root","BDTRF12_16",".*resolutionMIP");
 ///  AliNDFunctionInterface::LoadMVAReaderArray(1,"TMVA_RegressionOutput.root","BDTRF25_8",".*resolutionMIP");
 ///  AliNDFunctionInterface::LoadMVAReaderArray(2,"TMVA_RegressionOutput.root","KNN",".*resolutionMIP");
-///}
+/// }
 /// \endcode
 Int_t  AliNDFunctionInterface::LoadMVAReaderArray(Int_t id, const char * inputFile, const char *methodMask, const char *dirMask){
   auto fin = TFile::Open(inputFile);
@@ -573,7 +458,7 @@ Int_t  AliNDFunctionInterface::AppendMethodToArray(Int_t index, TMVA::MethodBase
 /// ------------------------------
 /// TODO - for the moment in evaluation we assume only one variable
 ///       - using the DNN or MLP we should start to support vectors
-/// TODO  - extend statistic
+/// TODO  - extend statistic list
 Double_t   AliNDFunctionInterface::EvalMVAStatArray(int id, int statType, vector<float> point){
   TObjArray * array = readerMethodBaseArray[id];
   if (array==NULL) return 0;

--- a/STAT/Macros/AliNDFunctionInterface.h
+++ b/STAT/Macros/AliNDFunctionInterface.h
@@ -3,7 +3,7 @@
 
 /// \ingroup STAT
 /// \namespace AliNDFunctionInterface
-/// \brief  Interface to Ndimension functional representations (THn and TMVA)
+/// \brief  Interface to N-dimensional functional representations (THn and TMVA)
 /// \authors Marian  Ivanov marian.ivanov@cern.ch
 /// see example usage in
 
@@ -29,13 +29,13 @@ namespace AliNDFunctionInterface {
   // Global function interface
   Double_t GetInterpolationLinear(Int_t index, Double_t *xyz, Int_t  verbose){return GetInterpolationLinear(hnMapArrayInt[index], xyz,verbose);}
   Double_t GetDeltaInterpolationLinear(Int_t index, Double_t *xyz, Int_t dIndex, Int_t  verbose) {
-      return GetDeltaInterpolationLinear(hnMapArrayInt[index], xyz, dIndex, verbose);
+    return GetDeltaInterpolationLinear(hnMapArrayInt[index], xyz, dIndex, verbose);
   }
   Double_t GetInterpolationLinear(const char *name, Double_t *xyz, Int_t  verbose){return GetInterpolationLinear(hnMapArrayName[name], xyz,verbose);}
   template<typename T, typename... Args> T EvalTHnLinear(int id, T v, Args... args);        /// variadic function evaluating THn
   /// TMVA interface
   map<int, TMVA::MethodBase *> readerMethodBase;            /// map of registered TMVA::MethodBase
-  map<int, TObjArray* > readerMethodBaseArray;              /// map of registered array of TMVA::MethodBase - used to define TMVA statistics (Mean, Median, RMS, quantiles)
+  map<int, TObjArray* > readerMethodBaseArray;              /// map of registered array of TMVA::MethodBase - used to define TMVA statistics (Mean, Median, RMS, quantile)
   map<std::string, std::string> regressionMethodSetting;    /// map of registered TMVA regression methods
   map<std::string, std::string> FactorySetting;    /// map of registered TMVA regression methods
   map<std::string, TMVA::Types::EMVA> regressionMethodID;   /// map of registered TMVA regression methods
@@ -44,10 +44,10 @@ namespace AliNDFunctionInterface {
   void registerMethod(std::string method,  std::string content, TMVA::Types::EMVA id){regressionMethodSetting[method]=content; regressionMethodID[method]=id;}
   Int_t  FitMVA(TTree *tree, const char *varFit, TCut cut, const char * variableList, const char *methodList, const char *weights=NULL, Int_t index=-1);   /// MVA regression
   Int_t  FitMVAClassification(const char * output , const char *input_trees, const char *cuts ,const char * variableList, const char *methodList, const char * factory_string=""); /// MVA Classification 
-  Int_t  FitMVARegression(const char * output, TTree *tree, const char *varFit, TCut cut, const char * variables, const char *methods,const char * factory_string="", const char *weights=NULL, Int_t index=-1); // new MVA Regression  
+  Int_t  FitMVARegression(const char * output, TTree *tree, const char *varFit, TCut cut, const char * variables, const char *methods,const char * factory_string=""); // new MVA Regression  
 
   TMVA::MethodBase * LoadMVAReader(Int_t id, const char * inputFile, const char *method, const char *dir);
-  TMVA::MethodBase * LoadMVAReader2(Int_t id, const char * inputFile, const char *method, const char *dir);
+  TMVA::MethodBase * LoadMVAReaderNew(Int_t id, const char * inputFile, const char *method, const char *dir);
   Int_t  LoadMVAReaderArray(Int_t id, const char * inputFile, const char *methodMask, const char *dirMask);
   Int_t  AppendMethodToArray(Int_t index, TMVA::MethodBase * method);         /// Append method into array of methods - used e.g for bootstrap statistics
   Double_t   EvalMVAStatArray(int id, int statType, vector<float> point);     /// Evaluate statistic
@@ -60,7 +60,7 @@ namespace AliNDFunctionInterface {
 /// \brief Helper function to create std vector in variadic function
 template<typename T> vector<T> AliNDFunctionInterface::add_to_vector(vector<T> &z, T v) {z.push_back(v); return z;}
 template<typename T, typename... Args> vector<T> AliNDFunctionInterface::add_to_vector(vector<T> &z, T v, Args... args) {
-    z.push_back(v);return add_to_vector<T>(z, args...);
+  z.push_back(v);return add_to_vector<T>(z, args...);
 }
 /// \brief Variadic function to create an vector (boost implementation )
 /// \tparam T
@@ -74,7 +74,7 @@ template<typename T, typename... Args> vector<T> AliNDFunctionInterface::add_to_
 ///    auto a = AliNDFunctionInterface::make_vector<int>(1, 1, 3);
 /// \endcode
 template<typename T, typename... Args> vector<T> AliNDFunctionInterface::make_vector(T v, Args... args) {
-    vector<T> z; z.push_back(v); return add_to_vector<T>(z, args...);
+  vector<T> z; z.push_back(v); return add_to_vector<T>(z, args...);
 }
 
 /// Variadic function to linearly interpolate THn
@@ -123,7 +123,7 @@ template<typename T, typename... Args> T AliNDFunctionInterface::EvalMVA(int id,
 };
 
 
-/// Templated variadic function - Evaluate statistic on top of array (readerMethodBaseArray;) of MVA methods
+/// Template variadic function - Evaluate statistic on top of array (readerMethodBaseArray;) of MVA methods
 /// To use the method - array o TMVA methods should be registered before using LoadMVAReaderArray or AppendMethodToArray
 /// \tparam T            - template type - be default float
 /// \tparam Args         -

--- a/STAT/Macros/AliNDFunctionInterface.h
+++ b/STAT/Macros/AliNDFunctionInterface.h
@@ -42,18 +42,14 @@ namespace AliNDFunctionInterface {
   void registerDefaultMVAMethods();                         /// example registering default methods ()
   void registerFactory(std::string factory, std::string content){FactorySetting[factory]=content;}
   void registerMethod(std::string method,  std::string content, TMVA::Types::EMVA id){regressionMethodSetting[method]=content; regressionMethodID[method]=id;}
-  Int_t  FitMVA(TTree *tree, const char *varFit, TCut cut, const char * variableList, const char *methodList, const char *weights=NULL, Int_t index=-1);   /// MVA regression
-  Int_t  FitMVAClassification(const char * output , const char *input_trees, const char *cuts ,const char * variableList, const char *methodList, const char * factory_string=""); /// MVA Classification 
-  Int_t  FitMVARegression(const char * output, TTree *tree, const char *varFit, TCut cut, const char * variables, const char *methods,const char * factory_string=""); // new MVA Regression  
-
+  Int_t  FitMVAClassification(const char * output , const char *inputTrees, const char *cuts ,const char * variableList, const char *methodList, const char * factoryString=""); /// MVA Classification
+  Int_t  FitMVARegression(const char * output, TTree *tree, const char *varFit, TCut cut, const char * variables, const char *methods,const char * factoryString=""); /// new MVA Regression
   TMVA::MethodBase * LoadMVAReader(Int_t id, const char * inputFile, const char *method, const char *dir);
-  TMVA::MethodBase * LoadMVAReaderNew(Int_t id, const char * inputFile, const char *method, const char *dir);
   Int_t  LoadMVAReaderArray(Int_t id, const char * inputFile, const char *methodMask, const char *dirMask);
   Int_t  AppendMethodToArray(Int_t index, TMVA::MethodBase * method);         /// Append method into array of methods - used e.g for bootstrap statistics
   Double_t   EvalMVAStatArray(int id, int statType, vector<float> point);     /// Evaluate statistic
   template<typename T, typename... Args> T EvalMVA(int id, T v, Args... args);        /// variadic function evaluating MVA
   template<typename T, typename... Args> T EvalMVAStat(int id, int statType,  T v, Args... args);        /// variadic function evaluating MVA array stat
-
 };
 
 
@@ -63,8 +59,8 @@ template<typename T, typename... Args> vector<T> AliNDFunctionInterface::add_to_
   z.push_back(v);return add_to_vector<T>(z, args...);
 }
 /// \brief Variadic function to create an vector (boost implementation )
-/// \tparam T
-/// \tparam Args
+/// \tparam T        - template type
+/// \tparam Args     - list of arguments
 /// \param v
 /// \param args
 /// \return
@@ -78,9 +74,9 @@ template<typename T, typename... Args> vector<T> AliNDFunctionInterface::make_ve
 }
 
 /// Variadic function to linearly interpolate THn
-/// \tparam T
-/// \tparam Args
-/// \param id
+/// \tparam T          - template type
+/// \tparam Args       - list of arguments
+/// \param id          - id of the function (e.g using  hash of the name)
 /// \param v
 /// \param args
 /// \return interpolated value

--- a/STAT/Macros/AliNDFunctionInterface.h
+++ b/STAT/Macros/AliNDFunctionInterface.h
@@ -37,11 +37,17 @@ namespace AliNDFunctionInterface {
   map<int, TMVA::MethodBase *> readerMethodBase;            /// map of registered TMVA::MethodBase
   map<int, TObjArray* > readerMethodBaseArray;              /// map of registered array of TMVA::MethodBase - used to define TMVA statistics (Mean, Median, RMS, quantiles)
   map<std::string, std::string> regressionMethodSetting;    /// map of registered TMVA regression methods
+  map<std::string, std::string> FactorySetting;    /// map of registered TMVA regression methods
   map<std::string, TMVA::Types::EMVA> regressionMethodID;   /// map of registered TMVA regression methods
   void registerDefaultMVAMethods();                         /// example registering default methods ()
+  void registerFactory(std::string factory, std::string content){FactorySetting[factory]=content;}
   void registerMethod(std::string method,  std::string content, TMVA::Types::EMVA id){regressionMethodSetting[method]=content; regressionMethodID[method]=id;}
   Int_t  FitMVA(TTree *tree, const char *varFit, TCut cut, const char * variableList, const char *methodList, const char *weights=NULL, Int_t index=-1);   /// MVA regression
+  Int_t  FitMVAClassification(const char * output , const char *input_trees, const char *cuts ,const char * variableList, const char *methodList, const char * factory_string=""); /// MVA Classification 
+  Int_t  FitMVARegression(const char * output, TTree *tree, const char *varFit, TCut cut, const char * variables, const char *methods,const char * factory_string="", const char *weights=NULL, Int_t index=-1); // new MVA Regression  
+
   TMVA::MethodBase * LoadMVAReader(Int_t id, const char * inputFile, const char *method, const char *dir);
+  TMVA::MethodBase * LoadMVAReader2(Int_t id, const char * inputFile, const char *method, const char *dir);
   Int_t  LoadMVAReaderArray(Int_t id, const char * inputFile, const char *methodMask, const char *dirMask);
   Int_t  AppendMethodToArray(Int_t index, TMVA::MethodBase * method);         /// Append method into array of methods - used e.g for bootstrap statistics
   Double_t   EvalMVAStatArray(int id, int statType, vector<float> point);     /// Evaluate statistic

--- a/STAT/Macros/QAtrendingFitExample.C
+++ b/STAT/Macros/QAtrendingFitExample.C
@@ -14,7 +14,7 @@
 ///  1.)  cacheTree();      /// needed in case friend trees or arrays - which are not supported by TMVA
 ///  3.)  RegisterFitters();
 ///  4.)  makeMVAFits();
-///  5.)  loadMVAreaders();
+///  5.)  loadMVAReaders();
 ///  tree->Draw("AliNDFunctionInterface::EvalMVA(2,interactionRate, bz0,qmaxQASum,qmaxQASumR):resolutionMIP:interactionRate","run==QA.EVS.run&&meanMIP>40&&bz0<-0.3","colz");
 
 
@@ -39,7 +39,7 @@ void loadTree() {
 
 /// CacheTree input variables to tree format usable by TMVA
 ///-------------------------------
-/// TMVA can not work with friend trees with indeces, respec. with array of the measurements, resp aliases and functions
+/// TMVA can not work with friend trees with indices, resp. with array of the measurements, resp aliases and functions
 /// * input "flat tree" for MVA learning to be created with variables of interest
 /// * AliTreePlayer::MakeCacheTree to create flat input tree for TMVA
 void cacheTree(){
@@ -89,35 +89,35 @@ void makeMVAFits(){
 ///Emulation of the bootstrap - training repeated several time
 ///----------------------------
 ///* TODO - Implement real bootstrap ( random sampling with replacement + other methods) in the TMVA (to check with ROOT)
-///* TODO - DNN example - TO USE DNN (Deep neural network)  BLASS or CBLASS library has to be enabled in ROOT. This is not the case for the default aliBuild recipies
+///* TODO - DNN example - TO USE DNN (Deep neural network)  BLASS or CBLASS library has to be enabled in ROOT. This is not the case for the default aliBuild recipes
 void makeMVABootstrapMI(Int_t nRegression=10){
   TFile *f= TFile::Open("TMVAInput.root");
   f->GetObject("MVAInput",treeCache);
   for (Int_t iBoot=0; iBoot<nRegression; iBoot++) {
     AliNDFunctionInterface::FitMVA(treeCache, "resolutionMIP", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN", 0, iBoot);
-     AliNDFunctionInterface::FitMVA(treeCache, "meanMIPeleR", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN", 0, iBoot);
-     AliNDFunctionInterface::FitMVA(treeCache, "tpcItsMatchA", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN", 0, iBoot);
+    AliNDFunctionInterface::FitMVA(treeCache, "meanMIPeleR", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN", 0, iBoot);
+    AliNDFunctionInterface::FitMVA(treeCache, "tpcItsMatchA", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN", 0, iBoot);
     if (useDNN){
       AliNDFunctionInterface::FitMVA(treeCache, "resolutionMIP", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "DNN_CPU", 0, iBoot);
     }
   }
 }
 
-void makeMVABootstrapMI2(Int_t nRegression=10){
+void makeMVABootstrapMI2New(Int_t nRegression=10){
   TFile *f= TFile::Open("TMVAInput.root");
   f->GetObject("MVAInput",treeCache);
   gSystem->Unlink("TMVA_RegressionOutput2.root");
   TString output="TMVA_RegressionOutput2.root#";
   for (Int_t iBoot=0; iBoot<nRegression; iBoot++) {
-    AliNDFunctionInterface::FitMVARegression(output+"resolutionMIP"+iBoot,treeCache, "resolutionMIP", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN", "", 0);
-    AliNDFunctionInterface::FitMVARegression(output+"meanMIPeleR"+iBoot,treeCache, "meanMIPeleR", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN","", 0);
-    AliNDFunctionInterface::FitMVARegression(output+"tpcItsMatchA"+iBoot,treeCache, "tpcItsMatchA", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN","", 0);
+    AliNDFunctionInterface::FitMVARegression(output+"resolutionMIP"+iBoot,treeCache, "resolutionMIP", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN", "");
+    AliNDFunctionInterface::FitMVARegression(output+"meanMIPeleR"+iBoot,treeCache, "meanMIPeleR", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN","");
+    AliNDFunctionInterface::FitMVARegression(output+"tpcItsMatchA"+iBoot,treeCache, "tpcItsMatchA", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN","");
   }
 }
 
 
 ///
-void loadMVAreaders(){
+void loadMVAReaders(){
   AliNDFunctionInterface::LoadMVAReader(0,"TMVA_RegressionOutput.root","MLP","dir_resolutionMIP");
   AliNDFunctionInterface::LoadMVAReader(1,"TMVA_RegressionOutput.root","KNN","dir_resolutionMIP");
   AliNDFunctionInterface::LoadMVAReader(2,"TMVA_RegressionOutput.root","BDTRF25_8","dir_resolutionMIP");
@@ -127,7 +127,7 @@ void loadMVAreaders(){
 
 /// Load array of regression  -used later in the array regression evaluation (mean, median, rms)
 ///-------------------------------
-void loadMVAreadersBootstrap() {
+void loadMVAReadersBootstrap() {
   AliNDFunctionInterface::LoadMVAReaderArray(0,"TMVA_RegressionOutput.root","BDTRF12_16",".*resolutionMIP");
   AliNDFunctionInterface::LoadMVAReaderArray(1,"TMVA_RegressionOutput.root","BDTRF25_8",".*resolutionMIP");
   AliNDFunctionInterface::LoadMVAReaderArray(2,"TMVA_RegressionOutput.root","KNN",".*resolutionMIP");
@@ -135,12 +135,10 @@ void loadMVAreadersBootstrap() {
 
 /// Load array of regression  -used later in the array regression evaluation (mean, median, rms)
 ///-------------------------------
-void loadMVAreadersBootstrap2() {
-  AliNDFunctionInterface::LoadMVAReaderArray(0,"TMVA_RegressionOutput2.root","BDTRF12_16",".*resolutionMIP");
-  AliNDFunctionInterface::LoadMVAReaderArray(1,"TMVA_RegressionOutput2.root","BDTRF25_8",".*resolutionMIP");
-  AliNDFunctionInterface::LoadMVAReaderArray(2,"TMVA_RegressionOutput2.root","KNN",".*resolutionMIP");
-
-
+void loadMVAReadersBootstrapNew() {
+  AliNDFunctionInterface::LoadMVAReaderArray(10,"TMVA_RegressionOutput2.root","BDTRF12_16",".*resolutionMIP");
+  AliNDFunctionInterface::LoadMVAReaderArray(11,"TMVA_RegressionOutput2.root","BDTRF25_8",".*resolutionMIP");
+  AliNDFunctionInterface::LoadMVAReaderArray(12,"TMVA_RegressionOutput2.root","KNN",".*resolutionMIP");
 }
 
 
@@ -149,6 +147,7 @@ void loadMVAreadersBootstrap2() {
 void QAtrendingFitExample(){
   /// 0.) Remove regression file
   gSystem->Unlink("TMVA_RegressionOutput.root");
+  gSystem->Unlink("TMVA_RegressionOutput2.root");
   /// 1.) Load Input data
   loadTree();
   /// 2.) Cache tree - TMVA expect variables  - not functions and aliases
@@ -157,8 +156,10 @@ void QAtrendingFitExample(){
   RegisterFitters();
   /// 4.) Make bootstrap regression
   makeMVABootstrapMI(10);
+  makeMVABootstrapMINew(10);
   /// 5.) Load array of regression readers
-  loadMVAreadersBootstrap();
+  loadMVAReadersBootstrap();
+  loadMVAReadersBootstrapNew();
   ///
   /// 6.) Draw example plots
   /// ===============================

--- a/STAT/Macros/QAtrendingFitExample.C
+++ b/STAT/Macros/QAtrendingFitExample.C
@@ -90,7 +90,7 @@ void makeMVAFits(){
 ///----------------------------
 ///* TODO - Implement real bootstrap ( random sampling with replacement + other methods) in the TMVA (to check with ROOT)
 ///* TODO - DNN example - TO USE DNN (Deep neural network)  BLASS or CBLASS library has to be enabled in ROOT. This is not the case for the default aliBuild recipies
-void makeMVABootstrapMI(Int_t nregression=10){
+void makeMVABootstrapMI(Int_t nRegression=10){
   TFile *f= TFile::Open("TMVAInput.root");
   f->GetObject("MVAInput",treeCache);
   for (Int_t iBoot=0; iBoot<nRegression; iBoot++) {
@@ -103,6 +103,19 @@ void makeMVABootstrapMI(Int_t nregression=10){
   }
 }
 
+void makeMVABootstrapMI2(Int_t nRegression=10){
+  TFile *f= TFile::Open("TMVAInput.root");
+  f->GetObject("MVAInput",treeCache);
+  gSystem->Unlink("TMVA_RegressionOutput2.root");
+  TString output="TMVA_RegressionOutput2.root#";
+  for (Int_t iBoot=0; iBoot<nRegression; iBoot++) {
+    AliNDFunctionInterface::FitMVARegression(output+"resolutionMIP"+iBoot,treeCache, "resolutionMIP", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN", "", 0);
+    AliNDFunctionInterface::FitMVARegression(output+"meanMIPeleR"+iBoot,treeCache, "meanMIPeleR", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN","", 0);
+    AliNDFunctionInterface::FitMVARegression(output+"tpcItsMatchA"+iBoot,treeCache, "tpcItsMatchA", "interactionRate>0", "interactionRate:bz0:qmaxQASum:qmaxQASumR", "BDTRF25_8:BDTRF12_16:KNN","", 0);
+  }
+}
+
+
 ///
 void loadMVAreaders(){
   AliNDFunctionInterface::LoadMVAReader(0,"TMVA_RegressionOutput.root","MLP","dir_resolutionMIP");
@@ -111,6 +124,7 @@ void loadMVAreaders(){
   AliNDFunctionInterface::LoadMVAReader(3,"TMVA_RegressionOutput.root","BDTRF12_16","dir_resolutionMIP");
 }
 
+
 /// Load array of regression  -used later in the array regression evaluation (mean, median, rms)
 ///-------------------------------
 void loadMVAreadersBootstrap() {
@@ -118,6 +132,18 @@ void loadMVAreadersBootstrap() {
   AliNDFunctionInterface::LoadMVAReaderArray(1,"TMVA_RegressionOutput.root","BDTRF25_8",".*resolutionMIP");
   AliNDFunctionInterface::LoadMVAReaderArray(2,"TMVA_RegressionOutput.root","KNN",".*resolutionMIP");
 }
+
+/// Load array of regression  -used later in the array regression evaluation (mean, median, rms)
+///-------------------------------
+void loadMVAreadersBootstrap2() {
+  AliNDFunctionInterface::LoadMVAReaderArray(0,"TMVA_RegressionOutput2.root","BDTRF12_16",".*resolutionMIP");
+  AliNDFunctionInterface::LoadMVAReaderArray(1,"TMVA_RegressionOutput2.root","BDTRF25_8",".*resolutionMIP");
+  AliNDFunctionInterface::LoadMVAReaderArray(2,"TMVA_RegressionOutput2.root","KNN",".*resolutionMIP");
+
+
+}
+
+
 /// QAtrendingFitExample
 /// ----------------------
 void QAtrendingFitExample(){


### PR DESCRIPTION
## ATO-445-TMVA regression (NON BACK COMP. CHANGE) + classification (ADD)

* modifying user interface for TMVA regression
  * adding output filte/directory specification
  * grouping variables and weights
  * iteration coding removed (used e.g for bootstrapping) can be done
   modifying output name
* Updated doxygen documentation
* Updated test (QAtrendigFitExample.C) for modified interface
* Fix "errors" reported by CLIon
  * camel convention of variable names
dab2acd

### Commit in 3 steps
* Add new interface 
  * https://github.com/alisw/AliRoot/commit/f0d207536ec401d5350835d5c2bb8d3223125105
* Test old/new interface (the same results)   
  * https://github.com/alisw/AliRoot/commit/426dda37554b2d82ab94f4903329c5d5d91f4d63
* Removed old interface 
  * https://github.com/alisw/AliRoot/commit/dab2acdaf0cd6147649426d697a51273f6ac8709