### PR TITLE
Generators will tell its length/time units to AliGenMC for Boost method

### DIFF
--- a/EVGEN/AliGenMC.h
+++ b/EVGEN/AliGenMC.h
@@ -63,6 +63,8 @@ class AliGenMC : public AliGenerator
     virtual void BeamCrossAngle();
     virtual void AddHeader(AliGenEventHeader* header);
 
+    virtual void SetGeneratorUnitsForMeterSecond(double lengthC=1., double timeC=1.);
+    
  protected:
     // check if particle is selected as parent particle
     Bool_t ParentSelected(Int_t ip) const;
@@ -92,16 +94,18 @@ class AliGenMC : public AliGenerator
     Decay_t      fForceDecay;    // Decay channel forced
     Float_t      fMaxLifeTime;   // Maximum lifetime for unstable particles
     Double_t     fDyBoost;       // dy for boost into lab frame
+    Double_t     fSpace2TimeCoeff;            // coeff to convert lenght/time units used by generator to m/s
+    Double_t     fTime2SpaceCoeff;            // coeff to convert time/length units used by generator to s/m
     AliGeometry* fGeometryAcceptance; // Geometry to which particles must be simulated
     Int_t        fPdgCodeParticleforAcceptanceCut;  // Abs(PDG Code) of the particle to which the GeometryAcceptance must be applied
     Int_t        fNumberOfAcceptedParticles;  // Number of accepted particles in GeometryAcceptance with the right Abs(PdgCode) 
     Int_t        fNprimaries;                 // Number of produced and stored particles
- 
+    
  private:
     AliGenMC(const AliGenMC &MC);
     AliGenMC & operator=(const AliGenMC & rhs);
     
-    ClassDef(AliGenMC,7)       // AliGenerator implementation for generators using MC methods
+    ClassDef(AliGenMC,8)       // AliGenerator implementation for generators using MC methods
 };
 #endif
 

--- a/PYTHIA6/AliPythia6/AliGenPythia.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythia.cxx
@@ -394,7 +394,10 @@ void AliGenPythia::SetEventListRange(Int_t eventFirst, Int_t eventLast)
 void AliGenPythia::Init()
 {
 // Initialisation
-    
+
+    // Coeffs to go from mm / mm to meter / second
+    SetGeneratorUnitsForMeterSecond(1.e-3, 1e-3/TMath::C()); 
+  
     SetMC(AliPythia::Instance());
     fPythia=(AliPythia*) fMCEvGen;
     

--- a/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
@@ -328,7 +328,10 @@ void AliGenPythiaPlus::Init()
     
 //    SetMC(AliPythia::Instance());
 //    fPythia=(AliPythia*) fMCEvGen;
-    
+  
+    // Coeffs to go from mm / mm to meter / second
+    SetGeneratorUnitsForMeterSecond(1.e-3, 1e-3/TMath::C()); 
+  
 //
     fParentWeight=1./Float_t(fNpart);
 //

--- a/TAmpt/TAmpt/AliGenAmpt.cxx
+++ b/TAmpt/TAmpt/AliGenAmpt.cxx
@@ -161,6 +161,9 @@ void AliGenAmpt::Init()
 {
   // Initialisation
 
+  // Coeffs to go to from cm/s to meter/seconds
+  SetGeneratorUnitsForMeterSecond(1.e-2, 1.); 
+  
   fFrame.Resize(8);
   fTarget.Resize(8);
   fProjectile.Resize(8);

--- a/TDPMjet/AliGenDPMjet.cxx
+++ b/TDPMjet/AliGenDPMjet.cxx
@@ -176,7 +176,10 @@ AliGenDPMjet::~AliGenDPMjet()
 void AliGenDPMjet::Init()
 {
 // Initialization
-    
+
+    // Coeffs to go from mm / mm to meter / second
+    SetGeneratorUnitsForMeterSecond(1.e-3, 1e-3/TMath::C()); 
+  
     if(fEnergyCMS>0. && fBeamEn<0.1) fBeamEn = fEnergyCMS/2;
     SetMC(new TDPMjet(fProcess, fAProjectile, fZProjectile, fATarget, fZTarget, 
 		      fBeamEn,fEnergyCMS));

--- a/THijing/AliGenHijing.cxx
+++ b/THijing/AliGenHijing.cxx
@@ -166,6 +166,10 @@ AliGenHijing::~AliGenHijing()
 void AliGenHijing::Init()
 {
 // Initialisation
+
+    // Coeffs to go from mm / mm to meter / second
+    SetGeneratorUnitsForMeterSecond(1.e-3, 1e-3/TMath::C()); 
+  
     fFrame.Resize(8);
     fTarget.Resize(8);
     fProjectile.Resize(8);


### PR DESCRIPTION
AliGenMC::Boost() method assumes m/s for length/time units. In case the generator
uses other units it must set the AliGenMC::SetGeneratorUnitsForMeterSecond(lgtC, timeC)
with lgtC and timeC being the coefficients translating generator's units to m/s.