### PR TITLE
[WIP] Utilize new features of AliTPCCommon (fast transform, HLT tracks in offline, ...)

### DIFF
--- a/HLT/BASE/AliHLTSystem.cxx
+++ b/HLT/BASE/AliHLTSystem.cxx
@@ -1296,7 +1296,8 @@ int AliHLTSystem::ScanOptions(const char* options)
 	} else if (token.BeginsWith("!lib") && token.EndsWith(".so")) {
 	  excludelibs+=token;
 	  excludelibs+=" ";
-	} else if ( (token.CompareTo("ignore-hltout")==0 ) || (token.Contains("TPC-input=")) ) {
+	} else if ( (token.CompareTo("ignore-hltout")==0 ) || (token.Contains("TPC-input=")) 
+		    || (token.Contains("TPC-transform:")) ) {
 	    // these options will be used when configuring subdetectors, do nothing here
 	} else {
 	  HLTWarning("unknown option \'%s\'", token.Data());

--- a/HLT/CMakeLists.txt
+++ b/HLT/CMakeLists.txt
@@ -56,6 +56,11 @@ add_subdirectory(shuttle)
 add_subdirectory(sim)
 add_subdirectory(ZMQ)
 
+if(DEFINED ALITPCCOMMON_DIR)
+    set(ALITPCCOMMON_BUILD_TYPE "ALIROOT")
+    add_subdirectory(${ALITPCCOMMON_DIR}/sources/Common AliTPCCommonBase)
+endif()
+
 if (DIM_FOUND)
     add_subdirectory(createGRP/lib)
 endif()

--- a/HLT/TPCLib/AliHLTTPCAgent.cxx
+++ b/HLT/TPCLib/AliHLTTPCAgent.cxx
@@ -109,6 +109,7 @@ int AliHLTTPCAgent::CreateConfigurations(AliHLTConfigurationHandler* handler,
 
     bool isRawHLTOUT = 1;
     int tpcInputMode = 0;
+    TString transformArg;
     if( pHLT ){
       TString hltoptions = pHLT->GetConfigurationString();
       TObjArray* pTokens=hltoptions.Tokenize(" ");
@@ -121,6 +122,8 @@ int AliHLTTPCAgent::CreateConfigurations(AliHLTConfigurationHandler* handler,
 	    isRawHLTOUT = 0;
 	  } else if (token.CompareTo("run-online-config")==0) {
 	    isRawHLTOUT = 0;
+	  } else if (token.Contains("TPC-transform:")) {
+	    transformArg = token.ReplaceAll("TPC-transform:", "");	  
 	  } else if (token.Contains("TPC-input=")) {
 	    TString param=token.ReplaceAll("TPC-input=", "");
 	    if (param == "default") {
@@ -223,9 +226,10 @@ int AliHLTTPCAgent::CreateConfigurations(AliHLTConfigurationHandler* handler,
  
     TString hwcfDecoder = "TPC-HWCFDecoder";
     handler->CreateConfiguration(hwcfDecoder.Data(), "TPCHWClusterDecoder",hwclustOutput.Data(), "");
-	
-	arg="-offline-mode";
-	if (!bPublishRaw) arg+=" -do-mc -offline-keep-initial-timestamp";
+
+    arg = transformArg;
+    arg+=" -offline-mode";
+    if (!bPublishRaw) arg+=" -do-mc -offline-keep-initial-timestamp";
 
     TString clusterTransformation = "TPC-ClusterTransformation";
     handler->CreateConfiguration(clusterTransformation.Data(), "TPCClusterTransformation",hwcfDecoder.Data(), arg.Data() );

--- a/HLT/TPCLib/AliHLTTPCClusterAccessHLTOUT.h
+++ b/HLT/TPCLib/AliHLTTPCClusterAccessHLTOUT.h
@@ -21,6 +21,7 @@
 class AliTPCParam;
 class TClonesArray;
 class AliHLTTPCDataCompressionDecoder;
+class AliTPCtracker;
 
 /**
  * @class AliHLTTPCClusterAccessHLTOUT
@@ -250,6 +251,8 @@ class AliHLTTPCClusterAccessHLTOUT : public TObject
   int fMarkEdgeClusters; //! mark edge clusters during decoding
   AliHLTTPCDataCompressionDecoder* fpDecoder; //! decoder instance
   AliTPCParam* fTPCParam; //! pointer to TPC param
+  int fCopySeeds; //! last command was to create seeds, so we will copy() seeds instead of clusters
+  AliTPCtracker* fTPCtracker; //!ptr to AliTPCtracker
 
   ClassDef(AliHLTTPCClusterAccessHLTOUT, 0)
 };

--- a/HLT/TPCLib/AliHLTTPCClusterTransformation.h
+++ b/HLT/TPCLib/AliHLTTPCClusterTransformation.h
@@ -4,13 +4,13 @@
 #ifndef ALIHLTTPCCLUSTERTRANSFORMATION_H
 #define ALIHLTTPCCLUSTERTRANSFORMATION_H
 
-//* This file is property of and copyright by the ALICE HLT Project        * 
+//* This file is property of and copyright by the ALICE HLT Project        *
 //* ALICE Experiment at CERN, All rights reserved.                         *
 //* See cxx source for full Copyright notice                               *
 
 /** @file   AliHLTTPCClusterTransformation.h
     @author Kalliopi Kanaki, Sergey Gorbunov
-    @date   
+    @date
     @brief
 */
 
@@ -41,7 +41,7 @@ namespace ali_tpc_common{
  *
  * The class transforms internal TPC coordinates (pad,time) to XYZ.
  * Allnecessary calibration and alignment corrections are applied
- * 
+ *
  * @ingroup alihlt_tpc_components
  */
 
@@ -50,14 +50,14 @@ class AliHLTTPCClusterTransformation{
  public:
 
   /// Enumeration of transformation kinds
-  enum  TransformationKind  { 
-    OldFastTransform = 0,    ///< old fast transfrom with splines
-    Original         = 1,    ///< original
-    FastIRS          = 2     ///< new fast transform with irregular splines from AliTPCCommon
+  enum  TransformationKind  {
+    TransformOldFastTransform = 0,    ///< old fast transfrom with splines
+    TransformOriginal         = 1,    ///< original
+    TransformFastIRS          = 2     ///< new fast transform with irregular splines from AliTPCCommon
    };
 
-  /** standard constructor */    
-  AliHLTTPCClusterTransformation();           
+  /** standard constructor */
+  AliHLTTPCClusterTransformation();
   /** destructor */
   virtual ~AliHLTTPCClusterTransformation();
 
@@ -123,7 +123,7 @@ class AliHLTTPCClusterTransformation{
 
   AliTPCTransform * fOrigTransform;  // offline transformation
   AliHLTTPCFastTransform fFastTransform; // fast transformation object
-  ali_tpc_common::tpc_fast_transformation::TPCFastTransform *fFastTransformIRS; // new fast transform with irregular splines 
+  ali_tpc_common::tpc_fast_transformation::TPCFastTransform *fFastTransformIRS; // new fast transform with irregular splines
   ali_tpc_common::tpc_fast_transformation::TPCFastTransformManager *fFastTransformManager; // manager
   
   bool fIsMC; //Do we process MC?
@@ -133,7 +133,7 @@ class AliHLTTPCClusterTransformation{
 
 inline Int_t AliHLTTPCClusterTransformation::Error(Int_t code, const char *msg)
 {
-  // Set error 
+  // Set error
   fError = msg;
   return code;
 }

--- a/HLT/TPCLib/AliHLTTPCClusterTransformationComponent.cxx
+++ b/HLT/TPCLib/AliHLTTPCClusterTransformationComponent.cxx
@@ -64,7 +64,7 @@ fInitializeByObjectInDoEvent(0),
 fInitialized(0),
 fTPCPresent(0),
 fIsMC(0),
-fUseOrigTransform(0),
+fTransformKind( AliHLTTPCClusterTransformation::TransformationKind::OldFastTransform ),
 fBenchmark("ClusterTransformation")
 {
   // see header file for class documentation
@@ -84,7 +84,6 @@ AliHLTTPCClusterTransformationComponent::~AliHLTTPCClusterTransformationComponen
 
 const char* AliHLTTPCClusterTransformationComponent::GetComponentID() { 
 // see header file for class documentation
-
   return "TPCClusterTransformation";
 }
 
@@ -143,7 +142,7 @@ int AliHLTTPCClusterTransformationComponent::DoInit( int argc, const char** argv
   if (iResult>=0 && argc>0)
     iResult=ConfigureFromArgumentString(argc, argv);
     
-  if (fUseOrigTransform)
+  if ( fTransformKind == AliHLTTPCClusterTransformation::TransformationKind::Original )
   {
     fOfflineMode = 1;
     fInitializeByObjectInDoEvent = 0;
@@ -165,8 +164,8 @@ int AliHLTTPCClusterTransformationComponent::DoInit( int argc, const char** argv
           HLTInfo( "Cluster Transformation will initialize on the fly in DoEvent loop via FastTransformation Data Object, skipping initialization." );
     }
     else if( fOfflineMode ) {
-      err = fgTransform.Init( GetBz(), GetTimeStamp(), fIsMC, fUseOrigTransform );
-	  fInitialized = true;
+      err = fgTransform.Init( GetTimeStamp(), fIsMC, fTransformKind );
+      fInitialized = true;
     } else {
        const char* defaultNotify = "";
        const char* cdbEntry = "HLT/ConfigTPC/TPCFastTransform";
@@ -246,8 +245,12 @@ int AliHLTTPCClusterTransformationComponent::ScanConfigurationArgument(int argc,
       HLTDebug("Processing Monte Carlo Data.");
       iRet++;
     } else if (argument.CompareTo("-use-orig-transform")==0){
-      fUseOrigTransform = 1;
+      fTransformKind = AliHLTTPCClusterTransformation::TransformationKind::Original;
       HLTInfo("Running unmodified original TPC transformation.");
+      iRet++;
+    } else if (argument.CompareTo("-use-irs-transform")==0){ 
+      fTransformKind = AliHLTTPCClusterTransformation::TransformationKind::FastIRS;
+      HLTInfo("Running TPC transformation with irregular splines");      
       iRet++;
     } else if (argument.CompareTo("-offline-keep-initial-timestamp")==0){
       fOfflineKeepInitialTimestamp = 1;

--- a/HLT/TPCLib/AliHLTTPCClusterTransformationComponent.cxx
+++ b/HLT/TPCLib/AliHLTTPCClusterTransformationComponent.cxx
@@ -17,8 +17,8 @@
 
 /** @file   AliHLTTPCClusterTransformationComponent.cxx
     @author Sergey Gorbunov
-    @date   
-    @brief 
+    @date
+    @brief
 */
 
 #include "AliHLTTPCReverseTransformInfoV1.h"
@@ -41,7 +41,7 @@
 //#include "TPCFastTransformQA.h"
 
 #include "TMath.h"
-#include "TObjString.h" 
+#include "TObjString.h"
 #include <cstdlib>
 #include <cerrno>
 #include <sys/time.h>
@@ -64,45 +64,45 @@ fInitializeByObjectInDoEvent(0),
 fInitialized(0),
 fTPCPresent(0),
 fIsMC(0),
-fTransformKind( AliHLTTPCClusterTransformation::TransformationKind::OldFastTransform ),
+fTransformKind( AliHLTTPCClusterTransformation::TransformOldFastTransform ),
 fBenchmark("ClusterTransformation")
 {
   // see header file for class documentation
   // or
   // refer to README to build package
   // or
-  // visit http://web.ift.uib.no/~kjeks/doc/alice-hlt  
+  // visit http://web.ift.uib.no/~kjeks/doc/alice-hlt
 
   fBenchmark.Reset();
   fBenchmark.SetTimer(0,"total");
 }
 
 AliHLTTPCClusterTransformationComponent::~AliHLTTPCClusterTransformationComponent()
-{ 
+{
   // destructor
 }
 
-const char* AliHLTTPCClusterTransformationComponent::GetComponentID() { 
+const char* AliHLTTPCClusterTransformationComponent::GetComponentID() {
 // see header file for class documentation
   return "TPCClusterTransformation";
 }
 
-void AliHLTTPCClusterTransformationComponent::GetInputDataTypes( vector<AliHLTComponentDataType>& list) { 
+void AliHLTTPCClusterTransformationComponent::GetInputDataTypes( vector<AliHLTComponentDataType>& list) {
   // see header file for class documentation
 
-  list.clear(); 
+  list.clear();
   list.push_back( AliHLTTPCDefinitions::RawClustersDataType() );
   list.push_back( AliHLTTPCDefinitions::AliHLTDataTypeClusterMCInfo() );
   list.push_back( AliHLTTPCDefinitions::TPCFastTransformDataObjectDataType() );
 }
 
-AliHLTComponentDataType AliHLTTPCClusterTransformationComponent::GetOutputDataType() { 
+AliHLTComponentDataType AliHLTTPCClusterTransformationComponent::GetOutputDataType() {
   // see header file for class documentation
 
   return kAliHLTMultipleDataType;
 }
 
-int AliHLTTPCClusterTransformationComponent::GetOutputDataTypes(AliHLTComponentDataTypeList& tgtList) { 
+int AliHLTTPCClusterTransformationComponent::GetOutputDataTypes(AliHLTComponentDataTypeList& tgtList) {
   // see header file for class documentation
 
   tgtList.clear();
@@ -112,20 +112,20 @@ int AliHLTTPCClusterTransformationComponent::GetOutputDataTypes(AliHLTComponentD
   return tgtList.size();
 }
 
-void AliHLTTPCClusterTransformationComponent::GetOutputDataSize( unsigned long& constBase, double& inputMultiplier ) { 
+void AliHLTTPCClusterTransformationComponent::GetOutputDataSize( unsigned long& constBase, double& inputMultiplier ) {
   // see header file for class documentation
   constBase = sizeof(AliHLTTPCClusterXYZData)*6*36;
   inputMultiplier = ( (double) sizeof(AliHLTTPCClusterXYZ) ) / ( sizeof(AliHLTTPCRawCluster) );
 }
 
-AliHLTComponent* AliHLTTPCClusterTransformationComponent::Spawn() { 
+AliHLTComponent* AliHLTTPCClusterTransformationComponent::Spawn() {
   // see header file for class documentation
 
   return new AliHLTTPCClusterTransformationComponent();
 }
 	
-int AliHLTTPCClusterTransformationComponent::DoInit( int argc, const char** argv ) 
-{ 
+int AliHLTTPCClusterTransformationComponent::DoInit( int argc, const char** argv )
+{
   // see header file for class documentation
 
   int iResult=0;
@@ -142,13 +142,13 @@ int AliHLTTPCClusterTransformationComponent::DoInit( int argc, const char** argv
   if (iResult>=0 && argc>0)
     iResult=ConfigureFromArgumentString(argc, argv);
     
-  if ( fTransformKind == AliHLTTPCClusterTransformation::TransformationKind::Original )
+  if ( fTransformKind == AliHLTTPCClusterTransformation::TransformOriginal )
   {
     fOfflineMode = 1;
     fInitializeByObjectInDoEvent = 0;
   }
 
-  AliTPCcalibDB *calib=AliTPCcalibDB::Instance();  
+  AliTPCcalibDB *calib=AliTPCcalibDB::Instance();
   if(!calib){
     HLTError("AliTPCcalibDB does not exist");
     return -ENOENT;
@@ -205,14 +205,14 @@ int AliHLTTPCClusterTransformationComponent::DoInit( int argc, const char** argv
   return iResult;
 } // end DoInit()
 
-int AliHLTTPCClusterTransformationComponent::DoDeinit() { 
-  // see header file for class documentation   
+int AliHLTTPCClusterTransformationComponent::DoDeinit() {
+  // see header file for class documentation
   if (fInitialized) fgTransform.DeInit();
   fInitialized = false;
   return 0;
 }
 
-int AliHLTTPCClusterTransformationComponent::Reconfigure(const char* /*cdbEntry*/, const char* /*chainId*/) { 
+int AliHLTTPCClusterTransformationComponent::Reconfigure(const char* /*cdbEntry*/, const char* /*chainId*/) {
   // see header file for class documentation
   return 0;//!! ConfigureFromCDBTObjString(fgkOCDBEntryClusterTransformation);
 }
@@ -224,7 +224,7 @@ int AliHLTTPCClusterTransformationComponent::ScanConfigurationArgument(int argc,
   if (argc<=0) return 0;
   int iRet = 0;
   for( int i=0; i<argc; i++ ){
-    TString argument=argv[i];  
+    TString argument=argv[i];
     if (argument.CompareTo("-change-dataId")==0){
       HLTWarning("Obsolete -change-dataId option received.");
       iRet++;
@@ -245,12 +245,12 @@ int AliHLTTPCClusterTransformationComponent::ScanConfigurationArgument(int argc,
       HLTDebug("Processing Monte Carlo Data.");
       iRet++;
     } else if (argument.CompareTo("-use-orig-transform")==0){
-      fTransformKind = AliHLTTPCClusterTransformation::TransformationKind::Original;
+      fTransformKind = AliHLTTPCClusterTransformation::TransformOriginal;
       HLTInfo("Running unmodified original TPC transformation.");
       iRet++;
-    } else if (argument.CompareTo("-use-irs-transform")==0){ 
-      fTransformKind = AliHLTTPCClusterTransformation::TransformationKind::FastIRS;
-      HLTInfo("Running TPC transformation with irregular splines");      
+    } else if (argument.CompareTo("-use-irs-transform")==0){
+      fTransformKind = AliHLTTPCClusterTransformation::TransformFastIRS;
+      HLTInfo("Running TPC transformation with irregular splines");
       iRet++;
     } else if (argument.CompareTo("-offline-keep-initial-timestamp")==0){
       fOfflineKeepInitialTimestamp = 1;
@@ -258,17 +258,17 @@ int AliHLTTPCClusterTransformationComponent::ScanConfigurationArgument(int argc,
       iRet++;
     } else {
       iRet = -EINVAL;
-      HLTError("Unknown argument %s",argv[i]);     
+      HLTError("Unknown argument %s",argv[i]);
     }
-  } 
+  }
   return iRet;
 }
 
 
-int AliHLTTPCClusterTransformationComponent::DoEvent(const AliHLTComponentEventData& evtData, 
-					          const AliHLTComponentBlockData* blocks, 
-					          AliHLTComponentTriggerData& /*trigData*/, AliHLTUInt8_t* outputPtr, 
-					          AliHLTUInt32_t& size, 
+int AliHLTTPCClusterTransformationComponent::DoEvent(const AliHLTComponentEventData& evtData,
+					          const AliHLTComponentBlockData* blocks,
+					          AliHLTComponentTriggerData& /*trigData*/, AliHLTUInt8_t* outputPtr,
+					          AliHLTUInt32_t& size,
 					          vector<AliHLTComponentBlockData>& outputBlocks ){
   // see header file for class documentation
  
@@ -315,7 +315,7 @@ int AliHLTTPCClusterTransformationComponent::DoEvent(const AliHLTComponentEventD
   
   if( !fgTransform.IsInitialised() ){
     HLTError(" TPC Transformation is not initialised ");
-    return -ENOENT;    
+    return -ENOENT;
   }
 
   fBenchmark.StartNewEvent();
@@ -339,14 +339,14 @@ int AliHLTTPCClusterTransformationComponent::DoEvent(const AliHLTComponentEventD
     fBenchmark.AddInput(iter->fSize);
     
     HLTDebug("Event 0x%08LX (%Lu) received datatype: %s - required datatype: %s or $s",
-	     evtData.fEventID, evtData.fEventID, 
-	     DataType2Text( iter->fDataType).c_str(), 
+	     evtData.fEventID, evtData.fEventID,
+	     DataType2Text( iter->fDataType).c_str(),
 	     DataType2Text(AliHLTTPCDefinitions::fgkRawClustersDataType).c_str(), DataType2Text(AliHLTTPCDefinitions::fgkAliHLTDataTypeClusterMCInfo).c_str());
  
     if( iter->fDataType == AliHLTTPCDefinitions::AliHLTDataTypeClusterMCInfo() ){
       // forward MC labels
       fBenchmark.AddOutput( iter->fSize );
-      outputBlocks.push_back( *iter );     
+      outputBlocks.push_back( *iter );
       continue;
     }
 
@@ -377,7 +377,7 @@ int AliHLTTPCClusterTransformationComponent::DoEvent(const AliHLTComponentEventD
  
     int firstRow = AliHLTTPCGeometry::GetFirstRow(partition);
 
-    // create AliHLTTPCClusterXYZData array in parallel to raw clusters, fill xyz==0 in case of problems 
+    // create AliHLTTPCClusterXYZData array in parallel to raw clusters, fill xyz==0 in case of problems
 
     AliHLTTPCClusterXYZData* outPtr  = reinterpret_cast<AliHLTTPCClusterXYZData*>(outputPtr);
     outPtr->fCount = rawClusters->fCount;
@@ -397,7 +397,7 @@ int AliHLTTPCClusterTransformationComponent::DoEvent(const AliHLTComponentEventD
 	continue;
       }
       Float_t xyz[3];
-      int err = fgTransform.Transform( slice, firstRow + padrow, cl.GetPad(), cl.GetTime(), xyz );	 
+      int err = fgTransform.Transform( slice, firstRow + padrow, cl.GetPad(), cl.GetTime(), xyz );
       if( err!=0 ){
 	HLTWarning(Form("Cannot transform the cluster, AliHLTTPCClusterTransformation returns error %d, %s",err, fgTransform.GetLastError()));
 	continue;
@@ -426,9 +426,9 @@ int AliHLTTPCClusterTransformationComponent::DoEvent(const AliHLTComponentEventD
      
     fBenchmark.AddOutput(bd.fSize);
     size   += mysize;
-    outputPtr += mysize; 
+    outputPtr += mysize;
  
-  } // end of loop over data blocks  
+  } // end of loop over data blocks
   
   if (size + sizeof(AliHLTTPCReverseTransformInfoV1) > maxOutSize)
   {
@@ -479,7 +479,7 @@ void AliHLTTPCClusterTransformationComponent::GetOCDBObjectDescription( TMap* co
   targetMap->Add(new TObjString("GRP/CTP/CTPtiming"),     new TObjString("content used in the cluster coordinate transformation in relation to the L0 trigger timing"));
 
   // OCDB entries necessary for replaying data on the HLT cluster
-  targetMap->Add(new TObjString("GRP/GRP/Data"), new TObjString("contains magnetic field info"));  
+  targetMap->Add(new TObjString("GRP/GRP/Data"), new TObjString("contains magnetic field info"));
  
   // OCDB entries needed to suppress fatals/errors/warnings during reconstruction
   targetMap->Add(new TObjString("TPC/Calib/Distortion"),  new TObjString("distortion map"));
@@ -511,12 +511,12 @@ void AliHLTTPCClusterTransformationComponent::PrintDebugInfo()
   for( int row=10; row<20; row++){
     Int_t slice=-1;
     Int_t slicerow=-1;
-    AliHLTTPCGeometry::Sector2Slice( slice, slicerow, sector, row); 
-    Float_t f[3]; 
+    AliHLTTPCGeometry::Sector2Slice( slice, slicerow, sector, row);
+    Float_t f[3];
     fgTransform.Transform( slice, slicerow, 10., 500., f );
-    Double_t xyz[3] = { f[0], f[1], f[2] };    
+    Double_t xyz[3] = { f[0], f[1], f[2] };
     std::cout<<std::scientific;
-#if __cplusplus >= 201103L      
+#if __cplusplus >= 201103L
     std::cout<<std::setprecision( 10 );
 #endif
     std::cout<<"HLT transform: "<<" sec "<<sector<<" row "<< row<<" "<<xyz[0]<<" "<<xyz[1]<<" "<<xyz[2]<<std::endl;

--- a/HLT/TPCLib/AliHLTTPCClusterTransformationComponent.h
+++ b/HLT/TPCLib/AliHLTTPCClusterTransformationComponent.h
@@ -21,8 +21,7 @@
 
 #include "AliHLTProcessor.h"
 #include "AliHLTComponentBenchmark.h"
-
-class AliHLTTPCClusterTransformation;
+#include "AliHLTTPCClusterTransformation.h"
 
 
 /**
@@ -94,7 +93,8 @@ private:
   bool fInitialized;	//Are we initialized?
   bool fTPCPresent;	//Is TPC present in GRP, if not skip init
   bool fIsMC; //Are we processing MC
-  bool fUseOrigTransform; //Use original TPC transform instead of fast HLT transform map
+
+  AliHLTTPCClusterTransformation::TransformationKind fTransformKind; // whichtransformation to use
 
   AliHLTComponentBenchmark fBenchmark; // benchmarks
 

--- a/HLT/TPCLib/CMakeLists.txt
+++ b/HLT/TPCLib/CMakeLists.txt
@@ -28,8 +28,9 @@ else()
     if(DEFINED ALITPCCOMMON_DIR)
         set(ALITPCCOMMON_BUILD_TYPE "ALIROOT")
         add_subdirectory(${ALITPCCOMMON_DIR}/sources/TPCCAGPUTracking TPCCAGPUTracking)
-#        add_subdirectory(${ALITPCCOMMON_DIR}/sources/TPCFastTransformation TPCFastTransformation)
-        include_directories(${ALITPCCOMMON_DIR}/sources/TPCCAGPUTracking/SliceTracker
+        add_subdirectory(${ALITPCCOMMON_DIR}/sources/TPCFastTransformation TPCFastTransformation)
+        include_directories(${ALITPCCOMMON_DIR}/sources/Common
+                            ${ALITPCCOMMON_DIR}/sources/TPCCAGPUTracking/SliceTracker
                             ${ALITPCCOMMON_DIR}/sources/TPCCAGPUTracking/Merger
                             ${ALITPCCOMMON_DIR}/sources/TPCCAGPUTracking/GlobalTracker
                             ${ALITPCCOMMON_DIR}/sources/TPCCAGPUTracking/DataCompression
@@ -39,7 +40,7 @@ else()
         message(FATAL_ERROR "cmake variable ALITPCCOMMON_DIR is not defined")
     endif()
     set(LIBDEPS ${LIBDEPS} AliTPCCAGPUTracking)
-#    set(LIBDEPS ${LIBDEPS} AliTPCFastTransformation)
+    set(LIBDEPS ${LIBDEPS} AliTPCFastTransformation)
 endif()
 
 # Module

--- a/HLT/VZERO/AliHLTVZEROOnlineCalibComponent.cxx
+++ b/HLT/VZERO/AliHLTVZEROOnlineCalibComponent.cxx
@@ -313,13 +313,13 @@ Int_t AliHLTVZEROOnlineCalibComponent::DoEvent(const AliHLTComponentEventData& /
     }
     if (esdVZERO && itsSpdVertex)
     {
-        printf("Vertex position: %f %f %f\n", itsSpdVertex->GetX(), itsSpdVertex->GetY(), itsSpdVertex->GetZ());
+        //printf("Vertex position: %f %f %f\n", itsSpdVertex->GetX(), itsSpdVertex->GetY(), itsSpdVertex->GetZ());
         //Rough V0 decision check (equiv to phys. sel.)
         if (esdVZERO->GetV0ADecision()!=AliVVZERO::kV0BB) lIsV0DecisionOK = false;
         if (esdVZERO->GetV0CDecision()!=AliVVZERO::kV0BB) lIsV0DecisionOK = false;
         if ( TMath::Abs(itsSpdVertex->GetZ())>10.0 ) lIsVertexPositionGood = false;
         if ( itsSpdVertex->GetNContributors() < 1 ) lIsVertexPositionGood = false; //not okay, no contributor
-        printf("Decisions: v0 decision is %d , vertex decision is %d\n", lIsV0DecisionOK, lIsVertexPositionGood);
+        //printf("Decisions: v0 decision is %d , vertex decision is %d\n", lIsV0DecisionOK, lIsVertexPositionGood);
         
         Double_t lQuantities[6] = {
             static_cast<Double_t>(esdVZERO->GetMTotV0A()+esdVZERO->GetMTotV0C()),

--- a/HLT/VZERO/macros/HLTVZeroCalibTest.C
+++ b/HLT/VZERO/macros/HLTVZeroCalibTest.C
@@ -3,6 +3,6 @@ void HLTVZeroCalibTest()
   // set up HLT system to enable configuration registration
   AliHLTSystem* pHLT=AliHLTPluginBase::GetInstance();
 
-  AliHLTConfiguration clusterStatOrig("VZEROCalib", "VZEROOnlineCalib", "VZERO-RECO", "");
+  AliHLTConfiguration vzeroCalib("VZEROCalib", "VZEROOnlineCalib", "VZERO-RECO ITS-SPD-vertexer", "");
   AliHLTConfiguration rootWriter("RootWriter", "ROOTFileWriter", "VZEROCalib", "-directory testDir -datafile test.root");
 }

--- a/TPC/TPCrec/AliTPCReconstructor.cxx
+++ b/TPC/TPCrec/AliTPCReconstructor.cxx
@@ -74,6 +74,7 @@ Double_t    AliTPCReconstructor::fgPrimaryZ2XCut = 0;
 Double_t    AliTPCReconstructor::fgZOutSectorCut = 0;
 Bool_t      AliTPCReconstructor::fgCompactClusters = kFALSE;
 Bool_t      AliTPCReconstructor::fgCountMCTrackClusters = kFALSE;
+Int_t       AliTPCReconstructor::fgUseHLTTracks = 0;
 
 AliTPCReconstructor::AliTPCReconstructor():
 AliReconstructor(),

--- a/TPC/TPCrec/AliTPCReconstructor.h
+++ b/TPC/TPCrec/AliTPCReconstructor.h
@@ -67,6 +67,8 @@ public:
 
   static Bool_t GetCountMCTrackClusters()                  {return fgCountMCTrackClusters;}
   static void   SetCountMCTrackClusters(Bool_t v=kTRUE)    {fgCountMCTrackClusters = v;}
+  static Int_t  GetUseHLTTracks()                          {return fgUseHLTTracks;}
+  static void   SetUseHLTTracks(Int_t v)                   {fgUseHLTTracks = v;}
   
 private:
   AliTPCReconstructor(const AliTPCReconstructor&); //Not implemented
@@ -87,6 +89,10 @@ private:
   static Double_t              fgZOutSectorCut;       // cut on Z going on other side of CE 
   static Bool_t                fgCompactClusters;     // if true, cluster coordinates will be set to 0 in clusterizer
   static Bool_t                fgCountMCTrackClusters; // create tree with Ncl per MC track
+  static Int_t                 fgUseHLTTracks;        //Copy tracks from HLT instead of running offline tracking
+                                                      //0: normal offline tracking, 1 use HLT tracks as seeds in Clusters2Tracks
+                                                      //2: use HLT tracks instead of running Clusters2Tracks
+                                                      //3: as 2 but no refit in PropagateBack, 4: as 3 bit no refit in RefitInward
   TObjArray *fArrSplines;                  // array of pid splines
 
   void SetSplinesFromOADB(const char* tmplt, AliESDpid *esdPID);

--- a/TPC/TPCrec/AliTPCclusterer.h
+++ b/TPC/TPCrec/AliTPCclusterer.h
@@ -120,7 +120,7 @@ private:
   Float_t** fAllBins; //! All sector bins
   Int_t** fAllSigBins;//! All signal bins in a sector
   Int_t*  fAllNSigBins;//! Number of signal bins in a sector
-  TObject* fHLTClusterAccess;// interface to HLT clusters
+  TObject* fHLTClusterAccess;//! interface to HLT clusters
 
   ClassDef(AliTPCclusterer,0)  // TPC cluster finder
 };
@@ -154,5 +154,3 @@ inline Bool_t AliTPCclusterer::IsMaximum(Float_t q,Int_t max,const Float_t *bins
 //-----------------------------------------------------------------
 
 #endif
-
-

--- a/TPC/TPCrec/AliTPCtracker.h
+++ b/TPC/TPCrec/AliTPCtracker.h
@@ -1,4 +1,3 @@
-
 #ifndef ALITPCTRACKER_H
 #define ALITPCTRACKER_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
@@ -157,7 +156,6 @@ public:
    void GetCachedSeedClusterStatistic(Int_t first, Int_t last, Int_t &found, Int_t &foundable, Int_t &shared, Bool_t plus2) const;
    void GetSeedClusterStatistic(const AliTPCseed* seed, Int_t first, Int_t last, Int_t &found, Int_t &foundable, Int_t &shared, Bool_t plus2) const;
    //
- public:
    void SetUseHLTClusters(Int_t useHLTClusters) {fUseHLTClusters = useHLTClusters;} // set usage from HLT clusters from rec.C options
 
    inline void SetTPCtrackerSectors(AliTPCtrackerSector *innerSec, AliTPCtrackerSector *outerSec); // set the AliTPCtrackerSector arrays from outside (toy MC)
@@ -195,6 +193,7 @@ public:
  protected:
    //private:
 
+  bool InitHLTClusterAccess();
   int GetAdjustedLabels(const AliTPCclusterMI* cl, int *lbReal);
   Bool_t IsFindable(AliTPCseed & t);
   AliTPCtracker(const AliTPCtracker& r);           //dummy copy constructor
@@ -247,7 +246,8 @@ public:
 
    Int_t PropagateToRowHLT(AliTPCseed *pt, int nrow);
    void TrackFollowingHLT(TObjArray *const arr);
-   TObjArray * MakeSeedsHLT(const AliESDEvent *hltEvent);
+   TObjArray * MakeSeedsHLT(const AliESDEvent *hltEvent); //Takes HLT ESD tracks, finds and attaches adjacent clusters
+   TObjArray * ReadSeedsFromHLT(); //Use HLT tracks directly, and attach clusters by matching HLT to offline clusters directly
 
    const Int_t fkNIS;        //number of inner sectors
    AliTPCtrackerSector *fInnerSec;  //array of inner sectors;
@@ -301,6 +301,8 @@ public:
    //
    Int_t fAccountDistortions;           //! flag to account for distortions. RS: to set!
    TTree* fMCtrackNClTree;              //! optional tree with N clusters per MC track
+   
+   TObject* fHLTClusterAccess;          //! interface to HLT clusters
    //
    ClassDef(AliTPCtracker,5) 
 };
@@ -373,5 +375,3 @@ void  AliTPCtracker::SetTPCtrackerSectors(AliTPCtrackerSector *innerSec, AliTPCt
 }
 
 #endif
-
-


### PR DESCRIPTION
This requires AliTPCCommon >= v1.4

@dberzano : This will require people to update their alidist. Merging is not urgent. Could you please pull it in whenever it seems suited for you.

@shahor02: The changes to AliTPCTracker are completely inactive if you do not set AliTPCReconstructor::SetUseHLTTracks(), so it will not affect normal reconstruction, but if you want you can have a look and double-check.