### PR TITLE
Remove most libdeps from the aliroot executable

### DIFF
--- a/ALIROOT/CMakeLists.txt
+++ b/ALIROOT/CMakeLists.txt
@@ -36,7 +36,13 @@ set(CSRCS
 )
 
 add_executable(aliroot ${SRCS} ${CSRCS})
-target_link_libraries(aliroot MUONevaluation MUONmapping MUONshuttle MUONgraphics MUONsim MUONrec MUONgeometry MUONcalib MUONbase MUONraw MUONtrigger MUONcore TPCbase TPCsim TPCrec TPCutil  ITSbase ITSsim ITSrec PMDbase PMDsim PMDrec TRDbase TRDsim TRDrec FMDbase FMDsim FMDrec TOFbase TOFrec TOFsim PHOSUtils PHOSbase PHOSsim PHOSrec ADbase ADsim ADrec ACORDEbase ACORDEsim ACORDErec HMPIDbase HMPIDrec HMPIDsim ZDCbase ZDCsim ZDCrec VZERObase VZEROsim VZEROrec MFTbase MFTsim MFTrec EMCALUtils EMCALbase EMCALsim EMCALrec EMCALraw BCM STRUCT T0base T0sim T0rec FASTSIM HLTbase HLTshuttle TRIGGERbase STEER STAT CDB AOD  STEERBase ESD ANALYSIS RAWDatasim RAWDatarec RAWDatabase Rint MLP Gui Physics Geom EG Hist MathCore VMC Matrix Minuit Gpad Graf GenVector Proof Spectrum ANALYSISalice Graf3d HistPainter XMLParser AliHLTHOMER GeomPainter Thread ANALYSISaliceBase XMLIO)
+if(ROOT_VERSION_MAJOR LESS 6)
+  # ROOT 5: many dependencies (brought by STEER)
+  target_link_libraries(aliroot STEER Core Rint)
+else()
+  # ROOT 6+: minimal dependencies
+  target_link_libraries(aliroot STEERBase Core Rint)
+endif()
 if(TARGET microcern)
   target_link_libraries(aliroot microcern)
 endif()

--- a/ALIROOT/aliroot.cxx
+++ b/ALIROOT/aliroot.cxx
@@ -13,8 +13,6 @@
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
 
-/* $Id$ */
-
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // aliroot                                                              //
@@ -33,19 +31,22 @@
 //////////////////////////////////////////////////////////////////////////
 
 //Standard Root includes
+#include <RVersion.h>
+#include <Riostream.h>
 #include <TROOT.h>
+#include <TInterpreter.h>
 #include <TRint.h>
 #include <TFile.h>
+#if ROOT_VERSION_CODE < ROOT_VERSION(5,99,0)
 #include <AliRun.h>
-#include "Riostream.h"
-#include "ARVersion.h"
-// STD
+#endif
+#include <AliLog.h>
+#include <ARVersion.h>
 #include <iostream>
 #include <algorithm>
 #include <sstream>
 #include <stdexcept>
 #include <functional>
-#include <AliLog.h>
 #include <sys/resource.h>
 #include <stdlib.h>
 #include <string>
@@ -127,13 +128,18 @@ int main(int argc, char **argv)
       return 0;
     }    
   }
-  
-  // Create new configuration 
-  
-  new AliRun("gAlice","The ALICE Off-line Simulation Framework");
+
+  // Create new configuration
+#if ROOT_VERSION_CODE < ROOT_VERSION(5,99,0)
+  // ROOT 5: aliroot is linked to the necessary libraries
+  new AliRun("gAlice", "The ALICE Off-line Simulation Framework");
+#else
+  // ROOT 6+: aliroot has minimal dependencies: init gAlice through the interpreter
+  gInterpreter->ProcessLine("new AliRun(\"gAlice\", \"The ALICE Off-line Simulation Framework\");");
+#endif
   AliLog::GetRootLogger();  // force AliLog to initialize at start time
   // Start interactive geant
-  
+
   TRint *theApp = new TRint("aliroot", &argc, argv);
 #ifdef FORTRAN_G95
   g95_runtime_start();


### PR DESCRIPTION
The `aliroot` executable produced with ROOT 6 now depends solely on `STEERBase`
because of the `AliLog` class: initialization of `gAlice` is now performed
through the ROOT interpreter at runtime.

This works around a problem seeing `aliroot` stuck in an infinite mutex loop
on SLC6. The problem is likely due to a bug in an old glibc. See ALIROOT-7993.