### PR TITLE
Unpack collections by default in the merger

### DIFF
--- a/HLT/BASE/util/ZMQROOTmerger.cxx
+++ b/HLT/BASE/util/ZMQROOTmerger.cxx
@@ -91,7 +91,7 @@ Bool_t  fAllowResetOnRequest=kTRUE;
 Bool_t  fAllowResetAtSOR=kTRUE;
 Bool_t  fAllowClearAtSOR=kFALSE;
 
-Bool_t  fUnpackCollections = kFALSE;
+Bool_t  fUnpackCollections = kTRUE;
 Bool_t  fUnpackContainers = kFALSE;
 Bool_t  fFullyDestroyAnalysisDataContainer = kFALSE;
 std::string fLoadLibs;
@@ -281,7 +281,7 @@ public:
     {
       mergeable = dynamic_cast<AliMergeable*>(fObject);
     }
-    else if (!fMergeCall && fObject->IsA())
+    if (!hist && !mergeable && !fMergeCall && fObject->IsA())
     {
       //use ROOT magic as last resort
       fMergeCall = new TMethodCall;

--- a/HLT/BASE/util/ZMQROOTmerger.cxx
+++ b/HLT/BASE/util/ZMQROOTmerger.cxx
@@ -188,7 +188,7 @@ const char* fUSAGE =
     " -ZMQtimeout: when to timeout the sockets (milliseconds)\n"
     " -SchemaOnRequest : include streamers ONCE (after a request)\n"
     " -SchemaOnSend : include streamers ALWAYS in each sent message\n"
-    " -UnpackCollections : cache/merge the contents of the collections instead of the collection itself\n"
+    " -UnpackCollections : cache/merge the contents of the collections instead of the collection itself - default, do not change!\n"
     " -UnpackContainers : unpack the contents of AliAnalysisDataContainers\n"
     " -IgnoreDefaultContainerNames : don't prefix default container names (TList,TObjArray)\n"
     " -FullyDestroyAnalysisDataContainer : explicitly delete consumers and producer members in the container to work around a memory leak\n"


### PR DESCRIPTION
+change of logic to allow the user to shoot himself in the foot when
directly merging collections - this is SLOOW and leaks due to ROOT's
(lack of) ownership model.