### PR TITLE
remove deprecated dynamic exception specifications incompatible to c++17

### DIFF
--- a/HLT/ITS/tracking/AliHLTITSTrack.cxx
+++ b/HLT/ITS/tracking/AliHLTITSTrack.cxx
@@ -89,7 +89,7 @@ AliHLTITSTrack &AliHLTITSTrack::operator=(const AliHLTITSTrack& t)
 
 
 //____________________________________________________________________________
-AliHLTITSTrack::AliHLTITSTrack(AliESDtrack& t,Bool_t c) throw (const Char_t *) :
+AliHLTITSTrack::AliHLTITSTrack(AliESDtrack& t,Bool_t c) :
   AliKalmanTrack(),
   fExpQ(40),
   fTPCtrackId( 0 )
@@ -113,7 +113,7 @@ AliHLTITSTrack::AliHLTITSTrack(AliESDtrack& t,Bool_t c) throw (const Char_t *) :
 }
 
 //____________________________________________________________________________
-AliHLTITSTrack::AliHLTITSTrack(AliExternalTrackParam& t ) throw (const Char_t *) :
+AliHLTITSTrack::AliHLTITSTrack(AliExternalTrackParam& t ) :
   AliKalmanTrack(),  
   fExpQ(40),
   fTPCtrackId( 0 )

--- a/HLT/ITS/tracking/AliHLTITSTrack.h
+++ b/HLT/ITS/tracking/AliHLTITSTrack.h
@@ -19,8 +19,8 @@ class AliHLTITSTrack : public AliKalmanTrack
  public:
 
   AliHLTITSTrack();
-  AliHLTITSTrack(AliESDtrack& t,Bool_t c=kFALSE) throw (const Char_t *);
-  AliHLTITSTrack(AliExternalTrackParam& t ) throw (const Char_t *);
+  AliHLTITSTrack(AliESDtrack& t,Bool_t c=kFALSE);
+  AliHLTITSTrack(AliExternalTrackParam& t );
   AliHLTITSTrack(const AliHLTITSTrack& t);
   AliHLTITSTrack &operator=(const AliHLTITSTrack& t);
 

--- a/HLT/MUON/AliHLTMUONCountedList.h
+++ b/HLT/MUON/AliHLTMUONCountedList.h
@@ -155,7 +155,7 @@ public:
 	 * This deletes all elements from the list and resizes the buffer which
 	 * is used to store the entries for the list.
 	 */
-	void Clear(AliHLTUInt32_t maxentries) throw(std::bad_alloc)
+	void Clear(AliHLTUInt32_t maxentries)
 	{
 		AliHLTMUONList<DataType>::Clear(maxentries);
 		fCount = 0;

--- a/HLT/MUON/AliHLTMUONList.h
+++ b/HLT/MUON/AliHLTMUONList.h
@@ -522,7 +522,7 @@ public:
 	 * This deletes all elements from the list and resizes the buffer which
 	 * is used to store the entries for the list.
 	 */
-	void Clear(AliHLTUInt32_t maxentries) throw(std::bad_alloc)
+	void Clear(AliHLTUInt32_t maxentries)
 	{
 		Clear();
 		
@@ -608,7 +608,7 @@ protected:
 	 * Locates the next free location in the fEntry buffer, creates a new node
 	 * at that location and returns the pointer.
 	 */
-	Node* NewNode() throw(std::bad_alloc)
+	Node* NewNode()
 	{
 		//return new Node();
 		assert( fNextFree < fMaxEntries );
@@ -631,7 +631,7 @@ protected:
 		throw std::bad_alloc();
 	}
 	
-	Node* NewNode(const DataType& data) throw(std::bad_alloc)
+	Node* NewNode(const DataType& data)
 	{
 		//return new Node(data);
 		assert( fNextFree < fMaxEntries );

--- a/HLT/trigger/AliHLTTriggerCounterComponent.cxx
+++ b/HLT/trigger/AliHLTTriggerCounterComponent.cxx
@@ -567,7 +567,7 @@ void AliHLTTriggerCounterComponent::SetInitialCounters(const TMap* counters)
 }
 
 
-void* AliHLTTriggerCounterComponent::AliRingBuffer::operator new (std::size_t size) throw (std::bad_alloc)
+void* AliHLTTriggerCounterComponent::AliRingBuffer::operator new (std::size_t size)
 {
 	// New operator used to catch and log exceptions.
 	

--- a/HLT/trigger/AliHLTTriggerCounterComponent.h
+++ b/HLT/trigger/AliHLTTriggerCounterComponent.h
@@ -135,7 +135,7 @@ private:
 		}
 		
 		/// Overloaded new operator to catch and log memory allocation failures.
-		void* operator new (std::size_t size) throw (std::bad_alloc);
+		void* operator new (std::size_t size);
 		
 		/// Symmetric delete operator for overloaded new.
 		void operator delete (void* mem) throw ();

--- a/TTherminator/Therminator/ReadPar.cxx
+++ b/TTherminator/Therminator/ReadPar.cxx
@@ -66,7 +66,7 @@ ReadPar::~ReadPar()
     free(fname);
 }
 
-int ReadPar::readFile(const char *aFName) throw (int)
+int ReadPar::readFile(const char *aFName)
 {
   option read_opt;
   STR buf_str;
@@ -119,7 +119,7 @@ int ReadPar::printOptions()
   return 0;
 }
 
-STR ReadPar::getPar(const char *name) throw(STR)
+STR ReadPar::getPar(const char *name)
 {
   VOPT::iterator c;
   STR pname(name);

--- a/TTherminator/Therminator/ReadPar.h
+++ b/TTherminator/Therminator/ReadPar.h
@@ -61,9 +61,9 @@ class ReadPar
   ReadPar& operator=(const ReadPar& aPar);
   ~ReadPar();
   
-  int readFile(const char *aFName) throw(int); 
+  int readFile(const char *aFName);
   int printOptions();
-  STR getPar(const char *name) throw(STR);
+  STR getPar(const char *name);
   
 };
 


### PR DESCRIPTION
Although AliRoot is not build against c++17 yet, these exception specifications are obsoleted and totally unncessary. Btw, after these changes AliRoot works with c++17.