### PR TITLE
Updating reader for RELDIS events

### DIFF
--- a/EVGEN/AliGenReaderEMD.cxx
+++ b/EVGEN/AliGenReaderEMD.cxx
@@ -71,7 +71,8 @@ AliGenReaderEMD::AliGenReaderEMD():
     fEtaomegaAside(0),
     fomegaPDGCode(0),
     fNomegaCside(0),
-    fEtaomegaCside(0)
+    fEtaomegaCside(0),
+    fNtupleName(0)
 {
 // Std constructor
     for(int i=0; i<70; i++){
@@ -144,7 +145,8 @@ AliGenReaderEMD::AliGenReaderEMD(const AliGenReaderEMD &reader):
     fEtaomegaAside(0),
     fomegaPDGCode(0),
     fNomegaCside(0),
-    fEtaomegaCside(0)
+    fEtaomegaCside(0),
+    fNtupleName(0)
 {
     // Copy Constructor
     for(int i=0; i<70; i++){
@@ -206,9 +208,9 @@ void AliGenReaderEMD::Init()
 	      pFile->cd();
 	       printf("\n %s file opened to read RELDIS EMD events\n\n", fFileName);
     }
-    fTreeNtuple = (TTree*)gDirectory->Get("h2032");
+    fTreeNtuple = (TTree*)gDirectory->Get(fNtupleName.Data());
     if(!fTreeNtuple){
-      Warning("Init", "No ntuple found!!!!");
+      Fatal("Init", "No ntuple found!!!!");
       return;
     }
     fNcurrent = fStartEvent;
@@ -337,8 +339,6 @@ Int_t AliGenReaderEMD::NextEvent()
       Warning("NextEvent", "No more entries found in external file!!!!");
       return 0;
     }
-
-    return 0;
 }
 
 // -----------------------------------------------------------------------------------
@@ -459,23 +459,30 @@ TParticle* AliGenReaderEMD::NextParticle()
 
     }
 
-   if(pdgCode!=1234567){
+   if(pdgCode!=1234567 && pdgCode!=0){
     Float_t ptot = TMath::Sqrt(p[0]*p[0]+p[1]*p[1]+p[2]*p[2]);
-    Double_t amass = TDatabasePDG::Instance()->GetParticle(pdgCode)->Mass();
-    p[3] = TMath::Sqrt(ptot*ptot+amass*amass);
+      Double_t amass = TDatabasePDG::Instance()->GetParticle(pdgCode)->Mass();
+      p[3] = TMath::Sqrt(ptot*ptot+amass*amass);
 
-    //if(p[3]<=amass){
-       //Warning("Generate","Particle %d  E = %f GeV p = %f GeV/c mass = %f GeV/c2 ",pdgCode,p[3],ptot,amass);
-    //}
+      //if(p[3]<=amass){
+         //Warning("Generate","Particle %d  E = %f GeV p = %f GeV/c mass = %f GeV/c2 ",pdgCode,p[3],ptot,amass);
+      //}
 
-    //printf("  Pc %d:  PDGcode %d  p(%1.2f, %1.2f, %1.2f, %1.3f)\n",	fNparticle,pdgCode,p[0], p[1], p[2], p[3]);
+      //printf("  Pc %d:  PDGcode %d  p(%1.2f, %1.2f, %1.2f, %1.3f)\n",	fNparticle,pdgCode,p[0], p[1], p[2], p[3]);
 
-    TParticle* particle = new TParticle(pdgCode, 0, -1, -1, -1, -1,
+      TParticle* particle = new TParticle(pdgCode, 0, -1, -1, -1, -1,
     	p[0], p[1], p[2], p[3], 0., 0., 0., 0.);
-    if((p[0]*p[0]+p[1]*p[1]+p[2]*p[2])>1e-5) particle->SetBit(kTransportBit);
-    fNparticle++;
-    return particle;
+      if(ptot>1e-4) particle->SetBit(kTransportBit);
+      fNparticle++;
+      return particle;
   }
+  else{
+      TParticle* particle = new TParticle(0, 0, -1, -1, -1, -1,
+    	 0., 0., 0., 0., 0., 0., 0., 0.);
+      fNparticle++;
+      return particle;
+  }
+
 }
 
 //___________________________________________________________

--- a/EVGEN/AliGenReaderEMD.h
+++ b/EVGEN/AliGenReaderEMD.h
@@ -15,13 +15,13 @@ class AliGenReaderEMD : public AliGenReader
 {
  public:
     enum TrackedPc{kAll=0, kOnlyNucleons=1, kNotNucleons=2};
-    
+
     AliGenReaderEMD();
-    
+
     AliGenReaderEMD(const AliGenReaderEMD &reader);
     virtual ~AliGenReaderEMD();
     AliGenReaderEMD & operator=(const AliGenReaderEMD & rhs);
-    // Initialise 
+    // Initialise
     virtual void Init();
     // Reader
     virtual Int_t NextEvent();
@@ -32,123 +32,119 @@ class AliGenReaderEMD : public AliGenReader
     void TrackOnlyNucleons() {fPcToTrack = kOnlyNucleons;}
     void TrackAllParticles() {fPcToTrack = kAll;}
     void SetStartEvent(Int_t nev) {fStartEvent = nev;}
-    
+    void SetNtupleName(TString s) {fNtupleName=s;}
+
  protected:
-    Int_t           fStartEvent;      	// points to the first event to read
-    Int_t           fNcurrent;      	// points to the current event to read
-    Int_t           fNparticle;     	// number of particles
-    TTree           *fTreeNtuple;   	// pointer to the TTree
+    Int_t       fStartEvent;      	// points to the first event to read
+    Int_t       fNcurrent;      	// points to the current event to read
+    Int_t       fNparticle;     	// number of particles
+    TTree      *fTreeNtuple;   	// pointer to the TTree
+    TString     fNtupleName; //name of the ntuple to be read
     //
     Int_t 	    fPcToTrack;		// flag for particles to be tracked
-    Int_t           fOffset;		// Needed to correctly read next particle
+    Int_t       fOffset;		// Needed to correctly read next particle
     //
     // --- Declaration of leaves types
     // **** neutrons
-    Int_t           fNnAside;		// No. of neutrons emitted on left side            
-    Float_t         fEnAside; 		// Forward energy A side
-    Int_t           fnPDGCode;		// PDG code
+    Int_t       fNnAside;		// No. of neutrons emitted on left side
+    Float_t     fEnAside; 		// Forward energy A side
+    Int_t       fnPDGCode;		// PDG code
     Float_t	    fPxnAside[70];     	// momentum x component A side
-    Float_t	    fPynAside[70];     	// momentum y component A side	  
-    Float_t	    fPznAside[70];     	// momentum z component A side	
-    //  
-    Int_t           fNnCside;		// No. of neutrons emitted on right side            
-    Float_t         fEnCside; 		// Forward energy C side
+    Float_t	    fPynAside[70];     	// momentum y component A side
+    Float_t	    fPznAside[70];     	// momentum z component A side
+    //
+    Int_t       fNnCside;		// No. of neutrons emitted on right side
+    Float_t     fEnCside; 		// Forward energy C side
     Float_t	    fPxnCside[70];     	// momentum x component C side
-    Float_t	    fPynCside[70];     	// momentum y component C side	  
-    Float_t	    fPznCside[70];     	// momentum z component C side	  
+    Float_t	    fPynCside[70];     	// momentum y component C side
+    Float_t	    fPznCside[70];     	// momentum z component C side
     //
     // **** protons
-    Int_t           fNpAside;		// No. of protons emitted on left side            
-    Float_t         fEtapAside; 	// Forward energy A side
-    Int_t           fpPDGCode;		// PDG code
+    Int_t       fNpAside;		// No. of protons emitted on left side
+    Float_t     fEtapAside; 	// Forward energy A side
+    Int_t       fpPDGCode;		// PDG code
     Float_t	    fPxpAside[50];     	// momentum x component A side
-    Float_t	    fPypAside[50];     	// momentum y component A side	  
-    Float_t	    fPzpAside[50];     	// momentum z component A side	
-    //  
-    Int_t           fNpCside;		// No. of protons emitted on right side            
-    Float_t         fEtapCside; 	// Forward energy C side
+    Float_t	    fPypAside[50];     	// momentum y component A side
+    Float_t	    fPzpAside[50];     	// momentum z component A side
+    //
+    Int_t       fNpCside;		// No. of protons emitted on right side
+    Float_t     fEtapCside; 	// Forward energy C side
     Float_t	    fPxpCside[50];     	// momentum x component C side
-    Float_t	    fPypCside[50];     	// momentum y component C side	  
+    Float_t	    fPypCside[50];     	// momentum y component C side
     Float_t	    fPzpCside[50];     	// momentum z component C side
     //
     // **** pi +
-    Int_t           fNppAside;		// No. of pi+ emitted pi+ on A side            
-    Float_t         fEtappAside; 	// Forward energy pi+ A side
-    Int_t           fppPDGCode;	// PDG code
+    Int_t       fNppAside;		// No. of pi+ emitted pi+ on A side
+    Float_t     fEtappAside; 	// Forward energy pi+ A side
+    Int_t       fppPDGCode;	// PDG code
     Float_t	    fPxppAside[30];     // momentum x component pi+ A side
-    Float_t	    fPyppAside[30];     // momentum y component pi+ A side	  
-    Float_t	    fPzppAside[30];     // momentum z component pi+ A side	
-    //  
-    Int_t           fNppCside;		// No. of pi+ emitted on C side            
-    Float_t         fEtappCside; 	// Forward energy pi+ C side
+    Float_t	    fPyppAside[30];     // momentum y component pi+ A side
+    Float_t	    fPzppAside[30];     // momentum z component pi+ A side
+    //
+    Int_t       fNppCside;		// No. of pi+ emitted on C side
+    Float_t     fEtappCside; 	// Forward energy pi+ C side
     Float_t	    fPxppCside[30];     // momentum x component pi+ C side
-    Float_t	    fPyppCside[30];     // momentum y component pi+ C side	  
+    Float_t	    fPyppCside[30];     // momentum y component pi+ C side
     Float_t	    fPzppCside[30];     // momentum z component pi+ C side
     //
     // **** pi -
-    Int_t           fNpmAside;		// No. of pi- emitted on A side            
-    Float_t         fEtapmAside; 	// Forward energy pi- A side
-    Int_t           fpmPDGCode;	// PDG code
+    Int_t       fNpmAside;		// No. of pi- emitted on A side
+    Float_t     fEtapmAside; 	// Forward energy pi- A side
+    Int_t       fpmPDGCode;	// PDG code
     Float_t	    fPxpmAside[30];     // momentum x component pi- A side
-    Float_t	    fPypmAside[30];     // momentum y component pi- A side	  
-    Float_t	    fPzpmAside[30];     // momentum z component pi- A side	
-    //  
-    Int_t           fNpmCside;		// No. of pi- emitted on C side            
-    Float_t         fEtapmCside; 	// Forward energy pi- C side
+    Float_t	    fPypmAside[30];     // momentum y component pi- A side
+    Float_t	    fPzpmAside[30];     // momentum z component pi- A side
+    //
+    Int_t       fNpmCside;		// No. of pi- emitted on C side
+    Float_t     fEtapmCside; 	// Forward energy pi- C side
     Float_t	    fPxpmCside[30];     // momentum x component pi- C side
-    Float_t	    fPypmCside[30];     // momentum y component pi- C side	  
+    Float_t	    fPypmCside[30];     // momentum y component pi- C side
     Float_t	    fPzpmCside[30];     // momentum z component pi- C side
     //
     // **** pi0
-    Int_t           fNp0Aside;		// No. of pi0 emitted on A side            
-    Float_t         fEtap0Aside; 	// Forward energy pi0 A side
-    Int_t           fp0PDGCode;	// PDG code
+    Int_t       fNp0Aside;		// No. of pi0 emitted on A side
+    Float_t     fEtap0Aside; 	// Forward energy pi0 A side
+    Int_t       fp0PDGCode;	// PDG code
     Float_t	    fPxp0Aside[30];     // momentum x component pi0 A side
-    Float_t	    fPyp0Aside[30];     // momentum y component pi0 A side	  
-    Float_t	    fPzp0Aside[30];     // momentum z component pi0 A side	
-    //  
-    Int_t           fNp0Cside;		// No. of pi0 emitted on C side            
-    Float_t         fEtap0Cside; 	// Forward energy pi0 C side
+    Float_t	    fPyp0Aside[30];     // momentum y component pi0 A side
+    Float_t	    fPzp0Aside[30];     // momentum z component pi0 A side
+    //
+    Int_t       fNp0Cside;		// No. of pi0 emitted on C side
+    Float_t     fEtap0Cside; 	// Forward energy pi0 C side
     Float_t	    fPxp0Cside[30];     // momentum x component pi0 C side
-    Float_t	    fPyp0Cside[30];     // momentum y component pi0 C side	  
+    Float_t	    fPyp0Cside[30];     // momentum y component pi0 C side
     Float_t	    fPzp0Cside[30];     // momentum z component pi0 C side
     //
     // **** eta
-    Int_t           fNetaAside;		// No. of eta emitted on A side            
-    Float_t         fEtaetaAside; 	// Forward energy eta A side
-    Int_t           fetaPDGCode;	// PDG code
+    Int_t       fNetaAside;		// No. of eta emitted on A side
+    Float_t     fEtaetaAside; 	// Forward energy eta A side
+    Int_t       fetaPDGCode;	// PDG code
     Float_t	    fPxetaAside[15];    // momentum x component eta A side
-    Float_t	    fPyetaAside[15];    // momentum y component eta A side	 
-    Float_t	    fPzetaAside[15];    // momentum z component eta A side     
-    //  
-    Int_t           fNetaCside;		// No. of eta emitted on C side            
-    Float_t         fEtaetaCside; 	// Forward energy eta C side
+    Float_t	    fPyetaAside[15];    // momentum y component eta A side
+    Float_t	    fPzetaAside[15];    // momentum z component eta A side
+    //
+    Int_t       fNetaCside;		// No. of eta emitted on C side
+    Float_t     fEtaetaCside; 	// Forward energy eta C side
     Float_t	    fPxetaCside[15];    // momentum x component eta C side
-    Float_t	    fPyetaCside[15];    // momentum y component eta C side	 
+    Float_t	    fPyetaCside[15];    // momentum y component eta C side
     Float_t	    fPzetaCside[15];    // momentum z component eta C side
     //
     // **** omega
-    Int_t           fNomegaAside;	// No. of omega emitted on A side            
-    Float_t         fEtaomegaAside; 	// Forward energy omega A side
-    Int_t           fomegaPDGCode;	// PDG code
+    Int_t       fNomegaAside;	// No. of omega emitted on A side
+    Float_t     fEtaomegaAside; 	// Forward energy omega A side
+    Int_t       fomegaPDGCode;	// PDG code
     Float_t	    fPxomegaAside[15];  // momentum x component omega A side
-    Float_t	    fPyomegaAside[15];  // momentum y component omega A side   
-    Float_t	    fPzomegaAside[15];  // momentum z component omega A side	 
-    //  
-    Int_t           fNomegaCside;	// No. of omega emitted on C side            
-    Float_t         fEtaomegaCside; 	// Forward energy omega C side
+    Float_t	    fPyomegaAside[15];  // momentum y component omega A side
+    Float_t	    fPzomegaAside[15];  // momentum z component omega A side
+    //
+    Int_t       fNomegaCside;	// No. of omega emitted on C side
+    Float_t     fEtaomegaCside; 	// Forward energy omega C side
     Float_t	    fPxomegaCside[15];  // momentum x component omega C side
-    Float_t	    fPyomegaCside[15];  // momentum y component omega C side	 
+    Float_t	    fPyomegaCside[15];  // momentum y component omega C side
     Float_t	    fPzomegaCside[15];  // momentum z component omega C side
-   
+
  private:
     void Copy(TObject&) const;
-    ClassDef(AliGenReaderEMD, 2) // Class to read EMD data
+    ClassDef(AliGenReaderEMD, 3) // Class to read EMD data
 };
 #endif
-
-
-
-
-
-

--- a/EVGEN/AliGenReadersEMD.h
+++ b/EVGEN/AliGenReadersEMD.h
@@ -15,13 +15,13 @@ class AliGenReadersEMD : public AliGenReader
 {
  public:
     enum TrackedPc{kAll=0, kNucleons=1, kOnlyNeutrons=2};
-    
+
     AliGenReadersEMD();
-    
+
     AliGenReadersEMD(const AliGenReadersEMD &reader);
     virtual ~AliGenReadersEMD();
     AliGenReadersEMD & operator=(const AliGenReadersEMD & rhs);
-    // Initialise 
+    // Initialise
     virtual void Init();
     // Reader
     virtual Int_t NextEvent();
@@ -32,24 +32,26 @@ class AliGenReadersEMD : public AliGenReader
     void TrackOnlyNeutrons() {fPcToTrack = kOnlyNeutrons;}
     void TrackAll() {fPcToTrack = kAll;}
     void SetStartEvent(Int_t nev) {fStartEvent = nev;}
-    
+    void SetNtupleName(TString s) {fNtupleName=s;}
+
  protected:
     Int_t           fStartEvent;      	// points to the first event to read
     Int_t           fNcurrent;      	// points to the current event to read
     Int_t           fNparticle;     	// number of particles
-    TTree           *fTreeNtuple;   	// pointer to the TTree
+    TTree          *fTreeNtuple;   	// pointer to the TTree
+    TString         fNtupleName; //name of the ntuple to be read
     //
     Int_t 	    fPcToTrack;		// flag for particles to be tracked
     Int_t           fOffset;		// Needed to correctly read next particle
     //
     // --- Declaration of leaves types
     // **** neutrons
-    Int_t           fNneu;		// No. of neutrons emitte on left side            
+    Int_t           fNneu;		// No. of neutrons emitte on left side
     Float_t         fEneu; 		// Energy
     Float_t	    fPxneu[70];	   	// momentum x component neutrons
     Float_t	    fPyneu[70];	   	// momentum y component neutrons
     Float_t	    fPzneu[70];	   	// momentum z component neutrons
-    //  
+    //
     Float_t	    fPxfrag;	    	// momentum x component fragments
     Float_t	    fPyfrag;	    	// momentum y component fragments
     Float_t	    fPzfrag;	    	// momentum z component fragments
@@ -57,20 +59,14 @@ class AliGenReadersEMD : public AliGenReader
     Float_t	    fZfrag;	    	// Z fragments
     //
     // **** protons
-    Int_t           fNpro;		// No. of protons emitted on left side            
+    Int_t           fNpro;		// No. of protons emitted on left side
     Float_t         fEpro; 		// Forward energy A side
     Float_t	    fPxpro[50];	   	// momentum x component A side
-    Float_t	    fPypro[50];	   	// momentum y component A side    
-    Float_t	    fPzpro[50];	   	// momentum z component A side  
-   
+    Float_t	    fPypro[50];	   	// momentum y component A side
+    Float_t	    fPzpro[50];	   	// momentum z component A side
+
  private:
     void Copy(TObject&) const;
-    ClassDef(AliGenReadersEMD, 1) // Class to read EMD data
+    ClassDef(AliGenReadersEMD, 2) // Class to read EMD data
 };
 #endif
-
-
-
-
-
-


### PR DESCRIPTION
This commit could be included in the release to run with RELDIS code (EM dissociation events in A-A collisions), some minor changes were included to comply with the outputs provided by Igor for 5.11 TeV (the current version can be used only with inputs calculated for 2.76 TeV since some changes were introduced in between).

Thanks for the help.
Chiara