### PR TITLE
[EMCAL-405] New OCDB object for bad channel histograms

### DIFF
--- a/EMCAL/EMCALbase/AliEMCALCalibBadChannels.cxx
+++ b/EMCAL/EMCALbase/AliEMCALCalibBadChannels.cxx
@@ -1,0 +1,71 @@
+/************************************************************************************
+ * Copyright (C) 2018, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <TH2.h>
+#include <TObjArray.h>
+#include "AliEMCALCalibBadChannels.h"
+#include "AliLog.h"
+
+ClassImp(AliEMCALCalibBadChannels);
+
+AliEMCALCalibBadChannels::AliEMCALCalibBadChannels():
+    TObject(),
+    fHistsCalibSupermodules(NULL)
+{
+
+}
+
+AliEMCALCalibBadChannels::~AliEMCALCalibBadChannels(){
+    if(fHistsCalibSupermodules) delete fHistsCalibSupermodules;
+}
+
+void AliEMCALCalibBadChannels::SetBadChannelHistForSupermodule(Int_t supermoduleID, TH2 *calibhist) {
+    if(!fHistsCalibSupermodules) {
+        fHistsCalibSupermodules = new TObjArray(20);
+        fHistsCalibSupermodules->SetOwner(true);
+    }
+    if(supermoduleID < 0 || supermoduleID >= 20) {
+        AliError(Form("Trying to add histogram for supermodule outside range: %d", supermoduleID));
+        return;
+    }
+    fHistsCalibSupermodules->AddAt(calibhist, supermoduleID);
+}
+
+TH2 *AliEMCALCalibBadChannels::GetBadChannelHistForSupermodule(Int_t supermoduleID){
+    if(supermoduleID < 0 || supermoduleID >= 20){
+        AliError(Form("Trying to access the calibration histogram for a supermodule outside the range: %d", supermoduleID));
+        return NULL;
+    }
+    if(!fHistsCalibSupermodules){
+        AliError("No calibration histograms found for the current object");
+        return NULL;
+    }
+    TH2 * histogram = static_cast<TH2 *>(fHistsCalibSupermodules->At(supermoduleID));
+    if(histogram) {
+        histogram->SetDirectory(NULL);
+    }
+    return histogram;
+}

--- a/EMCAL/EMCALbase/AliEMCALCalibBadChannels.h
+++ b/EMCAL/EMCALbase/AliEMCALCalibBadChannels.h
@@ -1,0 +1,75 @@
+/************************************************************************************
+ * Copyright (C) 2018, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALCALIBBADCHANNELS_H
+#define ALIEMCALCALIBBADCHANNELS_H
+
+#include <TObject.h>
+
+class TH2;
+class TObjArray;
+
+/**
+ * @class AliEMCALCalibBadChannels
+ * @brief EMCAL bad channel map in the format of the OADB container however as OCDB object, for the HLT
+ * @ingroup EMCALbase
+ * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+ * @since Oct 16, 2018
+ */
+class AliEMCALCalibBadChannels : public TObject {
+public:
+    /**
+     * @brief Dummy constructor
+     */
+    AliEMCALCalibBadChannels();
+    /**
+     * @brief Destructor, removing also histograms
+     */
+    virtual ~AliEMCALCalibBadChannels();
+
+    /**
+     * @brief Get the bad channel map for a given supermodule
+     * @param[in] supermoduleID ID of the supermodule (0-19)
+     * @return Histogram with bad and warm cells for the supermodule (NULL if outside range or object not initialized)
+     */
+    TH2 *GetBadChannelHistForSupermodule(Int_t supermoduleID);
+    /**
+     * @brief Set the histogram bad channel histogram for a certain supermodule
+     * @param[in] supermoduleID ID of the supermodule (0-19)
+     * @param[in] badchannels Calibration histogram for the given supermodule
+     */
+    void SetBadChannelHistForSupermodule(Int_t supermodueID, TH2 *badchannels);
+
+private:
+    AliEMCALCalibBadChannels(const AliEMCALCalibBadChannels &);
+    AliEMCALCalibBadChannels &operator=(const AliEMCALCalibBadChannels &);
+
+    TObjArray           *fHistsCalibSupermodules;                       ///< Calibration histograms for supermodules    
+
+    ClassDef(AliEMCALCalibBadChannels, 1);
+};
+
+#endif

--- a/EMCAL/EMCALbase/CMakeLists.txt
+++ b/EMCAL/EMCALbase/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SRCS
     AliCaloCalibSignal.cxx
     AliEMCALBiasAPD.cxx
     AliEMCALCalibAbs.cxx
+    AliEMCALCalibBadChannels.cxx
     AliEMCALCalibData.cxx
     AliEMCALCalibTime.cxx
     AliEMCALCalibMapAPD.cxx

--- a/EMCAL/EMCALbase/EMCALbaseLinkDef.h
+++ b/EMCAL/EMCALbase/EMCALbaseLinkDef.h
@@ -25,6 +25,7 @@
 #pragma link C++ class AliEMCALSpaceFrame+;
 #pragma link C++ class AliEMCALBiasAPD+;
 #pragma link C++ class AliEMCALCalibAbs+;
+#pragma link C++ class AliEMCALCalibBadChannels+;
 #pragma link C++ class AliEMCALCalibReference+;
 #pragma link C++ class AliEMCALCalibMapAPD+;
 #pragma link C++ class AliEMCALSuperModuleCalibTempCoeff+;


### PR DESCRIPTION
Container in same format as the OADB container (20 2D
histograms with ieta-iphi), however stored in the OCDB
as OCDB object. Needed for the HLT.