### PR TITLE
AliVertexGenFile will provide also the time

### DIFF
--- a/STEER/STEER/AliGenerator.cxx
+++ b/STEER/STEER/AliGenerator.cxx
@@ -354,7 +354,7 @@ void AliGenerator::VertexExternal()
     fVertex[0] = vertex.X();
     fVertex[1] = vertex.Y();
     fVertex[2] = vertex.Z();
-    fTime = 0.;
+    fTime = fVertexGenerator->GetLastVertexTime();
 }
 
 //_______________________________________________________________________

--- a/STEER/STEER/AliVertexGenFile.cxx
+++ b/STEER/STEER/AliVertexGenFile.cxx
@@ -45,7 +45,8 @@ AliVertexGenFile::AliVertexGenFile() :
   fTree(NULL),
   fHeader(NULL),
   fEventsPerEntry(0),
-  fEvent(0)
+  fEvent(0),
+  fLastTime(0)
 {
 // default constructor: initialize data members
 
@@ -58,7 +59,8 @@ AliVertexGenFile::AliVertexGenFile(const char* fileName,
   fTree(NULL),
   fHeader(NULL),
   fEventsPerEntry(eventsPerEntry),
-  fEvent(0)
+  fEvent(0),
+  fLastTime(0)
 {
 // main constructor:
 // fileName is the name of the galice file containing the vertices
@@ -110,6 +112,7 @@ TVector3 AliVertexGenFile::GetVertex()
 // get the vertex from the event header tree
 
   Int_t entry = fEvent++ / fEventsPerEntry;
+  fLastTime = 0;
   if (!fTree) {
     AliError("no header tree");
     return TVector3(0,0,0);
@@ -127,6 +130,7 @@ TVector3 AliVertexGenFile::GetVertex()
 
   TArrayF vertex(3);
   fHeader->GenEventHeader()->PrimaryVertex(vertex);
+  fLastTime = fHeader->GenEventHeader()->InteractionTime();
   return TVector3(vertex[0], vertex[1], vertex[2]);
 }
 

--- a/STEER/STEER/AliVertexGenFile.h
+++ b/STEER/STEER/AliVertexGenFile.h
@@ -25,6 +25,7 @@ class AliVertexGenFile: public AliVertexGenerator {
 
   virtual TVector3 GetVertex();
   time_t GetHeaderTimeStamp() const;
+  Float_t GetLastVertexTime() const {return fLastTime;}
   
  private:
   AliVertexGenFile(const AliVertexGenFile &vgf);
@@ -36,6 +37,7 @@ class AliVertexGenFile: public AliVertexGenerator {
   AliHeader*       fHeader;         //! event header
   Int_t            fEventsPerEntry; // number of events with same vertex
   Int_t            fEvent;          //! current event number
+  Float_t          fLastTime;       //! time of last produced vertex
 
   ClassDef(AliVertexGenFile, 1)     // generator for vertices taken from a file
 };

--- a/STEER/STEER/AliVertexGenerator.h
+++ b/STEER/STEER/AliVertexGenerator.h
@@ -12,6 +12,7 @@
 class AliVertexGenerator: public TObject {
  public:
   virtual TVector3 GetVertex() = 0;
+  virtual Float_t GetLastVertexTime() { return 0; }
 
   ClassDef(AliVertexGenerator, 1)    // Base class for vertex generators
 };


### PR DESCRIPTION
AliVertexGenFile used to pass the vertex from the underlying bg. event to the signal event being embedded to the bg, must pass also the fTime (smearing of the interaction time due to the finite size of the interaction diamond) used to generate the bg. event. Otherwise there is a ```sigma_VZ/c ``` time smearing between the data signal and bg. event