### PR TITLE
Reduction of Output for TRD Parameters

### DIFF
--- a/STEER/STEERBase/AliPIDResponse.cxx
+++ b/STEER/STEERBase/AliPIDResponse.cxx
@@ -1776,7 +1776,7 @@ void AliPIDResponse::SetTRDPidResponseMaster()
 }
 void AliPIDResponse::CheckTRDLikelihoodParameter(){
     Int_t nTracklets=1;
-    Int_t level=0.9;
+    Double_t level=0.9;
     Double_t params[4];
     Int_t centrality=0;
     Int_t iCharge=1;

--- a/STEER/STEERBase/AliPIDResponse.cxx
+++ b/STEER/STEERBase/AliPIDResponse.cxx
@@ -678,6 +678,7 @@ void AliPIDResponse::ExecNewRun()
   // ===| TRD part |============================================================
   SetTRDPidResponseMaster();
   //has to precede InitializeTRDResponse(), otherwise the read-out fTRDdEdxParams is not pased in TRDResponse!
+  CheckTRDLikelihoodParameter();
   SetTRDdEdxParams();
   SetTRDEtaMaps();
   SetTRDClusterMaps();
@@ -1772,6 +1773,26 @@ void AliPIDResponse::SetTRDPidResponseMaster()
       AliError(Form("TRD Response not found in run %d", fRun));
     }
   }
+}
+void AliPIDResponse::CheckTRDLikelihoodParameter(){
+    Int_t nTracklets=1;
+    Int_t level=0.9;
+    Double_t params[4];
+    Int_t centrality=0;
+    Int_t iCharge=1;
+    if(!fTRDPIDResponseObject->GetThresholdParameters(nTracklets, level, params,centrality,AliTRDPIDResponse::kLQ1D,iCharge)){
+        AliInfo("No Params for TRD Likelihood Threshold Parameters Found for Charge Dependence");
+        AliInfo("Using Parameters for both charges");
+        if((iCharge!=AliPID::kNoCharge)&&(!fTRDPIDResponseObject->GetThresholdParameters(nTracklets, level, params,centrality,AliTRDPIDResponse::kLQ1D,AliPID::kNoCharge))){
+            AliError("No Params TRD Likelihood Threshold Parameters Found!!");
+        }
+        if(iCharge==AliPID::kNoCharge){
+            AliError("No Params TRD Likelihood Threshold Parameters Found!!");
+        }
+    }
+    else {
+        AliInfo(Form("TRD Likelihood Threshold Parameters for Run %d Found",fRun));
+    }
 }
 
 //______________________________________________________________________________

--- a/STEER/STEERBase/AliPIDResponse.h
+++ b/STEER/STEERBase/AliPIDResponse.h
@@ -316,6 +316,7 @@ private:
 
   //TRD
   void SetTRDPidResponseMaster();
+  void CheckTRDLikelihoodParameter();
   void InitializeTRDResponse();
   void SetTRDSlices(UInt_t TRDslicesForPID[2],AliTRDPIDResponse::ETRDPIDMethod method) const;
   void SetTRDdEdxParams();

--- a/STEER/STEERBase/AliPIDResponse.h
+++ b/STEER/STEERBase/AliPIDResponse.h
@@ -380,7 +380,7 @@ private:
   EDetPidStatus GetPHOSPIDStatus(const AliVTrack *track) const;
   EDetPidStatus GetEMCALPIDStatus(const AliVTrack *track) const;
 
-  ClassDef(AliPIDResponse, 19);  //PID response handling
+  ClassDef(AliPIDResponse, 20);  //PID response handling
 };
 
 #endif

--- a/STEER/STEERBase/AliTRDPIDResponse.cxx
+++ b/STEER/STEERBase/AliTRDPIDResponse.cxx
@@ -855,10 +855,10 @@ Bool_t AliTRDPIDResponse::IdentifiedAsElectron(Int_t nTracklets, const Double_t 
     AliDebug(3,Form("probabilities like %f %f %f \n",probEle,like[AliPID::kElectron],like[AliPID::kPion]));
     Double_t params[4];
     if(!fkPIDResponseObject->GetThresholdParameters(nTracklets, level, params,centrality,PIDmethod,iCharge)){
-        AliError("No Params found for the given configuration with chosen Charge");
-        AliError("Using Parameters for both charges");
+        //AliError("No Params found for the given configuration with chosen Charge");
+        //AliError("Using Parameters for both charges");
         if((iCharge!=AliPID::kNoCharge)&&(!fkPIDResponseObject->GetThresholdParameters(nTracklets, level, params,centrality,PIDmethod,AliPID::kNoCharge))){
-            AliError("No Params found for the given configuration with charge 0");
+            //AliError("No Params found for the given configuration with charge 0");
             return kTRUE;
         }
         if(iCharge==AliPID::kNoCharge){


### PR DESCRIPTION
Instead of giving Output for every Call of IdentifiedAsElectron, Information about missing Parameters will now only be shown once