### PR TITLE
Hotfix: Check if File exists! If no TRD Response exists

### DIFF
--- a/STEER/STEERBase/AliPIDResponse.cxx
+++ b/STEER/STEERBase/AliPIDResponse.cxx
@@ -1780,18 +1780,20 @@ void AliPIDResponse::CheckTRDLikelihoodParameter(){
     Double_t params[4];
     Int_t centrality=0;
     Int_t iCharge=1;
-    if(!fTRDPIDResponseObject->GetThresholdParameters(nTracklets, level, params,centrality,AliTRDPIDResponse::kLQ1D,iCharge)){
-        AliInfo("No Params for TRD Likelihood Threshold Parameters Found for Charge Dependence");
-        AliInfo("Using Parameters for both charges");
-        if((iCharge!=AliPID::kNoCharge)&&(!fTRDPIDResponseObject->GetThresholdParameters(nTracklets, level, params,centrality,AliTRDPIDResponse::kLQ1D,AliPID::kNoCharge))){
-            AliError("No Params TRD Likelihood Threshold Parameters Found!!");
+    if (fTRDPIDResponseObject){
+        if(!fTRDPIDResponseObject->GetThresholdParameters(nTracklets, level, params,centrality,AliTRDPIDResponse::kLQ1D,iCharge)){
+            AliInfo("No Params for TRD Likelihood Threshold Parameters Found for Charge Dependence");
+            AliInfo("Using Parameters for both charges");
+            if((iCharge!=AliPID::kNoCharge)&&(!fTRDPIDResponseObject->GetThresholdParameters(nTracklets, level, params,centrality,AliTRDPIDResponse::kLQ1D,AliPID::kNoCharge))){
+                AliError("No Params TRD Likelihood Threshold Parameters Found!!");
+            }
+            if(iCharge==AliPID::kNoCharge){
+                AliError("No Params TRD Likelihood Threshold Parameters Found!!");
+            }
         }
-        if(iCharge==AliPID::kNoCharge){
-            AliError("No Params TRD Likelihood Threshold Parameters Found!!");
+        else {
+            AliInfo(Form("TRD Likelihood Threshold Parameters for Run %d Found",fRun));
         }
-    }
-    else {
-        AliInfo(Form("TRD Likelihood Threshold Parameters for Run %d Found",fRun));
     }
 }
 

--- a/STEER/STEERBase/AliPIDResponse.cxx
+++ b/STEER/STEERBase/AliPIDResponse.cxx
@@ -1787,9 +1787,6 @@ void AliPIDResponse::CheckTRDLikelihoodParameter(){
             if((iCharge!=AliPID::kNoCharge)&&(!fTRDPIDResponseObject->GetThresholdParameters(nTracklets, level, params,centrality,AliTRDPIDResponse::kLQ1D,AliPID::kNoCharge))){
                 AliError("No Params TRD Likelihood Threshold Parameters Found!!");
             }
-            if(iCharge==AliPID::kNoCharge){
-                AliError("No Params TRD Likelihood Threshold Parameters Found!!");
-            }
         }
         else {
             AliInfo(Form("TRD Likelihood Threshold Parameters for Run %d Found",fRun));


### PR DESCRIPTION
If there is not only no Parameters in the TRDPIDResponseObject, but no TRDPIDResponseObject at all, the code crashes. 
Includes an additional if check, if fTRDPIDResponseObject exists
Also removed one AliError, for better understanding of the Code