### PR TITLE
Add optional parameters for external MC generators

### DIFF
--- a/EVGEN/AliGenExtExec.cxx
+++ b/EVGEN/AliGenExtExec.cxx
@@ -35,6 +35,7 @@ AliGenExtExec::AliGenExtExec(const TString &scriptpath) :
   fPathFIFO("gen.hepmc"),
   fPathFile1("gen1.root"),
   fPathFile2("gen2.root"),
+  fGeneratorOptionalArguments(""),
   fEventNumberInFileMax(100),
   fMode(kFIFO),
   fInput(kHepMC),
@@ -53,6 +54,7 @@ AliGenExtExec::AliGenExtExec(Int_t npart, const TString &scriptpath) :
   fPathFIFO("gen.hepmc"),
   fPathFile1("gen1.root"),
   fPathFile2("gen2.root"),
+  fGeneratorOptionalArguments(""),
   fEventNumberInFileMax(100),
   fMode(kFIFO),
   fInput(kHepMC),
@@ -102,6 +104,12 @@ void AliGenExtExec::SetPathFile2(const TString &path)
 
   fPathFile2 = path;
   gSystem->ExpandPathName(fPathFile2);
+}
+
+void AliGenExtExec::SetGeneratorOptionalArguments(const TString &args)
+{
+  // set parameters that will be passed to generator shell script
+  fGeneratorOptionalArguments = args;
 }
 
 void AliGenExtExec::Init()
@@ -205,7 +213,7 @@ Bool_t AliGenExtExec::StartGen()
       AliError("forking generator failed");
       return kFALSE;
     } else if (fPID == 0) {
-      execl("/bin/bash", "bash", "-c", (fPathScript + " " + fPathFIFO + " > gen.log 2>&1").Data(), (char *) 0);
+      execl("/bin/bash", "bash", "-c", (fPathScript + " " + fPathFIFO + " " + fGeneratorOptionalArguments + " > gen.log 2>&1").Data(), (char *) 0);
     } else {
       AliInfo(Form("running generator with PID %i", fPID));
     }
@@ -218,7 +226,7 @@ Bool_t AliGenExtExec::StartGen()
       AliError("forking generator failed");
       return kFALSE;
     } else if (fPID == 0) {
-      execl("/bin/bash", "bash", "-c", (fPathScript + " " + fPathFile1 + " " + fPathFile2 + " > gen.log 2>&1").Data(), (char *) 0);
+      execl("/bin/bash", "bash", "-c", (fPathScript + " " + fPathFile1 + " " + fPathFile2 + " " + fGeneratorOptionalArguments + " > gen.log 2>&1").Data(), (char *) 0);
     } else {
       AliInfo(Form("running generator with PID %i", fPID));
     }

--- a/EVGEN/AliGenExtExec.h
+++ b/EVGEN/AliGenExtExec.h
@@ -36,6 +36,7 @@ public:
   virtual void SetPathFIFO(const TString &path = "gen.hepmc");
   virtual void SetPathFile1(const TString &path = "gen1.root");
   virtual void SetPathFile2(const TString &path = "gen2.root");
+  virtual void SetGeneratorOptionalArguments(const TString &args = "");
   virtual void SetMode(GenExtMode_t mode) { fMode = mode; }
   virtual void SetInput(GenExtInput_t input) { fInput = input; }
 
@@ -51,6 +52,7 @@ protected:
   TString fPathFIFO;             // path used for FIFO
   TString fPathFile1;            // path used for file 1
   TString fPathFile2;            // path used for file 2
+  TString fGeneratorOptionalArguments; // optional parameters for the generator
   Int_t fEventNumberInFileMax;   // max number of events in file
   GenExtMode_t fMode;            // mode for external generator
   GenExtInput_t fInput;          // input type to choose reader
@@ -64,7 +66,7 @@ private:
   AliGenExtExec(const AliGenExtExec &ext);              // not implemented
   AliGenExtExec & operator=(const AliGenExtExec & rhs); // not implemented
 
-  ClassDef(AliGenExtExec, 2)
+  ClassDef(AliGenExtExec, 3)
 };
 
 #endif


### PR DESCRIPTION
Hi,

This commit allows generic optional arguments for the generator and should be fully backward-compatible. In the default setting, no functionality was changed.

The idea behind this is to give the configuration (for JEWEL) directly as parameters instead of hard-coded files. The parameters will be passed as a string to the external generator script.
I have another pull request in AliPhysics that will add the corresponding JEWEL generator files, which is tested and worked fine locally.

Best,
Ruediger