### PR TITLE
ALIROOT-7077+ATO-453 - non liner coding of charge

### DIFF
--- a/STAT/AliFFTsmoother.h
+++ b/STAT/AliFFTsmoother.h
@@ -8,7 +8,7 @@ class TTreeSRedirector;
 namespace AliFFTsmoother
 {
   TGraph  * ReplaceOutlierFrequenciesMedian(TH1 *hinput, Double_t outlierCut, Int_t medianRange, Float_t smoothSigma,  Int_t lowBand, TTreeSRedirector * pcstream);
-
+  TGraph  * BandFilter(TH1 *hinput, Int_t lowBand, Int_t highBand, TTreeSRedirector * pcstream);
 };
 
 

--- a/TPC/TPCsim/AliTPCTrackHitsV2.cxx
+++ b/TPC/TPCsim/AliTPCTrackHitsV2.cxx
@@ -633,7 +633,8 @@ Bool_t AliTPCTrackHitsV2::FlushHitStack(Bool_t force)
     }
 
     paraml.HitDistance(i)= Short_t(TMath::Nint(dl/fStep));
-    paraml.Charge(i)= Short_t(fTempInfo->GetQStack(i));
+    //paraml.Charge(i)= Short_t(fTempInfo->GetQStack(i));
+    paraml.SetCharge(i,Short_t(fTempInfo->GetQStack(i)));
     paraml.Time(i)= Short_t(fTempInfo->GetTimeStack(i)/AliTPCTrackHitsV2::fgkTimePrecision);
   }    
   
@@ -830,4 +831,27 @@ AliTrackHitsParamV2 * AliTPCTrackHitsV2::GetParam()
   return (fCurrentHit->GetStatus())? 
     (AliTrackHitsParamV2 *)fArray->At(fCurrentHit->GetParamIndex()):0;
 }
+
+/// Code charge - used to limit charge representation to short_t
+/// \param charge
+/// \return  index for charge
+/// * coding formula:
+/// ````
+///  q*=base*log(1+q/base)
+/// ````
+/// * limit case
+///  * q*~q      at q<<base (3000)
+///  * q*~ln(q)  at q>>base
+Int_t AliTrackHitsParamV2::CodeCharge(Int_t charge){
+  const Double_t base=3000;
+  Int_t index=TMath::Nint(base*TMath::Log(1.+charge/base));
+  return index;
+}
+///
+Int_t AliTrackHitsParamV2::DeCodeCharge(Int_t codedCharge){
+  const Double_t base=3000;
+  Int_t charge = TMath::Nint((exp(codedCharge/base)-1)*base);
+  return charge;
+}
+
 

--- a/TPC/TPCsim/AliTPCTrackHitsV2.h
+++ b/TPC/TPCsim/AliTPCTrackHitsV2.h
@@ -55,11 +55,11 @@ public:
   Int_t   GetNHits()              const {return fNHits;}
 
   Short_t HitDistance(Int_t i) const {return fHitDistance[i];}
-  Short_t Charge(Int_t i)      const {return fCharge[i];}
+  Short_t Charge(Int_t i)      const {return AliTrackHitsParamV2::DeCodeCharge(fCharge[i]);}
   Short_t Time(Int_t i)        const {return fTime[i];}
 
   Short_t& HitDistance(Int_t i) {return fHitDistance[i];}
-  Short_t& Charge(Int_t i)      {return fCharge[i];}
+  void  SetCharge(Int_t i, Int_t q)      {fCharge[i]=AliTrackHitsParamV2::CodeCharge(q);}
   Short_t& Time(Int_t i)        {return fTime[i];}
 
   void SetHitDistance(Int_t i)
@@ -101,7 +101,8 @@ public:
   void SetNHits(Int_t n)       {fNHits=n;}
 
   Float_t Eta() const;
-
+  static Int_t CodeCharge(Int_t charge);
+  static Int_t DeCodeCharge(Int_t codedCharge);
  private:
   Int_t fTrackID; // ID of the track
   Short_t fVolumeID;// volume ID


### PR DESCRIPTION
## ALIROOT-7077 - adding FFT band fitter ￼…
* simplified version of outlier frequency filter
  * user defined frequency to replace 

## ATO-453 - non liner coding of charge ￼…
* possible to code in short t code up to 10**8
  * needed for magnetic monopole simulation
* coding formula:
````
q*=base*log(1+q/base)
````
* limit case
  * q*~q      at q<<base (3000)
  * q*~ln(q)  at q>>base