### PR TITLE
ATO-452, ATO-15 : adding AliOCDBtoolkit::DumpOCDBFile - from snapshot

### DIFF
--- a/STEER/CDB/AliOCDBtoolkit.h
+++ b/STEER/CDB/AliOCDBtoolkit.h
@@ -41,6 +41,7 @@ public:
   static void DumpObjectRecursive(TObject *obj, TString prefix, Int_t &counterRec);
   static void DumpOCDBFile(const char *finput , const char *foutput, Bool_t dumpMetaData, TString  printOption);
   static void MakeDiff(const TMap *cdbMap0, const TList *cdbList0, const TMap *cdbMap1, const TList *cdbList1, Int_t verbose);
+  static Int_t  DumpOCDBFile(const char *fileName, const char*objectName, const char *foutput, Bool_t dumpMetaData, TString  printOption);
   //
   // addopt OCDB entry
   //


### PR DESCRIPTION
#### Int_t  AliOCDBtoolkit::DumpOCDBFile(const char *fileName, const char*objectName, const char * * foutput, Bool_t dumpMetaData, TString  printOption)
* /// \param fileName         - OCDB snapshot file name .e.g OCDBsim.root or OCDBrec.root
* /// \param objectName       - OCDB entry name  e.g TPC/Calib/recoParam
* /// \param foutput          - output file name - e.g TPC_Calib_RecoParam.xml
* /// \param dumpMetaData     - switch dump also metadata
* /// \param printOption      - MI, xml, docdb (obejct dump) , pocdb (object print)
Example usage:
````
AliOCDBtoolkit::DumpOCDBFile("/lustre/nyx/alice/users/miranov/NOTESData/alice-tpc-notes/JIRA/ALIROOT-7077/test1211_PbPb_MCTail_2_2/OCDB/OCDBrec.root", "TPC/Calib/RecoParam", "TPC_Calib_RecoParamReco.xml",1,"XML")
````
