### PR TITLE
[EMCAL-409] Add MC offset for online patches

### DIFF
--- a/EMCAL/EMCALTriggerBase/AliEMCALTriggerOnlineQAPbPb.cxx
+++ b/EMCAL/EMCALTriggerBase/AliEMCALTriggerOnlineQAPbPb.cxx
@@ -279,7 +279,7 @@ void AliEMCALTriggerOnlineQAPbPb::ProcessPatch(const AliEMCALTriggerPatchInfo* p
       patch->GetTriggerBitConfig()->GetBkgBit()
   };
 
-  Int_t offsets[3] = { 0, AliEMCALTriggerPatchInfo::kRecalcOffset, AliEMCALTriggerPatchInfo::kOfflineOffset };
+  Int_t offsets[3] = { 5, AliEMCALTriggerPatchInfo::kRecalcOffset, AliEMCALTriggerPatchInfo::kOfflineOffset };// online patches start at the MC offset
   Int_t amplitudes[3] = { patch->GetADCAmp(),  patch->GetADCAmp(),  patch->GetADCOfflineAmp() };
   Double_t bkg[3] = {0};
 
@@ -350,7 +350,7 @@ void AliEMCALTriggerOnlineQAPbPb::ProcessBkgPatch(const AliEMCALTriggerPatchInfo
 {
   TString hname;
 
-  Int_t offsets[3] = { 0, AliEMCALTriggerPatchInfo::kRecalcOffset, AliEMCALTriggerPatchInfo::kOfflineOffset };
+  Int_t offsets[3] = { 5, AliEMCALTriggerPatchInfo::kRecalcOffset, AliEMCALTriggerPatchInfo::kOfflineOffset }; // online patches start at the MC offset
   Int_t amplitudes[3] = { patch->GetADCAmp(),  patch->GetADCAmp(),  patch->GetADCOfflineAmp() };
   Int_t bkgTriggerBit = patch->GetTriggerBitConfig()->GetBkgBit();
 


### PR DESCRIPTION
For checking the online bits the MC offset needs to be taken into
account, otherwise the patches are not idenfied. Fixing filling
histograms with online patches in the PbPb trigger QA component
on the HLT.