### PR TITLE
Fixing a bug in ZDC MAPPING DA related to TDC data streaming

### DIFF
--- a/ZDC/DA/ZDCMAPPINGda.cxx
+++ b/ZDC/DA/ZDCMAPPINGda.cxx
@@ -9,10 +9,10 @@ Messages on stdout are exported to DAQ log system.
 DA to write mapping for ADC modules and VME scaler
 
 Contact: Chiara.Oppedisano@to.infn.it
-Link: 
+Link:
 Run Type: PHYSICS
 DA Type: MON
-Number of events needed:  
+Number of events needed:
 Input Files:  ZDCTDCHistoLimits.dat
 Output Files: ZDCChMapping.dat ZDCTDCCalib.dat ZDCTDCHisto.root
 Trigger Types Used: different trigger types are used
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
                                         "*",
                                         "TStreamerInfo",
                                         "RIO",
-                                        "TStreamerInfo()"); 
+                                        "TStreamerInfo()");
   // needed for Minuit plugin
   gROOT->GetPluginManager()->AddHandler("ROOT::Math::Minimizer",
                                         "Minuit",
@@ -66,9 +66,9 @@ int main(int argc, char **argv) {
                                         "TMinuitMinimizer(const char*)");
 
   TVirtualFitter::SetDefaultFitter("Minuit");
-  
+
   /* log start of process */
-  printf("\n ZDC MAPPING program started\n");  
+  printf("\n ZDC MAPPING program started\n");
   signal(SIGSEGV, SIG_DFL);
 
   /* check that we got some arguments = list of files */
@@ -82,40 +82,49 @@ int main(int argc, char **argv) {
   if(err){
     printf("monitorDeclareTable() failed: %s\n", monitorDecodeError(err));
     return -1;
-  } 
-  
+  }
+
   // *** initializations ***************************
   int status=0, nphys=0;
   int const kNModules = 9;
   int const kNChannels = 24;
-  int const kNScChannels = 32;  
+  int const kNScChannels = 32;
 //  int const kZDCTDCGeo = 4;
-  
-  int itdc=0, iprevtdc=-1, ihittdc=0;
-  float tdcData[6], tdcL0=-999.;	
-  for(int ij=0; ij<6; ij++) tdcData[ij]=-999.;
+
+  //Variables for TDCs
+  int itdc=0, ihittdc[32];
+  bool istdcchread[32];
+  for(int ij=0; ij<32; ij++){
+     istdcchread[ij]=kFALSE;
+     ihittdc[ij]=0;
+  }
+  float tdcData[6][4], tdcL0=-999.;
+  for(int i=0; i<6; i++){
+    for(int j=0; j<4; j++)
+      tdcData[i][j]=-999.;
+  }
   bool hasL0arrived=kFALSE;
-  
+
   Int_t iMod=-1;
   Int_t modGeo[kNModules], modType[kNModules],modNCh[kNModules];
   for(Int_t kl=0; kl<kNModules; kl++){
      modGeo[kl]=modType[kl]=modNCh[kl]=0;
   }
-  
+
   Int_t ich=0;
   Int_t adcMod[2*kNChannels], adcCh[2*kNChannels], sigCode[2*kNChannels];
   Int_t det[2*kNChannels], sec[2*kNChannels];
   for(Int_t y=0; y<2*kNChannels; y++){
     adcMod[y]=adcCh[y]=sigCode[y]=det[y]=sec[y]=0;
   }
-  
+
   Int_t iScCh=0;
   Int_t scMod[kNScChannels], scCh[kNScChannels], scSigCode[kNScChannels];
   Int_t scDet[kNScChannels], scSec[kNScChannels];
   for(Int_t y=0; y<kNScChannels; y++){
     scMod[y]=scCh[y]=scSigCode[y]=scDet[y]=scSec[y]=0;
   }
-      
+
   Int_t itdcCh=0;
   Int_t tdcMod[kNScChannels], tdcCh[kNScChannels], tdcSigCode[kNScChannels];
   Int_t tdcDet[kNScChannels], tdcSec[kNScChannels];
@@ -124,16 +133,16 @@ int main(int argc, char **argv) {
   }
 
   // Module type codes
-  enum ZDCModules{kV965=1, kV830=2, kTRG=3, kTRGI=4, kPU=5, KV1290=6, kV775N=7}; 
-  
+  enum ZDCModules{kV965=1, kV830=2, kTRG=3, kTRGI=4, kPU=5, KV1290=6, kV775N=7};
+
   // Module type codes
   enum ZDCGeoAddr{kFirstADCGeo=0, kLastADCGeo=3, kADDADCGeo=5,
        kTDCFakeGeo=8, kZDCTDCGeo=4, kADDTDCGeo=6,
        kScalerGeo=16, kPUGeo=29, kTrigScales=30, kTrigHistory=31};
-  
-  // Signal codes for ZDC 
+
+  // Signal codes for ZDC
   // Same codes used in DAQ configuration file
-  // To be changed ONLY IF this file is changed!!! 
+  // To be changed ONLY IF this file is changed!!!
   // **** DO NOT CHANGE THE FOLLOWING LINES!!! ****
   enum ZDCSignal{
        kNotConnected=0, kVoid=1,
@@ -149,8 +158,8 @@ int main(int argc, char **argv) {
        kZPCCoot=41, kZPC1oot=42, kZPC2oot=43, kZPC3oot=44, kZPC4oot=45,
        kZEM1oot=46, kZEM2oot=47,
        kZDCAMonoot=48, kZDCCMonoot=49,
-       kL1MBI=50, kL1CNI=51, kL1SCI=52, kL1EMDI=53, kL0I=54, 
-       kL1MBO=55, kL1CNO=56, kL1SCO=57, kL1EMDO=58, 
+       kL1MBI=50, kL1CNI=51, kL1SCI=52, kL1EMDI=53, kL0I=54,
+       kL1MBO=55, kL1CNO=56, kL1SCO=57, kL1EMDO=58,
        kHMBCN=59, kHSCEMD=60,
        kZNACD=61, kZNA1D=62, kZNA2D=63, kZNA3D=64, kZNA4D=65,
        kZPACD=66, kZPA1D=67, kZPA2D=68, kZPA3D=69, kZPA4D=70,
@@ -159,15 +168,15 @@ int main(int argc, char **argv) {
        kZEM1D=81, kZEM2D=82,
        kZDCAMonD=83, kZDCCMonD=84,
        kZNAD=85, kZPAD=86, kZNCD=87, kZPCD=88, kZEMD=89,
-       kZNA0D=90, kZPA0D=91, kZNC0D=92, kZPC0D=93, k1kHzD=94, kGate=95, kAD=96, kCD=97, 
-       kAorCD=98, kAandCD=99, kZEMORD=100, kAorCorZEMORD=101, kAorCorZEMD=102, kAD0=103, kAD1=104, kAD2=105, 
-       kAD3=106, kAD4=107, kAD5=108, kAD6=109, kAD7=110, kAD8=111, kAD9=112, kAD10=113, 
+       kZNA0D=90, kZPA0D=91, kZNC0D=92, kZPC0D=93, k1kHzD=94, kGate=95, kAD=96, kCD=97,
+       kAorCD=98, kAandCD=99, kZEMORD=100, kAorCorZEMORD=101, kAorCorZEMD=102, kAD0=103, kAD1=104, kAD2=105,
+       kAD3=106, kAD4=107, kAD5=108, kAD6=109, kAD7=110, kAD8=111, kAD9=112, kAD10=113,
        kAD11=114, kAD12=115, kAD13=116, kAD14=117, kAD15=118, kAD0D=119, kAD1D=120, kAD2D=121,
        kAD3D=122, kAD4D=123, kAD5D=124, kAD6D=125, kAD7D=126, kAD8D=127, kAD9D=128, kAD10D=129,
        kAD11D=130, kAD12D=131, kAD13D=132, kAD14D=133, kAD15D=134, kL0=135,
        k1ZAC=136, k1ZED=137, k1ZMD=138, k1ZMB=139
        };
-  
+
   // *** read histo limits from data file ***************************
   float hlimit[2][6];
   for(int k=0; k<6; k++){
@@ -179,7 +188,7 @@ int main(int argc, char **argv) {
     printf("\t ERROR!!! ZDCTDCHistoLimits.dat file NOT FOUND in DAQ db!  0> Exiting....\n");
     return -11;
   }
-  
+
   FILE *fileHistLim = NULL;
   fileHistLim = fopen(HISTLIM_FILE,"r");
   if(fileHistLim==NULL) {
@@ -200,7 +209,7 @@ int main(int argc, char **argv) {
   // *** Creating a container for the histos ***************************
   TObjArray *hList = new TObjArray(0);
   hList->SetOwner(kTRUE);
- 
+
   TH1F * hTDC[6]={0x0,0x0,0x0,0x0,0x0,0x0};
   TString prefix = "TDC";
   for(int it=0; it<6; it++){
@@ -219,18 +228,18 @@ int main(int argc, char **argv) {
      hTDC[it] = new TH1F(hname.Data(), hname.Data(), int(limit[1]-limit[0]), limit[0], limit[1]);
      hList->Add(hTDC[it]);
   }
-  
+
   FILE *mapFile4Shuttle=NULL;
 
   /* read the data files */
   for(int n=1;n<argc;n++){
-   
+
     status=monitorSetDataSource( argv[n] );
     if (status!=0) {
       printf("monitorSetDataSource() failed : %s\n",monitorDecodeError(status));
       return -1;
     }
-    
+
     /* declare monitoring program */
     status=monitorDeclareMp( __FILE__ );
     if (status!=0) {
@@ -244,15 +253,15 @@ int main(int argc, char **argv) {
     int iev = 0;
     //Bool_t sodRead = kFALSE;
     //while(!sodRead){
-    
+
     /* loop on events (infinite) */
     for(;;) {
-      
+
       if(nphys > 50000) break;
-      
+
       struct eventHeaderStruct *event;
       eventTypeType eventT;
- 
+
       /* check shutdown condition */
       if (daqDA_checkShutdown()) {break;}
 
@@ -269,23 +278,23 @@ int main(int argc, char **argv) {
 
       /* retry if got no event */
       if(event==NULL) continue;
-      
+
       // Initalize raw-data reading and decoding
       AliRawReader *reader = new AliRawReaderDate((void*)event);
       reader->Reset();
       reader->Select("ZDC");
       //
       AliZDCRawStream *rawStreamZDC = new AliZDCRawStream(reader);
-        
-	
+
+
       /* use event - here, just write event id to result file */
       eventT=event->eventType;
-     
-      /*  READ MAPPING FROM SOD EVENT*/ 
+
+      /*  READ MAPPING FROM SOD EVENT*/
       if(eventT==START_OF_DATA){
-	  	
+
 	rawStreamZDC->SetSODReading(kTRUE);
-	
+
 	// --------------------------------------------------------
 	// --- Writing ascii data file for the Shuttle preprocessor
         mapFile4Shuttle = fopen(MAPDATA_FILE,"w");
@@ -300,7 +309,7 @@ int main(int argc, char **argv) {
 	       modType[iMod] = rawStreamZDC->GetModType();
 	       modNCh[iMod]  = rawStreamZDC->GetADCNChannels();
 	    }
-            if(rawStreamZDC->IsChMapping()){ 
+            if(rawStreamZDC->IsChMapping()){
 	      if(modType[iMod]==1){ // ADC mapping ----------------------
 	        adcMod[ich]  = rawStreamZDC->GetADCModFromMap(ich);
 	        adcCh[ich]   = rawStreamZDC->GetADCChFromMap(ich);
@@ -343,11 +352,11 @@ int main(int argc, char **argv) {
 	     modGeo[is],modType[is],modNCh[is]);
 	     //printf("  Mapping DA -> Module mapping: geo %d type %d #ch %d\n",modGeo[is],modType[is],modNCh[is]);
 	  }
-	  
+
         fclose(mapFile4Shuttle);
       }// SOD event
-      /*  READING PHYSICS EVENTS*/ 
-      else if(eventT==PHYSICS_EVENT){ 
+      /*  READING PHYSICS EVENTS*/
+      else if(eventT==PHYSICS_EVENT){
 
 	rawStreamZDC->SetSODReading(kTRUE);
 
@@ -367,23 +376,23 @@ int main(int argc, char **argv) {
 	   rawStreamZDC->SetTDCSignFromMap(l, tdcSigCode[l]);
 //printf(" %d setting TDC ch. %d to signal %d\n",l, tdcCh[l], tdcSigCode[l]);
 	}
-	
+
   	while(rawStreamZDC->Next()){
          if(rawStreamZDC->GetADCModule()!=kZDCTDCGeo) continue; //skipping ADCs, scalers and trigger cards
 
           if(rawStreamZDC->GetADCModule()==kZDCTDCGeo && rawStreamZDC->IsZDCTDCDatum()==kTRUE){
              //
-	     itdc = rawStreamZDC->GetChannel(); 
-             if(itdc==iprevtdc) ihittdc++;
-             else ihittdc=0;
-             iprevtdc=itdc;
+	     itdc = rawStreamZDC->GetChannel();
+	     //Cheking and setting q flag if current TDC ch. has already been read
+             if(istdcchread[itdc]==kTRUE) ihittdc[itdc]++;
+	     istdcchread[itdc]=kTRUE;
 	     //
-	     // NB -> THE TDC cabling has been varied in 12/2013 
+	     // NB -> THE TDC cabling has been varied in 12/2013
 	     // PLEASE CROSS-CHECK https://twiki.cern.ch/twiki/bin/view/ALICE/ZDCTDCCabl
-	     int firstintch = 16;
-	     int lastintch=23;
+	     int firstintch=0;
+	     int lastintch=32;
 	     int tdcmapch=-1;
-	     if((itdc>=firstintch && itdc<=lastintch) && ihittdc==0){
+	     if((itdc>=firstintch && itdc<=lastintch) && ihittdc[itdc]<4){ //only up to 4 hits considered
 //printf(" **** TDC ch. %d cabled signal: %d\n",itdc, rawStreamZDC->GetTDCSignFromMap(itdc));
                int sigcode = rawStreamZDC->GetTDCSignFromMap(itdc);
 	       //
@@ -393,52 +402,62 @@ int main(int argc, char **argv) {
 	       else if(sigcode==kZPCD) tdcmapch=3;
 	       else if(sigcode==kZNAD) tdcmapch=4;
 	       else if(sigcode==kZPAD) tdcmapch=5;
-	       if(tdcmapch>=0) tdcData[tdcmapch] = 0.025*rawStreamZDC->GetZDCTDCDatum();
+	       if(tdcmapch>=0) tdcData[tdcmapch][ihittdc[itdc]] = 0.025*rawStreamZDC->GetZDCTDCDatum();
 	       //
-//if(tdcmapch>=0) printf("   *** TDC %d -> tdcData[%d] = %f  \n",itdc,  tdcmapch, tdcData[tdcmapch]);
+//if(tdcmapch>-1) printf("   *** TDC %d -> tdcData[%d][%d] = %f  \n",itdc, tdcmapch, ihittdc[itdc], tdcData[tdcmapch][ihittdc[itdc]]);
 	       //
 	       else if(sigcode==kL0){
 		  hasL0arrived=kTRUE;
 	          tdcL0 = 0.025*rawStreamZDC->GetZDCTDCDatum();
 	          //
-//printf("    -> L0 = %f \n",tdcL0);
-		  for(int ic=0; ic<6; ic++){
-		    if(tdcData[ic]!=-999.){
-//printf("   \t    reading tdcData[%d] = %f  \n",ic, tdcData[ic]);
-		      hTDC[ic]->Fill(tdcData[ic]-tdcL0);
-		      //printf(" ev.%d -> Filling histo%d:  %f ns\n",nphys,ic, tdcData[ic]-tdcL0);
-		    }
-	            // Resetting TDC values after L0 reading
-  	            tdcData[ic]=-999.;
-		  }
+//printf("->  L0 = %f \n",tdcL0);
                }//L0
-	     }//Loop on TDC
+	     }//Loop on interesting TDC ch.
+	  }//Loop on TDC data
+
+        }//rawstream->Next()
+
+	  //if event has L0 calculate TDC-L0
+	  if(hasL0arrived){
+	    for(int ic=0; ic<6; ic++){
+	       for(int ih=0; ih<4; ih++){
+	         if(tdcData[ic][ih]!=-999.){
+		   hTDC[ic]->Fill(tdcData[ic][ih]-tdcL0);
+//printf(" ev.%d -> Filling histo%d:  %f ns\n",nphys,ic,tdcData[ic][ih]-tdcL0);
+	         }
+	       }
+            }
 	  }
-        }
-	
-        // Resetting TDC values after event reading
-        if(hasL0arrived==kFALSE) for(int ic=0; ic<6; ic++) tdcData[ic]=-999.;
-	
+
  	nphys++;
-      
+
         delete rawStreamZDC;
-        rawStreamZDC = 0x0;	
+        rawStreamZDC = 0x0;
 	delete reader;
 
-      }//(if PHYSICS_EVENT) 
+      }//(if PHYSICS_EVENT)
       else if(eventT==END_OF_RUN){
         printf("End Of Run detected\n");
         break;
       }
-      
-      iev++; 
-      hasL0arrived==kFALSE;
+
+      iev++;
+	  // Resetting TDC values and flags
+	  hasL0arrived = kFALSE;
+ 	  for(int i=0; i<6; i++){
+    	     for(int j=0; j<4; j++) tdcData[i][j]=-999.;
+          }
+	  for(int k=0; k<32; k++){
+             // Resetting TDC values and flags
+  	     istdcchread[k] = kFALSE;
+	     ihittdc[k] = 0;
+	  }
 
       /* free resources */
       free(event);
- 
-    } // event loop    
-      
+
+    } // event loop
+
   }
   printf(" \n # of physics events analyzed = %d\n\n", nphys);
 
@@ -458,7 +477,7 @@ int main(int argc, char **argv) {
          printf("\n WARNING! Something wrong with det %d histo \n\n", k);
          continue;
        }
-       // 
+       //
        xUp = (hTDC[k]->GetXaxis())->GetXmax();
        xLow = (hTDC[k]->GetXaxis())->GetXmin();
        deltaX = xUp-xLow;
@@ -474,16 +493,16 @@ int main(int argc, char **argv) {
      }
      else printf("  WARNING! TDC histo %d has no entries and can't be processed!\n",k);
   }
-  //						       
+  //
   fclose(fileShuttle);
-  
+
   TFile *histofile = new TFile(TDCHISTO_FILE,"RECREATE");
   histofile->cd();
-  for(int k=0; k<6; k++) hTDC[k]->Write();						       
+  for(int k=0; k<6; k++) hTDC[k]->Write();
   histofile->Close();
   //
   for(Int_t j=0; j<6; j++) delete hTDC[j];
-  
+
   /* store the result files on FES */
   // [1] File with mapping
   status = daqDA_FES_storeFile(MAPDATA_FILE, "MAPPING");


### PR DESCRIPTION
This change is important since it prevents the wrong handling of TDC data in DA needed for timing calibration object. It would be important to have it running at P2 for Pb-Pb...desperate attempt, but nevertheless if it could be ported we could ask for deployment at P2