### PR TITLE
[EMCAL-406] Track prop to Emcal using outer param. Off by default.

### DIFF
--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
@@ -123,6 +123,8 @@ AliAnalysisTaskESDfilter::AliAnalysisTaskESDfilter():
   fTPCaloneTrackCuts(0),
   fDoPropagateTrackToEMCal(kTRUE),
   fEMCalSurfaceDistance(440),
+  fUseMassForPropToEMCal(0),
+  fUseOuterParamForPropToEMCal(0),
   fRefitVertexTracks(-1),
   fRefitVertexTracksNCuts(0),
   fRefitVertexTracksCuts(0),
@@ -207,6 +209,8 @@ AliAnalysisTaskESDfilter::AliAnalysisTaskESDfilter(const char* name, Bool_t addP
   fTPCaloneTrackCuts(0),
   fDoPropagateTrackToEMCal(kTRUE),
   fEMCalSurfaceDistance(440),
+  fUseMassForPropToEMCal(0),
+  fUseOuterParamForPropToEMCal(0),
   fRefitVertexTracks(-1),
   fRefitVertexTracksNCuts(0),
   fRefitVertexTracksCuts(0),
@@ -2413,8 +2417,14 @@ void AliAnalysisTaskESDfilter::ConvertESDtoAOD()
   if (fDoPropagateTrackToEMCal) {
     const Int_t ntrack = esd->GetNumberOfTracks();
     for (Int_t i=0;i<ntrack;++i) {
+      const Double_t mass=0.1396;
+      const Double_t step=20; 
+      const Double_t minpT=0.35;
+      const Bool_t useMassForTracking = fUseMassForPropToEMCal;
+      const Bool_t useDCA = kFALSE;
+      const Bool_t useOuterParam = fUseOuterParamForPropToEMCal;
       AliESDtrack *t = esd->GetTrack(i);
-      AliEMCALRecoUtilsBase::ExtrapolateTrackToEMCalSurface(t,fEMCalSurfaceDistance);
+      AliEMCALRecoUtilsBase::ExtrapolateTrackToEMCalSurface(t,fEMCalSurfaceDistance,mass,step,minpT,useMassForTracking,useDCA,useOuterParam);
     }
   }
  

--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.h
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.h
@@ -78,8 +78,9 @@ class AliAnalysisTaskESDfilter : public AliAnalysisTaskSE
   void EnableV0CascadeVerticesReco() {fIsV0CascadeRecoEnabled = kTRUE;}
   void SetPropagateTrackToEMCal(Bool_t propagate) {fDoPropagateTrackToEMCal = propagate;}
   void SetEMCalSurfaceDistance(Double_t d)        {fEMCalSurfaceDistance = d;}
+  void SetUseMassForPropToEmcal(Bool_t b)         {fUseMassForPropToEMCal = b;}
+  void SetUseOuterParamForPropToEmcal(Bool_t b)   {fUseOuterParamForPropToEMCal = b;}
   void SetRefitVertexTracks(Int_t algo=6, Double_t* cuts=0);
-  
   void SetMuonCaloPass();
   void SetAddPCMv0s(Bool_t addPCMv0s) {fAddPCMv0s=addPCMv0s;}
 
@@ -174,18 +175,19 @@ private:
   Double_t           fCascadeCuts[8];              ///< Array to store the values for the different reco selections cascades related
   Bool_t             fDoPropagateTrackToEMCal;     ///< whether or not to propagate the tracks to the EMCal surface -- true by default
   Double_t           fEMCalSurfaceDistance;        ///< EMCal surface distance from the center of the detector (r = 440 by default)
+  Bool_t             fUseMassForPropToEMCal;       ///< Use reconstructed mass instead of pion in the track propagation (off by default, ie pion mass is used) 
+  Bool_t             fUseOuterParamForPropToEMCal; ///< Use the outer param for starting point of extrapolation (off by default)
   Int_t              fRefitVertexTracks;           ///< request to refit the vertex if >=0 (algoID if cuts not supplied, otherwise ncuts)
   Int_t              fRefitVertexTracksNCuts;      ///< number of cut parameters
-  /// optional cuts for vertex refit
-  Double_t*          fRefitVertexTracksCuts;       //[fRefitVertexTracksNCuts]
-  Bool_t fIsMuonCaloPass; ///< whether or not this filtering is used on a muon_calo ESD
+  Double_t*          fRefitVertexTracksCuts;       //[fRefitVertexTracksNCuts] optional cuts for vertex refit
+  Bool_t             fIsMuonCaloPass;              ///< whether or not this filtering is used on a muon_calo ESD
   Bool_t	     fAddPCMv0s;		   ///< Add pcm v0s when v0filter is switched on
   TBits* 	     fbitfieldPCMv0sA;		   ///< Bitfield with PCM v0s from on-fly v0 finder
   TBits* 	     fbitfieldPCMv0sB;		   ///< Bitfield with PCM v0s from offline v0 finder
   TH1D*		     fv0Histos; 		   ///< v0 histos for PCM consistency checks
   TList*	     fHistov0List;		  ///< TList containing PCM histos
   
-  ClassDef(AliAnalysisTaskESDfilter, 21); // Analysis task for standard ESD filtering
+  ClassDef(AliAnalysisTaskESDfilter, 22); // Analysis task for standard ESD filtering
 };
 
 #endif


### PR DESCRIPTION
Bring the esd filter to the level that potentially one could switch to use of outer param when creating the AODs, and also implemented a switch to use mass hypothesis rather than pion mass always.
By default, all settings are like they have been used so far.