### PR TITLE
[EMCAL-408] Add Rho value to the AOD calo trigger object

### DIFF
--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
@@ -1711,6 +1711,7 @@ void AliAnalysisTaskESDfilter::ConvertCaloTrigger(TString calo, const AliESDEven
   };
   aodTrigger.SetL1V0(v0);	
   aodTrigger.SetL1FrameMask(esdTrigger.GetL1FrameMask());
+  for(int i = 0; i < 2; i++) aodTrigger.SetMedian(i, esdTrigger.GetMedian(i));
 }
 
 //______________________________________________________________________________


### PR DESCRIPTION
Median value needs to be propagated to the AODs as well in order to be subtracted from from the raw patches at AOD level.