### PR TITLE
BugFix: base virt. function signature differed from derived one

### DIFF
--- a/STEER/STEER/AliVertexGenerator.h
+++ b/STEER/STEER/AliVertexGenerator.h
@@ -12,7 +12,7 @@
 class AliVertexGenerator: public TObject {
  public:
   virtual TVector3 GetVertex() = 0;
-  virtual Float_t GetLastVertexTime() { return 0; }
+  virtual Float_t GetLastVertexTime() const = 0;
 
   ClassDef(AliVertexGenerator, 1)    // Base class for vertex generators
 };


### PR DESCRIPTION
Fixes missing transfer of underlying event vertex time to embedded event, see
https://alice.its.cern.ch/jira/browse/ALIROOT-7654?focusedCommentId=222963&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-222963