### PR TITLE
Add HLT TRD definition, remove old friend class declaration

### DIFF
--- a/HLT/TRD/AliHLTTRDDefinitions.cxx
+++ b/HLT/TRD/AliHLTTRDDefinitions.cxx
@@ -48,6 +48,8 @@ const AliHLTComponentDataType AliHLTTRDDefinitions::fgkSimpleIntegerDataType = {
 
 const AliHLTComponentDataType AliHLTTRDDefinitions::fgkTRDTrackletDataType = { sizeof(AliHLTComponentDataType), {'T','R','A','C','K','L','E','T'},{'T','R','D',' '}};;
 
+const AliHLTComponentDataType AliHLTTRDDefinitions::fgkTRDMCTrackletDataType = { sizeof(AliHLTComponentDataType), {'T','R','C','K','L','T','M','C'},{'T','R','D',' '}};;
+
 const AliHLTComponentDataType AliHLTTRDDefinitions::fgkTRDTrackPointDataType = { sizeof(AliHLTComponentDataType), {'T','R','A','C','K','P','N','T'},{'T','R','D',' '}};;
 
 const AliHLTComponentDataType AliHLTTRDDefinitions::fgkTRDTrackDataType = { sizeof(AliHLTComponentDataType), {'T','R','D','T','R','A','C','K'},{'T','R','D',' '}};;

--- a/HLT/TRD/AliHLTTRDDefinitions.h
+++ b/HLT/TRD/AliHLTTRDDefinitions.h
@@ -39,6 +39,7 @@ public:
   static const AliHLTComponentDataType fgkCalibrationDataType; // Calibration with TRDtracks
   static const AliHLTComponentDataType fgkEORCalibrationDataType;//Calibration end of run
   static const AliHLTComponentDataType fgkTRDTrackletDataType; // TRD tracklets from raw data
+  static const AliHLTComponentDataType fgkTRDMCTrackletDataType; // TRD tracklets from simulation
   static const AliHLTComponentDataType fgkTRDTrackPointDataType; // TRD space point calculated from tracklet
   static const AliHLTComponentDataType fgkTRDTrackDataType; // tracks
 

--- a/TRD/TRDbase/AliTRDtrackV1.h
+++ b/TRD/TRDbase/AliTRDtrackV1.h
@@ -26,7 +26,6 @@ class AliTRDcluster;
 class AliTRDReconstructor;
 class AliTRDtrackV1 : public AliKalmanTrack
 {
-  friend class AliHLTTRDTrack; // allow HLT special access
 public:
   enum ETRDtrackSize { 
     kNdet      = AliTRDgeometry::kNdet


### PR DESCRIPTION
- definition for TRD MC tracklet labels
- friend class declaration was for a class that is not used anymore, does not work with the new templated class