### PR TITLE
AliAnalysisManager : Add CreateChain static method

### DIFF
--- a/ANALYSIS/ANALYSIS/AliAnalysisManager.cxx
+++ b/ANALYSIS/ANALYSIS/AliAnalysisManager.cxx
@@ -3162,7 +3162,7 @@ void AliAnalysisManager::InitInputData(AliVEvent* esdEvent, AliVfriendEvent* esd
  * @param friends Specify the root_file/friend_tree that is assumed to be in the same directory as the each input file; if friend_tree is not specified we will assume the defaults
  * @return TChain*
  */
-TChain* AliAnalysisManager::CreateChain(const char* filelist, const char* cTreeNameArg, const char* friends, Int_t iNumFiles, Int_t iStartWithFile)
+TChain* AliAnalysisManager::CreateChain(const char* filelist, const char* cTreeNameArg, Int_t iNumFiles, Int_t iStartWithFile)
 {
 TString sTreeNameArg (cTreeNameArg), treeName;
 
@@ -3197,43 +3197,5 @@ else
 TChain* chain = new TChain (treeName.Data(),""); // lets create the chain
 if ( chain->AddFileInfoList(list) == 0 ) { return NULL; } // and add file collection (THashList is a Tlist that is a TCollection)
 
-// start treatment of friends
-TChain* chainFriend = NULL;
-TString sFriends (friends);
-if (!sFriends.IsNull()) {
-  TString friends_treename, friends_filename;
-  TObjArray* arr = sFriends.Tokenize("/");
-  TObjString* strobj_file = dynamic_cast<TObjString*>(arr->At(0));
-  if (strobj_file) { friends_filename = strobj_file->GetString(); }
-  TObjString* strobj_tree = dynamic_cast<TObjString*>(arr->At(1));
-  if (strobj_tree) { friends_treename = strobj_tree->GetString(); }
-  delete arr;
-
-  if (friends_treename.IsNull()) {
-    if (treeName.EqualTo("esdTree")) {
-      friends_treename = "esdFriendTree"; }
-    else if (treeName.EqualTo("aodTree")) {
-      friends_treename = "aodTree"; }
-    else {
-      cout << "friends argument specified but tree name neither specified nor auto-detected (unknown tree name to associate with known friend tree name)";
-      return chain; // stop processing of friends, just return the chain created so far
-      }
-    }
-
-  chainFriend = new TChain(friends_treename.Data());
-  TString friendinfo_for_chain = "/" + friends_filename + "/" + friends_treename;
-
-  TIter next(list);
-  TFileInfo* fileinfo = NULL;
-  while (( fileinfo = dynamic_cast<TFileInfo*>(next()) )) {
-    TString dirname = gSystem->DirName(fileinfo->GetFirstUrl()->GetFile());
-    TString friend_for_chain = dirname + friendinfo_for_chain;
-    if (chainFriend) { chainFriend->Add(friend_for_chain.Data()); }
-    }
-
-  if (chainFriend) { chain->AddFriend(chainFriend); }
-  }
-
 return chain;
 }
-

--- a/ANALYSIS/ANALYSIS/AliAnalysisManager.cxx
+++ b/ANALYSIS/ANALYSIS/AliAnalysisManager.cxx
@@ -33,6 +33,15 @@
 #include <TROOT.h>
 #include <TCanvas.h>
 #include <TStopwatch.h>
+#include <TObject.h>
+#include <TObjArray.h>
+#include <TObjString.h>
+#include <TString.h>
+#include <TKey.h>
+#include <TCollection.h>
+#include <THashList.h>
+#include <TRegexp.h>
+#include <TFileInfo.h>
 
 #include "AliLog.h"
 #include "AliAnalysisSelector.h"
@@ -3139,3 +3148,92 @@ void AliAnalysisManager::InitInputData(AliVEvent* esdEvent, AliVfriendEvent* esd
     Fatal("PropagateHLTEvent", "Input Handler not found, we cannot use this method!");
   }
 }
+
+//______________________________________________________________________________
+/**
+ * Creates a chain from an list of files
+ * Using list of directories is not supported; use find to create a list of files; Ex:
+ * find /alice/data/2016/LHC16r/ -path "_*_/000266189/_*_" -path "_*_/pass1_CENT_wSDD/_*_" -name AliAOD.root -printf "file://%p\n"
+ * NB! on macos you need gfind that is installed with "brew install findutils"
+ * @param filelist Name of the file containing the list of files
+ * @param iNumFiles If iNumFiles > 0 only nfiles files are added
+ * @param iStartWithFile starting from file 'iStartWithFile' (>= 1).
+ * @param cTreeNameArg Tree name for chaining. if "auto" it will be taken as the first tree name from the first file from filelist
+ * @param friends Specify the root_file/friend_tree that is assumed to be in the same directory as the each input file; if friend_tree is not specified we will assume the defaults
+ * @return TChain*
+ */
+TChain* AliAnalysisManager::CreateChain(const char* filelist, const char* cTreeNameArg, const char* friends, Int_t iNumFiles, Int_t iStartWithFile)
+{
+TString sTreeNameArg (cTreeNameArg), treeName;
+
+TFileCollection filecoll ("anachain","File collection for analysis"); // easy manipulation of file collections
+Int_t iAddedFiles = filecoll.AddFromFile(filelist,iNumFiles,iStartWithFile);
+if ( iAddedFiles < 1 ) { std::cout << "NO Files added to collection !!!" << std::endl; return NULL; }
+
+// if cTreeNameArg is auto lets try to autodetect what type of tree we have;
+// the assuption is that all files are the same and the first one is reprezentative
+THashList* list =  filecoll.GetList();
+if ( sTreeNameArg.EqualTo("auto") ) { // if tree name is not specified
+  TRegexp tree_regex ("[aod,esd]Tree");
+  TFileInfo* fileinfo = dynamic_cast<TFileInfo*>(list->At(0)); // get first fileinfo in list
+  TFile file (fileinfo->GetFirstUrl()->GetFile()); // get the actual TFile
+  if (file.IsZombie()) { cout << "Should not reach this message!! Error opening file" << endl; return NULL; }
+
+  // lets parse the TFile
+  TIter next(file.GetListOfKeys());
+  TKey* key = NULL;
+  while (( key = dynamic_cast<TKey*>(next()) )) {
+    TString class_name = key->GetClassName();
+    if ( ! class_name.EqualTo("TTree") ) { continue; } // searching for first TTree
+
+    TString key_name = key->GetName();
+    if ( key_name.Contains(tree_regex) ) { treeName = key_name; break;} // that is named either aodTree or esdTree
+    }
+  file.Close();
+  }
+else
+  { treeName = sTreeNameArg ; } // tree name is specified
+
+TChain* chain = new TChain (treeName.Data(),""); // lets create the chain
+if ( chain->AddFileInfoList(list) == 0 ) { return NULL; } // and add file collection (THashList is a Tlist that is a TCollection)
+
+// start treatment of friends
+TChain* chainFriend = NULL;
+TString sFriends (friends);
+if (!sFriends.IsNull()) {
+  TString friends_treename, friends_filename;
+  TObjArray* arr = sFriends.Tokenize("/");
+  TObjString* strobj_file = dynamic_cast<TObjString*>(arr->At(0));
+  if (strobj_file) { friends_filename = strobj_file->GetString(); }
+  TObjString* strobj_tree = dynamic_cast<TObjString*>(arr->At(1));
+  if (strobj_tree) { friends_treename = strobj_tree->GetString(); }
+  delete arr;
+
+  if (friends_treename.IsNull()) {
+    if (treeName.EqualTo("esdTree")) {
+      friends_treename = "esdFriendTree"; }
+    else if (treeName.EqualTo("aodTree")) {
+      friends_treename = "aodTree"; }
+    else {
+      cout << "friends argument specified but tree name neither specified nor auto-detected (unknown tree name to associate with known friend tree name)";
+      return chain; // stop processing of friends, just return the chain created so far
+      }
+    }
+
+  chainFriend = new TChain(friends_treename.Data());
+  TString friendinfo_for_chain = "/" + friends_filename + "/" + friends_treename;
+
+  TIter next(list);
+  TFileInfo* fileinfo = NULL;
+  while (( fileinfo = dynamic_cast<TFileInfo*>(next()) )) {
+    TString dirname = gSystem->DirName(fileinfo->GetFirstUrl()->GetFile());
+    TString friend_for_chain = dirname + friendinfo_for_chain;
+    if (chainFriend) { chainFriend->Add(friend_for_chain.Data()); }
+    }
+
+  if (chainFriend) { chain->AddFriend(chainFriend); }
+  }
+
+return chain;
+}
+

--- a/ANALYSIS/ANALYSIS/AliAnalysisManager.h
+++ b/ANALYSIS/ANALYSIS/AliAnalysisManager.h
@@ -21,6 +21,7 @@
 
 class TClass;
 class TTree;
+class TChain;
 class TFile;
 class TFileCollection;
 class TStopwatch;
@@ -222,7 +223,8 @@ enum EAliAnalysisFlags {
 
    void                 ApplyDebugOptions();
    void                 AddClassDebug(const char *className, Int_t debugLevel);
-   
+   static TChain*       CreateChain(const char* filelist = "filelist.txt", const char* cTreeNameArg = "auto", const char* friends = "", Int_t iNumFiles = -1, Int_t iStartWithFile = 1);
+
    // Security
    Bool_t               IsLocked() const {return fLocked;}
    void                 Lock();

--- a/ANALYSIS/ANALYSIS/AliAnalysisManager.h
+++ b/ANALYSIS/ANALYSIS/AliAnalysisManager.h
@@ -223,7 +223,7 @@ enum EAliAnalysisFlags {
 
    void                 ApplyDebugOptions();
    void                 AddClassDebug(const char *className, Int_t debugLevel);
-   static TChain*       CreateChain(const char* filelist = "filelist.txt", const char* cTreeNameArg = "auto", const char* friends = "", Int_t iNumFiles = -1, Int_t iStartWithFile = 1);
+   static TChain*       CreateChain(const char* filelist = "filelist.txt", const char* cTreeNameArg = "auto", Int_t iNumFiles = -1, Int_t iStartWithFile = 1);
 
    // Security
    Bool_t               IsLocked() const {return fLocked;}


### PR DESCRIPTION
For local analysis (and not only) a static method for creating
a chain would be useful as it would bypass the need of LoadMacro
workarounds in ROOT6