### PR TITLE
Option to flag MC2RAW embedding

### DIFF
--- a/STEER/STEER/AliSimulation.cxx
+++ b/STEER/STEER/AliSimulation.cxx
@@ -63,7 +63,7 @@
 //                                                                           //
 // Background events can be merged by calling                                //
 //                                                                           //
-//   sim.MergeWith("background/galice.root", 2);                             //
+//   sim.MergeWith("background/galice.root", 2, raw);                        //
 //                                                                           //
 // The first argument is the file name of the background galice file. The    //
 // second argument is the number of signal events per background event.      //
@@ -71,6 +71,9 @@
 // background events. MergeWith can be called several times to merge more    //
 // than two event streams. It is assumed that the sdigits were already       //
 // produced for the background events.                                       //
+// The 3d optional (defaule=kFALSE) is to indicate that the background       //
+// event is extracted from the raw data, i.e. NO subsidiary event has to     //
+// created                                                                   //
 //                                                                           //
 // The output of raw data can be switched on by calling                      //
 //                                                                           //
@@ -613,20 +616,20 @@ Bool_t AliSimulation::MisalignGeometry(AliRunLoader *runLoader)
 }
 
 //_____________________________________________________________________________
-void AliSimulation::MergeWith(const char* fileName, Int_t nSignalPerBkgrd)
+void AliSimulation::MergeWith(const char* fileName, Int_t nSignalPerBkgrd, Bool_t raw)
 {
 // add a file with background events for merging
-
-  TObjString* fileNameStr = new TObjString(fileName);
+  TObjString* fileNameStr = new TObjString(fileName); 
   fileNameStr->SetUniqueID(nSignalPerBkgrd);
+  if (raw) fileNameStr->SetBit( AliStack::GetEmbeddingRawBit() );
   if (!fBkgrdFileNames) fBkgrdFileNames = new TObjArray;
   fBkgrdFileNames->Add(fileNameStr);
 }
 
-void AliSimulation::EmbedInto(const char* fileName, Int_t nSignalPerBkgrd)
+void AliSimulation::EmbedInto(const char* fileName, Int_t nSignalPerBkgrd, Bool_t raw)
 {
 // add a file with background events for embedding
-  MergeWith(fileName, nSignalPerBkgrd);
+  MergeWith(fileName, nSignalPerBkgrd, raw);
   fEmbeddingFlag = kTRUE;
 }
 

--- a/STEER/STEER/AliSimulation.h
+++ b/STEER/STEER/AliSimulation.h
@@ -51,8 +51,8 @@ public:
                    {fLoadAlObjsListOfDets = detectors;};
   void           SetMakeSDigits(const char* detectors) 
                    {fMakeSDigits = detectors;};
-  void           MergeWith(const char* fileName, Int_t nSignalPerBkgrd = 0);
-  void           EmbedInto(const char* fileName, Int_t nSignalPerBkgrd = 0);
+  void           MergeWith(const char* fileName, Int_t nSignalPerBkgrd = 0, Bool_t raw=kFALSE);
+  void           EmbedInto(const char* fileName, Int_t nSignalPerBkgrd = 0, Bool_t raw=kFALSE);
 
   Bool_t         GetEmbeddingFlag() const {return fEmbeddingFlag;}
   

--- a/STEER/STEERBase/AliMCEventHandler.cxx
+++ b/STEER/STEERBase/AliMCEventHandler.cxx
@@ -151,10 +151,15 @@ Bool_t AliMCEventHandler::Init(Option_t* opt)
       AliInfo("galice.root contains paths of background for embedding");
       embBKGPaths->Print();
       for (int ib=0;ib<embBKGPaths->GetEntriesFast();ib++) {
+	TObjString* objstr = (TObjString*)embBKGPaths->At(ib);
+	TString pth = objstr->GetName();
+	if (objstr->TestBit(AliStack::GetEmbeddingRawBit())) {
+	  AliInfoF("Backround from %s flagged is as RAW, skip MCEvent creation",pth.Data());
+	  continue;
+	}
 	if (!fSubsidiaryHandlers || fSubsidiaryHandlers->GetEntries()<ib) AddSubsidiaryHandler(new AliMCEventHandler());
 	// if needed, add subsidiary handlers
 	AliMCEventHandler* hs = (AliMCEventHandler*)fSubsidiaryHandlers->At(ib);
-	TString pth = gSystem->DirName(embBKGPaths->At(ib)->GetName());
 	// check if the path is relative
 	if ( !pth.BeginsWith("/") && !pth.BeginsWith("alien://")) {
 	  TString pths = fPathName->Data();

--- a/STEER/STEERBase/AliStack.h
+++ b/STEER/STEERBase/AliStack.h
@@ -27,6 +27,8 @@ enum {kKeepBit=1, kDaughtersBit=2, kDoneBit=4, kTransportBit=BIT(14)};
 class AliStack : public TVirtualMCStack
 {
   public:
+  enum {kEmbeddingRawBit = BIT(20)};
+  
     // creators, destructors
     AliStack(Int_t size, const char* name = "");
     AliStack();
@@ -36,7 +38,7 @@ class AliStack : public TVirtualMCStack
       {st.Copy(*this); return(*this);}
 
     // methods
-
+    
     virtual void  PushTrack(Int_t done, Int_t parent, Int_t pdg, 
                            const Float_t *pmom, const Float_t *vpos, const Float_t *polar, 
                            Float_t tof, TMCProcess mech, Int_t &ntr,
@@ -91,6 +93,7 @@ class AliStack : public TVirtualMCStack
     void        SetMCEmbeddingFlag(Bool_t v=kTRUE)        {fMCEmbeddingFlag = v;}
     Bool_t      GetMCEmbeddingFlag()                const {return fMCEmbeddingFlag;}
     static const char*   GetEmbeddingBKGPathsKey() {return fgkEmbedPathsKey;}
+    static UInt_t GetEmbeddingRawBit() {return kEmbeddingRawBit;}
     static TParticle* GetDummyParticle();
     
   protected:


### PR DESCRIPTION
AliSimulation::EmbedInto(path, NSig2Bg, RAWSTATUS) will flag the embedding as being done to raw
data if RAWSTATUS==kTRUE (default is FALSE). In this case the AliMCEventHandler will not try to load the kinematics of the background event as a subsidiary MC Event