### PR TITLE
Replacing TAlien specific classes with abstract TGrid classes

### DIFF
--- a/ANALYSIS/ANALYSISalice/AliEventPoolSparse.cxx
+++ b/ANALYSIS/ANALYSISalice/AliEventPoolSparse.cxx
@@ -29,7 +29,7 @@
   2) Merging the tag files
 
   TGrid::Connect("alien://");
-  TAlienCollection *collection = TAlienCollection::Open(xmlfile);
+  TGridCollection *collection = gGrid->OpenCollection(xmlfile);
   TGridResult* result = collection->GetGridResult("",0);
   AliTagCreator *t = new AliTagCreator();
   t->MergeTags("ESD",result);

--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -311,8 +311,8 @@ AliAnalysisAlien::AliAnalysisAlien(const AliAnalysisAlien& other)
                   fTreeName(other.fTreeName)
 {
 // Copy ctor.
-   fGridJDL = (TGridJDL*)gROOT->ProcessLine("new TAlienJDL()");
-   fMergingJDL = (TGridJDL*)gROOT->ProcessLine("new TAlienJDL()");
+   fGridJDL = gGrid->GetJDLGenerator();
+   fMergingJDL = gGrid->GetJDLGenerator();
    fRunRange[0] = other.fRunRange[0];
    fRunRange[1] = other.fRunRange[1];
    if (other.fInputFiles) {
@@ -359,8 +359,8 @@ AliAnalysisAlien &AliAnalysisAlien::operator=(const AliAnalysisAlien& other)
 // Assignment.
    if (this != &other) {
       AliAnalysisGrid::operator=(other);
-      fGridJDL = (TGridJDL*)gROOT->ProcessLine("new TAlienJDL()");
-      fMergingJDL = (TGridJDL*)gROOT->ProcessLine("new TAlienJDL()");
+      fGridJDL = gGrid->GetJDLGenerator();
+      fMergingJDL = gGrid->GetJDLGenerator();
       fPrice                   = other.fPrice;
       fTTL                     = other.fTTL;
       fSplitMaxInputFileNumber = other.fSplitMaxInputFileNumber;
@@ -1295,12 +1295,13 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
          }
          if (ncount == gMaxEntries) {
             Info("CreateDataset", "Dataset %s has more than 15K entries. Trying to merge...", file.Data());
-            cadd = (TGridCollection*)gROOT->ProcessLine(Form("new TAlienCollection(\"__tmp%d__%s\", 1000000);",stage,file.Data()));
+            cadd = gGrid->OpenCollection(Form("__tmp%d__%s", stage, file.Data()), 1000000);
             if (!cbase) cbase = cadd;
             else {
 	      // cholm - Avoid using very slow TAlienCollection 
 	      // cbase->Add(cadd);
 	      // cholm - Use AddFast (via interpreter)
+        // TODO: nhardi, Jan 2019
 	      gROOT->ProcessLine(Form("((TAlienCollection*)%p)->AddFast((TGridCollection*)%p)",cbase,cadd));
                delete cadd;
             }   

--- a/ANALYSIS/AliAnalysisGoodies.cxx
+++ b/ANALYSIS/AliAnalysisGoodies.cxx
@@ -324,7 +324,7 @@ Bool_t AliAnalysisGoodies::MakeEsdCollectionFromTagCollection(AliRunTagCuts *run
 
 #ifdef WITHALIEN
   
-  TGridCollection * collection = (TGridCollection*)gROOT->ProcessLine(Form("TAlienCollection::Open(\"%s\", 0)",in));
+  TGridCollection* collection = gGrid->OpenCollection(in, 0);
   TGridResult* result = collection->GetGridResult("", 0, 0);
   AliTagAnalysis * tagAna = new AliTagAnalysis(); 
   tagAna->ChainGridTags(result);
@@ -351,7 +351,7 @@ Bool_t AliAnalysisGoodies::MakeEsdCollectionFromTagCollection(const char * runCu
   
 #ifdef WITHALIEN
 
-  TGridCollection * collection = (TGridCollection*)gROOT->ProcessLine(Form("TAlienCollection::Open(\"%s\", 0)",in));
+  TGridCollection* collection = gGrid->OpenCollection(in, 0);
   TGridResult* result = collection->GetGridResult("", 0, 0);
   AliTagAnalysis * tagAna = new AliTagAnalysis(); 
   tagAna->ChainGridTags(result);
@@ -387,7 +387,7 @@ Bool_t AliAnalysisGoodies::Merge(const char * collectionFile, const char * subFi
   
 #ifdef WITHALIEN
 
-  TGridCollection * collection = (TGridCollection*)gROOT->ProcessLine(Form("TAlienCollection::Open(\"%s\", 0)",collectionFile));
+  TGridCollection* collection = gGrid->OpenCollection(collectionFile, 0);
   TGridResult* result = collection->GetGridResult("", 0, 0);
   
   Int_t index = 0  ;
@@ -662,7 +662,7 @@ Bool_t AliAnalysisGoodies::ProcessEsdXmlCollection(const char * xmlFile) const
 
 #ifdef WITHALIEN
   //AliXMLCollection * collection = AliXMLCollection::Open(xmlFile,0) ;
-  TGridCollection * collection =  (TGridCollection*)gROOT->ProcessLine(Form("TAlienCollection::Open(\"%s\", 0)", xmlFile));
+  TGridCollection* collection = gGrid->OpenCollection(xmlFile, 0);
   if (! collection) {
     AliError(Form("%s not found", xmlFile)) ; 
     return kFALSE ; 
@@ -711,7 +711,7 @@ Bool_t AliAnalysisGoodies::ProcessTagXmlCollection(const char * xmlFile, AliRunT
 
 #ifdef WITHALIEN
 
-  TGridCollection * collection = (TGridCollection*)gROOT->ProcessLine(Form("TAlienCollection::Open(\"%s\", 0)",xmlFile));
+  TGridCollection* collection = gGrid->OpenCollection(xmlFile, 0);
   if (! collection) {
     AliError(Form("%s not found", xmlFile)) ; 
     return kFALSE ; 
@@ -758,7 +758,7 @@ Bool_t AliAnalysisGoodies::ProcessTagXmlCollection(const char * xmlFile, const c
   if ( gSystem->AccessPathName(xmlFile) ) 
     TGrid::Connect("alien://"); 
 
-  TGridCollection * collection = (TGridCollection*)gROOT->ProcessLine(Form("TAlienCollection::Open(\"%s\", 0)",xmlFile));
+  TGridCollection* collection = gGrid->OpenCollection(xmlFile, 0);
   if (! collection) {
     AliError(Form("%s not found", xmlFile)) ; 
     return kFALSE ; 

--- a/ANALYSIS/macros/AnalysisTrainFilterMC.C
+++ b/ANALYSIS/macros/AnalysisTrainFilterMC.C
@@ -1297,7 +1297,7 @@ TChain* CreateChainSingle(const char* xmlfile, const char *treeName)
    printf("*******************************\n");
    printf("*** Getting the ESD Chain   ***\n");
    printf("*******************************\n");
-   TAlienCollection * myCollection  = TAlienCollection::Open(xmlfile);
+   TGridCollection * myCollection  = gGrid->OpenCollection(xmlfile);
 
    if (!myCollection) {
       ::Error("AnalysisTrainNew.C::CreateChainSingle", "Cannot create an AliEn collection from %s", xmlfile) ;

--- a/ANALYSIS/macros/AnalysisTrainNew.C
+++ b/ANALYSIS/macros/AnalysisTrainNew.C
@@ -1147,7 +1147,7 @@ TChain* CreateChainSingle(const char* xmlfile, const char *treeName)
    printf("*******************************\n");
    printf("*** Getting the ESD Chain   ***\n");
    printf("*******************************\n");
-   TAlienCollection * myCollection  = TAlienCollection::Open(xmlfile);
+   TGridCollection * myCollection  = gGrid->OpenCollection(xmlfile);
 
    if (!myCollection) {
       ::Error("AnalysisTrainNew.C::CreateChainSingle", "Cannot create an AliEn collection from %s", xmlfile) ;

--- a/ANALYSIS/macros/AnalysisTrainNewFilterAOD.C
+++ b/ANALYSIS/macros/AnalysisTrainNewFilterAOD.C
@@ -1181,7 +1181,7 @@ TChain* CreateChainSingle(const char* xmlfile, const char *treeName)
    printf("*******************************\n");
    printf("*** Getting the ESD Chain   ***\n");
    printf("*******************************\n");
-   TAlienCollection * myCollection  = TAlienCollection::Open(xmlfile);
+   TGridCollection * myCollection  = gGrid->OpenCollection(xmlfile);
 
    if (!myCollection) {
       ::Error("AnalysisTrainNew.C::CreateChainSingle", "Cannot create an AliEn collection from %s", xmlfile) ;

--- a/ANALYSIS/macros/AnalysisTrainNewFilterAODMC.C
+++ b/ANALYSIS/macros/AnalysisTrainNewFilterAODMC.C
@@ -1173,7 +1173,7 @@ TChain* CreateChainSingle(const char* xmlfile, const char *treeName)
    printf("*******************************\n");
    printf("*** Getting the ESD Chain   ***\n");
    printf("*******************************\n");
-   TAlienCollection * myCollection  = TAlienCollection::Open(xmlfile);
+   TGridCollection * myCollection  = gGrid->OpenCollection(xmlfile);
 
    if (!myCollection) {
       ::Error("AnalysisTrainNew.C::CreateChainSingle", "Cannot create an AliEn collection from %s", xmlfile) ;

--- a/ANALYSIS/macros/TaskBuzzer.C
+++ b/ANALYSIS/macros/TaskBuzzer.C
@@ -274,7 +274,7 @@ TChain* CreateChain(const char *xmlfile, const char *type)
    printf("***************************************\n");
    printf("    Getting chain of trees %s\n", treename.Data());
    printf("***************************************\n");
-   TAlienCollection *coll = TAlienCollection::Open(xmlfile);
+   TGridCollection *coll = gGrid->OpenCollection(xmlfile);
    if (!coll) {
       ::Error("CreateChain", "Cannot create an AliEn collection from %s", xmlfile);
       return NULL;

--- a/ANALYSIS/macros/runTaskNormalization.C
+++ b/ANALYSIS/macros/runTaskNormalization.C
@@ -18,7 +18,7 @@ void runTaskNormalization(const char * incollection,const char * filename = "LHC
   }
   else if (TString(incollection).Contains("xml")){
     TGrid::Connect("alien://");
-    TAlienCollection * coll = TAlienCollection::Open (incollection);
+    TGridCollection * coll = gGrid->OpenCollection(incollection);
     while(coll->Next()){
       analysisChain->Add(TString("alien://")+coll->GetLFN());
     }

--- a/HMPID/AnalysisTrainHMPID.C
+++ b/HMPID/AnalysisTrainHMPID.C
@@ -841,7 +841,7 @@ TChain* CreateChainSingle(const char* xmlfile, const char *treeName)
    printf("*******************************\n");
    printf("*** Getting the ESD Chain   ***\n");
    printf("*******************************\n");
-   TAlienCollection * myCollection  = TAlienCollection::Open(xmlfile);
+   TGridCollection * myCollection  = gGrid->OpenCollection(xmlfile);
 
    if (!myCollection) {
       ::Error("AnalysisTrainHMPID.C::CreateChainSingle", "Cannot create an AliEn collection from %s", xmlfile) ;

--- a/HMPID/HMPIDFindAlignTracks.C
+++ b/HMPID/HMPIDFindAlignTracks.C
@@ -5,7 +5,6 @@
 #include <TStopwatch.h>
 #include <TChain.h>
 #include <TGrid.h>
-#include <TAlienCollection.h>
 #include <TGridCollection.h>
 #include <TNtuple.h>
 #include <TGeoManager.h>
@@ -84,7 +83,7 @@ TChain *CreateChainFromCollection(const char* xmlfile, const char *treeName,Int_
   gSystem->Load("libANALYSISalice");  
 
   
-  TAlienCollection *myCollection  = TAlienCollection::Open(xmlfile);
+  TGridCollection *myCollection  = gGrid->OpenCollection(xmlfile);
 
    
    if (!myCollection) {

--- a/ITS/macrosSDD/ITSQArecoparam.C
+++ b/ITS/macrosSDD/ITSQArecoparam.C
@@ -1,6 +1,5 @@
 #if !defined(__CINT__) || defined(__MAKECINT__)
 #include <TFile.h>
-#include <TAlienFile.h>
 #include <TSystem.h>
 #include <TGrid.h>
 #include <TGridResult.h>

--- a/ITS/macrosSDD/PlotQASDD.C
+++ b/ITS/macrosSDD/PlotQASDD.C
@@ -1,7 +1,6 @@
 #if !defined(__CINT__) || defined(__MAKECINT__)
 #include <TFile.h>
 #include <TFileMerger.h>
-#include <TAlienFile.h>
 #include <TSystem.h>
 #include <TGrid.h>
 #include <TGridResult.h>
@@ -11,7 +10,6 @@
 #include <TKey.h>
 #include <TFile.h>
 #include <TFileMerger.h>
-#include <TAlienFile.h>
 //#include <TExec.h>
 #include <TSystem.h>
 #include <TGrid.h>

--- a/ITS/macrosSDD/ReadQASDD.C
+++ b/ITS/macrosSDD/ReadQASDD.C
@@ -1,7 +1,6 @@
 #if !defined(__CINT__) || defined(__MAKECINT__)
 #include <TFile.h>
 #include <TFileMerger.h>
-#include <TAlienFile.h>
 //#include <TExec.h>
 #include <TSystem.h>
 #include <TGrid.h>

--- a/ITS/macrosSDD/TrendQASDD.C
+++ b/ITS/macrosSDD/TrendQASDD.C
@@ -1,7 +1,6 @@
 #if !defined(__CINT__) || defined(__MAKECINT__)
 #include <TFile.h>
 #include <TFileMerger.h>
-#include <TAlienFile.h>
 //#include <TExec.h>
 #include <TSystem.h>
 #include <TGrid.h>

--- a/ITSMFT/ITS/FT2/MakeAODInputChain.C
+++ b/ITSMFT/ITS/FT2/MakeAODInputChain.C
@@ -7,13 +7,13 @@ TChain *MakeAODInputChain(const char* collectionfileAOD,
   // Origin: A.Rossi, andrea.rossi@ts.infn.it
   //
 
-  TAlienCollection *collectionAOD       = TAlienCollection::Open(collectionfileAOD);
+  TGridCollection *collectionAOD       = gGrid->OpenCollection(collectionfileAOD);
   TGridResult *tagResultAOD = collectionAOD->GetGridResult("",0,0);
   TChain *chainAOD = new TChain("aodTree");
   TChain *chainAODfriend = new TChain("aodTree");
   Int_t nmaxentr;
   if(collectionfileAODfriend!="none"){
-    TAlienCollection *collectionAODfriend = TAlienCollection::Open(collectionfileAODfriend);
+    TGridCollection *collectionAODfriend = gGrid->OpenCollection(collectionfileAODfriend);
     TGridResult *tagResultAODFriend = collectionAODfriend->GetGridResult("",0,0);
     //  tagResultAOD->Print();
     TMap *mappa;
@@ -185,7 +185,7 @@ TFileCollection* MakeRootArchFileCollection(const char* collectionfileAOD,
   // Origin: A.Rossi, andrea.rossi@ts.infn.it
   //
   
-  TAlienCollection *collectionAOD       = TAlienCollection::Open(collectionfileAOD);
+  TGridCollection *collectionAOD       = gGrid->OpenCollection(collectionfileAOD);
   TGridResult *tagResultAOD = collectionAOD->GetGridResult("",0,0);
 
   Int_t nmaxentr;

--- a/ITSMFT/ITS/v0/FastVsSlowSim.C
+++ b/ITSMFT/ITS/v0/FastVsSlowSim.C
@@ -18,7 +18,6 @@
 #include "AliFMDDigit.h"
 #include "AliTPCAltroMapping.h"
 #include "AliTriggerConfiguration.h"
-#include "TAlienCollection.h"
 #include "AliTriggerClass.h"
 #include "TGrid.h"
 #include "TPRegexp.h"

--- a/PHOS/macros/pi0Calib/AnaPi0Select.C
+++ b/PHOS/macros/pi0Calib/AnaPi0Select.C
@@ -27,9 +27,9 @@ void AnaPi0Select(const char* dataset="minbias_LHC09a4_81040_81050.xml")
 
     // Create the chain
     TChain* chain = new TChain("esdTree");
-    TGridCollection * collection = dynamic_cast<TGridCollection*>(TAlienCollection::Open(dataset));
+    TGridCollection * collection = gGrid->OpenCollection(dataset);
    
-    TAlienResult* result = collection->GetGridResult("",0 ,0);
+    TGridResult* result = collection->GetGridResult("",0 ,0);
     TList* rawFileList = result->GetFileInfoList();
 
     for (Int_t counter=0 ; counter < rawFileList->GetEntries() ; counter++) {

--- a/STEER/STEER/AliQAManager.cxx
+++ b/STEER/STEER/AliQAManager.cxx
@@ -872,7 +872,7 @@ Bool_t AliQAManager::MergeXML(const Char_t * collectionFile, const Char_t * subF
   // Open the file collection 
   AliInfoClass(Form("*** Create Collection       ***\n***  Wk-Dir = |%s|             \n***  Coll   = |%s|             \n",gSystem->WorkingDirectory(), collectionFile));              	
   
-  TGridCollection * collection = (TGridCollection*)gROOT->ProcessLine(Form("TAlienCollection::Open(\"%s\")",collectionFile));
+  TGridCollection * collection = gGrid->OpenCollection(collectionFile);
   TGridResult* result = collection->GetGridResult("", 0, 0);
   
   Int_t index = 0  ;

--- a/STEER/macros/CreateTags.C
+++ b/STEER/macros/CreateTags.C
@@ -50,7 +50,7 @@ void CreateTags() {
   //_________Alien stored ESDs_________//
   //___________________________________//
   //XML collection
-  //TAlienCollection *collection = TAlienCollection::Open("pp.xml");
+  //TGridCollection *collection = gGrid->OpenCollection("pp.xml");
   //TGridResult* result = collection->GetGridResult("");
   //Read the TGridResult, create the tags and store them
   //t->ReadGridCollection(result);

--- a/STEER/macros/CreateXML.C
+++ b/STEER/macros/CreateXML.C
@@ -42,7 +42,7 @@ Bool_t CreateXML(char * coll_in="pp.xml", char * coll_out="global2")
 
   TGrid::Connect("alien://pcapiserv01.cern.ch:10000","elopez");
   //TGrid::Connect("alien://"); 
-  TAlienCollection* coll = TAlienCollection::Open(coll_in);
+  TGridCollection* coll = gGrid->OpenCollection(coll_in);
   TGridResult* TagResult = coll->GetGridResult("",0,0);
   cout << endl << "Chain Grid Tags..."  << endl;
   TagAna->ChainGridTags(TagResult);

--- a/STEER/macros/MergeTags.C
+++ b/STEER/macros/MergeTags.C
@@ -28,7 +28,7 @@ void MergeTags(const char* fCollectionName) {
   //__________Merge tag files__________//
   //___________________________________//
   //XML collection
-  TAlienCollection *collection = TAlienCollection::Open(fCollectionName);
+  TGridCollection *collection = gGrid->OpenCollection(fCollectionName);
   TGridResult* result = collection->GetGridResult("");
   //Read the TGridResult and merge the tags
   t->MergeTags(result);

--- a/T0/T0calib/raw2treeGrid_collection.C
+++ b/T0/T0calib/raw2treeGrid_collection.C
@@ -9,7 +9,7 @@ void raw2treeGrid_collection()
   Int_t allData[220][5];
   TGrid::Connect("alien://");
   TTree *fT0OutTree=new TTree("t0tree","None here");
- TAlienCollection *collnum = TAlienCollection::Open("wn.xml");
+  TGridCollection *collnum = gGrid->OpenCollection("wn.xml");
   Int_t numrun;
   collnum->Reset();
   collnum->Next();
@@ -79,7 +79,7 @@ void raw2treeGrid_collection()
    fT0OutTree->Branch("event", &event);
    ULong64_t triggerMask;
    fT0OutTree->Branch("triggers", &triggerMask);
-    TAlienCollection *coll = TAlienCollection::Open("wn.xml");
+    TGridCollection *coll = gGrid->OpenCollection("wn.xml");
       coll->Reset();
     
    AliRawReader *reader;

--- a/TOF/TOFCalibPass0.C
+++ b/TOF/TOFCalibPass0.C
@@ -31,10 +31,10 @@ SteerTask(const Char_t *inputfilename, Int_t maxFiles = kMaxInt, Int_t maxEv = k
   if (str.EndsWith(".xml")) {
     TGrid::Connect("alien://");
     Info("SteerTaskEventTime", "reading data list from collection:");
-    TAlienCollection coll(inputfilename, maxFiles);
-    coll.Reset();
-    while (coll.Next()) {
-      filename = coll.GetTURL();
+    TGridCollection *coll = gGrid->OpenCollection(inputfilename, maxFiles);
+    coll->Reset();
+    while (coll->Next()) {
+      filename = coll->GetTURL();
       Info("SteerTaskEventTime", Form("%s", filename));
       chain->Add(filename);
     }

--- a/cmake/FindROOT.cmake
+++ b/cmake/FindROOT.cmake
@@ -183,48 +183,35 @@ if(ROOTSYS)
     string(STRIP "${ROOT_GLIBRARIES}" ROOT_GLIBRARIES)
     separate_arguments(ROOT_GLIBRARIES)
 
-    # Checking for AliEn support
-    # If AliEn support is enabled we need to point to AliEn
-    execute_process(COMMAND ${ROOT_CONFIG} --has-alien OUTPUT_VARIABLE ROOT_HASALIEN ERROR_VARIABLE error OUTPUT_STRIP_TRAILING_WHITESPACE )
-    if(error)
-        message(FATAL_ERROR "Error checking if ROOT was built with AliEn support: ${error}")
-    endif(error)
+    # We assume that AliEn support comes as an external ROOT plugin, 
+    # so we don't check if ROOT has alien feature enabled.
+    if(ALIEN)
+        add_definitions(-DWITHALIEN)
 
-    #if defined
-    if(ROOT_HASALIEN)
-        string(STRIP "${ROOT_HASALIEN}" ROOT_HASALIEN)
-        if(ROOT_HASALIEN STREQUAL "yes")
-            if(ALIEN)
-                add_definitions(-DWITHALIEN)
-
-                # AliEn might bring some system libraries, we need to use them
-                if(EXISTS "${ALIEN}/lib")
-                    link_directories(${ALIEN}/lib)
-                endif()
-
-                # api/lib should always exists
-                if(EXISTS "${ALIEN}/api/lib")
-                    link_directories(${ALIEN}/api/lib)
-                endif()
-
-                # include for AliEn
-                if(EXISTS "${ALIEN}/include")
-                    include_directories(SYSTEM ${ALIEN}/include)
-                endif()
-
-                # api/include always exists
-                if(EXISTS "${ALIEN}/api/include")
-                    include_directories(SYSTEM ${ALIEN}/api/include)
-                endif()
-
-                set(ROOT_HASALIEN TRUE)
-            else(ALIEN)
-                message(FATAL_ERROR "ROOT was built with AliEn support but no AliEn installation found. Please set \"ALIEN\" to point to your AliEn installation.")
-            endif(ALIEN)
-        else()
-            set(ROOT_HASALIEN FALSE)
+        # AliEn might bring some system libraries, we need to use them
+        if(EXISTS "${ALIEN}/lib")
+            link_directories(${ALIEN}/lib)
         endif()
-    endif(ROOT_HASALIEN)
+
+        # api/lib should always exists
+        if(EXISTS "${ALIEN}/api/lib")
+            link_directories(${ALIEN}/api/lib)
+        endif()
+
+        # include for AliEn
+        if(EXISTS "${ALIEN}/include")
+            include_directories(SYSTEM ${ALIEN}/include)
+        endif()
+
+        # api/include always exists
+        if(EXISTS "${ALIEN}/api/include")
+            include_directories(SYSTEM ${ALIEN}/api/include)
+        endif()
+
+        set(ROOT_HASALIEN TRUE)
+    else(ALIEN)
+        message(FATAL_ERROR "No AliEn installation found. Please set \"ALIEN\" to point to your AliEn installation.")
+    endif(ALIEN)
 
     # Checking for xml support
     execute_process(COMMAND ${ROOT_CONFIG} --has-xml OUTPUT_VARIABLE ROOT_HASXML ERROR_VARIABLE error OUTPUT_STRIP_TRAILING_WHITESPACE )

--- a/cmake/PARfiles/Makefile.in
+++ b/cmake/PARfiles/Makefile.in
@@ -35,7 +35,6 @@ endif
 
 # Get some ROOT build flags from the current installation
 ROOT_DEFINES += $(shell root-config --features | grep -q xml && echo '-DWITHXML')
-ROOT_DEFINES += $(shell root-config --features | grep -q alien && echo '-DWITHALIEN')
 ifneq ($(FASTJET),)
 	ROOT_DEFINES += -DHAVE_FASTJET
 endif

--- a/test/QA/rawqa.C
+++ b/test/QA/rawqa.C
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <fstream>
 
-#include <TAlienCollection.h>
+#include <TGridCollection.h>
 #include <TFile.h>
 #include <TGrid.h>
 #include <TGridResult.h>
@@ -55,8 +55,8 @@ void rawqa(const Int_t runNumber, Int_t maxFiles = 10, const char* year = "08")
 		TString collectionFile(pattern) ; 
 		collectionFile.ReplaceAll("*.root", ".xml") ; 
 		if ( gSystem->AccessPathName(collectionFile) == 0 ) { // get the list of files from an a-priori created collection file
-			TAlienCollection collection(collectionFile.Data(), maxFiles) ; 
-			result = collection.GetGridResult("", 0, 0); 
+			TGridCollection *collection gGrid->OpenCollection(collectionFile.Data(), maxFiles);
+			result = collection->GetGridResult("", 0, 0);
 		} else { 
 			TString baseDir; 
 			baseDir.Form("/alice/data/20%s/",year);


### PR DESCRIPTION
This pull request introduces changes in AliRoot in such a way that access to the GRID is done through abstract classes instead of using specific implementations. These changes are needed in order to support both GRID plugins and their corresponding classes (TAlien and TJalien). Modifications in this pull request have been discussed in Computing Board (link).

The corresponding AliPhysics pull request is here: https://github.com/alisw/AliPhysics/pull/8186

The changes are split into the following 5 steps:

- [x] 527f58a1027d69114e72adbacccb33b9dd887708 Don't check if ROOT has alien
- [x] 5da15eca047cdaac229b9e82a8336e1a92e89dac, 4487e0b04f41aae244efb0c4423d85e28d9c4158, eecd93bd086f1b8d7668c2dc11048db106800060 Remove strong dependencies on TAlien in .cxx files
- [x] fc5320ecc5332b5e302e71d3a5eb26874e1e7dc7, Changes from TAlien to TGrid in macros (runtime)
- [ ] ~Changes related to TAlienCollection and TAlienFile (needs more attention)~
- [ ] ~Update validation scripts to check for JAliEn errors, too~

Edit 1: Formatting, and fixed the commit hashes.
Edit 2: Added commit hash for changes in the macros.