### PR TITLE
Add modified version of forced Lc->pK0 decay to AliDecayerPythia

### DIFF
--- a/EVGEN/AliDecayer.h
+++ b/EVGEN/AliDecayer.h
@@ -23,7 +23,7 @@ typedef enum
     kElectronEM, kGammaEM, kDiElectronEM, kBeautyUpgrade,
     kHadronicDWithV0,kHadronicDWithout4BodiesWithV0,kAllEM,
     kLcpKpi, kLcpK0S, kHFYellowReport, kHadronicDPionicD0, kHadronicDWithV0PionicD0, kHadronicDWithout4BodiesPionicD0,
-    kHadronicDWithout4BodiesWithV0PionicD0,kHadronicDPionicD0pure,kHadronicDPionicD0K,kHadronicDPionicD0pi
+    kHadronicDWithout4BodiesWithV0PionicD0,kHadronicDPionicD0pure,kHadronicDPionicD0K,kHadronicDPionicD0pi, kLcpK0SBDTsig
 } Decay_t;
 #endif
 

--- a/PYTHIA6/AliPythia6/AliDecayerPythia.cxx
+++ b/PYTHIA6/AliPythia6/AliDecayerPythia.cxx
@@ -591,7 +591,9 @@ void AliDecayerPythia::ForceDecay()
      case kLcpK0S:
         ForceHadronicD(0,0,2);
         break;
-
+     case kLcpK0SBDTsig:
+        ForceHadronicD(0,0,4);
+        break;
     }
 }
 
@@ -912,13 +914,18 @@ void AliDecayerPythia::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, In
     }
     if (optForceLcChannel == 2) { //pK0S
       ForceParticleDecay(4122,prodLcpK0S,multLcpK0S,2,1); //Lc to p + K0
-      ForceParticleDecay(311,310,1);	//K0 -> K0S
-      ForceParticleDecay(310,211,2);	//K0S -> pion x 2
     }
     if(optForceLcChannel == 3) { // Lambda Pi+ Pi0
       ForceParticleDecay(4122, prodLcLambdaPiPlPi0, multLcLambdaPiPlPi0, 3, 1);
     }
-      
+    
+    if(optForceLcChannel == 4) { // pK0S for BDT signal training: force all K0->K0S->pi+pi-
+      ForceParticleDecay(4122,prodLcpK0S,multLcpK0S,2,1); //Lc to p + K0
+      ForceParticleDecay(311,310,1); // K0 -> K0S
+      ForceParticleDecay(310,211,2); // K0S -> pi+ pi-
+    }
+
+  
 
 }
 

--- a/PYTHIA6/AliPythia6/AliDecayerPythia.cxx
+++ b/PYTHIA6/AliPythia6/AliDecayerPythia.cxx
@@ -911,7 +911,9 @@ void AliDecayerPythia::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, In
       ForceParticleDecay(4122,prodLcpKpi,multLcpKpi,3,1);
     }
     if (optForceLcChannel == 2) { //pK0S
-      ForceParticleDecay(4122,prodLcpK0S,multLcpK0S,2,1);
+      ForceParticleDecay(4122,prodLcpK0S,multLcpK0S,2,1); //Lc to p + K0
+      ForceParticleDecay(311,310,1);	//K0 -> K0S
+      ForceParticleDecay(310,211,2);	//K0S -> pion x 2
     }
     if(optForceLcChannel == 3) { // Lambda Pi+ Pi0
       ForceParticleDecay(4122, prodLcLambdaPiPlPi0, multLcLambdaPiPlPi0, 3, 1);


### PR DESCRIPTION
Modification to "forced" Lambda_c ->pK0 option in AliDecayerPythia to force the decays of the K0 daughter in the correct channel (K0 -> K0S -> pi+pi-), to be used for simulation of training signal samples for ML analyses.

As the modified option affects all kaons in the sample we add it as a separate option (kLcpK0SBDTsig) complementary to the original option (kLcpK0S). Corresponding custom generator will be added by pull request to AliDPG shortly.