### PR TITLE
Fix: avoid non-init members, set extra module info properly.

### DIFF
--- a/ITS/ITSbase/AliITStrackV2.cxx
+++ b/ITS/ITSbase/AliITStrackV2.cxx
@@ -79,6 +79,7 @@ AliITStrackV2::AliITStrackV2(AliESDtrack& t,Bool_t c):
   }
 
   for(Int_t i=0; i<AliITSgeomTGeo::kNLayers; i++) {fSharedWeight[i]=0;}
+  for(Int_t i=0; i<2*AliITSgeomTGeo::kNLayers; i++) { fModule[i] = -1;}
   for(Int_t i=0; i<4; i++) fdEdxSample[i]=0;
 }
 
@@ -87,7 +88,7 @@ void AliITStrackV2::ResetClusters() {
   //------------------------------------------------------------------
   // Reset the array of attached clusters.
   //------------------------------------------------------------------
-  for (Int_t i=0; i<2*AliITSgeomTGeo::kNLayers; i++) fIndex[i]=-1;
+  for (Int_t i=0; i<2*AliITSgeomTGeo::kNLayers; i++) {fIndex[i]=-1; fModule[i] = -1;}
   for (Int_t i=0; i<AliITSgeomTGeo::kNLayers; i++) {fSharedWeight[i]=0;}
   SetChi2(0.); 
   SetNumberOfClusters(0);

--- a/ITS/ITSbase/AliITStrackerMI.cxx
+++ b/ITS/ITSbase/AliITStrackerMI.cxx
@@ -2708,7 +2708,8 @@ Bool_t AliITStrackerMI::RefitAt(Double_t xx,AliITStrackMI *track,
        }
        if (cci>=0) {
 	 track->SetExtraCluster(ilayer,(ilayer<<28)+cci);
-	 track->SetExtraModule(ilayer,idetExtra);
+	 //track->SetExtraModule(ilayer,idetExtra);
+	 track->SetModuleIndexInfo(ilayer+AliITSgeomTGeo::kNLayers, idetExtra);
        }
      } // end search for extra clusters in overlapped modules
      


### PR DESCRIPTION
fModule member of ITStrackV2 was not initialized, leading to random
values stored in the ESDtrack::fITSModule array.

When "extra" clusters were recorded, the module ID was not stored according
to the conventions of SetModuleIndexInfo.