### PR TITLE
remove cause for format-truncation warning

### DIFF
--- a/STEER/STEER/AliLHCDipValT.h
+++ b/STEER/STEER/AliLHCDipValT.h
@@ -117,8 +117,8 @@ Char_t* AliLHCDipValT<Element>::TimeAsString(double t, Bool_t utc)
   static char buff[22];
   time_t tt = (time_t) t;
   struct tm *time = utc ? gmtime(&tt) : localtime(&tt);
-  if (snprintf(buff,21,"%02d:%02d:%02d %02d/%02d/%04d",time->tm_hour,time->tm_min,time->tm_sec,
-	  time->tm_mday,time->tm_mon+1,time->tm_year+1900) ) return (char*)buff;
+  if ( snprintf(buff,21,"%02d:%02d:%02d %02d/%02d/%04d",time->tm_hour,time->tm_min,time->tm_sec,
+	  time->tm_mday,time->tm_mon+1,time->tm_year+1900) > 0 ) return (char*)buff;
   return 0x0;
 }
 

--- a/STEER/STEER/AliLHCDipValT.h
+++ b/STEER/STEER/AliLHCDipValT.h
@@ -117,9 +117,9 @@ Char_t* AliLHCDipValT<Element>::TimeAsString(double t, Bool_t utc)
   static char buff[22];
   time_t tt = (time_t) t;
   struct tm *time = utc ? gmtime(&tt) : localtime(&tt);
-  snprintf(buff,21,"%02d:%02d:%02d %02d/%02d/%04d",time->tm_hour,time->tm_min,time->tm_sec,
-	  time->tm_mday,time->tm_mon+1,time->tm_year+1900);
-  return (char*)buff;
+  if (snprintf(buff,21,"%02d:%02d:%02d %02d/%02d/%04d",time->tm_hour,time->tm_min,time->tm_sec,
+	  time->tm_mday,time->tm_mon+1,time->tm_year+1900) ) return (char*)buff;
+  return 0x0;
 }
 
 //__________________________________________________________________________


### PR DESCRIPTION
on gcc version >=7, the snprintf call caused a format-truncation warning. By default, -Werror is used, so the warning prevented compilation.  