### PR TITLE
Fix behaviour when 1st generated particle has unknown PDG (R. Shahoyan)

### DIFF
--- a/STEER/STEERBase/AliStack.cxx
+++ b/STEER/STEERBase/AliStack.cxx
@@ -177,8 +177,9 @@ void AliStack::PushTrack(Int_t done, Int_t parent, Int_t pdg, const Float_t *pmo
 		 vpos[0], vpos[1], vpos[2], tof, polar[0], polar[1], polar[2],
 		 mech, ntr, weight, is);
     } else {
-	AliWarning(Form("Particle type %d not defined in PDG Database !", pdg));
-	AliWarning("Particle skipped !");
+      ntr = -1;
+      AliWarning(Form("Particle type %d not defined in PDG Database !", pdg));
+      AliWarning("Particle skipped !");
     }
 }
 

--- a/THijing/AliGenHijing.cxx
+++ b/THijing/AliGenHijing.cxx
@@ -465,8 +465,10 @@ void AliGenHijing::Generate()
 		 //printf(" Putting spec.p from targ. %d into the stack\n", countSpecTp);
 	      }
 	      PushTrack(tFlag,imo,kf,p,origin,polar,tof,kPNoProcess,nt, 1., ks);
-	      fNprimaries++;
-	      KeepTrack(nt);
+	      if (nt>=0) {
+		fNprimaries++;
+		KeepTrack(nt);
+	      }
 	      newPos[i] = nt;
 	  } // if selected
       } // particle loop


### PR DESCRIPTION
This is needed for HIJING, e.g. when particle 3124 is the first (and
its PDG is unknown), then the track is not added, and we should
account for this.