### PR TITLE
MTR: fix unitialised values reported by valgrind

### DIFF
--- a/MUON/MUONgeometry/AliMUONVGeometryBuilder.cxx
+++ b/MUON/MUONgeometry/AliMUONVGeometryBuilder.cxx
@@ -23,6 +23,8 @@
 // 23/01/2004
 //-----------------------------------------------------------------------------
 
+#include <cassert>
+
 #include "AliMUONVGeometryBuilder.h"
 #include "AliMUONGeometryModule.h"
 #include "AliMUONGeometryDetElement.h"
@@ -288,7 +290,8 @@ void AliMUONVGeometryBuilder::SetTransformation(Int_t moduleId,
     = TGeoCombiTrans(translation, rotation);
 
   // Apply frame transform
-  TGeoHMatrix newTransform = ConvertTransform(transformation);
+  TGeoHMatrix newTransform;
+  assert(newTransform = ConvertTransform(transformation));
 
   // Set new transformation
   geometry->SetTransformation(newTransform);

--- a/MUON/MUONsim/AliMUONTriggerGeometryBuilder.cxx
+++ b/MUON/MUONsim/AliMUONTriggerGeometryBuilder.cxx
@@ -1623,7 +1623,7 @@ void AliMUONTriggerGeometryBuilder::BuildChamberTypeE(Int_t& iVolNum, Int_t icou
     Float_t zRatio = AliMUONConstants::DefaultRatioTriggerChamber(icount);      
     Float_t xEnv = (fgkDXZERO+fgkXMAX/2.)*zRatio;
    
-   Double_t dpar[3];    
+   Double_t dpar[3];     
    Double_t spar[3];    
    Double_t ppar[3];    
 
@@ -1632,6 +1632,9 @@ void AliMUONTriggerGeometryBuilder::BuildChamberTypeE(Int_t& iVolNum, Int_t icou
    Float_t yEnvM = 0;
    yEnvP = (fYEnvMsave + fgkYMIN * zRatio ) * zpm + fgkYMIN * zRatio;
    yEnvM = (fYEnvPsave + fgkYMIN * zRatio ) * zmp + fgkYMIN * zRatio;
+   dpar[0] = (fgkXMAX/2.)*zRatio;
+   dpar[1] =  fgkYMIN*zRatio;
+   dpar[2] = 0.4;
 
    Int_t detElemId = (10+icount+1)*100+15;
    TString volEnv1 = GetVolEnvName(icount, 1);


### PR DESCRIPTION
valgrind reports "Conditional jump or move depends on uninitialised value(s)", here are two fixes.
 
One of them could come from a bug:

 AliMUONTriggerGeometryBuilder::BuildChamberTypeE

Double_t dpar[3] = {0., 0., 0.};

why not initialised?