### PR TITLE
Fix compiler warnings & indentation inconsistencies

### DIFF
--- a/EVE/EveBase/AliEveESDTracks.cxx
+++ b/EVE/EveBase/AliEveESDTracks.cxx
@@ -884,7 +884,7 @@ TEveElementList* AliEveESDTracks::ByPt()
 //                if(shade>3)shade=-3;
 //            }
 //            
-            track->SetName(Form("ESD Track idx=%d, pt=%d", at->GetID(), pt));
+            track->SetName(Form("ESD Track idx=%d, pt=%f", at->GetID(), pt));
             tlist->AddElement(track);
 //        }
     }
@@ -1067,10 +1067,3 @@ TEveTrackList* AliEveESDTracks::HLTTracks()
     
     return cont;
 }
-
-
-
-
-
-
-

--- a/MUON/MUONcalib/AliMUONPedestal.cxx
+++ b/MUON/MUONcalib/AliMUONPedestal.cxx
@@ -336,18 +336,18 @@ void AliMUONPedestal::Finalize()
     {
       if(nADCmax>0)
 	{ frac1 = float(nADCmax)/float(fNChannel); 
-	  detail=Form("%s : Warning: Nb of Channels with bad Pedestal (Ped=4095) = %d over %d (%6.2f%)",fPrefixLDC.Data(),nADCmax,fNChannel,frac1*100.);
+	  detail=Form("%s : Warning: Nb of Channels with bad Pedestal (Ped=4095) = %d over %d (%6.2f%%)",fPrefixLDC.Data(),nADCmax,fNChannel,frac1*100.);
 	  printf("%s\n",detail);
 	  (*fFilcout) <<  detail << endl;}
 
       if(nADC4090>0)
 	{ frac2 = 1.*nADC4090/fNChannel; 
-	  detail=Form("%s : Warning: Nb of Channels with PedSigma<0.5 (Ped=4090) = %d over %d (%6.2f%)",fPrefixLDC.Data(),nADC4090,fNChannel,frac2*100.);
+	  detail=Form("%s : Warning: Nb of Channels with PedSigma<0.5 (Ped=4090) = %d over %d (%6.2f%%)",fPrefixLDC.Data(),nADC4090,fNChannel,frac2*100.);
 	  printf("%s\n",detail);
 	  (*fFilcout) <<  detail << endl; }
 
       if (frac1+frac2 > frac_badped) { status=-1 ;
-	detail=Form("\n%s !!! ERROR : fraction of Channels with Pedestal>=4090 = %6.2f% (> %5.2f%)  (status= %d) \n",fPrefixLDC.Data(),(frac1+frac2)*100.,frac_badped*100.,status);
+	detail=Form("\n%s !!! ERROR : fraction of Channels with Pedestal>=4090 = %6.2f%% (> %5.2f%%)  (status= %d) \n",fPrefixLDC.Data(),(frac1+frac2)*100.,frac_badped*100.,status);
 	//2015-02-08	(*fFilcout) <<  detail << endl; printf("%s",detail) ;}
 	(*fFilcout) <<  detail << endl; fprintf(stderr,"%s",detail) ;}
     }

--- a/STEER/AOD/AliAODEvent.h
+++ b/STEER/AOD/AliAODEvent.h
@@ -267,8 +267,10 @@ class AliAODEvent : public AliVEvent {
     {new((*fJets)[fJets->GetEntriesFast()]) AliAODJet(*vtx); return fJets->GetEntriesFast()-1;}
 
   // -- Tracklets
-  AliAODTracklets *GetTracklets() const { return fTracklets; }  
-  AliAODTracklets *GetMultiplicity() const {return GetTracklets();}
+  using AliVEvent::GetMultiplicity;
+  AliAODTracklets *GetTracklets() const { return fTracklets; }
+  virtual AliAODTracklets *GetMultiplicity() const { return GetTracklets(); }
+
   // -- Calorimeter Cells
   AliAODCaloCells *GetEMCALCells() const { return fEmcalCells; }
   AliAODCaloCells *GetPHOSCells() const { return fPhosCells; }
@@ -328,9 +330,10 @@ class AliAODEvent : public AliVEvent {
   AliAODTZERO *GetTZEROData() const { return fAODTZERO; }
   Double32_t GetT0TOF(Int_t icase) const { return fAODTZERO?fAODTZERO->GetT0TOF(icase):999999;}
   const Double32_t * GetT0TOF() const { return fAODTZERO?fAODTZERO->GetT0TOF():0x0;}
- 
-  // VZERO 
-  AliAODVZERO *GetVZEROData() const { return fAODVZERO; }
+
+  // VZERO
+  using AliVEvent::GetVZEROData;
+  virtual AliAODVZERO *GetVZEROData() const { return fAODVZERO; }
   virtual const Float_t* GetVZEROEqFactors() const {return fHeader?fHeader->GetVZEROEqFactors():0x0;}
   virtual Float_t        GetVZEROEqMultiplicity(Int_t i) const;
   virtual void   SetVZEROEqFactors(Float_t factors[64]) const {

--- a/STEER/AOD/AliAODEvent.h
+++ b/STEER/AOD/AliAODEvent.h
@@ -47,7 +47,7 @@ class AliEventplane;
 
 class AliAODEvent : public AliVEvent {
 
- public :
+public:
   enum AODListIndex_t {kAODHeader,
 		       kAODTracks,
 		       kAODVertices,
@@ -58,8 +58,8 @@ class AliAODEvent : public AliVEvent {
 		       kAODEmcalCells,
 		       kAODPhosCells,
 		       kAODCaloClusters,
-	           kAODEMCALTrigger,
-	           kAODPHOSTrigger,
+	               kAODEMCALTrigger,
+	               kAODPHOSTrigger,
 		       kAODFmdClusters,
 		       kAODPmdClusters,
                        kAODHMPIDrings,
@@ -68,7 +68,7 @@ class AliAODEvent : public AliVEvent {
 		       kAODVZERO,
 		       kAODZDC,
 		       kAODAD,
-		       kTOFHeader,                       
+		       kTOFHeader,
 		       kAODTrdTracks,
 		       kAODListN
   };
@@ -83,16 +83,16 @@ class AliAODEvent : public AliVEvent {
   void          AddObject(TObject *obj);
   void          RemoveObject(TObject *obj);
   TObject      *FindListObject(const char *objName) const;
-  TList        *GetList()                const { return fAODObjects; }
+  TList        *GetList() const { return fAODObjects; }
   void          SetConnected(Bool_t conn=kTRUE) {fConnected=conn;}
   Bool_t        GetConnected() const {return fConnected;}
   Bool_t        AreTracksConnected() const {return fTracksConnected;}
 
   // -- Header
-  AliVHeader    *GetHeader()              const { return fHeader; }
+  AliVHeader   *GetHeader() const { return fHeader; }
   void          AddHeader(const AliVHeader* hdx)
     {
-      delete fHeader; 
+      delete fHeader;
       if(dynamic_cast<const AliAODHeader*>(hdx)) {
 	fHeader = new AliAODHeader(*(const AliAODHeader*)hdx);
       } else if (dynamic_cast<const AliNanoAODHeader*>(hdx)) {
@@ -101,7 +101,7 @@ class AliAODEvent : public AliVEvent {
       else {
         AliError(Form("Unknown header type %s", hdx->ClassName()));
       }
-        (fAODObjects->FirstLink())->SetObject(fHeader);
+      fAODObjects->FirstLink()->SetObject(fHeader);
     }
 
   virtual  Bool_t InitMagneticField() const {return fHeader ? fHeader->InitMagneticField() : kFALSE;}
@@ -136,7 +136,7 @@ class AliAODEvent : public AliVEvent {
   Double_t GetSigma2DiamondX() const {return fHeader ? fHeader->GetSigma2DiamondX() : -999.;}
   Double_t GetSigma2DiamondY() const {return fHeader ? fHeader->GetSigma2DiamondY() : -999.;}
   Double_t GetSigma2DiamondZ() const {return fHeader ? fHeader->GetSigma2DiamondZ() : -999.;}
-  
+
   void      SetEventType(UInt_t eventType){fHeader->SetEventType(eventType);}
   void      SetTriggerMask(ULong64_t n) {fHeader->SetTriggerMask(n);}
   void      SetTriggerCluster(UChar_t n) {fHeader->SetTriggerCluster(n);}
@@ -178,7 +178,7 @@ class AliAODEvent : public AliVEvent {
   AliAODVertex *GetVertex(Int_t nVertex) const { return fVertices?(AliAODVertex*)fVertices->At(nVertex):0; }
   Int_t         AddVertex(const AliAODVertex* vtx)
   {new((*fVertices)[fVertices->GetEntriesFast()]) AliAODVertex(*vtx); return fVertices->GetEntriesFast()-1;}
-  
+
   // primary vertex
   using AliVEvent::GetPrimaryVertex;
   using AliVEvent::GetPrimaryVertexSPD;
@@ -188,7 +188,7 @@ class AliAODEvent : public AliVEvent {
   virtual AliAODVertex *GetVertex() const { return GetPrimaryVertexSPD(); }
   virtual AliAODVertex *GetPrimaryVertexTPC() const;
 
-  // -- Pileup vertices 
+  // -- Pileup vertices
   Int_t         GetNumberOfPileupVerticesTracks()   const;
   Int_t         GetNumberOfPileupVerticesSPD()    const;
   virtual AliAODVertex *GetPileupVertexSPD(Int_t iV=0) const;
@@ -224,13 +224,13 @@ class AliAODEvent : public AliVEvent {
   AliAODCaloCluster *GetCaloCluster(Int_t nCluster) const { return fCaloClusters?(AliAODCaloCluster*)fCaloClusters->UncheckedAt(nCluster):0x0; }
   Int_t         AddCaloCluster(const AliAODCaloCluster* clus)
   {new((*fCaloClusters)[fCaloClusters->GetEntriesFast()]) AliAODCaloCluster(*clus); return fCaloClusters->GetEntriesFast()-1;}
-  AliAODCaloTrigger *GetCaloTrigger(TString calo) const 
-  { 	  
+  AliAODCaloTrigger *GetCaloTrigger(TString calo) const
+  {
      if (calo.Contains("EMCAL")) return fEMCALTrigger;
      else
-     return fPHOSTrigger; 
-  }	
-	
+     return fPHOSTrigger;
+  }
+
   Int_t GetEMCALClusters(TRefArray *clusters) const;
   Int_t GetPHOSClusters(TRefArray *clusters) const;
 
@@ -249,16 +249,16 @@ class AliAODEvent : public AliVEvent {
   Int_t         AddPmdCluster(const AliAODPmdCluster* clus)
   {new((*fPmdClusters)[fPmdClusters->GetEntriesFast()]) AliAODPmdCluster(*clus); return fPmdClusters->GetEntriesFast()-1;}
 
-  // -- HMPID objects 
-  TClonesArray *GetHMPIDrings()       const {return fHMPIDrings; } 
+  // -- HMPID objects
+  TClonesArray *GetHMPIDrings()       const {return fHMPIDrings; }
   Int_t         GetNHMPIDrings()      const;
   AliAODHMPIDrings *GetHMPIDring(Int_t nRings) const;
-  Int_t         AddHMPIDrings(const  AliAODHMPIDrings* ring) 
+  Int_t         AddHMPIDrings(const  AliAODHMPIDrings* ring)
   {new((*fHMPIDrings)[fHMPIDrings->GetEntriesFast()]) AliAODHMPIDrings(*ring); return fHMPIDrings->GetEntriesFast()-1;}
-  
+
   AliAODHMPIDrings *GetHMPIDringForTrackID(Int_t trackID) const;
-  
-  
+
+
   // -- Jet
   TClonesArray *GetJets()            const { return fJets; }
   Int_t         GetNJets()           const { return fJets?fJets->GetEntriesFast():0; }
@@ -284,7 +284,7 @@ class AliAODEvent : public AliVEvent {
   Int_t         GetNumberOfDimuons() const;
   AliAODDimuon *GetDimuon(Int_t nDimu) const;
   Int_t         AddDimuon(const AliAODDimuon* dimu);
-  
+
   // // -- TRD
   Int_t GetNumberOfTrdTracks() const { return fTrdTracks ? fTrdTracks->GetEntriesFast() : 0; }
   AliAODTrdTrack* GetTrdTrack(Int_t i) const {
@@ -297,36 +297,36 @@ class AliAODEvent : public AliVEvent {
   void    SetStdNames();
   void    GetStdContent();
   void    CreateStdFolders();
-  void    ResetStd(Int_t trkArrSize = 0, 
-		   Int_t vtxArrSize = 0, 
-		   Int_t v0ArrSize = 0, 
+  void    ResetStd(Int_t trkArrSize = 0,
+		   Int_t vtxArrSize = 0,
+		   Int_t v0ArrSize = 0,
 		   Int_t cascadeArrSize = 0,
-		   Int_t jetSize = 0, 
-		   Int_t caloClusSize = 0, 
-		   Int_t fmdClusSize = 0, 
+		   Int_t jetSize = 0,
+		   Int_t caloClusSize = 0,
+		   Int_t fmdClusSize = 0,
 		   Int_t pmdClusSize = 0,
                    Int_t hmpidRingsSize = 0,
 		   Int_t dimuonArrsize =0,
 		   Int_t nTrdTracks = 0
 		   );
   void    ClearStd();
-  void    Reset(); 
+  void    Reset();
   void    ReadFromTree(TTree *tree, Option_t* opt = "");
   void    WriteToTree(TTree* tree) const {tree->Branch(fAODObjects);}
 
   void  Print(Option_t *option="") const;
   void  MakeEntriesReferencable();
   static void AssignIDtoCollection(const TCollection* col);
-  
+
     //Following needed only for mixed event
   virtual Int_t        EventIndex(Int_t)       const {return 0;}
   virtual Int_t        EventIndexForCaloCluster(Int_t) const {return 0;}
   virtual Int_t        EventIndexForPHOSCell(Int_t)    const {return 0;}
-  virtual Int_t        EventIndexForEMCALCell(Int_t)   const {return 0;} 
-  AliCentrality*       GetCentrality() {return fHeader->GetCentralityP();} 
+  virtual Int_t        EventIndexForEMCALCell(Int_t)   const {return 0;}
+  AliCentrality*       GetCentrality() {return fHeader->GetCentralityP();}
   AliEventplane*       GetEventplane() {return fHeader->GetEventplaneP();}
 
-  // TZERO 
+  // TZERO
   AliAODTZERO *GetTZEROData() const { return fAODTZERO; }
   Double32_t GetT0TOF(Int_t icase) const { return fAODTZERO?fAODTZERO->GetT0TOF(icase):999999;}
   const Double32_t * GetT0TOF() const { return fAODTZERO?fAODTZERO->GetT0TOF():0x0;}
@@ -342,14 +342,14 @@ class AliAODEvent : public AliVEvent {
 
   //ZDC
   AliAODZDC   *GetZDCData() const { return fAODZDC; }
-  
+
   //AD
   AliAODAD   *GetADData() const { return fAODAD; }
 
   virtual AliVEvent::EDataLayoutType GetDataLayoutType() const;
   void FixCascades();
 
-  private :
+private:
 
   TList   *fAODObjects; ///< list of AODObjects
   TFolder *fAODFolder;  ///< folder structure of branches
@@ -381,7 +381,7 @@ class AliAODEvent : public AliVEvent {
                              //  It contains also TOF time resolution
                              //  and T0spread as written in OCDB
   TClonesArray    *fTrdTracks;    //!<! TRD AOD tracks (triggered)
-  
+
   static const char* fAODListName[kAODListN]; //!<!
 
   ClassDef(AliAODEvent,94);

--- a/STEER/ESD/AliCascadeVertexer.cxx
+++ b/STEER/ESD/AliCascadeVertexer.cxx
@@ -280,12 +280,12 @@ Double_t AliCascadeVertexer::PropagateToDCACurvedBachelor(AliESDv0 *v, AliExtern
   // assumes that bachelor track is not straight
   // algorithm based on AliExternalTrackParam::GetDCA with zero curvature track
   //--------------------------------------------------------------------
-  Double_t alpha=t->GetAlpha(), cs1=TMath::Cos(alpha), sn1=TMath::Sin(alpha);
+  // Double_t alpha=t->GetAlpha(), cs1=TMath::Cos(alpha), sn1=TMath::Sin(alpha);
   Double_t r[3]; t->GetXYZ(r);
-  Double_t x1=r[0], y1=r[1], z1=r[2];
+  // Double_t x1=r[0], y1=r[1], z1=r[2];
   Double_t p[3]; t->GetPxPyPz(p);
-  Double_t px1=p[0], py1=p[1], pz1=p[2];
-  
+  // Double_t px1=p[0], py1=p[1], pz1=p[2];
+
   Double_t x2,y2,z2;     // position and momentum of V0
   Double_t px2,py2,pz2;
   

--- a/STEER/STEERBase/AliMixedEvent.h
+++ b/STEER/STEERBase/AliMixedEvent.h
@@ -1,4 +1,4 @@
-// -*- mode: C++ -*- 
+// -*- mode: C++ -*-
 #ifndef ALIMIXEDEVENT_H
 #define ALIMIXEDEVENT_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
@@ -9,9 +9,9 @@
 
 //-------------------------------------------------------------------------
 //                          Class AliMixedEvent
-// VEvent which is the container of several VEvents 
-// Use Case: Event Mixing     
-// Origin: Andreas Morsch, CERN, Andreas.Morsch@cern.ch 
+// VEvent which is the container of several VEvents
+// Use Case: Event Mixing
+// Origin: Andreas Morsch, CERN, Andreas.Morsch@cern.ch
 //-------------------------------------------------------------------------
 
 #include "AliVEvent.h"
@@ -24,22 +24,22 @@ class AliVVertex;
 class AliMixedEvent : public AliVEvent {
 
 public:
-    
+
     AliMixedEvent();
     virtual ~AliMixedEvent() ;
-    AliMixedEvent(const AliMixedEvent& vEvnt); 
+    AliMixedEvent(const AliMixedEvent& vEvnt);
     AliMixedEvent& operator=(const AliMixedEvent& vEvnt);
-    
+
     // Services from VEvent
     virtual void AddObject(TObject* /*obj*/) {;}
     virtual TObject* FindListObject(const char* /*name*/) const {return 0;}
     virtual TList* GetList() const {return 0;}
     virtual void CreateStdContent() {;}
     virtual void GetStdContent() {;}
-    virtual void ReadFromTree(TTree* /*tree*/, Option_t* /*opt*/) {;} 
+    virtual void ReadFromTree(TTree* /*tree*/, Option_t* /*opt*/) {;}
     virtual void WriteToTree(TTree* /*tree*/) const {;}
-    virtual void SetStdNames() {;} 
-    virtual void Print(Option_t * /*option*/) const  {;} 
+    virtual void SetStdNames() {;}
+    virtual void Print(Option_t * /*option*/) const  {;}
     // Specific Services
     virtual void AddEvent(AliVEvent* evt);
     virtual void SetPrimaryVertex(AliVVertex* newVertex) {fMeanVertex = newVertex;}
@@ -47,29 +47,29 @@ public:
     virtual void Init();
     const AliVVertex* GetEventVertex(Int_t i) const;
     const AliVVertex* GetVertexOfEvent(Int_t i) const;
-    Int_t        GetNumberOfEvents() {return fNEvents;}      
-  
+    Int_t        GetNumberOfEvents() {return fNEvents;}
+
     // Header
     virtual AliVHeader* GetHeader() const {return 0;}
 
     // Delegated methods for fESDRun or AODHeader
-  
-    virtual void     SetRunNumber(Int_t /*n*/)         {;} 
-    virtual void     SetPeriodNumber(UInt_t /*n*/)     {;} 
-    virtual void     SetMagneticField(Double_t /*mf*/) {;} 
-    
-    virtual Int_t    GetRunNumber()     const  {return -999 ;} 
-    virtual UInt_t   GetPeriodNumber()  const  {return    0 ;} 
+
+    virtual void     SetRunNumber(Int_t /*n*/)         {;}
+    virtual void     SetPeriodNumber(UInt_t /*n*/)     {;}
+    virtual void     SetMagneticField(Double_t /*mf*/) {;}
+
+    virtual Int_t    GetRunNumber()     const  {return -999 ;}
+    virtual UInt_t   GetPeriodNumber()  const  {return    0 ;}
     virtual Double_t GetMagneticField() const;
-    
-    
+
+
     virtual Double_t GetDiamondX() const {return -999.;}
     virtual Double_t GetDiamondY() const {return -999.;}
     virtual void     GetDiamondCovXY(Float_t cov[3]) const
 	{cov[0]=-999.; return;}
-  
+
   // Delegated methods for fHeader
-    virtual void      SetOrbitNumber(UInt_t /*n*/)        {;} 
+    virtual void      SetOrbitNumber(UInt_t /*n*/)        {;}
     virtual void      SetBunchCrossNumber(UShort_t /*n*/) {;}
     virtual void      SetEventType(UInt_t /*eventType*/)  {;}
     virtual void      SetTriggerMask(ULong64_t /*n*/)     {;}
@@ -80,20 +80,20 @@ public:
     virtual UInt_t    GetEventType()        const  {return    0;}
     virtual ULong64_t GetTriggerMask()      const  {return    0;}
     virtual UChar_t   GetTriggerCluster()   const  {return    0;}
-    virtual TString   GetFiredTriggerClasses() const {return    ("");}     
+    virtual TString   GetFiredTriggerClasses() const {return    ("");}
 
     virtual Double_t  GetZDCN1Energy()            const {return -999.;}
     virtual Double_t  GetZDCP1Energy()            const {return -999.;}
     virtual Double_t  GetZDCN2Energy()            const {return -999.;}
     virtual Double_t  GetZDCP2Energy()            const {return -999.;}
     virtual Double_t  GetZDCEMEnergy(Int_t /*i*/) const {return -999.;}
- 
+
   // Tracks
     virtual AliVParticle *GetTrack(Int_t i)    const;
     virtual Int_t        GetNumberOfTracks()   const {return fNumberOfTracks;}
     virtual Int_t        GetNumberOfV0s()      const {return -999;}
     virtual Int_t        GetNumberOfCascades() const {return -999;}
-  
+
     // Calo Clusters and cells
   virtual AliVCluster *GetCaloCluster(Int_t i)     const;
   virtual Int_t        GetNumberOfCaloClusters()   const {return fNumberOfCaloClusters;}
@@ -101,8 +101,8 @@ public:
   virtual AliVCaloCells *GetEMCALCells()           const {return fEMCALCells;}
   virtual Int_t        GetNumberOfPHOSCells()      const {return fNumberOfPHOSCells;}
   virtual Int_t        GetNumberOfEMCALCells()     const {return fNumberOfEMCALCells;}
-  virtual Int_t*       GetPHOSCellsCumul()         const {return fNPHOSCellsCumul;} 
-  virtual Int_t*       GetEMCALCellsCumul()        const {return fNEMCALCellsCumul;} 
+  virtual Int_t*       GetPHOSCellsCumul()         const {return fNPHOSCellsCumul;}
+  virtual Int_t*       GetEMCALCellsCumul()        const {return fNEMCALCellsCumul;}
   virtual Int_t        GetNCaloClustersCumul(Int_t iev) const {return fNCaloClustersCumul[iev];}
 
 
@@ -127,7 +127,7 @@ public:
 
 private:
   TList   fEventList;            //! List of Events
-  Int_t   fNEvents;              //! Number of Events 
+  Int_t   fNEvents;              //! Number of Events
   Int_t   fNumberOfTracks;       //! Total number of tracks
   Int_t   fNumberOfCaloClusters; //! Total number of calo clusters
   Int_t   fNumberOfPHOSCells;    //! Total number of PHOS Cells
@@ -136,11 +136,10 @@ private:
   Int_t*  fNCaloClustersCumul;   //! Cumulant
   Int_t*  fNPHOSCellsCumul;      //! Cumulant
   Int_t*  fNEMCALCellsCumul;     //! Cumulant
-  AliVCaloCells* fPHOSCells;     //! array ofPHOS cells  
-  AliVCaloCells* fEMCALCells;    //! array ofPHOS cells  
+  AliVCaloCells* fPHOSCells;     //! array ofPHOS cells
+  AliVCaloCells* fEMCALCells;    //! array ofPHOS cells
   AliVVertex* fMeanVertex;    //! Mean vertex
-    
+
     ClassDef(AliMixedEvent, 0)  // Container for mixed events
 };
-#endif 
-
+#endif

--- a/STEER/STEERBase/AliMixedEvent.h
+++ b/STEER/STEERBase/AliMixedEvent.h
@@ -113,14 +113,18 @@ public:
 
   virtual AliCentrality* GetCentrality() {return 0;}
   virtual AliEventplane* GetEventplane() {return 0;}
+
   // Primary vertex
     using AliVEvent::GetPrimaryVertex;
     virtual const AliVVertex   *GetPrimaryVertex() const {return fMeanVertex;}
     virtual Bool_t ComputeVtx(const TObjArray *vertices, Double_t *pos,Double_t *sig,Int_t *nContributors);
+
   // VZERO
+  using AliVEvent::GetVZEROData;
   virtual AliVVZERO *GetVZEROData() const {return 0;}
   virtual AliVZDC     *GetZDCData() const {return 0;}
   virtual EDataLayoutType GetDataLayoutType() const;
+
 private:
   TList   fEventList;            //! List of Events
   Int_t   fNEvents;              //! Number of Events 

--- a/STEER/STEERBase/AliTPCPIDResponse.cxx
+++ b/STEER/STEERBase/AliTPCPIDResponse.cxx
@@ -84,9 +84,9 @@ AliTPCPIDResponse::AliTPCPIDResponse():
   fhEtaSigmaPar1(0x0),
   fSigmaPar0(0.0),
   fCurrentEventMultiplicity(0),
+  fIsNewPbPbParam(kFALSE),
   fCorrFuncSlope(0x0),
   fCorrFuncCurv(0x0),
-  fIsNewPbPbParam(kFALSE),
   fCorrFuncMultiplicity(0x0),
   fCorrFuncMultiplicityTanTheta(0x0),
   fCorrFuncSigmaMultiplicity(0x0),
@@ -210,10 +210,10 @@ AliTPCPIDResponse::AliTPCPIDResponse(const AliTPCPIDResponse& that):
   fhEtaCorr(0x0),
   fhEtaSigmaPar1(0x0),
   fSigmaPar0(that.fSigmaPar0),
+  fCurrentEventMultiplicity(that.fCurrentEventMultiplicity),
+  fIsNewPbPbParam(that.fIsNewPbPbParam),
   fCorrFuncSlope(0x0),
   fCorrFuncCurv(0x0),
-  fIsNewPbPbParam(that.fIsNewPbPbParam),
-  fCurrentEventMultiplicity(that.fCurrentEventMultiplicity),
   fCorrFuncMultiplicity(0x0),
   fCorrFuncMultiplicityTanTheta(0x0),
   fCorrFuncSigmaMultiplicity(0x0),
@@ -227,8 +227,11 @@ AliTPCPIDResponse::AliTPCPIDResponse(const AliTPCPIDResponse& that):
   fSplineArray()
 {
   //copy ctor
-  for (Int_t i=0; i<fgkNumberOfGainScenarios; i++) {fRes0[i]=that.fRes0[i];fResN2[i]=that.fResN2[i];}
- 
+  for (Int_t i=0; i<fgkNumberOfGainScenarios; i++) {
+    fRes0[i] = that.fRes0[i];
+    fResN2[i] = that.fResN2[i];
+  }
+
   // Copy eta maps
   if (that.fhEtaCorr) {
     fhEtaCorr = new TH2D(*(that.fhEtaCorr));


### PR DESCRIPTION
These commits fix minor compiler warnings:

- Hidden-methods for `AliVEvent`: `GetVZEROData` & `GetMultiplicity`
- Member-initialization order in `AliTPCPIDResponse`
- Improper '%' in formatting strings
- Unused variables in `AliCascadeVertexer`

Much of the changes is removal of trailing whitespace & indentation alignment