### PR TITLE
With embedding MCEvent::GenEventHeader combines all headers

### DIFF
--- a/STEER/AOD/AliAODHandler.cxx
+++ b/STEER/AOD/AliAODHandler.cxx
@@ -258,10 +258,9 @@ void AliAODHandler::StoreMCParticles(){
   // Get the Event Header 
   // 
 
-  AliHeader* header = fMCEventH->MCEvent()->Header();
+  //  AliHeader* header = fMCEventH->MCEvent()->Header();
    // get the MC vertex
-  AliGenEventHeader* genHeader = 0;
-  if (header) genHeader = header->GenEventHeader();
+  AliGenEventHeader* genHeader = fMCEventH->MCEvent()->GenEventHeader();
   if (genHeader) {
       TArrayF vtxMC(3);
       genHeader->PrimaryVertex(vtxMC);

--- a/STEER/STEERBase/AliMCEvent.h
+++ b/STEER/STEERBase/AliMCEvent.h
@@ -29,6 +29,7 @@ class AliEventplane;
 class AliStack;
 class AliHeader;
 class AliGenEventHeader;
+class AliGenCocktailEventHeader;
 
 class TClonesArray;
 class TList;
@@ -202,6 +203,7 @@ private:
     Int_t             fNprimaries;       // Number of primaries
     Int_t             fNparticles;       // Number of particles
     TList            *fSubsidiaryEvents; // List of possible subsidiary events (for example merged underlying event)
+    AliGenCocktailEventHeader* fCombinedEvenHeader; //! cocktail from headers of subsidiary events (if any)
     Int_t             fPrimaryOffset;    // Offset for primaries
     Int_t             fSecondaryOffset;  // Offset for secondaries
     Bool_t            fExternal;         // True if external particle array
@@ -211,7 +213,7 @@ private:
     Int_t             fNBG;              //! Background particles in current event
     Int_t             fBGEventReused;    // In case of embedding counts how many time currebt BKG event was used
   
-    ClassDef(AliMCEvent, 3)              // AliVEvent realisation for MC data
+    ClassDef(AliMCEvent, 4)              // AliVEvent realisation for MC data
 };
 
 


### PR DESCRIPTION
In case of embedding AliMCEvent::GenEventHeader() will return AliGenCocktailEventHeader 
(downcasted to AliGenEventHeader) containing the headers of both embedded and background events. 
In order to correspond to primary tracks ordering and make work methods like GetGenerator(itrack), 
the headers of the embedded event are added first, followed by the BKG event headers (e.g. Hijing).