### PR TITLE
AliDirList

### DIFF
--- a/ANALYSIS/ANALYSIS/ANALYSISLinkDef.h
+++ b/ANALYSIS/ANALYSIS/ANALYSISLinkDef.h
@@ -15,5 +15,6 @@
 #pragma link C++ class  AliAnalysisTaskCfg+;
 #pragma link C++ class  AliAnalysisFileDescriptor+;
 #pragma link C++ class  AliXMLParser+;
+#pragma link C++ class  AliDirList;
 
 #endif

--- a/ANALYSIS/ANALYSIS/AliAnalysisDataContainer.cxx
+++ b/ANALYSIS/ANALYSIS/AliAnalysisDataContainer.cxx
@@ -95,6 +95,7 @@ AliAnalysisDataContainer::AliAnalysisDataContainer(const char *name, TClass *typ
 /// Default constructor.
 
    SetTitle(fType->GetName());
+   if (fType->InheritsFrom("AliDirList")) SetDirList(true);
 }
 
 //______________________________________________________________________________
@@ -462,7 +463,9 @@ void AliAnalysisDataContainer::ImportData(AliAnalysisDataWrapper *pack)
       fDataReady = kTRUE;
       // Imported wrappers do not own data anymore (AG 13-11-07)
       pack->SetDeleteData(kFALSE);
-   }   
+      // Imported data is read from file, the container must own it
+      SetDataOwned(true);
+   }
 }      
       
 ClassImp (AliAnalysisDataWrapper)

--- a/ANALYSIS/ANALYSIS/AliAnalysisDataContainer.h
+++ b/ANALYSIS/ANALYSIS/AliAnalysisDataContainer.h
@@ -73,7 +73,6 @@ enum EAnalysisContainerFlags {
    void                      ResetDataReady()     {fDataReady = kFALSE;}
    virtual Bool_t            SetData(TObject *data, Option_t *option="");
    void                      SetDataOwned(Bool_t flag) {fOwnedData = flag;}
-   void                      SetDirList(Bool_t flag) {TObject::SetBit(kDirList,flag);}
    void                      SetExchange(Bool_t flag) {TObject::SetBit(kExchangeData,flag);}
    void                      SetPostEventLoop(Bool_t flag=kTRUE) {TObject::SetBit(kPostEventLoop,flag);}
    void                      SetSpecialOutput(Bool_t flag=kTRUE) {TObject::SetBit(kSpecialOutput,flag);}
@@ -107,7 +106,8 @@ enum EAnalysisContainerFlags {
    void                      PrintContainer(Option_t *option="all", Int_t indent=0) const;
 
 private:
-   void                      SetType(TClass *type) {fType = type;}   
+   void                      SetDirList(Bool_t flag) {TObject::SetBit(kDirList,flag);}
+   void                      SetType(TClass *type) {fType = type;}
 
 protected:
    Bool_t                    fDataReady;  ///< Flag that data is ready

--- a/ANALYSIS/ANALYSIS/AliAnalysisDataContainer.h
+++ b/ANALYSIS/ANALYSIS/AliAnalysisDataContainer.h
@@ -49,7 +49,8 @@ enum EAnalysisContainerFlags {
    kSpecialOutput = BIT(15),
    kRegisterDataset = BIT(16),
    kExchangeData  = BIT(17),
-   kTouchedFlag   = BIT(18)
+   kTouchedFlag   = BIT(18),
+   kDirList       = BIT(19)
 };     
    AliAnalysisDataContainer();
    AliAnalysisDataContainer(const AliAnalysisDataContainer &cont);
@@ -72,6 +73,7 @@ enum EAnalysisContainerFlags {
    void                      ResetDataReady()     {fDataReady = kFALSE;}
    virtual Bool_t            SetData(TObject *data, Option_t *option="");
    void                      SetDataOwned(Bool_t flag) {fOwnedData = flag;}
+   void                      SetDirList(Bool_t flag) {TObject::SetBit(kDirList,flag);}
    void                      SetExchange(Bool_t flag) {TObject::SetBit(kExchangeData,flag);}
    void                      SetPostEventLoop(Bool_t flag=kTRUE) {TObject::SetBit(kPostEventLoop,flag);}
    void                      SetSpecialOutput(Bool_t flag=kTRUE) {TObject::SetBit(kSpecialOutput,flag);}
@@ -87,6 +89,7 @@ enum EAnalysisContainerFlags {
    void                      ImportData(AliAnalysisDataWrapper *pack);
    /// Container status checking
    Bool_t                    IsDataReady() const  {return fDataReady;}
+   Bool_t                    IsDirList() const    {return TObject::TestBit(kDirList);}
    Bool_t                    IsExchange() const      {return TObject::TestBit(kExchangeData);}
    Bool_t                    IsPostEventLoop() const {return TObject::TestBit(kPostEventLoop);}
    Bool_t                    IsSpecialOutput() const {return TObject::TestBit(kSpecialOutput);}

--- a/ANALYSIS/ANALYSIS/AliAnalysisManager.cxx
+++ b/ANALYSIS/ANALYSIS/AliAnalysisManager.cxx
@@ -1018,8 +1018,8 @@ void AliAnalysisManager::ImportWrappers(TList *source)
          TString folder = cont->GetFolderName();
          if (!folder.IsNull()) f->cd(folder);
          // Special treatment for a directory list
-         if (cont->IsDirList() || (cont->GetProducer() && cont->GetProducer()->IsListsToFolders())) {
-            auto dirlist = AliDirList::CreateFrom((TDirectoryFile*)gDirectory, cont->GetName());
+         if (cont->IsDirList()) {
+            auto dirlist = AliDirList::CreateFrom(cont->GetName());
             if (dirlist) dirlist->SetOwner(true);
             obj = dirlist;
          }
@@ -1210,18 +1210,13 @@ void AliAnalysisManager::Terminate()
          file->cd(dir);
       }  
       if (fDebug > 1) printf("...writing container %s to file %s:%s\n", output->GetName(), file->GetName(), output->GetFolderName());
+      if (output->IsDirList()) (static_cast<AliDirList*>(output->GetData()))->SetName(output->GetName());
       if (output->GetData()->InheritsFrom(TCollection::Class())) {
       // If data is a collection, we set the name of the collection 
       // as the one of the container and we save as a single key.
          TCollection *coll = (TCollection*)output->GetData();
          coll->SetName(output->GetName());
-         if (output->GetProducer() && output->GetProducer()->IsListsToFolders()) {
-            // Write the collection in a folder having the same name as the container
-            auto dirlist = AliDirList(output->GetName(), coll);
-            dirlist.Write();
-         } else {
-            coll->Write(output->GetName(), TObject::kSingleKey);
-         }
+         coll->Write(output->GetName(), TObject::kSingleKey);
       } else {
          if (output->GetData()->InheritsFrom(TTree::Class())) {
             TTree *tree = (TTree*)output->GetData();
@@ -1229,8 +1224,8 @@ void AliAnalysisManager::Terminate()
             tree->AutoSave();
          } else {
             output->GetData()->Write();
-         }   
-      }      
+         }
+      }
       if (opwd) opwd->cd();
    }
    gROOT->cd();

--- a/ANALYSIS/ANALYSIS/AliAnalysisTask.h
+++ b/ANALYSIS/ANALYSIS/AliAnalysisTask.h
@@ -107,8 +107,7 @@ class AliAnalysisTask : public TTask {
     kTaskUsed           = BIT(14),
     kTaskZombie         = BIT(15),
     kTaskChecked        = BIT(16),
-    kTaskPostEventLoop  = BIT(17),
-    kTaskListsToFolders = BIT(18)
+    kTaskPostEventLoop  = BIT(17)
   };
 
   //=====================================================================
@@ -204,7 +203,6 @@ public:
   TObject                  *GetOutputData(Int_t islot) const;  
   Bool_t                    IsOutputReady(Int_t islot) const {return fOutputReady[islot];}
   Bool_t                    IsChecked() const  {return TObject::TestBit(kTaskChecked);}
-  Bool_t                    IsListsToFolders() const {return TObject::TestBit(kTaskListsToFolders);}
   Bool_t                    IsPostEventLoop() const {return TObject::TestBit(kTaskPostEventLoop);}
   Bool_t                    IsInitialized() const  {return fInitialized;}
   Bool_t                    IsReady() const  {return fReady;}
@@ -216,7 +214,6 @@ public:
   Bool_t                    ProducersTouched() const;
   void                      SetBranches(const char *names) {fBranchNames = names;}
   void                      SetChecked(Bool_t flag=kTRUE) {TObject::SetBit(kTaskChecked,flag);}
-  void                      SetListsToFolders(Bool_t flag=kTRUE) {TObject::SetBit(kTaskListsToFolders,flag);}
   void                      SetPostEventLoop(Bool_t flag=kTRUE);
   void                      SetUsed(Bool_t flag=kTRUE);
   void                      SetZombie(Bool_t flag=kTRUE) {TObject::SetBit(kTaskZombie,flag);}

--- a/ANALYSIS/ANALYSIS/AliAnalysisTask.h
+++ b/ANALYSIS/ANALYSIS/AliAnalysisTask.h
@@ -104,10 +104,11 @@ class AliAnalysisDataContainer;
 class AliAnalysisTask : public TTask {
  public:
   enum EAnalysisTaskFlags {
-    kTaskUsed    = BIT(14),
-    kTaskZombie  = BIT(15),
-    kTaskChecked = BIT(16),
-    kTaskPostEventLoop = BIT(17)
+    kTaskUsed           = BIT(14),
+    kTaskZombie         = BIT(15),
+    kTaskChecked        = BIT(16),
+    kTaskPostEventLoop  = BIT(17),
+    kTaskListsToFolders = BIT(18)
   };
 
   //=====================================================================
@@ -203,6 +204,7 @@ public:
   TObject                  *GetOutputData(Int_t islot) const;  
   Bool_t                    IsOutputReady(Int_t islot) const {return fOutputReady[islot];}
   Bool_t                    IsChecked() const  {return TObject::TestBit(kTaskChecked);}
+  Bool_t                    IsListsToFolders() const {return TObject::TestBit(kTaskListsToFolders);}
   Bool_t                    IsPostEventLoop() const {return TObject::TestBit(kTaskPostEventLoop);}
   Bool_t                    IsInitialized() const  {return fInitialized;}
   Bool_t                    IsReady() const  {return fReady;}
@@ -214,6 +216,7 @@ public:
   Bool_t                    ProducersTouched() const;
   void                      SetBranches(const char *names) {fBranchNames = names;}
   void                      SetChecked(Bool_t flag=kTRUE) {TObject::SetBit(kTaskChecked,flag);}
+  void                      SetListsToFolders(Bool_t flag=kTRUE) {TObject::SetBit(kTaskListsToFolders,flag);}
   void                      SetPostEventLoop(Bool_t flag=kTRUE);
   void                      SetUsed(Bool_t flag=kTRUE);
   void                      SetZombie(Bool_t flag=kTRUE) {TObject::SetBit(kTaskZombie,flag);}

--- a/ANALYSIS/ANALYSIS/AliDirList.cxx
+++ b/ANALYSIS/ANALYSIS/AliDirList.cxx
@@ -1,0 +1,158 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: The ALICE Off-line Project.                                    *
+ * Contributors are mentioned in the code where appropriate.              *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+#include "AliDirList.h"
+
+#include <iostream>
+
+#include <TClass.h>
+#include <TDirectoryFile.h>
+#include <TKey.h>
+
+//______________________________________________________________________________
+TObject *AliDirList::PHolder::Get(TDirectory *dir)
+{
+   // Return stored object if any, otherwise read from directory.
+   if (fObj) return fObj;
+   if (dir) fObj = dir->Get(fName.Data());
+   return fObj;
+}
+
+const AliDirList::PHolder &AliDirList::PHolder::operator=(const AliDirList::PHolder &other)
+{
+   if (&other != this) {
+      TNamed::operator=(other);
+      fObj = other.fObj;
+      fClassName = other.fClassName;
+   }
+   return *this;
+}
+
+//______________________________________________________________________________
+AliDirList::AliDirList(const char *name, TCollection *list)
+           :TNamed(name, "")
+{
+   // Create a directory list from a collection
+   TIter next(list);
+   TObject *obj;
+   while ((obj = next())) Add(obj);
+}
+
+//______________________________________________________________________________
+AliDirList::~AliDirList()
+{
+   Clear();
+}
+
+//______________________________________________________________________________
+TObject *AliDirList::At(int i)
+{
+   // Return element at position i.
+   if (!fDir || i > fList.size() - 1) return nullptr;
+   PHolder &h = fList[i];
+   return h.Get(fDir);
+}
+
+//______________________________________________________________________________
+void AliDirList::Clear(Option_t *)
+{
+   if (fOwner) {
+      for (auto &h : fList)
+         h.ClearObject(fOwner);
+   }
+   fList.clear();
+}
+
+//______________________________________________________________________________
+TObject *AliDirList::FindObject(const char *name) {
+   for (auto &h : fList) {
+      if (!strcmp(h.GetName(), name))
+         return h.Get(fDir);
+   }
+   return nullptr;
+}
+
+//______________________________________________________________________________
+void AliDirList::ls(Option_t *)  const
+{
+   for (auto &h : fList) {
+      TObject *obj = h.GetObject();
+      if (obj)
+         std::cout << "  MEM:    " << "\t" << h.GetClassName() << "\t" << h.GetName() << "\t" << h.GetTitle() << std::endl;
+      else
+         std::cout << "  ONFILE: " << "\t" << h.GetClassName() << "\t" << h.GetName() << "\t" << h.GetTitle() << std::endl;
+   }
+}
+
+//______________________________________________________________________________
+void AliDirList::Print(Option_t *option)  const
+{
+   std::cout << "Directory list: " << GetName() << std::endl;
+   ls(option);
+}
+
+//______________________________________________________________________________
+AliDirList *AliDirList::CreateFrom(TDirectoryFile *parent, const char *dirname)
+{
+   TDirectory *dir = parent->GetDirectory(dirname);
+   if (!dir) return nullptr;
+   TDirectory *cdir = gDirectory;
+   parent->cd();
+   AliDirList *list = new AliDirList(dirname);
+   list->Read();
+   cdir->cd();
+   return list;
+}
+
+//______________________________________________________________________________
+Int_t AliDirList::Read(const char *name)
+{
+   // Read keys from the current directory and create placeholders.
+   // Does not actually read the objects. These are read when calling At function.
+   if (name && name[0] != '\0') SetName(name);
+   fDir = gDirectory->GetDirectory(GetName());
+   if (!fDir) return 0;
+   TIter next(fDir->GetListOfKeys());
+   TKey *key;
+   while ((key = (TKey*)next())) {
+      TClass *cl = TClass::GetClass(key->GetClassName());
+      if (!cl->InheritsFrom(TDirectory::Class())) {
+         // Good key, create placeholder for the key name
+         fList.push_back(PHolder(key->GetName(), key->GetTitle(), key->GetClassName()));
+      }
+   }
+   return 0;
+}
+
+//______________________________________________________________________________
+Int_t AliDirList::Write(const char *name, Int_t, Int_t)
+{
+   // Write content to directory. If directory does not exist, create it in the 
+   // current directory with the name of the list.
+   Int_t sum = 0;
+   if (name && name[0] != '\0')
+      SetName(name);
+   fDir = gDirectory->GetDirectory(GetName());
+   if (!fDir)
+      fDir = gDirectory->mkdir(GetName());
+   if (!fDir->InheritsFrom(TDirectoryFile::Class())) {
+      Error("Write", "Current directory not connected to a file. List not written");
+      return 0;
+   }
+   fDir->cd();
+   for (auto &h : fList)
+      sum += h.Get()->Write();
+   return sum;
+}

--- a/ANALYSIS/ANALYSIS/AliDirList.h
+++ b/ANALYSIS/ANALYSIS/AliDirList.h
@@ -34,8 +34,8 @@ class AliDirList : public TNamed
       TString  fClassName;        //! class name
 
    public:
-      PHolder(const char *name, const char *title = "", const char *classname = "")
-         : TNamed(name, title), fClassName(classname) {}
+      PHolder(const char *name, const char *title = "", const char *classname = "", TObject *obj = nullptr)
+         : TNamed(name, title), fObj(obj), fClassName(classname) {}
       PHolder(TObject *obj) : TNamed(obj->GetName(), obj->ClassName()), fObj(obj) {}
       PHolder(const PHolder &other) : TNamed(other), fObj(other.fObj), fClassName(other.fClassName) {}
       ~PHolder() {}
@@ -51,7 +51,7 @@ class AliDirList : public TNamed
    };
 
 private:
-   Bool_t fOwner = false;                //! Container owns the content
+   Bool_t fOwner = kFALSE;                //! Container owns the content
    TDirectory *fDir = nullptr;           //! Directory containing the the objects to read
    std::vector<PHolder> fList;           //! List content
 
@@ -60,19 +60,25 @@ public:
    AliDirList(const char *name, TCollection *list);
    virtual ~AliDirList();
 
+   // Compatibility methods (TCollection, TList, TObjArray)
    void           Add(TObject *obj) { fList.push_back(PHolder(obj)); }
    TObject       *At(Int_t i);
    TObject       *operator[](Int_t i) { return At(i); }
    virtual void   Clear(Option_t *option = "");
-   size_t         Size() const { return fList.size(); }
-   TObject       *FindObject(const char *name);
-   static AliDirList *CreateFrom(TDirectoryFile *parent, const char *dirname);
+   TObject       *First() { return At(0); }
+   TObject       *Last() { return At(Size() - 1); }
+   int            GetSize() const { return (Int_t)fList.size(); }
+   int            GetEntries() const { return (Int_t)fList.size(); }
+   int            GetEntriesFast() const { return (Int_t)fList.size(); }
+   TObject       *FindObject(const char *name) const;
+   static AliDirList *CreateFrom(const char *dirname, bool mem = kFALSE);
 
    virtual void   ls (Option_t *option="") const;
    virtual void   Print(Option_t *option="") const;
    void           SetOwner(Bool_t flag = true) { fOwner = flag; }
-   virtual Int_t  Write (const char *name="", Int_t option=0, Int_t bufsize=0);
-   virtual Int_t  Read(const char *name="");
+   size_t         Size() const { return fList.size(); }
+   Int_t          Write (const char *dir="", Int_t option=0, Int_t bufsize=0);
+   Int_t          ReadFrom(const char *dir="", bool mem = kFALSE);
 
    ClassDef(AliDirList, 0)  // Class representing a special list of objects from a ROOT directory
 };

--- a/ANALYSIS/ANALYSIS/AliDirList.h
+++ b/ANALYSIS/ANALYSIS/AliDirList.h
@@ -1,0 +1,79 @@
+#ifndef ALIDIRLIST_H
+#define ALIDIRLIST_H
+/* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/// \class AliDirList
+/// \author Mihaela Gheata
+/// \brief AliDirList
+/// A special list handling objects to be written or retrieved from a ROOT directory.
+/// The list itself is not persistent, writing it to a file will create first a directory
+/// and then call the method Write for all objects in the list. Getting back AliDirList
+/// from a file requires having gDirectory pointing to the parent directory in the file.
+/// The objects in the list are internally hold into a smart placeholder object. AliDirList
+/// will scan the content of the folder to be loaded and create empty placeholders for each
+/// object. When the Get() method is invoked, the placeholder will do the actual reading from
+/// file and hand over the read object. This is to read in memory only the objects requested
+// by the user. A AliDirList cannot contain other AliDirList, all directories from the read
+/// directory will be skipped.
+/// \date 21/01/2018
+
+#include <vector>
+
+#include <TNamed.h>
+
+class TDirectory;
+class TDirectoryFile;
+class TCollection;
+
+class AliDirList : public TNamed
+{
+   // Internal placeholder for AliDirList items
+   class PHolder : public TNamed {
+      TObject *fObj = nullptr;    //! pointer to object
+      TString  fClassName;        //! class name
+
+   public:
+      PHolder(const char *name, const char *title = "", const char *classname = "")
+         : TNamed(name, title), fClassName(classname) {}
+      PHolder(TObject *obj) : TNamed(obj->GetName(), obj->ClassName()), fObj(obj) {}
+      PHolder(const PHolder &other) : TNamed(other), fObj(other.fObj), fClassName(other.fClassName) {}
+      ~PHolder() {}
+
+      const PHolder &operator=(const PHolder &other);
+
+      inline void     ClearObject(bool del) { if (del) delete fObj; fObj = nullptr; }
+      TObject        *Get(TDirectory *dir = nullptr);
+      inline TObject *GetObject() const { return fObj; }
+      inline void     Set(TObject *obj) { fObj = obj; }
+      const char     *GetClassName() const { return (fObj) ? fObj->ClassName() : fClassName.Data(); }
+      void            SetClassName(const char *name) { fClassName = name; }
+   };
+
+private:
+   Bool_t fOwner = false;                //! Container owns the content
+   TDirectory *fDir = nullptr;           //! Directory containing the the objects to read
+   std::vector<PHolder> fList;           //! List content
+
+public:
+   AliDirList(const char *name = "") : TNamed(name, "") {}
+   AliDirList(const char *name, TCollection *list);
+   virtual ~AliDirList();
+
+   void           Add(TObject *obj) { fList.push_back(PHolder(obj)); }
+   TObject       *At(Int_t i);
+   TObject       *operator[](Int_t i) { return At(i); }
+   virtual void   Clear(Option_t *option = "");
+   size_t         Size() const { return fList.size(); }
+   TObject       *FindObject(const char *name);
+   static AliDirList *CreateFrom(TDirectoryFile *parent, const char *dirname);
+
+   virtual void   ls (Option_t *option="") const;
+   virtual void   Print(Option_t *option="") const;
+   void           SetOwner(Bool_t flag = true) { fOwner = flag; }
+   virtual Int_t  Write (const char *name="", Int_t option=0, Int_t bufsize=0);
+   virtual Int_t  Read(const char *name="");
+
+   ClassDef(AliDirList, 0)  // Class representing a special list of objects from a ROOT directory
+};
+#endif // ALIDIRLIST_H

--- a/ANALYSIS/ANALYSIS/CMakeLists.txt
+++ b/ANALYSIS/ANALYSIS/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SRCS
     AliAnalysisTaskCfg.cxx
     AliAnalysisTask.cxx
     AliXMLParser.cxx
+    AliDirList.cxx
    )
 
 # Headers from sources


### PR DESCRIPTION
This PR introduces a special container AliDirList that allows writing its content into a folder and reading content from a folder in a lazy manner. This container is useful for handling large outputs of analysis tasks during the grid merging phase and after, when running the Terminate method. To use, simply replace the output type of a task from TList/TObjArray to AliDirList.

The output content of a task having a AliDirList output will be placed in a folder named the same as the data container. Note that the AddTask macro for such a task needs to be changed to create a container of type AliDirList instread of the usual TList/TObjArray. During merging, the memory footprint will be reduced to the size of the largest object being merged, instread of the size of the full list. During the Terminate method, the AliDirList will be created from the merged file by scanning the appropriate folder. Note that the list will appear as having all objects inside, but these will be read from file only when actually accessed (lazy reading). This will also minimize the memory use during the Terminate phase.

The PR is fully backward compatible, not affecting any tasks not using this special container.
