### PR TITLE
Fix: allow compiling AliRoot without AliEn

### DIFF
--- a/cmake/FindROOT.cmake
+++ b/cmake/FindROOT.cmake
@@ -210,7 +210,7 @@ if(ROOTSYS)
 
         set(ROOT_HASALIEN TRUE)
     else(ALIEN)
-        message(FATAL_ERROR "No AliEn installation found. Please set \"ALIEN\" to point to your AliEn installation.")
+        message(WARNING "No AliEn installation found. Please set \"ALIEN\" to point to your AliEn installation.")
     endif(ALIEN)
 
     # Checking for xml support


### PR DESCRIPTION
This used to be possible but was broken when AliEn-ROOT-Legacy was extracted from ROOT. When AliEn is missing, just print a warning instead of throwin a fatal error.