### PR TITLE
AliESDtrackCuts: added pt dependent cov matrix cut

### DIFF
--- a/ANALYSIS/ANALYSISalice/AliESDtrackCuts.cxx
+++ b/ANALYSIS/ANALYSISalice/AliESDtrackCuts.cxx
@@ -763,18 +763,6 @@ void AliESDtrackCuts::SetCutGeoNcrNcl(Float_t deadZoneWidth,Float_t cutGeoNcrNcl
   fCutGeoNcrNclFractionNcl=cutGeoNcrNclFractionNcl;
 }
 
-void AliESDtrackCuts::SetMinNClustersTPCPtDep(TFormula *f1, Float_t ptmax)
-{
-  /// Sets the pT dependent NClustersTPC cut
-
-  if(f1){
-    delete f1CutMinNClustersTPCPtDep;
-    f1CutMinNClustersTPCPtDep = (TFormula*)f1->Clone("f1CutMinNClustersTPCPtDep");
-  }
-  fCutMaxPtDepNClustersTPC=ptmax;
-}
-
-
 //____________________________________________________________________
 AliESDtrackCuts* AliESDtrackCuts::GetStandardTPCOnlyTrackCuts()
 {

--- a/ANALYSIS/ANALYSISalice/AliESDtrackCuts.cxx
+++ b/ANALYSIS/ANALYSISalice/AliESDtrackCuts.cxx
@@ -115,6 +115,8 @@ AliESDtrackCuts::AliESDtrackCuts(const Char_t* name, const Char_t* title) :
   fCutMaxC44(0),
   fCutMaxC55(0),
   fCutMaxRel1PtUncertainty(0),
+  fCutMaxRel1PtUncertaintyPtDep(""),
+  f1CutMaxRel1PtUncertaintyPtDep(0x0),
   fCutAcceptKinkDaughters(0),
   fCutAcceptSharedTPCClusters(0),
   fCutMaxFractionSharedTPCClusters(0),
@@ -235,6 +237,8 @@ AliESDtrackCuts::AliESDtrackCuts(const AliESDtrackCuts &c) :
   fCutMaxC44(0),
   fCutMaxC55(0),
   fCutMaxRel1PtUncertainty(0),
+  fCutMaxRel1PtUncertaintyPtDep(""),
+  f1CutMaxRel1PtUncertaintyPtDep(0x0),  
   fCutAcceptKinkDaughters(0),
   fCutAcceptSharedTPCClusters(0),
   fCutMaxFractionSharedTPCClusters(0),
@@ -350,6 +354,9 @@ AliESDtrackCuts::~AliESDtrackCuts()
     if (fhTOFdistance[i])
       delete fhTOFdistance[i];
   }
+  
+  if(f1CutMaxRel1PtUncertaintyPtDep)delete f1CutMaxRel1PtUncertaintyPtDep;
+  f1CutMaxRel1PtUncertaintyPtDep = 0;
 
   if(f1CutMaxDCAToVertexXYPtDep)delete f1CutMaxDCAToVertexXYPtDep;
   f1CutMaxDCAToVertexXYPtDep = 0;
@@ -397,6 +404,11 @@ void AliESDtrackCuts::Init()
   fCutMaxC55 = 0;
 
   fCutMaxRel1PtUncertainty = 0;
+  
+  fCutMaxRel1PtUncertaintyPtDep = "";
+  
+  if(f1CutMaxRel1PtUncertaintyPtDep)delete f1CutMaxRel1PtUncertaintyPtDep;
+  f1CutMaxRel1PtUncertaintyPtDep = 0;  
 
   fCutAcceptKinkDaughters = 0;
   fCutAcceptSharedTPCClusters = 0;
@@ -419,7 +431,7 @@ void AliESDtrackCuts::Init()
   fCutMaxDCAToVertexZPtDep = "";
   fCutMinDCAToVertexXYPtDep = "";
   fCutMinDCAToVertexZPtDep = "";
-
+  
   if(f1CutMaxDCAToVertexXYPtDep)delete f1CutMaxDCAToVertexXYPtDep;
   f1CutMaxDCAToVertexXYPtDep = 0;
   if( f1CutMaxDCAToVertexXYPtDep) delete  f1CutMaxDCAToVertexXYPtDep;
@@ -430,8 +442,7 @@ void AliESDtrackCuts::Init()
   f1CutMinDCAToVertexXYPtDep = 0;
   if(f1CutMinDCAToVertexZPtDep)delete f1CutMinDCAToVertexZPtDep;
   f1CutMinDCAToVertexZPtDep = 0;
-
-
+  
   fPMin = 0;
   fPMax = 0;
   fPtMin = 0;
@@ -542,6 +553,11 @@ void AliESDtrackCuts::Copy(TObject &c) const
   target.fCutMaxC55 = fCutMaxC55;
 
   target.fCutMaxRel1PtUncertainty = fCutMaxRel1PtUncertainty;
+  target.fCutMaxRel1PtUncertaintyPtDep = fCutMaxRel1PtUncertaintyPtDep;
+  if(fCutMaxRel1PtUncertaintyPtDep.Length()>0)target.SetMaxRel1PtUncertaintyPtDep(fCutMaxRel1PtUncertaintyPtDep.Data());
+  if(f1CutMaxRel1PtUncertaintyPtDep){
+    target.f1CutMaxRel1PtUncertaintyPtDep = (TFormula*) f1CutMaxRel1PtUncertaintyPtDep->Clone("f1CutMaxRel1PtUncertaintyPtDep");
+  }  
 
   target.fCutAcceptKinkDaughters = fCutAcceptKinkDaughters;
   target.fCutAcceptSharedTPCClusters = fCutAcceptSharedTPCClusters;
@@ -747,7 +763,16 @@ void AliESDtrackCuts::SetCutGeoNcrNcl(Float_t deadZoneWidth,Float_t cutGeoNcrNcl
   fCutGeoNcrNclFractionNcl=cutGeoNcrNclFractionNcl;
 }
 
+void AliESDtrackCuts::SetMinNClustersTPCPtDep(TFormula *f1, Float_t ptmax)
+{
+  /// Sets the pT dependent NClustersTPC cut
 
+  if(f1){
+    delete f1CutMinNClustersTPCPtDep;
+    f1CutMinNClustersTPCPtDep = (TFormula*)f1->Clone("f1CutMinNClustersTPCPtDep");
+  }
+  fCutMaxPtDepNClustersTPC=ptmax;
+}
 
 
 //____________________________________________________________________
@@ -1305,6 +1330,8 @@ Bool_t AliESDtrackCuts::AcceptTrack(const AliESDtrack* esdTrack)
     bCov[0]=0; bCov[2]=0;
   }
 
+  // set pt-dependent pt resolution cut
+  SetPtDepUncertaintyCuts(esdTrack->Pt());
 
   // set pt-dependent DCA cuts, if requested
   SetPtDepDCACuts(esdTrack->Pt());
@@ -2840,6 +2867,56 @@ Bool_t AliESDtrackCuts::CheckPtDepDCA(TString dist,Bool_t print) const {
    tmp.ReplaceAll("pt","x");
    f1CutMinDCAToVertexZPtDep = new TFormula("f1CutMinDCAToVertexZPtDep",tmp.Data());
 }
+
+
+//--------------------------------------------------------------------------
+
+void AliESDtrackCuts::SetPtDepUncertaintyCuts(Double_t pt) {
+  /// set the pt-dependent cut on pt resolution
+
+  if(f1CutMaxRel1PtUncertaintyPtDep) {
+     fCutMaxRel1PtUncertainty=f1CutMaxRel1PtUncertaintyPtDep->Eval(pt);
+  }
+
+  return;
+}
+
+
+//--------------------------------------------------------------------------
+
+Bool_t AliESDtrackCuts::CheckPtDepUncertainty(TString dist,Bool_t print) const {
+  /// Check the correctness of the string syntax
+
+  Bool_t retval=kTRUE;
+
+  if(!dist.Contains("pt")) {
+    if(print) AliError("string must contain \"pt\"");
+    retval= kFALSE;
+  }
+  return retval;
+}
+
+//--------------------------------------------------------------------------
+
+ void AliESDtrackCuts::SetMaxRel1PtUncertaintyPtDep(const char *dist){
+
+   if(f1CutMaxRel1PtUncertaintyPtDep){
+     delete f1CutMaxRel1PtUncertaintyPtDep;
+     // reset both
+     f1CutMaxRel1PtUncertaintyPtDep = 0;
+     fCutMaxRel1PtUncertaintyPtDep = "";
+   }
+   if(!CheckPtDepUncertainty(dist,kTRUE)){
+     return;
+   }
+   fCutMaxRel1PtUncertaintyPtDep = dist;
+   TString tmp(dist);
+   tmp.ReplaceAll("pt","x");
+   f1CutMaxRel1PtUncertaintyPtDep = new TFormula("f1CutMaxRel1PtUncertaintyPtDep",tmp.Data());
+
+}
+
+//--------------------------------------------------------------------------
 
 AliESDtrackCuts* AliESDtrackCuts::GetMultEstTrackCuts(MultEstTrackCuts cut)
 {

--- a/ANALYSIS/ANALYSISalice/AliESDtrackCuts.h
+++ b/ANALYSIS/ANALYSISalice/AliESDtrackCuts.h
@@ -118,6 +118,7 @@ public:
   void SetMaxCovDiagonalElements(Float_t c1=1e10, Float_t c2=1e10, Float_t c3=1e10, Float_t c4=1e10, Float_t c5=1e10) 
     {fCutMaxC11=c1; fCutMaxC22=c2; fCutMaxC33=c3; fCutMaxC44=c4; fCutMaxC55=c5;}
   void SetMaxRel1PtUncertainty(Float_t max=1e10)      {fCutMaxRel1PtUncertainty=max;}
+  void SetMaxRel1PtUncertaintyPtDep(const char *dist="");
 
 
   // track to vertex cut setters
@@ -159,6 +160,7 @@ public:
   void    GetMaxCovDiagonalElements(Float_t& c1, Float_t& c2, Float_t& c3, Float_t& c4, Float_t& c5) const
       {c1 = fCutMaxC11; c2 = fCutMaxC22; c3 = fCutMaxC33; c4 = fCutMaxC44; c5 = fCutMaxC55;}
   Float_t GetMaxRel1PtUncertainty()  const   { return fCutMaxRel1PtUncertainty;}
+  const char* GetMaxRel1PtUncertaintyPtDep() const   { return fCutMaxRel1PtUncertaintyPtDep;}
   Float_t GetMaxNsigmaToVertex()     const   { return fCutNsigmaToVertex;}
   Float_t GetMaxDCAToVertexXY()      const   { return fCutMaxDCAToVertexXY;}
   Float_t GetMaxDCAToVertexZ()       const   { return fCutMaxDCAToVertexZ;}
@@ -220,7 +222,10 @@ protected:
   Bool_t CheckITSClusterRequirement(ITSClusterRequirement req, Bool_t clusterL1, Bool_t clusterL2);
   Bool_t CheckPtDepDCA(TString dist,Bool_t print=kFALSE) const;
   void SetPtDepDCACuts(Double_t pt);
-
+  
+  Bool_t CheckPtDepUncertainty(TString dist,Bool_t print=kFALSE) const;
+  void SetPtDepUncertaintyCuts(Double_t pt);
+  
   enum { kNCuts = 45 }; 
 
   //######################################################
@@ -258,8 +263,11 @@ protected:
   Float_t fCutMaxC33;                 ///< max cov. matrix diag. elements (res. sin(phi)^2)
   Float_t fCutMaxC44;                 ///< max cov. matrix diag. elements (res. tan(theta_dip)^2)
   Float_t fCutMaxC55;                 ///< max cov. matrix diag. elements (res. 1/pt^2)
-
-  Float_t fCutMaxRel1PtUncertainty;   ///< max relative uncertainty of 1/pt
+  
+  //cut on relative pt resolution
+  Float_t fCutMaxRel1PtUncertainty;           ///< max relative uncertainty of 1/pt
+  TString fCutMaxRel1PtUncertaintyPtDep;      ///< pt-dep max relative uncertainty of 1/pt
+  TFormula *f1CutMaxRel1PtUncertaintyPtDep;   ///< only internal use (pt-dep max relative uncertainty of 1/pt)
 
   Bool_t  fCutAcceptKinkDaughters;    ///< accepting kink daughters?
   Bool_t  fCutAcceptSharedTPCClusters;///< accepting shared clusters in TPC?
@@ -382,7 +390,7 @@ protected:
   /// TOF signal distance dx vs dz
   TH2F* fhTOFdistance[2];            //->
 
-  ClassDef(AliESDtrackCuts, 23)
+  ClassDef(AliESDtrackCuts, 24)
 };
 
 


### PR DESCRIPTION
Added the possibility to cut on the covariance matrix relative pt resolution in a pt dependent way