### PR TITLE
Added bach-baryon cospa to AliAODcascade for nanoAODs

### DIFF
--- a/STEER/AOD/AliAODcascade.cxx
+++ b/STEER/AOD/AliAODcascade.cxx
@@ -35,7 +35,8 @@ AliAODcascade::AliAODcascade() :
   
   fMomBachX(999),
   fMomBachY(999),
-  fMomBachZ(999)
+  fMomBachZ(999),
+  fBachBaryonCosPA(0)
    
 {
   //--------------------------------------------------------------------
@@ -58,7 +59,8 @@ AliAODcascade::AliAODcascade(const AliAODcascade& rSource) :
   
   fMomBachX( rSource.fMomBachX ),
   fMomBachY( rSource.fMomBachY ),
-  fMomBachZ( rSource.fMomBachZ )
+  fMomBachZ( rSource.fMomBachZ ),
+  fBachBaryonCosPA( rSource.fBachBaryonCosPA)
   
 {
   /// Copy constructor
@@ -79,7 +81,8 @@ AliAODcascade::AliAODcascade( AliAODVertex* rAODVertexXi,
 		      Double_t rDcaV0ToPrimVertex,
 		const Double_t *rMomPos,
 		const Double_t *rMomNeg,
-		      Double_t *rDcaDaughterToPrimVertex
+		      Double_t *rDcaDaughterToPrimVertex,
+              Double_t  rBachBaryonCosPA
 		) :
   AliAODv0(rAODVertexV0, rDcaV0Daughters, rDcaV0ToPrimVertex, rMomPos, rMomNeg, rDcaDaughterToPrimVertex),
   fDecayVertexXi( rAODVertexXi ),
@@ -89,7 +92,8 @@ AliAODcascade::AliAODcascade( AliAODVertex* rAODVertexXi,
   fDcaBachToPrimVertex( rDcaBachToPrimVertex ),
   fMomBachX( rMomBach[0] ),          
   fMomBachY( rMomBach[1] ),      
-  fMomBachZ( rMomBach[2] )  
+  fMomBachZ( rMomBach[2] ),
+  fBachBaryonCosPA( rBachBaryonCosPA )
 {
   /// Constructor via setting each data member
 
@@ -104,7 +108,8 @@ AliAODcascade::AliAODcascade( AliAODVertex* rAODVertexXi,
 		      Double_t      rDcaXiToPrimVertex,
 		      Double_t      rDcaBachToPrimVertex,
 		const Double_t*     rMomBach,
-		const AliAODv0&     rAODv0 ) :
+		const AliAODv0&     rAODv0,
+              Double_t  rBachBaryonCosPA ) :
   AliAODv0(rAODv0),
   fDecayVertexXi(rAODVertexXi),
   fChargeXi( rChargeXi ),    
@@ -113,7 +118,8 @@ AliAODcascade::AliAODcascade( AliAODVertex* rAODVertexXi,
   fDcaBachToPrimVertex( rDcaBachToPrimVertex ),
   fMomBachX( rMomBach[0] ),          
   fMomBachY( rMomBach[1] ),      
-  fMomBachZ( rMomBach[2] )
+  fMomBachZ( rMomBach[2] ),
+  fBachBaryonCosPA( rBachBaryonCosPA )
 {
   /// Constructor via setting each Xi data member + setting AODv0
 
@@ -141,6 +147,8 @@ AliAODcascade& AliAODcascade::operator=(const AliAODcascade& rSource){
   this->fMomBachY            = rSource.fMomBachY;
   this->fMomBachZ            = rSource.fMomBachZ;
   
+  this->fBachBaryonCosPA     = rSource.fBachBaryonCosPA;
+    
   return *this;
 }
 
@@ -163,7 +171,8 @@ void  AliAODcascade::Fill(AliAODVertex* rAODVertexXi,
 		      Double_t      rDcaV0ToPrimVertex,
 		const Double_t*     rMomPos,
 		const Double_t*     rMomNeg,
-		      Double_t*     rDcaDaughterToPrimVertex )
+		      Double_t*     rDcaDaughterToPrimVertex,
+              Double_t      rBachBaryonCosPA )
 {
   /// Fill the AODcascade
 
@@ -177,7 +186,9 @@ void  AliAODcascade::Fill(AliAODVertex* rAODVertexXi,
 
       fMomBachX = rMomBach[0];   
       fMomBachY = rMomBach[1];          
-      fMomBachZ = rMomBach[2];        
+      fMomBachZ = rMomBach[2];
+    
+      fBachBaryonCosPA = rBachBaryonCosPA;
 }                
 
 
@@ -204,6 +215,8 @@ void AliAODcascade::ResetXi(){
   fMomBachX = 999;
   fMomBachY = 999;
   fMomBachZ = 999;
+    
+  fBachBaryonCosPA = 0.0; 
   
   
 }

--- a/STEER/AOD/AliAODcascade.h
+++ b/STEER/AOD/AliAODcascade.h
@@ -36,7 +36,8 @@ public:
 		      Double_t      rDcaV0ToPrimVertex, 
 		const Double_t*     rMomPos,            
 		const Double_t*     rMomNeg,
-		      Double_t*     rDcaDaughterToPrimVertex ); // const? -> Need agreement at AliAODRecoDecay level
+		      Double_t*     rDcaDaughterToPrimVertex,
+              Double_t      rBachBaryonCosPA = 0 ); // const? -> Need agreement at AliAODRecoDecay level
 
   		
   AliAODcascade( AliAODVertex* rAODVertexXi,  // No "const" param, see above.
@@ -45,9 +46,8 @@ public:
 		      Double_t      rDcaXiToPrimVertex,
 		      Double_t      rDcaBachToPrimVertex,
 		const Double_t*     rMomBach,
-		const AliAODv0&     rAODv0 );
-		
-		
+		const AliAODv0&     rAODv0,
+              Double_t      rBachBaryonCosPA = 0 );
 		
   virtual ~AliAODcascade();
 
@@ -65,7 +65,8 @@ public:
 		      Double_t  rDcaV0ToPrimVertex,
 		const Double_t* rMomPos,
 		const Double_t* rMomNeg,
-		      Double_t* rDcaDaughterToPrimVertex ); // const? -> Need agreement at AliAODRecoDecay level
+		      Double_t* rDcaDaughterToPrimVertex,
+              Double_t  rBachBaryonCosPA = 0 ); // const? -> Need agreement at AliAODRecoDecay level
   
 //   void  Fill(   AliAODVertex*   rAODVertexXi, 
 //                       Int_t     rChargeXi,
@@ -110,6 +111,8 @@ public:
   Double_t MomBachX()       const;
   Double_t MomBachY()       const;
   Double_t MomBachZ()       const;
+    
+  Double_t BachBaryonCosPA()const;
   
   Double_t MomXiX()         const;
   Double_t MomXiY()         const;
@@ -147,7 +150,9 @@ protected:
   Double32_t    fMomBachY;            ///< momemtum of bachelor along Y
   Double32_t    fMomBachZ;            ///< momemtum of bachelor along Z
   
-  ClassDef(AliAODcascade,1)   
+    Double32_t    fBachBaryonCosPA;     ///< bach/baryon cosPA (for rejection)
+    
+  ClassDef(AliAODcascade,2)
 };
 
 //-----------------------------------------------------------
@@ -182,6 +187,8 @@ inline Double_t AliAODcascade::DecayLengthXi(const Double_t& rPrimVtxX,
 inline Double_t AliAODcascade::MomBachX() const {return fMomBachX;}
 inline Double_t AliAODcascade::MomBachY() const {return fMomBachY;}
 inline Double_t AliAODcascade::MomBachZ() const {return fMomBachZ;}
+
+inline Double_t AliAODcascade::BachBaryonCosPA() const {return fBachBaryonCosPA;}
 
 inline Double_t AliAODcascade::MomXiX() const {return MomV0X()+fMomBachX;}
 inline Double_t AliAODcascade::MomXiY() const {return MomV0Y()+fMomBachY;}


### PR DESCRIPTION
This commit is necessary to make full use of AODs for the cascade analysis in Pb-Pb, which is badly needed to avoid excessive CPU usage by LEGO trains. The change is essentially the addition of an extra data member to AliAODcascade that stores the bachelor+baryon CosPA such that the analyser can select / reject based on that variable at the AOD level. To be tested. Please check this code for correctness, indeed. Thank you! 