### PR TITLE
Corrected for zero-length section

### DIFF
--- a/TPC/TPCsim/AliTPCv0.cxx
+++ b/TPC/TPCsim/AliTPCv0.cxx
@@ -1473,7 +1473,7 @@ TGeoCompositeShape *tpcorh9 = new TGeoCompositeShape("tpcorh9", "tpcorh1-tpcorh2
 //
 // outer rod plug left
 //
-TGeoPcon *outplug = new TGeoPcon("outplug", 0.0, 360.0, 14); 
+TGeoPcon *outplug = new TGeoPcon("outplug", 0.0, 360.0, 13); 
 
 outplug->DefineSection(0, 0.5, 0.0, 2.2);
 outplug->DefineSection(1, 0.7, 0.0, 2.2);
@@ -1487,14 +1487,13 @@ outplug->DefineSection(5, 1.2, 1.55, 1.75);
 outplug->DefineSection(6, 1.2, 1.55, 2.2);
 outplug->DefineSection(7, 1.875, 1.55, 2.2);
 
-outplug->DefineSection(8, 1.875, 1.55, 2.2);
-outplug->DefineSection(9, 2.47, 1.75, 2.2);
+outplug->DefineSection(8, 2.47, 1.75, 2.2);
 
-outplug->DefineSection(10, 2.47, 1.75, 2.08);
-outplug->DefineSection(11, 2.57, 1.8, 2.08);
+outplug->DefineSection(9, 2.47, 1.75, 2.08);
+outplug->DefineSection(10, 2.57, 1.8, 2.08);
 
-outplug->DefineSection(12, 2.57, 1.92, 2.08);
-outplug->DefineSection(13, 2.95, 1.92, 2.08);
+outplug->DefineSection(11, 2.57, 1.92, 2.08);
+outplug->DefineSection(12, 2.95, 1.92, 2.08);
 //
 shift1[0] = 0.0;
 shift1[1] = 2.09;

--- a/TPC/TPCsim/AliTPCv2.cxx
+++ b/TPC/TPCsim/AliTPCv2.cxx
@@ -1693,7 +1693,7 @@ TGeoCompositeShape *tpcorh9 = new TGeoCompositeShape("tpcorh9", "tpcorh1-tpcorh2
 //
 // outer rod plug left
 //
-TGeoPcon *outplug = new TGeoPcon("outplug", 0.0, 360.0, 14); 
+TGeoPcon *outplug = new TGeoPcon("outplug", 0.0, 360.0, 13); 
 
 outplug->DefineSection(0, 0.5, 0.0, 2.2);
 outplug->DefineSection(1, 0.7, 0.0, 2.2);
@@ -1707,14 +1707,14 @@ outplug->DefineSection(5, 1.2, 1.55, 1.75);
 outplug->DefineSection(6, 1.2, 1.55, 2.2);
 outplug->DefineSection(7, 1.875, 1.55, 2.2);
 
-outplug->DefineSection(8, 1.875, 1.55, 2.2);
-outplug->DefineSection(9, 2.47, 1.75, 2.2);
 
-outplug->DefineSection(10, 2.47, 1.75, 2.08);
-outplug->DefineSection(11, 2.57, 1.8, 2.08);
+outplug->DefineSection(8, 2.47, 1.75, 2.2);
 
-outplug->DefineSection(12, 2.57, 1.92, 2.08);
-outplug->DefineSection(13, 2.95, 1.92, 2.08);
+outplug->DefineSection(9, 2.47, 1.75, 2.08);
+outplug->DefineSection(10, 2.57, 1.8, 2.08);
+
+outplug->DefineSection(11, 2.57, 1.92, 2.08);
+outplug->DefineSection(12, 2.95, 1.92, 2.08);
 //
 shift1[0] = 0.0;
 shift1[1] = 2.09;

--- a/TPC/TPCsim/AliTPCv4.cxx
+++ b/TPC/TPCsim/AliTPCv4.cxx
@@ -1549,7 +1549,7 @@ TGeoCompositeShape *tpcorh9 = new TGeoCompositeShape("tpcorh9", "tpcorh1-tpcorh2
 //
 // outer rod plug left
 //
-TGeoPcon *outplug = new TGeoPcon("outplug", 0.0, 360.0, 14); 
+TGeoPcon *outplug = new TGeoPcon("outplug", 0.0, 360.0, 13); 
 
 outplug->DefineSection(0, 0.5, 0.0, 2.2);
 outplug->DefineSection(1, 0.7, 0.0, 2.2);
@@ -1563,15 +1563,15 @@ outplug->DefineSection(5, 1.2, 1.55, 1.75);
 outplug->DefineSection(6, 1.2, 1.55, 2.2);
 outplug->DefineSection(7, 1.875, 1.55, 2.2);
 
-outplug->DefineSection(8, 1.875, 1.55, 2.2);
-outplug->DefineSection(9, 2.47, 1.75, 2.2);
 
-outplug->DefineSection(10, 2.47, 1.75, 2.08);
-outplug->DefineSection(11, 2.57, 1.8, 2.08);
+outplug->DefineSection(8, 2.47, 1.75, 2.2);
 
-outplug->DefineSection(12, 2.57, 1.92, 2.08);
-outplug->DefineSection(13, 2.95, 1.92, 2.08);
-//
+outplug->DefineSection(9, 2.47, 1.75, 2.08);
+outplug->DefineSection(10, 2.57, 1.8, 2.08);
+
+outplug->DefineSection(11, 2.57, 1.92, 2.08);
+outplug->DefineSection(12, 2.95, 1.92, 2.08);
+
 shift1[0] = 0.0;
 shift1[1] = 2.09;
 shift1[2] = 1.01;


### PR DESCRIPTION
corrected for zero section for outplug, it's necessary for root6.