### PR TITLE
Modification on SpaceCharge distortion on Driftline classes for TPCBase

### DIFF
--- a/GPU/TPCSpaceChargeBase/AliTPCPoissonSolver.cxx
+++ b/GPU/TPCSpaceChargeBase/AliTPCPoissonSolver.cxx
@@ -24,12 +24,15 @@
 ClassImp(AliTPCPoissonSolver)
   /// \endcond
 
-  const Double_t AliTPCPoissonSolver::fgkTPCZ0 = 249.7;                        ///< nominal gating grid position
+  // const Double_t AliTPCPoissonSolver::fgkTPCZ0 = 249.7;                        ///< nominal gating grid position
+  const Double_t AliTPCPoissonSolver::fgkTPCZ0 = 249.525;                        ///< nominal G1T position
 const Double_t AliTPCPoissonSolver::fgkIFCRadius = 83.5;                       ///< radius which renders the "18 rod manifold" best -> compare calc. of Jim Thomas
 const Double_t AliTPCPoissonSolver::fgkOFCRadius = 254.5;                      ///< Mean Radius of the Outer Field Cage (252.55 min, 256.45 max) (cm)
 const Double_t AliTPCPoissonSolver::fgkZOffSet = 0.2;                          ///< Offset from CE: calculate all distortions closer to CE as if at this point
-const Double_t AliTPCPoissonSolver::fgkCathodeV = -100000.0;                   ///< Cathode Voltage (volts)
-const Double_t AliTPCPoissonSolver::fgkGG = -70.0;                             ///< Gating Grid voltage (volts)
+// const Double_t AliTPCPoissonSolver::fgkCathodeV = -100000.0;                   ///< Cathode Voltage (volts)
+// const Double_t AliTPCPoissonSolver::fgkGG = -70.0;                             ///< Gating Grid voltage (volts)
+const Double_t AliTPCPoissonSolver::fgkCathodeV = -103410.0;                   ///< Cathode Voltage (volts) with GEM ROCs
+const Double_t AliTPCPoissonSolver::fgkGG = -3600.0;                             ///< G1T voltage (volts)
 const Double_t AliTPCPoissonSolver::fgkdvdE = 0.0024;                          ///< [cm/V] drift velocity dependency on the E field (from Magboltz for NeCO2N2 at standard environment)
 const Double_t AliTPCPoissonSolver::fgkEM = -1.602176487e-19 / 9.10938215e-31; ///< charge/mass in [C/kg]
 const Double_t AliTPCPoissonSolver::fgke0 = 8.854187817e-12;                   ///< vacuum permittivity [A·s/(V·m)]

--- a/GPU/TPCSpaceChargeBase/AliTPCPoissonSolver.cxx
+++ b/GPU/TPCSpaceChargeBase/AliTPCPoissonSolver.cxx
@@ -24,15 +24,12 @@
 ClassImp(AliTPCPoissonSolver)
   /// \endcond
 
-  // const Double_t AliTPCPoissonSolver::fgkTPCZ0 = 249.7;                        ///< nominal gating grid position
-  const Double_t AliTPCPoissonSolver::fgkTPCZ0 = 249.525;                        ///< nominal G1T position
+  const Double_t AliTPCPoissonSolver::fgkTPCZ0 = 249.7;                        ///< nominal gating grid position
 const Double_t AliTPCPoissonSolver::fgkIFCRadius = 83.5;                       ///< radius which renders the "18 rod manifold" best -> compare calc. of Jim Thomas
 const Double_t AliTPCPoissonSolver::fgkOFCRadius = 254.5;                      ///< Mean Radius of the Outer Field Cage (252.55 min, 256.45 max) (cm)
 const Double_t AliTPCPoissonSolver::fgkZOffSet = 0.2;                          ///< Offset from CE: calculate all distortions closer to CE as if at this point
-// const Double_t AliTPCPoissonSolver::fgkCathodeV = -100000.0;                   ///< Cathode Voltage (volts)
-// const Double_t AliTPCPoissonSolver::fgkGG = -70.0;                             ///< Gating Grid voltage (volts)
-const Double_t AliTPCPoissonSolver::fgkCathodeV = -103410.0;                   ///< Cathode Voltage (volts) with GEM ROCs
-const Double_t AliTPCPoissonSolver::fgkGG = -3600.0;                             ///< G1T voltage (volts)
+const Double_t AliTPCPoissonSolver::fgkCathodeV = -100000.0;                   ///< Cathode Voltage (volts)
+const Double_t AliTPCPoissonSolver::fgkGG = -70.0;                             ///< Gating Grid voltage (volts)
 const Double_t AliTPCPoissonSolver::fgkdvdE = 0.0024;                          ///< [cm/V] drift velocity dependency on the E field (from Magboltz for NeCO2N2 at standard environment)
 const Double_t AliTPCPoissonSolver::fgkEM = -1.602176487e-19 / 9.10938215e-31; ///< charge/mass in [C/kg]
 const Double_t AliTPCPoissonSolver::fgke0 = 8.854187817e-12;                   ///< vacuum permittivity [A·s/(V·m)]

--- a/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.cxx
+++ b/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.cxx
@@ -479,9 +479,9 @@ void AliTPCSpaceCharge3DCalc::InitSpaceCharge3DPoissonIntegralDz(
   Double_t rList[nRRow], zList[nZColumn], phiList[phiSlice];
 
   // pointer to current TF1 for potential boundary values
-  TF1* f1BoundaryIFC = nullptr;
-  TF1* f1BoundaryOFC = nullptr;
-  TF1* f1BoundaryROC = nullptr;
+  TF2* f1BoundaryIFC = nullptr;
+  TF2* f1BoundaryOFC = nullptr;
+  TF2* f1BoundaryROC = nullptr;
   TStopwatch w;
 
   for (Int_t k = 0; k < phiSlice; k++) {
@@ -630,22 +630,22 @@ void AliTPCSpaceCharge3DCalc::InitSpaceCharge3DPoissonIntegralDz(
               // boundary IFC
               if (i == 0) {
                 if (f1BoundaryIFC != nullptr) {
-                  (*matrixV)(i, j) = f1BoundaryIFC->Eval(z0);
+                  (*matrixV)(i, j) = f1BoundaryIFC->Eval(z0, phi0);
                 }
               }
               if (i == (nRRow - 1)) {
                 if (f1BoundaryOFC != nullptr) {
-                  (*matrixV)(i, j) = f1BoundaryOFC->Eval(z0);
+                  (*matrixV)(i, j) = f1BoundaryOFC->Eval(z0, phi0);
                 }
               }
               if (j == 0) {
                 if (fFormulaBoundaryCE) {
-                  (*matrixV)(i, j) = fFormulaBoundaryCE->Eval(radius0);
+                  (*matrixV)(i, j) = fFormulaBoundaryCE->Eval(radius0, phi0);
                 }
               }
               if (j == (nZColumn - 1)) {
                 if (f1BoundaryROC != nullptr) {
-                  (*matrixV)(i, j) = f1BoundaryROC->Eval(radius0);
+                  (*matrixV)(i, j) = f1BoundaryROC->Eval(radius0, phi0);
                 }
               }
             } else {
@@ -908,9 +908,9 @@ void AliTPCSpaceCharge3DCalc::InitSpaceCharge3DPoissonIntegralDz(
   Double_t rList[nRRow], zList[nZColumn], phiList[phiSlice];
 
   // pointer to current TF1 for potential boundary values
-  TF1* f1BoundaryIFC = nullptr;
-  TF1* f1BoundaryOFC = nullptr;
-  TF1* f1BoundaryROC = nullptr;
+  TF2* f1BoundaryIFC = nullptr;
+  TF2* f1BoundaryOFC = nullptr;
+  TF2* f1BoundaryROC = nullptr;
   TStopwatch w;
 
   for (Int_t k = 0; k < phiSlice; k++) {
@@ -1285,9 +1285,9 @@ void AliTPCSpaceCharge3DCalc::InitSpaceCharge3DPoissonIntegralDz(
   Double_t rList[nRRow], zList[nZColumn], phiList[phiSlice];
 
   // pointer to current TF1 for potential boundary values
-  TF1* f1BoundaryIFC = nullptr;
-  TF1* f1BoundaryOFC = nullptr;
-  TF1* f1BoundaryROC = nullptr;
+  TF2* f1BoundaryIFC = nullptr;
+  TF2* f1BoundaryOFC = nullptr;
+  TF2* f1BoundaryROC = nullptr;
   TStopwatch w;
 
   for (Int_t k = 0; k < phiSlice; k++) {

--- a/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.h
+++ b/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.h
@@ -18,7 +18,7 @@
 #ifndef ALI_TPC_SPACECHARGE3D_CALC_H
 #define ALI_TPC_SPACECHARGE3D_CALC_H
 
-#include "TF1.h"
+#include "TF2.h"
 #include "TH3F.h"
 #include "TMatrixD.h"
 #include "AliTPCPoissonSolver.h"
@@ -201,19 +201,19 @@ class AliTPCSpaceCharge3DCalc
   TFormula* GetPotentialVFormula() const { return fFormulaPotentialV; }
   TFormula* GetChargeRhoFormula() const { return fFormulaChargeRho; }
 
-  void SetBoundaryIFCA(TF1* f1) { fFormulaBoundaryIFCA = new TF1(*f1); }
+  void SetBoundaryIFCA(TF2* f1) { fFormulaBoundaryIFCA = new TF2(*f1); }
 
-  void SetBoundaryIFCC(TF1* f1) { fFormulaBoundaryIFCC = new TF1(*f1); }
+  void SetBoundaryIFCC(TF2* f1) { fFormulaBoundaryIFCC = new TF2(*f1); }
 
-  void SetBoundaryOFCA(TF1* f1) { fFormulaBoundaryOFCA = new TF1(*f1); }
+  void SetBoundaryOFCA(TF2* f1) { fFormulaBoundaryOFCA = new TF2(*f1); }
 
-  void SetBoundaryOFCC(TF1* f1) { fFormulaBoundaryOFCC = new TF1(*f1); }
+  void SetBoundaryOFCC(TF2* f1) { fFormulaBoundaryOFCC = new TF2(*f1); }
 
-  void SetBoundaryROCA(TF1* f1) { fFormulaBoundaryROCA = new TF1(*f1); }
+  void SetBoundaryROCA(TF2* f1) { fFormulaBoundaryROCA = new TF2(*f1); }
 
-  void SetBoundaryROCC(TF1* f1) { fFormulaBoundaryROCC = new TF1(*f1); }
+  void SetBoundaryROCC(TF2* f1) { fFormulaBoundaryROCC = new TF2(*f1); }
 
-  void SetBoundaryCE(TF1* f1) { fFormulaBoundaryCE = new TF1(*f1); }
+  void SetBoundaryCE(TF2* f1) { fFormulaBoundaryCE = new TF2(*f1); }
 
   void SetElectricFieldFormula(TFormula* formulaEr, TFormula* formulaEPhi, TFormula* formulaEz)
   {
@@ -259,7 +259,7 @@ class AliTPCSpaceCharge3DCalc
   Double_t* fListPotentialBoundaryA; //[fNRRows + fNNColumns] * 2 * fNPhiSlices
   Double_t* fListPotentialBoundaryC; //[fNRRows + fNNColumns] * 2 * fNPhiSlices
 
-  Int_t fCorrectionType = 1;      ///> use regular or irregular grid method
+  Int_t fCorrectionType = 0;      ///> use regular or irregular grid method
   Int_t fInterpolationOrder = 5;  ///>  Order of interpolation (1-> tri linear, 2->Lagrange interpolation order 2, 3> cubic spline)
   Int_t fIrregularGridSize = 3;   ///>  Size of irregular grid cubes for interpolation (min 3)
   Int_t fRBFKernelType = 0;       ///>  RBF kernel type
@@ -341,13 +341,13 @@ class AliTPCSpaceCharge3DCalc
   TH3* fHistogram3DSpaceCharge;  //-> Histogram with the input space charge histogram - used as an optional input
   TH3* fHistogram3DSpaceChargeA; //-> Histogram with the input space charge histogram - used as an optional input side A
   TH3* fHistogram3DSpaceChargeC; //-> Histogram with the input space charge histogram - used as an optional input side C
-  TF1* fFormulaBoundaryIFCA;     //-> function define boundary values for IFC side A V(z) assuming symmetry in phi and r.
-  TF1* fFormulaBoundaryIFCC;     //-> function define boundary values for IFC side C V(z) assuming symmetry in phi and r.
-  TF1* fFormulaBoundaryOFCA;     //-> function define boundary values for OFC side A V(z) assuming symmetry in phi and r.
-  TF1* fFormulaBoundaryOFCC;     ///<- function define boundary values for IFC side C V(z) assuming symmetry in phi and r.
-  TF1* fFormulaBoundaryROCA;     ///<- function define boundary values for ROC side A V(r) assuming symmetry in phi and z.
-  TF1* fFormulaBoundaryROCC;     ///<- function define boundary values for ROC side V V(t) assuming symmetry in phi and z.
-  TF1* fFormulaBoundaryCE;       ///<- function define boundary values for CE V(z) assuming symmetry in phi and z.
+  TF2* fFormulaBoundaryIFCA;     //-> function define boundary values for IFC side A V(z,phi)
+  TF2* fFormulaBoundaryIFCC;     //-> function define boundary values for IFC side C V(z,phi)
+  TF2* fFormulaBoundaryOFCA;     //-> function define boundary values for OFC side A V(z,phi)
+  TF2* fFormulaBoundaryOFCC;     ///<- function define boundary values for IFC side C V(z,phi)
+  TF2* fFormulaBoundaryROCA;     ///<- function define boundary values for ROC side A V(r,phi)
+  TF2* fFormulaBoundaryROCC;     ///<- function define boundary values for ROC side V V(r,phi)
+  TF2* fFormulaBoundaryCE;       ///<- function define boundary values for CE V(z,phi)
 
   TFormula* fFormulaPotentialV; ///<- potential V(r,rho,z) function
   TFormula* fFormulaChargeRho;  ///<- charge density Rho(r,rho,z) function

--- a/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.h
+++ b/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.h
@@ -1,14 +1,9 @@
-// Copyright CERN and copyright holders of ALICE O2. This software is
-// distributed under the terms of the GNU General Public License v3 (GPL
-// Version 3), copied verbatim in the file "COPYING".
-//
-// See http://alice-o2.web.cern.ch/license for full licensing information.
-//
-// In applying this license CERN does not waive the privileges and immunities
-// granted to it by virtue of its status as an Intergovernmental Organization
-// or submit itself to any jurisdiction.
+/* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
 
-/// \file AliTPCSpaceCharge3DCalc.h
+/* $Id$ */
+
+/// \class AliTPCSpaceCharge3DCalc
 /// \brief This class provides distortion and correction map calculation with integration following electron drift
 /// TODO: validate distortion z by comparing with exisiting classes
 ///
@@ -29,9 +24,8 @@
 
 class TFormula;
 
-class AliTPCSpaceCharge3DCalc
-{
- public:
+class AliTPCSpaceCharge3DCalc {
+public:
   AliTPCSpaceCharge3DCalc();
   AliTPCSpaceCharge3DCalc(Int_t nRRow, Int_t nZColumn, Int_t nPhiSlice);
   AliTPCSpaceCharge3DCalc(Int_t nRRow, Int_t nZColumn, Int_t nPhiSlice,
@@ -39,30 +33,18 @@ class AliTPCSpaceCharge3DCalc
   virtual ~AliTPCSpaceCharge3DCalc();
   void InitSpaceCharge3DPoissonIntegralDz(Int_t nRRow, Int_t nZColumn, Int_t phiSlice, Int_t maxIteration,
                                           Double_t stopConvergence);
-
-  // outdated, to be removed after modifications in aliroot are pushed
   void InitSpaceCharge3DPoissonIntegralDz(
     Int_t nRRow, Int_t nZColumn, Int_t phiSlice, Int_t maxIteration, Double_t stopConvergence,
-    TMatrixD** matricesErA, TMatrixD** matricesEphiA, TMatrixD** matricesEzA,
-    TMatrixD** matricesErC, TMatrixD** matricesEphiC, TMatrixD** matricesEzC,
-    TMatrixD** matricesDistDrDzA, TMatrixD** matricesDistDPhiRDzA, TMatrixD** matricesDistDzA,
-    TMatrixD** matricesCorrDrDzA, TMatrixD** matricesCorrDPhiRDzA, TMatrixD** matricesCorrDzA,
-    TMatrixD** matricesDistDrDzC, TMatrixD** matricesDistDPhiRDzC, TMatrixD** matricesDistDzC,
-    TMatrixD** matricesCorrDrDzC, TMatrixD** matricesCorrDPhiRDzC, TMatrixD** matricesCorrDzC,
-    TFormula* intErDzTestFunction, TFormula* intEPhiRDzTestFunction, TFormula* intDzTestFunction);
-
-  void InitSpaceCharge3DPoissonIntegralDz(
-    Int_t nRRow, Int_t nZColumn, Int_t phiSlice, Int_t maxIteration, Double_t stopConvergence,
-    TMatrixD** matricesErA, TMatrixD** matricesEphiA, TMatrixD** matricesEzA,
-    TMatrixD** matricesErC, TMatrixD** matricesEphiC, TMatrixD** matricesEzC,
-    TMatrixD** matricesDistDrDzA, TMatrixD** matricesDistDPhiRDzA, TMatrixD** matricesDistDzA,
-    TMatrixD** matricesCorrDrDzA, TMatrixD** matricesCorrDPhiRDzA, TMatrixD** matricesCorrDzA,
-    TMatrixD** matricesDistDrDzC, TMatrixD** matricesDistDPhiRDzC, TMatrixD** matricesDistDzC,
-    TMatrixD** matricesCorrDrDzC, TMatrixD** matricesCorrDPhiRDzC, TMatrixD** matricesCorrDzC,
-    TFormula* intErDzTestFunction, TFormula* intEPhiRDzTestFunction, TFormula* intDzTestFunction, TFormula* ezF);
+    TMatrixD **matricesErA, TMatrixD **matricesEphiA, TMatrixD **matricesEzA,
+    TMatrixD **matricesErC, TMatrixD **matricesEphiC, TMatrixD **matricesEzC,
+    TMatrixD **matricesDistDrDzA, TMatrixD **matricesDistDPhiRDzA, TMatrixD **matricesDistDzA,
+    TMatrixD **matricesCorrDrDzA, TMatrixD **matricesCorrDPhiRDzA, TMatrixD **matricesCorrDzA,
+    TMatrixD **matricesDistDrDzC, TMatrixD **matricesDistDPhiRDzC, TMatrixD **matricesDistDzC,
+    TMatrixD **matricesCorrDrDzC, TMatrixD **matricesCorrDPhiRDzC, TMatrixD **matricesCorrDzC,
+    TFormula *intErDzTestFunction, TFormula *intEPhiRDzTestFunction, TFormula *intDzTestFunction, TFormula *ezF);
 
   void
-    InitSpaceCharge3DPoisson(Int_t nRRow, Int_t nZColumn, Int_t phiSlice, Int_t maxIteration, Double_t stopConvergence);
+  InitSpaceCharge3DPoisson(Int_t nRRow, Int_t nZColumn, Int_t phiSlice, Int_t maxIteration, Double_t stopConvergence);
   void ForceInitSpaceCharge3DPoissonIntegralDz(Int_t nRRow, Int_t nZColumn, Int_t phiSlice, Int_t maxIteration,
                                                Double_t stopConvergence);
   void GetDistortionCyl(const Float_t x[], Short_t roc, Float_t dx[]);
@@ -70,45 +52,45 @@ class AliTPCSpaceCharge3DCalc
   void GetCorrectionCyl(const Float_t x[], Short_t roc, Float_t dx[]);
   void GetCorrectionCylAC(const Float_t x[], Short_t roc, Float_t dx[]);
   void GetCorrectionCylACIrregular(const Float_t x[], Short_t roc, Float_t dx[]);
-  void GetCorrectionCylACIrregular(const Float_t x[], Short_t roc, Float_t dx[], const Int_t side);
+  void GetCorrectionCylACIrregular(const Float_t x[], Short_t roc, Float_t dx[],const Int_t side);
   void GetDistortion(const Float_t x[], Short_t roc, Float_t dx[]);
 
   void GetCorrection(const Float_t x[], Short_t roc, Float_t dx[]);
-  void GetCorrection(const Float_t x[], Short_t roc, Float_t dx[], const Int_t side);
+  void GetCorrection(const Float_t x[], Short_t roc, Float_t dx[],const Int_t side);
 
   Double_t GetChargeCylAC(const Float_t x[], Short_t roc);
   Double_t GetPotentialCylAC(const Float_t x[], Short_t roc);
 
   Double_t GetInverseChargeCylAC(const Float_t x[], Short_t roc);
 
-  void SetCorrectionType(Int_t correctionType) { fCorrectionType = correctionType; }
+  void SetCorrectionType(Int_t correctionType) {
+    fCorrectionType = correctionType;
+  }
 
   enum {
     kNumSector = 18
   };
 
   enum CorrectionType {
-    kRegularInterpolator = 0,   ///< use interpolation with regular interpolator for correction look up table
-    kIrregularInterpolator = 1, ///< use irregular interpolator for correction look up table
+    kRegularInterpolator = 0,     ///< use interpolation with regular interpolator for correction look up table
+    kIrregularInterpolator = 1,   ///< use irregular interpolator for correction look up table
   };
 
   enum IntegrationStrategy {
-    kNaive = 0, ///< use interpolation with regular interpolator for correction look up table
+    kNaive = 0,     ///< use interpolation with regular interpolator for correction look up table
     kOpt = 1,   ///< use irregular interpolator for correction look up table
   };
-  void SetInputSpaceCharge(TH3* hisSpaceCharge3D, Double_t norm);
-  void SetInputSpaceCharge(TH3* hisSpaceCharge3D) { SetInputSpaceCharge(hisSpaceCharge3D, 1); }
-  void SetInputSpaceCharge(TH3* hisSpaceCharge3D, Double_t norm, Int_t side);
-  void SetInputSpaceCharge(TH3* hisSpaceCharge3D, Int_t side) { SetInputSpaceCharge(hisSpaceCharge3D, 1, side); }
+  void SetInputSpaceCharge(TH3 *hisSpaceCharge3D, Double_t norm);
+  void SetInputSpaceCharge(TH3 *hisSpaceCharge3D) { SetInputSpaceCharge(hisSpaceCharge3D, 1); }
+  void SetInputSpaceCharge(TH3 *hisSpaceCharge3D, Double_t norm, Int_t side);
+  void SetInputSpaceCharge(TH3 *hisSpaceCharge3D, Int_t side) { SetInputSpaceCharge(hisSpaceCharge3D, 1, side); }
 
-  void SetInputSpaceChargeA(TMatrixD** matricesLookUpCharge)
-  {
+  void SetInputSpaceChargeA(TMatrixD **matricesLookUpCharge) {
     fInterpolatorChargeA->SetValue(matricesLookUpCharge);
     fInterpolatorChargeA->InitCubicSpline();
   }
 
-  void SetInputSpaceChargeC(TMatrixD** matricesLookUpCharge)
-  {
+  void SetInputSpaceChargeC(TMatrixD **matricesLookUpCharge) {
     fInterpolatorChargeC->SetValue(matricesLookUpCharge);
     fInterpolatorChargeC->InitCubicSpline();
   }
@@ -125,30 +107,26 @@ class AliTPCSpaceCharge3DCalc
 
   Int_t GetNZColumns() { return fNZColumns; }
 
-  void SetPoissonSolver(AliTPCPoissonSolver* poissonSolver)
-  {
-    if (fPoissonSolver != nullptr) {
-      delete fPoissonSolver;
-    }
-    fPoissonSolver = poissonSolver;
+  void SetPoissonSolver(AliTPCPoissonSolver *poissonSolver) {
+    if (fPoissonSolver != NULL) delete fPoissonSolver;
+    fPoissonSolver= poissonSolver;
   }
 
-  AliTPCPoissonSolver* GetPoissonSolver() { return fPoissonSolver; }
+  AliTPCPoissonSolver *GetPoissonSolver() { return fPoissonSolver; }
 
-  void SetInterpolationOrder(Int_t order);
+  void SetInterpolationOrder(Int_t order); 
+ 
 
   Int_t GetInterpolationOrder() { return fInterpolationOrder; }
 
-  void SetOmegaTauT1T2(Float_t omegaTau, Float_t t1, Float_t t2)
-  {
+  void SetOmegaTauT1T2(Float_t omegaTau, Float_t t1, Float_t t2) {
     const Double_t wt0 = t2 * omegaTau;
     fC0 = 1. / (1. + wt0 * wt0);
     const Double_t wt1 = t1 * omegaTau;
     fC1 = wt1 / (1. + wt1 * wt1);
   };
 
-  void SetC0C1(Float_t c0, Float_t c1)
-  {
+  void SetC0C1(Float_t c0, Float_t c1) {
     fC0 = c0;
     fC1 = c1;
   }
@@ -161,30 +139,30 @@ class AliTPCSpaceCharge3DCalc
 
   Float_t GetCorrectionFactor() const { return fCorrectionFactor; }
 
-  void InverseDistortionMaps(TMatrixD** matricesCharge, TMatrixD** matricesEr, TMatrixD** matricesEPhi,
-                             TMatrixD** matricesEz, TMatrixD** matricesInvLocalIntErDz,
-                             TMatrixD**, TMatrixD** matricesInvLocalEz,
-                             TMatrixD** matricesDistDrDz, TMatrixD** matricesDistDPhiRDz, TMatrixD** matricesDistDz,
+  void InverseDistortionMaps(TMatrixD **matricesCharge, TMatrixD **matricesEr, TMatrixD **matricesEPhi,
+                             TMatrixD **matricesEz, TMatrixD **matricesInvLocalIntErDz,
+                             TMatrixD **, TMatrixD **matricesInvLocalEz,
+                             TMatrixD **matricesDistDrDz, TMatrixD **matricesDistDPhiRDz, TMatrixD **matricesDistDz,
                              const Int_t nRRow, const Int_t nZColumn, const Int_t phiSlice, const Int_t nStep,
                              const Bool_t useCylAC, Int_t stepR, Int_t stepZ, Int_t stepPhi, Int_t interpType);
 
-  void InverseDistortionMapsNoDrift(TMatrixD** matricesCharge, TMatrixD** matricesEr, TMatrixD** matricesEPhi,
-                                    TMatrixD** matricesEz, TMatrixD** matricesInvLocalIntErDz,
-                                    TMatrixD** matricesInvLocalIntEPhiDz, TMatrixD** matricesInvLocalEz,
-                                    TMatrixD** matricesDistDrDz, TMatrixD** matricesDistDPhiRDz,
-                                    TMatrixD** matricesDistDz, const Int_t nRRow, const Int_t nZColumn,
+  void InverseDistortionMapsNoDrift(TMatrixD **matricesCharge, TMatrixD **matricesEr, TMatrixD **matricesEPhi,
+                                    TMatrixD **matricesEz, TMatrixD **matricesInvLocalIntErDz,
+                                    TMatrixD **matricesInvLocalIntEPhiDz, TMatrixD **matricesInvLocalEz,
+                                    TMatrixD **matricesDistDrDz, TMatrixD **matricesDistDPhiRDz,
+                                    TMatrixD **matricesDistDz, const Int_t nRRow, const Int_t nZColumn,
                                     const Int_t phiSlice);
 
   void GetCorrectionCylNoDrift(const Float_t x[], const Short_t roc, Float_t dx[]);
 
   void GetDistortionCylNoDrift(const Float_t x[], Short_t roc, Float_t dx[]);
 
-  void InverseGlobalToLocalDistortionNoDrift(TMatrixD** matricesDistDrDz, TMatrixD** matricesDistDPhiRDz,
-                                             TMatrixD** matricesDistDz, Double_t* rList, Double_t* zList,
-                                             Double_t* phiList, const Int_t nRRow, const Int_t nZColumn,
+  void InverseGlobalToLocalDistortionNoDrift(TMatrixD **matricesDistDrDz, TMatrixD **matricesDistDPhiRDz,
+                                             TMatrixD **matricesDistDz, Double_t *rList, Double_t *zList,
+                                             Double_t *phiList, const Int_t nRRow, const Int_t nZColumn,
                                              const Int_t phiSlice);
 
-  void GetChargeDensity(TMatrixD** matricesChargeA, TMatrixD** matricesChargeC, TH3* spaceChargeHistogram3D,
+  void GetChargeDensity(TMatrixD **matricesChargeA, TMatrixD **matricesChargeC, TH3 *spaceChargeHistogram3D,
                         const Int_t nRRow, const Int_t nZColumn, const Int_t phiSlice);
 
   void GetInverseLocalDistortionCyl(const Float_t x[], Short_t roc, Float_t dx[]);
@@ -197,9 +175,9 @@ class AliTPCSpaceCharge3DCalc
 
   Int_t GetRBFKernelType() { return fRBFKernelType; }
 
-  void SetPotentialBoundaryAndChargeFormula(TFormula* vTestFunction, TFormula* rhoTestFunction);
-  TFormula* GetPotentialVFormula() const { return fFormulaPotentialV; }
-  TFormula* GetChargeRhoFormula() const { return fFormulaChargeRho; }
+  void SetPotentialBoundaryAndChargeFormula(TFormula *vTestFunction, TFormula *rhoTestFunction);
+  TFormula *GetPotentialVFormula() const { return fFormulaPotentialV; }
+  TFormula *GetChargeRhoFormula() const { return fFormulaChargeRho; }
 
   void SetBoundaryIFCA(TF2* f1) { fFormulaBoundaryIFCA = new TF2(*f1); }
 
@@ -215,32 +193,32 @@ class AliTPCSpaceCharge3DCalc
 
   void SetBoundaryCE(TF2* f1) { fFormulaBoundaryCE = new TF2(*f1); }
 
-  void SetElectricFieldFormula(TFormula* formulaEr, TFormula* formulaEPhi, TFormula* formulaEz)
-  {
+  void SetElectricFieldFormula(TFormula *formulaEr, TFormula *formulaEPhi, TFormula *formulaEz) {
     fFormulaEr = formulaEr;
     fFormulaEPhi = formulaEPhi;
     fFormulaEz = formulaEz;
   }
-  TFormula* GetErFormula() const { return fFormulaEr; }
-  TFormula* GetEPhiFormula() const { return fFormulaEPhi; }
-  TFormula* GetEzFormula() const { return fFormulaEz; }
+  TFormula *GetErFormula() const { return fFormulaEr; }
+  TFormula *GetEPhiFormula() const { return fFormulaEPhi; }
+  TFormula *GetEzFormula() const { return fFormulaEz; }
 
   Float_t GetSpaceChargeDensity(Float_t r, Float_t phi, Float_t z);
   Float_t GetPotential(Float_t r, Float_t phi, Float_t z);
   void GetElectricFieldCyl(const Float_t x[], Short_t roc, Double_t dx[]);
   struct Profile {
-    Double_t poissonSolverTime;
-    Double_t electricFieldTime;
-    Double_t localDistortionTime;
-    Double_t globalDistortionTime;
-    Double_t interpolationInitTime;
-    Int_t iteration;
+	Double_t poissonSolverTime;
+	Double_t electricFieldTime;
+	Double_t localDistortionTime;
+	Double_t globalDistortionTime;
+	Double_t interpolationInitTime;
+	Int_t iteration;
   };
 
   Profile GetProfile() { return myProfile; }
-  void SetIntegrationStrategy(Int_t integrationStrategy) { fIntegrationStrategy = integrationStrategy; }
-
- private:
+  void SetIntegrationStrategy(Int_t integrationStrategy) {
+    fIntegrationStrategy = integrationStrategy;
+  }
+private:
   static const Int_t kNMaxPhi = 360;
   Profile myProfile;
   Int_t fNRRows = 129;             ///< the maximum on row-slices so far ~ 2cm slicing
@@ -353,96 +331,86 @@ class AliTPCSpaceCharge3DCalc
   TFormula* fFormulaChargeRho;  ///<- charge density Rho(r,rho,z) function
 
   // analytic formula for E
-  TFormula* fFormulaEPhi; ///<- ePhi EPhi(r,rho,z) electric field (phi) function
-  TFormula* fFormulaEr;   ///<- er Er(r,rho,z) electric field (r) function
-  TFormula* fFormulaEz;   ///<- ez Ez(r,rho,z) electric field (z) function
+  TFormula *fFormulaEPhi; ///<- ePhi EPhi(r,rho,z) electric field (phi) function
+  TFormula *fFormulaEr; ///<- er Er(r,rho,z) electric field (r) function
+  TFormula *fFormulaEz; ///<- ez Ez(r,rho,z) electric field (z) function
 
-  AliTPCPoissonSolver* fPoissonSolver; //-> Pointer to a poisson solver
 
-  void ElectricField(TMatrixD** matricesV, TMatrixD** matricesEr, TMatrixD** matricesEPhi, TMatrixD** matricesEz,
+
+  AliTPCPoissonSolver *fPoissonSolver; //-> Pointer to a poisson solver
+
+  void ElectricField(TMatrixD **matricesV, TMatrixD **matricesEr, TMatrixD **matricesEPhi, TMatrixD **matricesEz,
                      const Int_t nRRow, const Int_t nZColumn, const Int_t phiSlices, const Float_t gridSizeR,
                      const Float_t gridSizePhi, const Float_t gridSizeZ, const Int_t symmetry,
                      const Float_t innerRadius);
 
   void
-    LocalDistCorrDz(TMatrixD** matricesEr, TMatrixD** matricesEPhi, TMatrixD** matricesEz, TMatrixD** matricesDistDrDz,
-                    TMatrixD** matricesDistDPhiRDz, TMatrixD** matricesDistDz, TMatrixD** matricesCorrDrDz,
-                    TMatrixD** matricesCorrDPhiRDz, TMatrixD** matricesCorrDz, const Int_t nRRow, const Int_t nZColumn,
-                    const Int_t phiSlice, const Float_t gridSizeZ, const Double_t ezField);
+  LocalDistCorrDz(TMatrixD **matricesEr, TMatrixD **matricesEPhi, TMatrixD **matricesEz, TMatrixD **matricesDistDrDz,
+                  TMatrixD **matricesDistDPhiRDz, TMatrixD **matricesDistDz, TMatrixD **matricesCorrDrDz,
+                  TMatrixD **matricesCorrDPhiRDz, TMatrixD **matricesCorrDz, const Int_t nRRow, const Int_t nZColumn,
+                  const Int_t phiSlice, const Float_t gridSizeZ, const Double_t ezField);
 
-  void IntegrateDistCorrDriftLineDz(AliTPCLookUpTable3DInterpolatorD* lookupLocalDist, TMatrixD** matricesGDistDrDz,
-                                    TMatrixD** matricesGDistDPhiRDz, TMatrixD** matricesGDistDz,
-                                    AliTPCLookUpTable3DInterpolatorD* lookupLocalCorr, TMatrixD** matricesGCorrDrDz,
-                                    TMatrixD** matricesGCorrDPhiRDz, TMatrixD** matricesGCorrDz,
-                                    TMatrixD** matricesGCorrIrregularDrDz, TMatrixD** matricesGCorrIrregularDPhiRDz,
-                                    TMatrixD** matricesGCorrIrregularDz,
-                                    TMatrixD** matricesRIrregular, TMatrixD** matricesPhiIrregular,
-                                    TMatrixD** matricesZIrregular,
+  void IntegrateDistCorrDriftLineDz(AliTPCLookUpTable3DInterpolatorD *lookupLocalDist, TMatrixD **matricesGDistDrDz,
+                                    TMatrixD **matricesGDistDPhiRDz, TMatrixD **matricesGDistDz,
+                                    AliTPCLookUpTable3DInterpolatorD *lookupLocalCorr, TMatrixD **matricesGCorrDrDz,
+                                    TMatrixD **matricesGCorrDPhiRDz, TMatrixD **matricesGCorrDz,
+                                    TMatrixD **matricesGCorrIrregularDrDz, TMatrixD **matricesGCorrIrregularDPhiRDz,
+                                    TMatrixD **matricesGCorrIrregularDz,
+                                    TMatrixD **matricesRIrregular, TMatrixD **matricesPhiIrregular,
+                                    TMatrixD **matricesZIrregular,
                                     const Int_t nRRow, const Int_t nZColumn, const Int_t phiSlice,
-                                    const Double_t* rList, const Double_t* phiList, const Double_t* zList);
-
-  // outdated, to be removed once modifications in aliroot are pushed
-  void IntegrateDistCorrDriftLineDz(
-    TFormula* intErDzTestFunction, TFormula* intEPhiRDzTestFunction, TFormula* intDzTestFunction,
-    const Double_t ezField, TMatrixD** matricesGDistDrDz, TMatrixD** matricesGDistDPhiRDz,
-    TMatrixD** matricesGDistDz,
-    TMatrixD** matricesGCorrDrDz, TMatrixD** matricesGCorrDPhiRDz, TMatrixD** matricesGCorrDz,
-    TMatrixD** matricesGCorrIrregularDrDz, TMatrixD** matricesGCorrIrregularDPhiRDz,
-    TMatrixD** matricesGCorrIrregularDz, TMatrixD** matricesRIrregular, TMatrixD** matricesPhiIrregular,
-    TMatrixD** matricesZIrregular, const Int_t nRRow, const Int_t nZColumn, const Int_t phiSlice,
-    const Double_t* rList,
-    const Double_t* phiList, const Double_t* zList);
+                                    const Double_t *rList, const Double_t *phiList, const Double_t *zList);
 
   void IntegrateDistCorrDriftLineDz(
-    TFormula* intErDzTestFunction, TFormula* intEPhiRDzTestFunction, TFormula* intDzTestFunction, TFormula* ezF,
-    const Double_t ezField, TMatrixD** matricesGDistDrDz, TMatrixD** matricesGDistDPhiRDz,
-    TMatrixD** matricesGDistDz,
-    TMatrixD** matricesGCorrDrDz, TMatrixD** matricesGCorrDPhiRDz, TMatrixD** matricesGCorrDz,
-    TMatrixD** matricesGCorrIrregularDrDz, TMatrixD** matricesGCorrIrregularDPhiRDz,
-    TMatrixD** matricesGCorrIrregularDz, TMatrixD** matricesRIrregular, TMatrixD** matricesPhiIrregular,
-    TMatrixD** matricesZIrregular, const Int_t nRRow, const Int_t nZColumn, const Int_t phiSlice,
-    const Double_t* rList,
-    const Double_t* phiList, const Double_t* zList);
+    TFormula *intErDzTestFunction, TFormula *intEPhiRDzTestFunction, TFormula *intDzTestFunction, TFormula *ezF,
+    const Double_t ezField, TMatrixD **matricesGDistDrDz, TMatrixD **matricesGDistDPhiRDz,
+    TMatrixD **matricesGDistDz,
+    TMatrixD **matricesGCorrDrDz, TMatrixD **matricesGCorrDPhiRDz, TMatrixD **matricesGCorrDz,
+    TMatrixD **matricesGCorrIrregularDrDz, TMatrixD **matricesGCorrIrregularDPhiRDz,
+    TMatrixD **matricesGCorrIrregularDz, TMatrixD **matricesRIrregular, TMatrixD **matricesPhiIrregular,
+    TMatrixD **matricesZIrregular, const Int_t nRRow, const Int_t nZColumn, const Int_t phiSlice,
+    const Double_t *rList,
+    const Double_t *phiList, const Double_t *zList);
 
-  void IntegrateDistCorrDriftLineDzWithLookUp(AliTPCLookUpTable3DInterpolatorD* lookupLocalDist, TMatrixD** matricesGDistDrDz, TMatrixD** matricesGDistDPhiRDz, TMatrixD** matricesGDistDz, AliTPCLookUpTable3DInterpolatorD* lookupLocalCorr, TMatrixD** matricesGCorrDrDz, TMatrixD** matricesGCorrDPhiRDz, TMatrixD** matricesGCorrDz, const Int_t nRRow, const Int_t nZColumn, const Int_t phiSlice, Double_t* rList, Double_t* phiList, Double_t* zList);
+  void IntegrateDistCorrDriftLineDzWithLookUp ( AliTPCLookUpTable3DInterpolatorD *lookupLocalDist, TMatrixD** matricesGDistDrDz,  	TMatrixD** matricesGDistDPhiRDz, 	TMatrixD** matricesGDistDz, 	AliTPCLookUpTable3DInterpolatorD *lookupLocalCorr, 	TMatrixD** matricesGCorrDrDz,  	TMatrixD** matricesGCorrDPhiRDz, TMatrixD** matricesGCorrDz, const Int_t nRRow,  	const Int_t nZColumn, 	const Int_t phiSlice,	Double_t *rList,	 Double_t *phiList,  Double_t *zList );
 
-  void FillLookUpTable(AliTPCLookUpTable3DInterpolatorD* lookupGlobal, TMatrixD** lookupRDz, TMatrixD** lookupPhiRDz,
-                       TMatrixD** lookupDz, const Int_t nRRow, const Int_t nZColumn, const Int_t phiSlice,
-                       const Double_t* rList, const Double_t* phiList, const Double_t* zList);
+  void FillLookUpTable(AliTPCLookUpTable3DInterpolatorD *lookupGlobal, TMatrixD **lookupRDz, TMatrixD **lookupPhiRDz,
+                       TMatrixD **lookupDz, const Int_t nRRow, const Int_t nZColumn, const Int_t phiSlice,
+                       const Double_t *rList, const Double_t *phiList, const Double_t *zList);
 
-  Double_t InterpolatePhi(TH3* h3, const Double_t r, const Double_t phi, const Double_t z);
+  Double_t InterpolatePhi(TH3 *h3, const Double_t r, const Double_t phi, const Double_t z);
 
-  void InverseGlobalToLocalDistortionGlobalInvTable(TMatrixD** matricesDistDrDz, TMatrixD** matricesDistDPhiRDz,
-                                                    TMatrixD** matricesDistDz, Double_t* rList, Double_t* zList,
-                                                    Double_t* phiList, const Int_t nRRow, const Int_t nZColumn,
+  void InverseGlobalToLocalDistortionGlobalInvTable(TMatrixD **matricesDistDrDz, TMatrixD **matricesDistDPhiRDz,
+                                                    TMatrixD **matricesDistDz, Double_t *rList, Double_t *zList,
+                                                    Double_t *phiList, const Int_t nRRow, const Int_t nZColumn,
                                                     const Int_t phiSlice, const Int_t nStep, const Bool_t useCylAC,
                                                     Int_t stepR, Int_t stepZ, Int_t stepPhi, Int_t type);
 
-  void InverseLocalDistortionToElectricField(TMatrixD** matricesEr, TMatrixD** matricesEPhi, TMatrixD** matricesEz,
-                                             TMatrixD** matricesInvLocalIntErDz, TMatrixD** matricesInvLocalIntEPhiDz,
-                                             TMatrixD** matricesInvLocalIntEz, TMatrixD** matricesDistDrDz,
-                                             TMatrixD** matricesDistDPhiRDz, TMatrixD** matricesDistDz,
-                                             Double_t* rList, Double_t* zList, Double_t* phiList, const Int_t nRRow,
+  void InverseLocalDistortionToElectricField(TMatrixD **matricesEr, TMatrixD **matricesEPhi, TMatrixD **matricesEz,
+                                             TMatrixD **matricesInvLocalIntErDz, TMatrixD **matricesInvLocalIntEPhiDz,
+                                             TMatrixD **matricesInvLocalIntEz, TMatrixD **matricesDistDrDz,
+                                             TMatrixD **matricesDistDPhiRDz, TMatrixD **matricesDistDz,
+                                             Double_t *rList, Double_t *zList, Double_t *phiList, const Int_t nRRow,
                                              const Int_t nZColumn, const Int_t phiSlice);
 
-  void InverseElectricFieldToCharge(TMatrixD** matricesCharge, TMatrixD** matricesEr, TMatrixD** matricesEPhi,
-                                    TMatrixD** matricesEz, Double_t* rList, Double_t* zList, Double_t* phiList,
+  void InverseElectricFieldToCharge(TMatrixD **matricesCharge, TMatrixD **matricesEr, TMatrixD **matricesEPhi,
+                                    TMatrixD **matricesEz, Double_t *rList, Double_t *zList, Double_t *phiList,
                                     const Int_t nRRow, const Int_t nZColumn, const Int_t phiSlice);
 
-  void CalculateEField(TMatrixD** matricesV, TMatrixD** matricesErOverEz, TMatrixD** matricesEPhiOverEz,
-                       TMatrixD** matricesDeltaEz, const Int_t nRRow, const Int_t nZColumn, const Int_t nPhiSlice,
+  void CalculateEField(TMatrixD **matricesV, TMatrixD **matricesErOverEz, TMatrixD **matricesEPhiOverEz,
+                       TMatrixD **matricesDeltaEz, const Int_t nRRow, const Int_t nZColumn, const Int_t nPhiSlice,
                        const Int_t symmetry, Bool_t rocDisplacement = kFALSE);
 
   void
-    IntegrateEz(TMatrixD** matricesExOverEz, TMatrixD** matricesEx, const Int_t nRRow, const Int_t nZColumn,
-                const Int_t nPhiSlice, const Double_t ezField);
+  IntegrateEz(TMatrixD **matricesExOverEz, TMatrixD **matricesEx, const Int_t nRRow, const Int_t nZColumn,
+              const Int_t nPhiSlice, const Double_t ezField);
 
   void InitAllocateMemory();
 
-  /// \cond CLASSIMP
+/// \cond CLASSIMP
   ClassDef(AliTPCSpaceCharge3DCalc,
-           1);
-  /// \endcond
+  1);
+/// \endcond
 };
 
 #endif

--- a/TPC/TPCbase/AliTPCSpaceCharge3DDriftLine.cxx
+++ b/TPC/TPCbase/AliTPCSpaceCharge3DDriftLine.cxx
@@ -138,7 +138,7 @@ void AliTPCSpaceCharge3DDriftLine::InitSpaceCharge3DPoissonIntegralDz(
   TMatrixD **matricesCorrDrDzA,  TMatrixD **matricesCorrDPhiRDzA, TMatrixD **matricesCorrDzA,
   TMatrixD **matricesDistDrDzC,  TMatrixD **matricesDistDPhiRDzC, TMatrixD **matricesDistDzC,
   TMatrixD **matricesCorrDrDzC,  TMatrixD **matricesCorrDPhiRDzC, TMatrixD **matricesCorrDzC,
-  TFormula *intErDzTestFunction,  TFormula *intEPhiRDzTestFunction, TFormula *intDzTestFunction) {
+  TFormula *intErDzTestFunction,  TFormula *intEPhiRDzTestFunction, TFormula *intDzTestFunction, TFormula *ezFunction) {
   fSpaceCharge3DCalc.InitSpaceCharge3DPoissonIntegralDz(nRRow, nZColumn, phiSlice, maxIteration, stopConvergence,
     matricesErA, matricesEPhiA, matricesEzA,
     matricesErC, matricesEPhiC, matricesEzC,
@@ -146,7 +146,7 @@ void AliTPCSpaceCharge3DDriftLine::InitSpaceCharge3DPoissonIntegralDz(
     matricesCorrDrDzA,  matricesCorrDPhiRDzA, matricesCorrDzA,
     matricesDistDrDzC,  matricesDistDPhiRDzC, matricesDistDzC,
     matricesCorrDrDzC,  matricesCorrDPhiRDzC, matricesCorrDzC,
-    intErDzTestFunction, intEPhiRDzTestFunction, intDzTestFunction);
+    intErDzTestFunction, intEPhiRDzTestFunction, intDzTestFunction, ezFunction);
 }
 /// Creating look-up tables of Correction/Distortion by linear integration
 /// on z line
@@ -223,6 +223,13 @@ void AliTPCSpaceCharge3DDriftLine::GetCorrection(const Float_t x[], Short_t roc,
   fSpaceCharge3DCalc.GetCorrection(x, roc, dx);
 }
 ///
+/// \param x
+/// \param roc
+/// \param dx
+void AliTPCSpaceCharge3DDriftLine::GetCorrection(const Float_t x[], Short_t roc, Float_t dx[],const Int_t side) {
+  fSpaceCharge3DCalc.GetCorrection(x, roc, dx,side);
+}
+///
 /// \param z
 /// \param nx
 /// \param ny
@@ -238,6 +245,7 @@ TH2F *AliTPCSpaceCharge3DDriftLine::CreateHistogramDistDRInXY(Float_t z, Int_t n
                        "drDist [cm]",
                        nx, -250., 250., ny, -250., 250.);
   Float_t x[3], dx[3];
+  Float_t r0,r1;
   x[2] = z;
   Int_t roc = z > 0. ? 0 : 18; // FIXME
   for (Int_t iy = 1; iy <= ny; ++iy) {
@@ -277,6 +285,7 @@ TH2F *AliTPCSpaceCharge3DDriftLine::CreateHistogramCorrDRInXY
                        "drDist [cm]",
                        nx, -250., 250., ny, -250., 250.);
   Float_t x[3], dx[3];
+  Float_t r0,r1;
   x[2] = z;
   Int_t roc = z > 0. ? 0 : 18; // FIXME
   for (Int_t iy = 1; iy <= ny; ++iy) {
@@ -284,10 +293,10 @@ TH2F *AliTPCSpaceCharge3DDriftLine::CreateHistogramCorrDRInXY
     for (Int_t ix = 1; ix <= nx; ++ix) {
       x[0] = h->GetXaxis()->GetBinCenter(ix);
       GetCorrection(x, roc, dx);
-      Float_t r0 = TMath::Sqrt((x[0]) * (x[0]) + (x[1]) * (x[1]));
-      Float_t r1 = TMath::Sqrt((x[0] + dx[0]) * (x[0] + dx[0]) + (x[1] + dx[1]) * (x[1] + dx[1]));
+      r0 = TMath::Sqrt((x[0]) * (x[0]) + (x[1]) * (x[1]));
+      r1 = TMath::Sqrt((x[0] + dx[0]) * (x[0] + dx[0]) + (x[1] + dx[1]) * (x[1]+ dx[1]));
       if (tpcParam->GetPadRowRadii(0, 0) <= r0 && r0 <= tpcParam->GetPadRowRadii(36, 95)) {
-        h->SetBinContent(ix, iy, r1 - r0);
+        h->SetBinContent(ix, iy, r1-r0);
       } else
         h->SetBinContent(ix, iy, 0.);
     }
@@ -508,9 +517,14 @@ TTree *AliTPCSpaceCharge3DDriftLine::CreateDistortionTree(Double_t step) {
         xyz[1] = phi;
         xyz[2] = z;
 
+	
         GetLocalDistortionCyl(xyz, roc, localDist);
 
-        GetCorrection(xyzDist, roc, corr);
+	if (z >= 0)	
+        	GetCorrection(xyzDist, roc, corr,0);
+	else
+        	GetCorrection(xyzDist, roc, corr,1);
+
 
         for (Int_t i = 0; i < 3; ++i) {
           xyzCorr[i] = xyzDist[i] + corr[i];
@@ -648,8 +662,6 @@ TTree *AliTPCSpaceCharge3DDriftLine::CreateDistortionTree(const Int_t nRRowTest,
 
           phi0 = m * dPhi;
           r0 = ifcRadius + (dRadius * i);
-          Double_t x0 = r0 * std::cos(phi0);
-          Double_t y0 = r0 * std::sin(phi0);
           z0 = dZ * j;
           if (side == 1) z0 = -1*z0;
           charge = GetSpaceChargeDensity(r0, phi0, z0);
@@ -696,9 +708,6 @@ TTree *AliTPCSpaceCharge3DDriftLine::CreateDistortionTree(const Int_t nRRowTest,
           dzCorr = corr[2];
 
           (*pcStream) << "distortion" <<
-                      "side=" << side <<
-                      "x=" << x0 <<
-                      "y=" << y0 <<
                       "z=" << z0 <<
                       "r=" << r0 <<
                       "phi=" << phi0 <<
@@ -727,6 +736,7 @@ TTree *AliTPCSpaceCharge3DDriftLine::CreateDistortionTree(const Int_t nRRowTest,
     }
   }
   delete pcStream;
+  Info("AliTPCSpaceCharge3DDriftLine::CreateDistortionTree","%s",Form("Distortion Tree Dump (%d,%d,%d), file name: distortion%s.root\n", nRRowTest,nZColTest,nPhiSliceTest,GetName()));
   TFile f(Form("distortion%s.root", GetName()));
   TTree *tree = (TTree *) f.Get("distortion");
 

--- a/TPC/TPCbase/AliTPCSpaceCharge3DDriftLine.cxx
+++ b/TPC/TPCbase/AliTPCSpaceCharge3DDriftLine.cxx
@@ -246,8 +246,9 @@ TH2F *AliTPCSpaceCharge3DDriftLine::CreateHistogramDistDRInXY(Float_t z, Int_t n
       x[0] = h->GetXaxis()->GetBinCenter(ix);
       GetDistortion(x, roc, dx);
       Float_t r0 = TMath::Sqrt((x[0]) * (x[0]) + (x[1]) * (x[1]));
+      Float_t r1 = TMath::Sqrt((x[0] + dx[0]) * (x[0] + dx[0]) + (x[1] + dx[1]) * (x[1] + dx[1]));
       if (tpcParam->GetPadRowRadii(0, 0) <= r0 && r0 <= tpcParam->GetPadRowRadii(36, 95)) {
-        h->SetBinContent(ix, iy, dx[2]);
+        h->SetBinContent(ix, iy, r1 - r0);
       } else
         h->SetBinContent(ix, iy, 0.);
     }
@@ -284,8 +285,9 @@ TH2F *AliTPCSpaceCharge3DDriftLine::CreateHistogramCorrDRInXY
       x[0] = h->GetXaxis()->GetBinCenter(ix);
       GetCorrection(x, roc, dx);
       Float_t r0 = TMath::Sqrt((x[0]) * (x[0]) + (x[1]) * (x[1]));
+      Float_t r1 = TMath::Sqrt((x[0] + dx[0]) * (x[0] + dx[0]) + (x[1] + dx[1]) * (x[1] + dx[1]));
       if (tpcParam->GetPadRowRadii(0, 0) <= r0 && r0 <= tpcParam->GetPadRowRadii(36, 95)) {
-        h->SetBinContent(ix, iy, dx[2]);
+        h->SetBinContent(ix, iy, r1 - r0);
       } else
         h->SetBinContent(ix, iy, 0.);
     }
@@ -646,6 +648,8 @@ TTree *AliTPCSpaceCharge3DDriftLine::CreateDistortionTree(const Int_t nRRowTest,
 
           phi0 = m * dPhi;
           r0 = ifcRadius + (dRadius * i);
+          Double_t x0 = r0 * std::cos(phi0);
+          Double_t y0 = r0 * std::sin(phi0);
           z0 = dZ * j;
           if (side == 1) z0 = -1*z0;
           charge = GetSpaceChargeDensity(r0, phi0, z0);
@@ -692,6 +696,9 @@ TTree *AliTPCSpaceCharge3DDriftLine::CreateDistortionTree(const Int_t nRRowTest,
           dzCorr = corr[2];
 
           (*pcStream) << "distortion" <<
+                      "side=" << side <<
+                      "x=" << x0 <<
+                      "y=" << y0 <<
                       "z=" << z0 <<
                       "r=" << r0 <<
                       "phi=" << phi0 <<

--- a/TPC/TPCbase/AliTPCSpaceCharge3DDriftLine.h
+++ b/TPC/TPCbase/AliTPCSpaceCharge3DDriftLine.h
@@ -18,7 +18,7 @@
 /// \author Rifki Sadikin <rifki.sadikin@cern.ch>, Indonesian Institute of Sciences
 /// \date Nov 20, 2017
 
-#include "TF1.h"
+#include "TF2.h"
 #include "TH2F.h"
 #include "TH3F.h"
 #include "TMatrixD.h"
@@ -181,31 +181,31 @@ public:
 
   void SetPotentialBoundaryAndChargeFormula(TFormula *vTestFunction, TFormula *rhoTestFunction);
 
-  void SetBoundaryIFCA(TF1 *f1) {
+  void SetBoundaryIFCA(TF2 *f1) {
     fSpaceCharge3DCalc.SetBoundaryIFCA(f1);
   }
 
-  void SetBoundaryIFCC(TF1 *f1) {
+  void SetBoundaryIFCC(TF2 *f1) {
     fSpaceCharge3DCalc.SetBoundaryIFCC(f1);
   }
 
-  void SetBoundaryOFCA(TF1 *f1) {
+  void SetBoundaryOFCA(TF2 *f1) {
     fSpaceCharge3DCalc.SetBoundaryOFCA(f1);
   }
 
-  void SetBoundaryOFCC(TF1 *f1) {
+  void SetBoundaryOFCC(TF2 *f1) {
     fSpaceCharge3DCalc.SetBoundaryOFCC(f1);
   }
 
-  void SetBoundaryROCA(TF1 *f1) {
+  void SetBoundaryROCA(TF2 *f1) {
     fSpaceCharge3DCalc.SetBoundaryROCA(f1);
   }
 
-  void SetBoundaryROCC(TF1 *f1) {
+  void SetBoundaryROCC(TF2 *f1) {
     fSpaceCharge3DCalc.SetBoundaryROCC(f1);
   }
 
-  void SetBoundaryCE(TF1 *f1) {
+  void SetBoundaryCE(TF2 *f1) {
     fSpaceCharge3DCalc.SetBoundaryCE(f1);
   }
 

--- a/TPC/TPCbase/AliTPCSpaceCharge3DDriftLine.h
+++ b/TPC/TPCbase/AliTPCSpaceCharge3DDriftLine.h
@@ -46,7 +46,7 @@ public:
     TMatrixD **matricesCorrDrDzA, TMatrixD **matricesCorrDPhiRDzA, TMatrixD **matricesCorrDzA,
     TMatrixD **matricesDistDrDzC, TMatrixD **matricesDistDPhiRDzC, TMatrixD **matricesDistDzC,
     TMatrixD **matricesCorrDrDzC, TMatrixD **matricesCorrDPhiRDzC, TMatrixD **matricesCorrDzC,
-    TFormula *intErDzTestFunction, TFormula *intEPhiRDzTestFunction, TFormula *intDzTestFunction);
+    TFormula *intErDzTestFunction, TFormula *intEPhiRDzTestFunction, TFormula *intDzTestFunction, TFormula *ezFunction);
 
   void
   InitSpaceCharge3DPoisson(Int_t nRRow, Int_t nZColumn, Int_t phiSlice, Int_t maxIteration, Double_t stopConvergence);
@@ -60,6 +60,7 @@ public:
   void GetDistortion(const Float_t x[], Short_t roc, Float_t dx[]);
 
   void GetCorrection(const Float_t x[], Short_t roc, Float_t dx[]);
+  void GetCorrection(const Float_t x[], Short_t roc, Float_t dx[],const Int_t side);
 
   Double_t GetChargeCylAC(const Float_t x[], Short_t roc);
   Double_t GetPotentialCylAC(const Float_t x[], Short_t roc);
@@ -218,6 +219,15 @@ public:
   void GetElectricFieldCyl(const Float_t x[], Short_t roc, Double_t dx[]);
   void Init();
 
+  AliTPCSpaceCharge3DCalc::Profile GetProfile() {
+	  return fSpaceCharge3DCalc.GetProfile();
+  }
+
+  void SetIntegrationStrategy(Int_t  strategy) {
+	  fSpaceCharge3DCalc.SetIntegrationStrategy(strategy);
+
+  }
+  
 private:
 AliTPCSpaceCharge3DCalc fSpaceCharge3DCalc; // Lookup table calculator
 

--- a/TPC/TPCbase/test/spacechargeTest.sh
+++ b/TPC/TPCbase/test/spacechargeTest.sh
@@ -23,6 +23,7 @@ if [[ ! $ALIROOT_SOURCE ]]; then
 fi
 
 export ROOT_HIST=0
+EXPECTED_N_GOOD=13
 
 testAliTPCSpaceCharge3DDriftLine() {
   cp $ALIROOT_SOURCE/TPC/TPCbase/test/AliTPCSpaceCharge3DDriftLineTest.C .
@@ -33,7 +34,7 @@ EOF
   N_GOOD=$(grep -cE 'AliTPCSpaceCharge3DDriftLineTest.*Test.*OK.*' testAliTPCSpaceCharge3DDriftLineTest.log)
   N_BAD=$(grep -cE 'AliTPCSpaceCharge3DDriftLineTest.*Test.*FAILED.*' testAliTPCSpaceCharge3DDriftLineTest.log)
   TEST_STATUS=0
-  if [[ $N_GOOD < 13 ]]; then
+  if [[ $N_GOOD < $EXPECTED_N_GOOD ]]; then
     # alilog_error "spacechargeTest.testAliTPCSpaceCharge3DDriftLine: Invariant test failed"
     ((TEST_STATUS++))
   fi


### PR DESCRIPTION
Here I modified the implementation of AliTPCSpaceCharge3DDriftLine at the folder TPC/TPCbase:
1. Improved correction map generation algorithm using Irregular interpolation
2. Bug fixed on memory free at the GPU/TPCSpaceChargeBased helper classes
3. Modifying test units at TPC/TPCbase/test for testing the implementation on correctness and consistency
4. Provide interface for setting up boundary function in TF2