### PR TITLE
Improvements to ITS geometry to check material budget discrepancies

### DIFF
--- a/ITS/ITSsim/AliITSv11GeometrySDD.cxx
+++ b/ITS/ITSsim/AliITSv11GeometrySDD.cxx
@@ -1004,7 +1004,7 @@ void AliITSv11GeometrySDD::CreateBasicObjects() {
   fLaddSegCommonVol[16]= bottomBeam2Vol; fLaddSegCommonTr[16]= bottomBeamTransf3;
   fLaddSegCommonVol[17]= bottomBeam3Vol; fLaddSegCommonTr[17]= bottomBeamTransf4;
   fLaddSegCommonVol[18]= bottomBeam3Vol; fLaddSegCommonTr[18]= bottomBeamTransf5;
-  fLaddSegCommonVol[19]= groundWireVol;  fLaddSegCommonTr[19]= trGroundWire;
+//  fLaddSegCommonVol[19]= groundWireVol;  fLaddSegCommonTr[19]= trGroundWire;
 
  
   //********************************************************************

--- a/ITS/ITSsim/AliITSv11GeometrySDD.h
+++ b/ITS/ITSsim/AliITSv11GeometrySDD.h
@@ -142,7 +142,7 @@ class AliITSv11GeometrySDD : public AliITSv11Geometry {
   TGeoVolume* fCommonVol[2];      //!  some common vol. used in several places
   TGeoMatrix* fCommonTr[2];       //!  some common transformations
 
-  static const Int_t fgkNladdSegCommonVol = 20;       //  Number of vol.
+  static const Int_t fgkNladdSegCommonVol = 19;       //  Number of vol.
   TGeoVolume* fLaddSegCommonVol[fgkNladdSegCommonVol];//! volumes in ladder
   TGeoMatrix* fLaddSegCommonTr[fgkNladdSegCommonVol]; //! their transf.
 

--- a/ITS/ITSsim/AliITSv11GeometrySPD.cxx
+++ b/ITS/ITSsim/AliITSv11GeometrySPD.cxx
@@ -417,7 +417,8 @@ void AliITSv11GeometrySPD::CarbonFiberSector(TGeoVolume *moth, Int_t sect,
     //TGeoMedium *medSPDal      = 0;//SPD support cone SDD mounting bracket Al
     TGeoMedium *medSPDcf     = GetMedium("SPD C (M55J)$", mgr);
     TGeoMedium *medSPDss     = GetMedium("INOX$", mgr);
-    TGeoMedium *medSPDcoolfl = GetMedium("Freon$", mgr); //ITSspdCoolingFluid
+//    TGeoMedium *medSPDcoolfl = GetMedium("Freon$", mgr); //ITSspdCoolingFluid
+    TGeoMedium *medSPDcoolfl = GetMedium("GASEOUS FREON$", mgr); //ITSspdCoolingFluid
     //
     const Double_t ksecDz           =  0.5 * 500.0 * fgkmm;
     //const Double_t ksecLen        = 30.0 * fgkmm;

--- a/ITS/ITSsim/AliITSv11GeometrySupport.cxx
+++ b/ITS/ITSsim/AliITSv11GeometrySupport.cxx
@@ -331,7 +331,8 @@ void AliITSv11GeometrySupport::SPDCone(TGeoVolume *moth,const TGeoManager *mgr)
 
   // Finally the actual shape
   TGeoCompositeShape *centralshape = new TGeoCompositeShape("centralTS",
-    "upTS+lwTS+omTS-mhTS:m1p-mhTS:m1n-mhTS:m2p-mhTS:m2n-mhTS:m3p-mhTS:m3n-mhTS:m4p-mhTS:m4n-mhTS:m5p-mhTS:m5n-shTS:s1p-shTS:s1n-shTS:s2p-shTS:s2n-shTS:s3p-shTS:s3n-shTS:s4p-shTS:s4n-shTS:s5p-shTS:s5n");
+    "upTS+lwTS-mhTS:m1p-mhTS:m1n-mhTS:m2p-mhTS:m2n-mhTS:m3p-mhTS:m3n-mhTS:m4p-mhTS:m4n-mhTS:m5p-mhTS:m5n-shTS:s1p-shTS:s1n-shTS:s2p-shTS:s2n-shTS:s3p-shTS:s3n-shTS:s4p-shTS:s4n-shTS:s5p-shTS:s5n");
+//    "upTS+lwTS+omTS-mhTS:m1p-mhTS:m1n-mhTS:m2p-mhTS:m2n-mhTS:m3p-mhTS:m3n-mhTS:m4p-mhTS:m4n-mhTS:m5p-mhTS:m5n-shTS:s1p-shTS:s1n-shTS:s2p-shTS:s2n-shTS:s3p-shTS:s3n-shTS:s4p-shTS:s4n-shTS:s5p-shTS:s5n");
 
   // The end cap half shield: a Composite Shape of carbon fiber.
   // We need Composite Shapes because we have elements partially
@@ -820,6 +821,14 @@ void AliITSv11GeometrySupport::SPDCone(TGeoVolume *moth,const TGeoManager *mgr)
   centralshield->SetFillColor(centralshield->GetLineColor());
   centralshield->SetFillStyle(4090); // 90% transparent
 
+  TGeoVolume *omegashield = new TGeoVolume("SPDomegashield",
+					     omegashape,medSPDcf);
+  omegashield->SetVisibility(kTRUE);
+  omegashield->SetLineColor(3);
+  omegashield->SetLineWidth(1);
+  omegashield->SetFillColor(omegashield->GetLineColor());
+  omegashield->SetFillStyle(4090); // 90% transparent
+
   TGeoVolume *endcapshield = new TGeoVolume("SPDendcapshield",
 					     endcapshape,medSPDcf);
   endcapshield->SetVisibility(kTRUE);
@@ -1007,6 +1016,9 @@ void AliITSv11GeometrySupport::SPDCone(TGeoVolume *moth,const TGeoManager *mgr)
   const Double_t kLittleZTrans = 0.1*fgkmm;
   vM->AddNode(centralshield,1,new TGeoTranslation(0,0,-kLittleZTrans));
   vM->AddNode(centralshield,2,new TGeoCombiTrans( 0,0,-kLittleZTrans,
+				  new TGeoRotation("",180,0,0)));
+  vM->AddNode(omegashield,1,new TGeoTranslation(0,0,-kLittleZTrans));
+  vM->AddNode(omegashield,2,new TGeoCombiTrans( 0,0,-kLittleZTrans,
 				  new TGeoRotation("",180,0,0)));
 
   zpos = kHalfLengthCentral+kHalfLengthEndCap;


### PR DESCRIPTION
Some details in the ITS geometry descriptions were improved to check the discrepancies in material budget between data and MonteCarlo. Namely:
- the copper wire running above all SDD ladders was removed
- the material inside SPD cooling pipes was changed from Liquid Freon to Gaseous Freon
- the so-called Omega Shape inside the SPD Thermal Shield was reimplemented (it was part of a complex CompositeShape, now it is a standalone volume)
