### PR TITLE
Corrects the setting of the patch size for L1 Jet Trigger.

### DIFF
--- a/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/AliEMCALTriggerSTUDCSConfig.cxx
@@ -120,7 +120,8 @@ void AliEMCALTriggerSTUDCSConfig::GetSegmentation(TVector2& v1, TVector2& v2, TV
   v2.Set(2., 2.);
   v3.Set(4., 4.);
   
-  Double_t js = 2 + (fFw >> 16);
+  //Double_t js = 2 + (fFw >> 16); // Old method for getting patch size, valid in Run 1
+  Double_t js = 2 + fPatchSize; // Patch Size = 0 or 2, from OCDB
   v4.Set(js, js);
 }
 

--- a/EMCAL/EMCALsim/AliEMCALTriggerElectronics.cxx
+++ b/EMCAL/EMCALsim/AliEMCALTriggerElectronics.cxx
@@ -90,6 +90,15 @@ fGeometry(0)
   fMedianMode = stuConf->GetMedianMode();
   AliEMCALTriggerSTUDCSConfig* stuConfDCal = 0;
 
+  if (iTriggerMapping == 1) {
+    // In Run 1, the patch size was stored in the FW version number, not OCDB
+    Int_t fFW = stuConf->GetFw();
+    if ((fFW >> 16) == 2) {
+      stuConf->SetPatchSize(2);
+      AliDebug(999,TString::Format("Patch size has been set to 16x16 (value 2) based on the EMCALSTU firmware version. This should only occur for Run 1"));
+    }
+  }
+
   if (iTriggerMapping >= 2) {
     rSize.Set( 40., 48. );  // This should be accurate
     stuConfDCal = dcsConf->GetSTUDCSConfig(true);


### PR DESCRIPTION
Now set based on OCDB patch value, not firmware version.
Old behavior for Run 1.