### PR TITLE
Updated deacyer configs for Eta Prime MC generator

### DIFF
--- a/PYTHIA6/AliPythia6/AliDecayerPythia.cxx
+++ b/PYTHIA6/AliPythia6/AliDecayerPythia.cxx
@@ -595,7 +595,17 @@ void AliDecayerPythia::ForceDecay()
         ForceHadronicD(0,0,4);
         break;
      case kEtaPrime:
-	ForceParticleDecay(331,22,2);
+	if(gRandom->Rndm()<0.5) {
+		products1[0]=211;
+		products1[1]=-211;
+		products1[2]=221;
+		mult1[0]=1;
+		mult1[1]=1;
+		mult1[2]=1;
+        	ForceParticleDecay(331,products1,mult1,1);
+	} else {
+		ForceParticleDecay(331,22,2);
+	}
 	break;
     }
 }


### PR DESCRIPTION
Changed eta prime decayer config to include also a pi+pi-eta decay, in addition to the gamma gamma decay, with a 50:50 branching ratio.