### PR TITLE
Fix to allow to trigger on antiparticles also for HF signals

### DIFF
--- a/PYTHIA6/AliPythia6/AliGenPythia.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythia.cxx
@@ -1136,7 +1136,6 @@ Int_t  AliGenPythia::GenerateMB()
       TParticle *mother;
       Bool_t  theQ=kFALSE,theQbar=kFALSE,inYcut=kFALSE;
       Bool_t  theChild=kFALSE;
-      Bool_t  triggered=kFALSE;
       Float_t y;  
       Int_t   pdg, mpdg, mpdgUpperFamily;
       Bool_t  theHFFound=kFALSE;
@@ -1153,9 +1152,6 @@ Int_t  AliGenPythia::GenerateMB()
 			     (partCheck->Energy()-partCheck->Pz()+1.e-13));
 	  if(fUseYCutHQ && y>fYMinHQ && y<fYMaxHQ) inYcut=kTRUE;
 	  if(!fUseYCutHQ && y>fYMin && y<fYMax) inYcut=kTRUE;
-	}
-	if(fTriggerParticle) {
-	  if(TMath::Abs(pdg)==fTriggerParticle) triggered=kTRUE;
 	}
 	if(fCutOnChild==1 && TMath::Abs(pdg) == fPdgCodeParticleforAcceptanceCut) {
 	  Int_t mi = partCheck->GetFirstMother() - 1;
@@ -1205,12 +1201,6 @@ Int_t  AliGenPythia::GenerateMB()
 	delete[] pParent;
 	return 0;	
       }
-
-      if(fTriggerParticle && !triggered) { // particle requested is not produced
-	delete[] pParent;
-	return 0;	
-      }
-
     }
 
     //Introducing child cuts in case kPyW, kPyZ, kPyMb, and kPyMbNonDiff


### PR DESCRIPTION
This modification allows to trigger on particles with negative PDG code also for HF.
With the previous code, the trigger particle PDG code was checked with the absolute value also in the HF related event selections.
As a consequence, in HF productions only particles were selected as trigger particles.
With this fix one can select particles or antiparticles as triggers.

