### PR TITLE
Change ESD->AOD filter to add BachBaryon CosPA automatically

### DIFF
--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.h
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.h
@@ -83,6 +83,9 @@ class AliAnalysisTaskESDfilter : public AliAnalysisTaskSE
   void SetRefitVertexTracks(Int_t algo=6, Double_t* cuts=0);
   void SetMuonCaloPass();
   void SetAddPCMv0s(Bool_t addPCMv0s) {fAddPCMv0s=addPCMv0s;}
+  
+  //helper
+  Float_t GetCosPA(AliESDtrack *lPosTrack, AliESDtrack *lNegTrack, Float_t lB, Float_t *lVtx);
 
   AliAnalysisFilter* GetTrackFilter() const { return fTrackFilter;}
 


### PR DESCRIPTION
This change is meant to add one extra Float_t to each AliAODcascade during ESD->AOD filtering automatically. This additional variable, which is the cosine of pointing angle value for the V0 comprised of the baryon + bachelor of any given cascade candidate, is crucial for rejecting an unwanted background structure in high-multiplicity environments. More details can be found in this [analysis note](https://alice-notes.web.cern.ch/node/588). 