### PR TITLE
Optionally put reprocessed vertices to external array

### DIFF
--- a/STEER/ESD/AliESDUtils.h
+++ b/STEER/ESD/AliESDUtils.h
@@ -25,6 +25,7 @@
 class AliVEvent;
 class AliESDEvent;
 class AliVertexerTracks;
+class TClonesArray;
 
 namespace AliESDUtils {
 
@@ -34,7 +35,7 @@ namespace AliESDUtils {
 
   Float_t GetCorrV0(const AliVEvent* esd, Float_t &v0CorrResc, Float_t *v0multChCorr = NULL, Float_t *v0multChCorrResc = NULL);
   Float_t GetCorrSPD2(Float_t spd2raw,Float_t zv);
-  TObjArray*  RefitESDVertexTracks(AliESDEvent* esdEv, Int_t algo=6, const Double_t* cuts=0);
+  TObjArray*  RefitESDVertexTracks(AliESDEvent* esdEv, Int_t algo=6, const Double_t* cuts=0, TClonesArray* extDest=0);
   Float_t GetCorrV0A0(Float_t v0araw,Float_t zv);
   Float_t GetCorrV0A(Float_t v0araw,Float_t zv);
   Float_t GetCorrV0C(Float_t v0craw,Float_t zv);

--- a/STEER/ESD/AliVertexerTracks.h
+++ b/STEER/ESD/AliVertexerTracks.h
@@ -160,7 +160,9 @@ class AliVertexerTracks : public TObject {
   Double_t GetDeltaZCutForCluster() const {return fDeltaZCutForCluster;}
   Double_t GetnSigmaZCutForCluster() const {return fnSigmaZCutForCluster;}
 
-
+  void SetExternalDestination(TClonesArray* arr) { fExtDest = arr; }
+  TClonesArray* GetExternalDestination() { return fExtDest; }
+  
   //
  protected:
   void     HelixVertexFinder();
@@ -246,6 +248,8 @@ class AliVertexerTracks : public TObject {
   Double_t fDeltaZCutForCluster;       // minimum distance in z between tracks to create new cluster
   Double_t fnSigmaZCutForCluster;      // minimum distacnce in number of sigma along z to create new cluster
   //
+  TClonesArray* fExtDest;              //! optional externally set destination array for vertices
+  
  private:
   AliVertexerTracks(const AliVertexerTracks & source);
   AliVertexerTracks & operator=(const AliVertexerTracks & source);


### PR DESCRIPTION
Now AliESDUtils::RefitESDVertexTracks allows to store newly found vertices to
externally provided TClonesArray, w/o modifying original ESDEvent
Example:
````
TFile fesd("AliESDs.root");
TTree* esdTree = (TTree*)fesd.Get("esdTree");
AliESDEvent ev;
ev.ReadFromTree(esdTree);

TClonesArray arr("AliESDVertex"); // destination

esdTree->GetEntry(52)
ev.ConnectTracks();

AliESDUtils::RefitESDVertexTracks(&ev,6,0, &arr); // run in MultiVertexer mode with default settings
arr.Print(); // 1st entry will correspond to primary vertex (even if invalid), the rest is pile-up ordered in multipicity

arr.Clear("C");
````