### PR TITLE
AliAnalysisAlien improvements related to using the generic grid plugin interface

### DIFF
--- a/ANALYSIS/ANALYSIS/AliAnalysisDataContainer.cxx
+++ b/ANALYSIS/ANALYSIS/AliAnalysisDataContainer.cxx
@@ -557,16 +557,16 @@ AliAnalysisFileDescriptor::AliAnalysisFileDescriptor(const TFile *file)
                            fOpenTime(0.), fProcessingTime(0.), fThroughput(0.), fTimer()
 {
 // Normal constructor
-   if (file->InheritsFrom("TAlienFile")) {
-      fLfn =(const char*)gROOT->ProcessLine(Form("((TAlienFile*)%p)->GetLfn();", file));
-      fGUID =(const char*)gROOT->ProcessLine(Form("((TAlienFile*)%p)->GetGUID();", file));
-      fUrl =(const char*)gROOT->ProcessLine(Form("((TAlienFile*)%p)->GetUrl();", file));
-      fPfn =(const char*)gROOT->ProcessLine(Form("((TAlienFile*)%p)->GetPfn();", file));
-      fSE = (const char*)gROOT->ProcessLine(Form("((TAlienFile*)%p)->GetSE();", file));
-      fImage = (Int_t)gROOT->ProcessLine(Form("((TAlienFile*)%p)->GetImage();", file));
-      fNreplicas = (Int_t)gROOT->ProcessLine(Form("((TAlienFile*)%p)->GetNreplicas();", file));
-      fOpenedAt = gROOT->ProcessLine(Form("((TAlienFile*)%p)->GetOpenTime();", file));
-      gROOT->ProcessLine(Form("((AliAnalysisFileDescriptor*)%p)->SetOpenTime(((TAlienFile*)%p)->GetElapsed());", this, file));
+   if (file->InheritsFrom("TAliceFile")) {
+      fLfn =(const char*)gROOT->ProcessLine(Form("((TAliceFile*)%p)->GetLfn();", file));
+      fGUID =(const char*)gROOT->ProcessLine(Form("((TAliceFile*)%p)->GetGUID();", file));
+      fUrl =(const char*)gROOT->ProcessLine(Form("((TAliceFile*)%p)->GetUrl();", file));
+      fPfn =(const char*)gROOT->ProcessLine(Form("((TAliceFile*)%p)->GetPfn();", file));
+      fSE = (const char*)gROOT->ProcessLine(Form("((TAliceFile*)%p)->GetSE();", file));
+      fImage = (Int_t)gROOT->ProcessLine(Form("((TAliceFile*)%p)->GetImage();", file));
+      fNreplicas = (Int_t)gROOT->ProcessLine(Form("((TAliceFile*)%p)->GetNreplicas();", file));
+      fOpenedAt = gROOT->ProcessLine(Form("((TAliceFile*)%p)->GetOpenTime();", file));
+      gROOT->ProcessLine(Form("((AliAnalysisFileDescriptor*)%p)->SetOpenTime(((TAliceFile*)%p)->GetElapsed());", this, file));
    } else {
       fLfn = file->GetName();
       fPfn = file->GetName();

--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -3664,7 +3664,7 @@ Bool_t AliAnalysisAlien::StartAnalysis(Long64_t nentries, Long64_t firstEntry)
       jobID = fGridJobIDs;
    }   
          
-   if (fDropToShell) {
+   if (fDropToShell && gGrid->InheritsFrom("TAlien")) {
       Info("StartAnalysis", "\n#### STARTING AN ALIEN SHELL FOR YOU. EXIT WHEN YOUR JOB %s HAS FINISHED. #### \
       \n You may exit at any time and terminate the job later using the option <terminate> \
       \n ##################################################################################", jobID.Data());
@@ -3843,7 +3843,7 @@ Bool_t AliAnalysisAlien::SubmitMerging()
       if (!fRunNumbers.Length() && !fRunRange[0]) break;
    }
    if (!ntosubmit) return kTRUE;
-   if (fDropToShell) {
+   if (fDropToShell && gGrid->InheritsFrom("TAlien")) {
       Info("StartAnalysis", "\n #### STARTING AN ALIEN SHELL FOR YOU. You can exit any time or inspect your jobs in a different shell.##########\
                              \n Make sure your jobs are in a final state (you can resubmit failed ones via 'masterjob <id> resubmit ERROR_ALL')\
                              \n Rerun in 'terminate' mode to submit all merging stages, each AFTER the previous one completed. The final merged \

--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -1233,7 +1233,7 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
    delimiter.Strip();
    if (delimiter.Contains(" ")) delimiter = "";
    else delimiter = " ";
-   TString options = "-x collection ";
+   TString options = " ";
    if (TestBit(AliAnalysisGrid::kTest)) options += Form("-l %d ", fNtestFiles);
    else options += Form("-l %d ", gMaxEntries);  // Protection for the find command
    TString conditions = "";
@@ -1271,13 +1271,13 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
             printf("command: %s\n", command.Data());
             res = dynamic_cast<TAliceCollection*>(gGrid->OpenCollectionQuery(gGrid->Command(command)));
 
-            if(res->GetSize() == 0) {
+            if(res->GetNofGroups() == 0) {
                 Error("CreateDataset","Dataset %s produced by the previous find command is empty !", file.Data());
                 delete res;
                 return kFALSE;
             }
 
-               ncount = res->GetSize();
+            ncount = res->GetNofGroups();
          }
          if (ncount == gMaxEntries) {
             Info("CreateDataset", "Dataset %s has more than 15K entries. Trying to merge...", file.Data());
@@ -1298,7 +1298,6 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
                delete cbase; cbase = 0;
             } else {
                cbase->ExportXML(Form("file://%s", file.Data()),kFALSE,kFALSE, file, "Merged entries for a run");
-               TFile::Cp(Form("file://%s", file.Data()), file.Data());
             }
             Info("CreateDataset", "Created dataset %s with %d files", file.Data(), nstart+ncount);
             break;
@@ -1346,14 +1345,14 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
                command += pattern;
                command += conditions;
                res = dynamic_cast<TAliceCollection*>(gGrid->OpenCollectionQuery(gGrid->Command(command)));
-               Bool_t nullFile = res->GetSize() == 0;
+               Bool_t nullFile = res->GetNofGroups() == 0;
                if (nullFile) {
                    Warning("CreateDataset","Dataset %s produced by: <%s> is empty !", file.Data(), command.Data());
                    fRunNumbers.ReplaceAll(os->GetString().Data(), "");
                    delete res;
                    break;
                }
-               ncount = res->GetSize();
+               ncount = res->GetNofGroups();
 
                nullResult = kFALSE;         
             }
@@ -1380,8 +1379,9 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
                   delete cadd;
                   delete cbase; cbase = 0;               
                } else {
+                  cbase = res;
                   cbase->ExportXML(Form("file://%s", file.Data()),kFALSE,kFALSE, file, "Merged entries for a run");
-                  TFile::Cp(Form("file://%s", file.Data()), file.Data());
+                  delete cbase;
                }
                Info("CreateDataset", "Created dataset %s with %d files", file.Data(), nstart+ncount);
                break;
@@ -1473,13 +1473,13 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
                command += pattern;
                command += conditions;
                res = dynamic_cast<TAliceCollection*>(gGrid->OpenCollectionQuery(gGrid->Command(command)));
-               Bool_t nullFile = res->GetSize() == 0;
+               Bool_t nullFile = res->GetNofGroups() == 0;
                if (nullFile) {
                    Warning("CreateDataset","Dataset %s produced by: <%s> is empty !", file.Data(), command.Data());
                    delete res;
                    break;
                }
-               ncount = res->GetSize() == 0;
+               ncount = res->GetNofGroups() == 0;
                nullResult = kFALSE;         
             }   
             if (ncount == gMaxEntries) {
@@ -1505,8 +1505,8 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
                   delete cadd;
                   delete cbase; cbase = 0;               
                } else {
+                  cbase = res;
                   cbase->ExportXML(Form("file://%s", file.Data()),kFALSE,kFALSE, file, "Merged entries for a run");
-                  TFile::Cp(Form("file://%s", file.Data()), file.Data());
                }
                Info("CreateDataset", "Created dataset %s with %d files", file.Data(), nstart+ncount);
                break;

--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -1339,37 +1339,22 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
             ncount = 0;
             stage++;
             if (gSystem->AccessPathName(file) || TestBit(AliAnalysisGrid::kTest) || fOverwriteMode) {
-               command = "alien_find ";
+               command = "find ";
                command +=  Form("%s -o %d ",options.Data(), nstart);
                command += path;
                command += delimiter;
                command += pattern;
                command += conditions;
-               //TGridResult *res = gGrid->Command(command);
-               //if (res) delete res;
-               // Write standard output to file
-               //gROOT->ProcessLine(Form("gGrid->Stdout(); > __tmp%d__%s", stage,file.Data()));
-               gSystem->Exec(Form("%s > __tmp%d__%s 2>/dev/null", command.Data(), stage, file.Data()));
-               Bool_t hasGrep = (gSystem->Exec("grep --version 2>/dev/null > /dev/null")==0)?kTRUE:kFALSE;
-               Bool_t nullFile = kFALSE;
-               if (!hasGrep) {
-                  Warning("CreateDataset", "'grep' command not available on this system - cannot validate the result of the grid 'find' command");
-               } else {
-                  nullFile = (gSystem->Exec(Form("grep -c /event __tmp%d__%s 2>/dev/null > __tmp__",stage,file.Data()))==0)?kFALSE:kTRUE;
-                  if (nullFile) {
-                     Warning("CreateDataset","Dataset %s produced by: <%s> is empty !", file.Data(), command.Data());
-                     gSystem->Exec("rm -f __tmp*");
-                     fRunNumbers.ReplaceAll(os->GetString().Data(), "");
-                     break;
-                  }   
-                  TString line;
-                  ifstream in;
-                  in.open("__tmp__");
-                  in >> line;
-                  in.close();
-                  gSystem->Exec("rm -f __tmp__");   
-                  ncount = line.Atoi();
+               res = dynamic_cast<TAliceCollection*>(gGrid->OpenCollectionQuery(gGrid->Command(command)));
+               Bool_t nullFile = res->GetSize() == 0;
+               if (nullFile) {
+                   Warning("CreateDataset","Dataset %s produced by: <%s> is empty !", file.Data(), command.Data());
+                   fRunNumbers.ReplaceAll(os->GetString().Data(), "");
+                   delete res;
+                   break;
                }
+               ncount = res->GetSize();
+
                nullResult = kFALSE;         
             }
             if (ncount == gMaxEntries) {
@@ -1377,26 +1362,26 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
                if (fNrunsPerMaster > 1) {
                   Error("CreateDataset", "File %s has more than %d entries. Please set the number of runs per master to 1 !", 
                           file.Data(),gMaxEntries);
+                  delete res;
                   return kFALSE;
                }
-               cadd = dynamic_cast<TAliceCollection*>(gGrid->OpenCollection(Form("__tmp%d__%s", stage,file.Data())));
+               cadd = res;
                if (!cbase) cbase = cadd;
                else {
-                  gROOT->ProcessLine(Form("((TJAlienCollection*)%p)->AddFast((TGridCollection*)%p)",cbase,cadd));
+                  cbase->AddFast(cadd);
                   delete cadd;
                }   
                nstart += ncount;
             } else {
                if (cbase && fNrunsPerMaster<2) {
-                  cadd = dynamic_cast<TAliceCollection*>(gGrid->OpenCollection(Form("__tmp%d__%s", stage,file.Data())));
-                  gROOT->ProcessLine(Form("((TJAlienCollection*)%p)->AddFast((TGridCollection*)%p)",cbase,cadd));
-                  delete cadd;
+                  cadd = res;
+                  cbase->AddFast(cadd);
                   cbase->ExportXML(Form("file://%s", file.Data()),kFALSE,kFALSE, file, "Merged entries for a run");
+                  delete cadd;
                   delete cbase; cbase = 0;               
                } else {
-                  TFile::Cp(Form("__tmp%d__%s",stage, file.Data()), file.Data());
+                  TFile::Cp(Form("file://%s", file.Data()), fileData());
                }
-               gSystem->Exec("rm -f __tmp*");   
                Info("CreateDataset", "Created dataset %s with %d files", file.Data(), nstart+ncount);
                break;
             }

--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -1140,7 +1140,7 @@ Int_t AliAnalysisAlien::CopyLocalDataset(const char *griddir, const char *patter
       Error("CopyLocalDataset", "Data directory %s not existing.", griddir);
       return 0;
    }
-   TString command = Form("find -z -l %d %s %s", nfiles, griddir, pattern);
+   TString command = Form("find -l %d %s %s", nfiles, griddir, pattern);
    printf("Running command: %s\n", command.Data());
    TGridResult *res = gGrid->Command(command);
    Int_t nfound = res->GetEntries();

--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -1244,7 +1244,8 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
    TString path;
    Int_t nruns = 0;
    TString schunk, schunk2;
-   TAliceCollection *cbase=0, *cadd=0;
+   TAliceCollection *cbase=0, *cadd=0, *res=0;
+
    if (!fRunNumbers.Length() && !fRunRange[0]) {
       if (fInputFiles && fInputFiles->GetEntries()) return kTRUE;
       // Make a single data collection from data directory.
@@ -1261,59 +1262,44 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
          ncount = 0;
          stage++;
          if (gSystem->AccessPathName(file) || TestBit(AliAnalysisGrid::kTest) || fOverwriteMode) {
-            command = "alien_find ";
+            command = "find ";
             command += Form("%s -o %d ",options.Data(), nstart);
             command += path;
             command += delimiter;
             command += pattern;
             command += conditions;
             printf("command: %s\n", command.Data());
-            //TGridResult *res = gGrid->Command(command);
-            //if (res) delete res;
-            // Write standard output to file
-	    // Write standard error to null device
-            gSystem->Exec(Form("%s > __tmp%d__%s 2>/dev/null", command.Data(), stage, file.Data()));
-            //gROOT->ProcessLine(Form("gGrid->Stdout(); > __tmp%d__%s", stage, file.Data()));
-            Bool_t hasGrep = (gSystem->Exec("grep --version 2>/dev/null > /dev/null")==0)?kTRUE:kFALSE;
-            Bool_t nullFile = kFALSE;
-            if (!hasGrep) {
-                Warning("CreateDataset", "'grep' command not available on this system - cannot validate the result of the grid 'find' command");
-            } else {
-               nullFile = (gSystem->Exec(Form("grep -c /event __tmp%d__%s 2>/dev/null > __tmp__",stage,file.Data()))==0)?kFALSE:kTRUE;
-               if (nullFile) {
-                  Error("CreateDataset","Dataset %s produced by the previous find command is empty !", file.Data());
-                  gSystem->Exec("rm -f __tmp*");
-                  return kFALSE;
-               }
-               TString line;
-               ifstream in;
-               in.open("__tmp__");
-               in >> line;
-               in.close();
-               gSystem->Exec("rm -f __tmp__");
-               ncount = line.Atoi();
-            }         
+            res = dynamic_cast<TAliceCollection*>(gGrid->OpenCollectionQuery(gGrid->Command(command)));
+
+            if(res->GetSize() == 0) {
+                Error("CreateDataset","Dataset %s produced by the previous find command is empty !", file.Data());
+                delete res;
+                return kFALSE;
+            }
+
+               ncount = res->GetSize();
          }
          if (ncount == gMaxEntries) {
             Info("CreateDataset", "Dataset %s has more than 15K entries. Trying to merge...", file.Data());
-            cadd = dynamic_cast<TAliceCollection*>(gGrid->OpenCollection(Form("__tmp%d__%s", stage, file.Data())));
+            cadd = res;
             if (!cbase) cbase = cadd;
             else {
-               gROOT->ProcessLine(Form("((TJAlienCollection*)%p)->AddFast((TGridCollection*)%p)",cbase,cadd));
+               cbase->AddFast(cadd);
                delete cadd;
             }   
             nstart += ncount;
          } else {
             if (cbase) {
-                cadd = dynamic_cast<TAliceCollection*>(gGrid->OpenCollection(Form("__tmp%d__%s", stage, file.Data())));
+               cadd = res;
+               printf("... please wait - TAlienCollection::Add() scales badly...\n");
                cbase->AddFast(cadd);
-               delete cadd;
                cbase->ExportXML(Form("file://%s", file.Data()),kFALSE,kFALSE, file, "Merged entries for a run");
-               delete cbase; cbase = 0;               
+               delete cadd;
+               delete cbase; cbase = 0;
             } else {
-               TFile::Cp(Form("__tmp%d__%s",stage, file.Data()), file.Data());
+               cbase->ExportXML(Form("file://%s", file.Data()),kFALSE,kFALSE, file, "Merged entries for a run");
+               TFile::Cp(Form("file://%s", file.Data()), file.Data());
             }
-            gSystem->Exec("rm -f __tmp*");   
             Info("CreateDataset", "Created dataset %s with %d files", file.Data(), nstart+ncount);
             break;
          }
@@ -1332,6 +1318,7 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
       AddDataFile(Form("%s/%s", workdir.Data(), file.Data()));
       return kTRUE;
    }   
+
    // Several runs
    Bool_t nullResult = kTRUE;
    if (fRunNumbers.Length()) {

--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -1380,7 +1380,8 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
                   delete cadd;
                   delete cbase; cbase = 0;               
                } else {
-                  TFile::Cp(Form("file://%s", file.Data()), fileData());
+                  cbase->ExportXML(Form("file://%s", file.Data()),kFALSE,kFALSE, file, "Merged entries for a run");
+                  TFile::Cp(Form("file://%s", file.Data()), file.Data());
                }
                Info("CreateDataset", "Created dataset %s with %d files", file.Data(), nstart+ncount);
                break;
@@ -1465,36 +1466,20 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
             ncount = 0;
             stage++;
             if (gSystem->AccessPathName(file) || TestBit(AliAnalysisGrid::kTest) || fOverwriteMode) {
-               command = "alien_find ";
+               command = "find ";
                command +=  Form("%s -o %d ",options.Data(), nstart);
                command += path;
                command += delimiter;
                command += pattern;
                command += conditions;
-               //TGridResult *res = gGrid->Command(command);
-               //if (res) delete res;
-               // Write standard output to file
-               gSystem->Exec(Form("%s > __tmp%d__%s 2>/dev/null", command.Data(), stage, file.Data()));
-               //gROOT->ProcessLine(Form("gGrid->Stdout(); > __tmp%d__%s", stage,file.Data()));
-               Bool_t hasGrep = (gSystem->Exec("grep --version 2>/dev/null > /dev/null")==0)?kTRUE:kFALSE;
-               Bool_t nullFile = kFALSE;
-               if (!hasGrep) {
-                  Warning("CreateDataset", "'grep' command not available on this system - cannot validate the result of the grid 'find' command");
-               } else {
-                  nullFile = (gSystem->Exec(Form("grep -c /event __tmp%d__%s 2>/dev/null > __tmp__",stage,file.Data()))==0)?kFALSE:kTRUE;
-                  if (nullFile) {
-                     Warning("CreateDataset","Dataset %s produced by: <%s> is empty !", file.Data(), command.Data());
-                     gSystem->Exec("rm -f __tmp*");
-                     break;
-                  }   
-                  TString line;
-                  ifstream in;
-                  in.open("__tmp__");
-                  in >> line;
-                  in.close();
-                  gSystem->Exec("rm -f __tmp__");   
-                  ncount = line.Atoi();
+               res = dynamic_cast<TAliceCollection*>(gGrid->OpenCollectionQuery(gGrid->Command(command)));
+               Bool_t nullFile = res->GetSize() == 0;
+               if (nullFile) {
+                   Warning("CreateDataset","Dataset %s produced by: <%s> is empty !", file.Data(), command.Data());
+                   delete res;
+                   break;
                }
+               ncount = res->GetSize() == 0;
                nullResult = kFALSE;         
             }   
             if (ncount == gMaxEntries) {
@@ -1502,6 +1487,7 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
                if (fNrunsPerMaster > 1) {
                   Error("CreateDataset", "File %s has more than %d entries. Please set the number of runs per master to 1 !", 
                           file.Data(),gMaxEntries);
+                  delete res;
                   return kFALSE;
                }
                cadd = dynamic_cast<TAliceCollection*>(gGrid->OpenCollection(Form("__tmp%d__%s", stage, file.Data())));
@@ -1513,13 +1499,14 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
                nstart += ncount;
             } else {
                if (cbase && fNrunsPerMaster<2) {
-                   cadd = dynamic_cast<TAliceCollection*>(gGrid->OpenCollection(Form("__tmp%d__%s", stage, file.Data())));
-		            cbase->Add(cadd);
-                  delete cadd;
+                  cadd = dynamic_cast<TAliceCollection*>(gGrid->OpenCollection(Form("__tmp%d__%s", stage, file.Data())));
+                  cbase->Add(cadd);
                   cbase->ExportXML(Form("file://%s", file.Data()),kFALSE,kFALSE, file, "Merged entries for a run");
+                  delete cadd;
                   delete cbase; cbase = 0;               
                } else {
-                  TFile::Cp(Form("__tmp%d__%s",stage, file.Data()), file.Data());
+                  cbase->ExportXML(Form("file://%s", file.Data()),kFALSE,kFALSE, file, "Merged entries for a run");
+                  TFile::Cp(Form("file://%s", file.Data()), file.Data());
                }
                Info("CreateDataset", "Created dataset %s with %d files", file.Data(), nstart+ncount);
                break;

--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -312,8 +312,8 @@ AliAnalysisAlien::AliAnalysisAlien(const AliAnalysisAlien& other)
                   fTreeName(other.fTreeName)
 {
 // Copy ctor.
-   fGridJDL = gGrid->GetJDLGenerator();
-   fMergingJDL = gGrid->GetJDLGenerator();
+   fGridJDL = NULL;
+   fMergingJDL = NULL;
    fRunRange[0] = other.fRunRange[0];
    fRunRange[1] = other.fRunRange[1];
    if (other.fInputFiles) {
@@ -360,8 +360,8 @@ AliAnalysisAlien &AliAnalysisAlien::operator=(const AliAnalysisAlien& other)
 // Assignment.
    if (this != &other) {
       AliAnalysisGrid::operator=(other);
-      fGridJDL = gGrid->GetJDLGenerator();
-      fMergingJDL = gGrid->GetJDLGenerator();
+      fGridJDL                 = NULL;
+      fMergingJDL              = NULL;
       fPrice                   = other.fPrice;
       fTTL                     = other.fTTL;
       fSplitMaxInputFileNumber = other.fSplitMaxInputFileNumber;
@@ -1598,6 +1598,13 @@ Bool_t AliAnalysisAlien::CreateJDL()
       Error("CreateJDL", "Alien connection required");
       return kFALSE;
    }   
+   // Initialize the JDLs
+   if (fGridJDL) delete fGridJDL;
+   fGridJDL = gGrid->GetJDLGenerator();
+
+   if (fMergingJDL) delete fMergingJDL;
+   fMergingJDL = gGrid->GetJDLGenerator();
+
    // Check validity of alien workspace
    TString workdir;
    if (!fProductionMode && !fGridWorkingDir.BeginsWith("/alice")) workdir = gGrid->GetHomeDirectory();
@@ -2608,8 +2615,9 @@ void AliAnalysisAlien::SetDefaults()
 {
 // Set default values for everything. What cannot be filled will be left empty.
    if (fGridJDL) delete fGridJDL;
-   fGridJDL = gGrid->GetJDLGenerator();
-   fMergingJDL = gGrid->GetJDLGenerator();
+   if (fMergingJDL) delete fMergingJDL;
+   fGridJDL                    = NULL;
+   fMergingJDL                 = NULL;
    fPrice                      = 1;
    fTTL                        = 30000;
    fSplitMaxInputFileNumber    = 100;

--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -43,6 +43,7 @@
 #include "AliAnalysisDataContainer.h"
 #include "AliMultiInputEventHandler.h"
 #include "TAliceCollection.h"
+#include "TAliceJobStatus.h"
 
 using std::ofstream;
 using std::ifstream;
@@ -2394,15 +2395,15 @@ const char *AliAnalysisAlien::GetJobStatus(Int_t jobidstart, Int_t lastid, Int_t
    TGridJobStatusList *list = gGrid->Ps("");
    if (!list) return mstatus;
    Int_t nentries = list->GetSize();
-   TGridJobStatus *status;
+   TAliceJobStatus *status;
    Int_t pid;
    for (Int_t ijob=0; ijob<nentries; ijob++) {
-      status = (TGridJobStatus *)list->At(ijob);
+      status = dynamic_cast<TAliceJobStatus*>(list->At(ijob));
       // To avoid explicit casting, we need TGridJobStatus::GetKey interface
-      pid = gROOT->ProcessLine(Form("atoi(((TJAlienJobStatus*)%p)->GetKey(\"queueId\"));", status));
+      pid = atoi(status->GetKey("queueId"));
       if (pid<jobidstart) continue;
       if (pid == lastid) {
-         gROOT->ProcessLine(Form("sprintf((char*)%p,((TJAlienJobStatus*)%p)->GetKey(\"status\"));",mstatus, status));
+         strncpy(mstatus, status->GetKey("status"), 20);
       }   
       switch (status->GetStatus()) {
          case TGridJobStatus::kWAITING:

--- a/STEER/CDB/AliCDBManager.cxx
+++ b/STEER/CDB/AliCDBManager.cxx
@@ -75,7 +75,7 @@ void AliCDBManager::Init() {
   RegisterFactory(new AliCDBLocalFactory());
   // AliCDBGridFactory is registered only if AliEn libraries are enabled in Root
   static int hltOnlineMode = getenv("HLT_ONLINE_MODE") && strcmp(getenv("HLT_ONLINE_MODE"), "on") == 0;
-  if(!hltOnlineMode && TClass::GetClass("TAlien")){
+  if(!hltOnlineMode){
     AliInfo("AliEn classes enabled in Root. AliCDBGrid factory registered.");
     RegisterFactory(new AliCDBGridFactory());
     fCondParam = CreateParameter(fgkCondUri);

--- a/cmake/FindROOT.cmake
+++ b/cmake/FindROOT.cmake
@@ -208,6 +208,16 @@ if(ROOTSYS)
             include_directories(SYSTEM ${ALIEN}/api/include)
         endif()
 
+        if(EXISTS "${JALIEN_LIBS}/include")
+          message(INFO "JALIEN_LIBS location: ${JALIEN_LIBS}/include")
+          include_directories(SYSTEM "${JALIEN_LIBS}/include")
+        endif()
+
+        if(EXISTS "${ALIEN_LIBS}/include")
+          message(INFO "ALIEN_LIBS location: ${ALIEN_LIBS}/include")
+          include_directories(SYSTEM "${ALIEN_LIBS}/include")
+        endif()
+
         set(ROOT_HASALIEN TRUE)
     else(ALIEN)
         message(WARNING "No AliEn installation found. Please set \"ALIEN\" to point to your AliEn installation.")


### PR DESCRIPTION
This pull request is required for JAliEn integration. It decouples the AliRoot analysis plugin from the legacy AliEn ROOT Grid plugin by using the interfaces that are defined in ROOT and are common for both Grid plugins.

For this purpose some new interfaces are defined in the Alice-Grid-Utils package, namely:
- [x] TAliceCollection,
- [x] TAliceFile and
- [x] TAliceJobStatus

The biggest change in this pull request is how collections are created. We no longer call `alien_find` standalone tool, but use the `gGrid->Command()` interface and build the collections in memory. The `TAliceCollection::AddFast()` method is used here exclusively for performance reasons. Use `TGridCollection` instead of `TAliceCollection` wherever possible.