### PR TITLE
Makes TriggerTRU not contribute to L1 triggers if disabled by STU

### DIFF
--- a/EMCAL/EMCALsim/AliEMCALTriggerTRU.cxx
+++ b/EMCAL/EMCALsim/AliEMCALTriggerTRU.cxx
@@ -511,6 +511,10 @@ void AliEMCALTriggerTRU::GetL0Region(const int time, Int_t arr[][4])
 //________________
 void AliEMCALTriggerTRU::GetL0Region(const int time, Int_t ** arr)
 {
+  if(!fActive) {
+    AliDebug(999, "Not filling L0 Region for inactive TRU");
+    return;
+  }
   Int_t r0 = time - fDCSConfig->GetRLBKSTU();
 
   if (r0 < 0) 


### PR DESCRIPTION
Corrects TriggerTRU code so that masking by STU actually prevents the TRU from contributing to L1 Triggers.