### PR TITLE
Small fixes in AliTPCDcalibRes

### DIFF
--- a/TPC/TPCcalib/AliTPCDcalibRes.cxx
+++ b/TPC/TPCcalib/AliTPCDcalibRes.cxx
@@ -239,6 +239,9 @@ AliTPCDcalibRes::~AliTPCDcalibRes()
   delete[] fMaxY2X;
   delete[] fDY2X;
   delete[] fDY2XI;
+  delete[] fY2XBinsCenter;
+  delete[] fY2XBinsDH;
+  delete[] fY2XBinsDI;
   delete[] fZ2XBinsCenter;
   delete[] fZ2XBinsDH;
   delete[] fZ2XBinsDI;
@@ -2708,7 +2711,6 @@ float AliTPCDcalibRes::MAD2Sigma(int np, float* y)
   // the input array is not modified
   if (np<2) return 0;
   int nph = np>>1;
-  if (nph&0x1) nph -= 1;
   // don't abuse stack
   float *ycHeap=0, ycStack[np<kMaxOnStack ? np:1],*yc=np<kMaxOnStack ? &ycStack[0] : (ycHeap = new float[np]);
   memcpy(yc,y,np*sizeof(float));

--- a/TPC/TPCcalib/AliTPCDcalibRes.h
+++ b/TPC/TPCcalib/AliTPCDcalibRes.h
@@ -664,7 +664,7 @@ inline Float_t AliTPCDcalibRes::GetDY2X(int ix, int iy)
   if (fUniformBins[kVoxF]) {
     return fDY2X[ix];
   }
-  return fMaxY2X[ix]*fY2XBinsDH[iy];
+  return 2.f*fMaxY2X[ix]*fY2XBinsDH[iy];
 }
 
 //________________________________________________________________


### PR DESCRIPTION
- fix in median calculation
- add fY2XBins* arrays to destructor
- fix GetDY2X method: before the results were not matching for the case of uniform and variable binnings. But I think this is not really an issue, since as far as I can see this function is not used