### PR TITLE
Fix a bug in AliAnalysisAlien::CreateDataset

### DIFF
--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -1382,7 +1382,6 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
                } else {
                   cbase = res;
                   cbase->ExportXML(Form("file://%s", file.Data()),kFALSE,kFALSE, file, "Merged entries for a run");
-                  delete cbase; cbase = 0;
                }
                Info("CreateDataset", "Created dataset %s with %d files", file.Data(), nstart+ncount);
                break;


### PR DESCRIPTION
This is a proposed hotfix for a bug introduced after switching to the TGrid API for creating the Grid collections in the analysis plugin.