### PR TITLE
Ensure consistent storage of Kinks in the AOD (P.Ganoti + RS)

### DIFF
--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
@@ -67,7 +67,8 @@
 
 using std::cout;
 using std::endl;
-ClassImp(AliAnalysisTaskESDfilter)
+
+ClassImp(AliAnalysisTaskESDfilter);
 
 AliAnalysisTaskESDfilter::AliAnalysisTaskESDfilter():
   AliAnalysisTaskSE(),
@@ -407,6 +408,12 @@ TClonesArray& AliAnalysisTaskESDfilter::V0s()
 TClonesArray& AliAnalysisTaskESDfilter::Vertices()
 {
   return *(AODEvent()->GetVertices());
+}
+
+//______________________________________________________________________________
+TClonesArray& AliAnalysisTaskESDfilter::Kinks()
+{
+  return *(AODEvent()->GetKinks());
 }
 
 //______________________________________________________________________________
@@ -962,9 +969,9 @@ void AliAnalysisTaskESDfilter::ConvertV0s(const AliESDEvent& esd)
   }
   UInt_t posInt;
 
-  for (Int_t nV0 = 0; nV0 < esd.GetNumberOfV0s(); ++nV0) {
+  for (Int_t nV0 = 0; nV0 < esd.GetNumberOfV0s(); ++nV0)  {
     if (fAddPCMv0s) {posInt = (UInt_t) nV0;}
-    if (fUsedV0[nV0]){
+    if (fUsedV0[nV0]) {
 	if(fbitfieldPCMv0sA){
 	  if(fbitfieldPCMv0sA->TestBitNumber(posInt) && posInt <= fbitfieldPCMv0sA->GetNbits()){
 	    fv0Histos->Fill(5);
@@ -997,13 +1004,13 @@ void AliAnalysisTaskESDfilter::ConvertV0s(const AliESDEvent& esd)
     UInt_t selectV0 = 0;
 
     //Add PCM V0s
-    if(fbitfieldPCMv0sA){
+    if(fbitfieldPCMv0sA) {
       if(fbitfieldPCMv0sA->TestBitNumber(posInt) && posInt <= fbitfieldPCMv0sA->GetNbits()){
 	selectV0 = 2;
 	fv0Histos->Fill(1);
       }
     }
-    if(fbitfieldPCMv0sB){
+    if(fbitfieldPCMv0sB) {
       if(fbitfieldPCMv0sB->TestBitNumber(posInt) && posInt <= fbitfieldPCMv0sB->GetNbits()){
 	selectV0 = 2;
 	fv0Histos->Fill(2);
@@ -1824,174 +1831,106 @@ void AliAnalysisTaskESDfilter::ConvertKinks(const AliESDEvent& esd)
   // The loop is on the tracks in order to find the mother and daugther of each kink
 
   Double_t covTr[21]={0.};
+  Double_t chi2(0.0);
+  Double_t covVtx[6] = { 0. };
+  Double_t motherPos[3] = { 0. };
+  Double_t p[3] = { 0. };
+  Double_t pos[3] = { 0. };
   //  Double_t pid[10]={0.};
   AliAODPid* detpid(0x0);
   Int_t tofLabel[3] = {0};
 
-  fNumberOfKinks = esd.GetNumberOfKinks();
+  // fNumberOfKinks = esd.GetNumberOfKinks();
 
   const AliESDVertex* vtx = esd.GetPrimaryVertex();
 
-  for (Int_t iTrack=0; iTrack<esd.GetNumberOfTracks(); ++iTrack)
-  {
+  for (Int_t iTrack=0; iTrack<esd.GetNumberOfTracks(); ++iTrack) {
+    
     AliESDtrack * esdTrack = esd.GetTrack(iTrack);
+    Int_t indexkink = esdTrack->GetKinkIndex(0);
+    if(indexkink>=0) continue; // we look for mother kink
 
-    Int_t ikink = esdTrack->GetKinkIndex(0);
-
-    if (ikink && fNumberOfKinks) {
-      // Negative kink index: mother, positive: daughter
-      // Search for the second track of the kink
-
-      for (Int_t jTrack = iTrack+1; jTrack<esd.GetNumberOfTracks(); ++jTrack) {
-        AliESDtrack * esdTrack1 = esd.GetTrack(jTrack);
-        Int_t jkink = esdTrack1->GetKinkIndex(0);
-
-        if ( TMath::Abs(ikink)==TMath::Abs(jkink) ) {
-          // The two tracks are from the same kink
-          if (fUsedKink[TMath::Abs(ikink)-1]) continue; // skip used kinks
-
-          Int_t imother = -1;
-          Int_t idaughter = -1;
-
-          if (ikink<0 && jkink>0) {
-            imother = iTrack;
-            idaughter = jTrack;
-          } else if (ikink>0 && jkink<0) {
-	    imother = jTrack;
-            idaughter = iTrack;
-          } else {
-            //cerr << "Error: Wrong combination of kink indexes: "
-            //	   << ikink << " " << jkink << endl;
-            continue;
-          }
-
-          // Add the mother track if it passed primary track selection cuts
-          AliAODTrack * mother = NULL;
-
-          UInt_t selectInfo = 0;
-          if (fTrackFilter) {
-            selectInfo = fTrackFilter->IsSelected(esd.GetTrack(imother));
-            if (!selectInfo) continue;
-          }
-
-          if (!fUsedTrack[imother]) {
-            fUsedTrack[imother] = kTRUE;
-            AliESDtrack *esdTrackM = esd.GetTrack(imother);
-            Double_t p[3] = { 0. };
-            Double_t pos[3] = { 0. };
-            esdTrackM->GetPxPyPz(p);
-            esdTrackM->GetXYZ(pos);
-            esdTrackM->GetCovarianceXYZPxPyPz(covTr);
-	    //            esdTrackM->GetESDpid(pid);
-	    esdTrackM->GetTOFLabel(tofLabel);
-            if(fMChandler)fMChandler->SelectParticle(esdTrackM->GetLabel());
-            mother = new(Tracks()[fNumberOfTracks++]) AliAODTrack(esdTrackM->GetID(),
-								  esdTrackM->GetLabel(),
-								  p,
-								  kTRUE,
-								  pos,
-								  kFALSE,
-								  covTr,
-								  (Short_t)esdTrackM->GetSign(),
-								  esdTrackM->GetITSClusterMap(),
-								  // pid,
-								  fPrimaryVertex,
-								  kTRUE, // check if this is right
-								  vtx->UsesTrack(esdTrack->GetID()),
-								  AliAODTrack::kPrimary,
-								  selectInfo);
-	    mother->SetITSSharedMap(esdTrackM->GetITSSharedMap());
-	    mother->SetITSchi2(esdTrackM->GetITSchi2());
-	    mother->SetPIDForTracking(esdTrackM->GetPIDForTracking());
-            mother->SetTPCFitMap(esdTrackM->GetTPCFitMap());
-            mother->SetTPCClusterMap(esdTrackM->GetTPCClusterMap());
-            mother->SetTPCSharedMap (esdTrackM->GetTPCSharedMap());
-            mother->SetChi2perNDF(Chi2perNDF(esdTrackM));
-            mother->SetTPCPointsF(esdTrackM->GetTPCNclsF());
-	    mother->SetTPCNCrossedRows(UShort_t(esdTrackM->GetTPCCrossedRows()));
-	    mother->SetIntegratedLength(esdTrackM->GetIntegratedLength());
-	    mother->SetTOFLabel(tofLabel);
-	    CopyChi2TPCConstrainedVsGlobal(esdTrackM, mother);
-	    CopyCaloProps(esdTrackM,mother);
-            fAODTrackRefs->AddAt(mother, imother);
-            if (esdTrackM->GetSign() > 0) ++fNumberOfPositiveTracks;
-            mother->SetFlags(esdTrackM->GetStatus());
-            mother->ConvertAliPIDtoAODPID();
-            fPrimaryVertex->AddDaughter(mother);
-            mother->ConvertAliPIDtoAODPID();
-            SetAODPID(esdTrackM,mother,detpid);
-          }
-          else {
-            //cerr << "Error: event " << esd.GetEventNumberInFile() << " kink " << TMath::Abs(ikink)-1
-            //     << " track " << imother << " has already been used!" << endl;
-          }
-
-          // Add the kink vertex
-          AliESDkink * kink = esd.GetKink(TMath::Abs(ikink)-1);
-
-          AliAODVertex * vkink = new(Vertices()[fNumberOfVertices++]) AliAODVertex(kink->GetPosition(),
-										   NULL,
-										   0.,
-										   mother,
-										   esdTrack->GetID(),  // ID of mother's track!
-										   AliAODVertex::kKink);
-          // Add the daughter track
-          AliAODTrack * daughter = NULL;
-          if (!fUsedTrack[idaughter]) {
-            fUsedTrack[idaughter] = kTRUE;
-            AliESDtrack *esdTrackD = esd.GetTrack(idaughter);
-            Double_t p[3] = { 0. };
-            Double_t pos[3] = { 0. };
-            esdTrackD->GetPxPyPz(p);
-            esdTrackD->GetXYZ(pos);
-            esdTrackD->GetCovarianceXYZPxPyPz(covTr);
-	    //            esdTrackD->GetESDpid(pid);
-	    esdTrackD->GetTOFLabel(tofLabel);
-            selectInfo = 0;
-            if (fTrackFilter) selectInfo = fTrackFilter->IsSelected(esdTrackD);
-            if(fMChandler)fMChandler->SelectParticle(esdTrackD->GetLabel());
-            daughter = new(Tracks()[fNumberOfTracks++]) AliAODTrack(esdTrackD->GetID(),
-								    esdTrackD->GetLabel(),
-								    p,
-								    kTRUE,
-								    pos,
-								    kFALSE,
-								    covTr,
-								    (Short_t)esdTrackD->GetSign(),
-								    esdTrackD->GetITSClusterMap(),
-								    // pid,
-								    vkink,
-								    kTRUE, // check if this is right
-								    vtx->UsesTrack(esdTrack->GetID()),
-								    AliAODTrack::kFromDecayVtx,
-								    selectInfo);
-	    daughter->SetITSSharedMap(esdTrackD->GetITSSharedMap());
-	    daughter->SetITSchi2(esdTrackD->GetITSchi2());
-	    daughter->SetPIDForTracking(esdTrackD->GetPIDForTracking());
-            daughter->SetTPCFitMap(esdTrackD->GetTPCFitMap());
-            daughter->SetTPCClusterMap(esdTrackD->GetTPCClusterMap());
-            daughter->SetTPCSharedMap (esdTrackD->GetTPCSharedMap());
-	    daughter->SetTPCPointsF(esdTrackD->GetTPCNclsF());
-	    daughter->SetTPCNCrossedRows(UShort_t(esdTrackD->GetTPCCrossedRows()));
-	    daughter->SetIntegratedLength(esdTrackD->GetIntegratedLength());
-	    daughter->SetTOFLabel(tofLabel);
-	    CopyChi2TPCConstrainedVsGlobal(esdTrackD, daughter);
-	    CopyCaloProps(esdTrackD,daughter);
-            fAODTrackRefs->AddAt(daughter, idaughter);
-            if (esdTrackD->GetSign() > 0) ++fNumberOfPositiveTracks;
-            daughter->SetFlags(esdTrackD->GetStatus());
-            daughter->ConvertAliPIDtoAODPID();
-            vkink->AddDaughter(daughter);
-            daughter->ConvertAliPIDtoAODPID();
-            SetAODPID(esdTrackD,daughter,detpid);
-          } else {
-            //cerr << "Error: event " << esd.GetEventNumberInFile() << " kink " << TMath::Abs(ikink)-1
-            //     << " track " << idaughter << " has already been used!" << endl;
-          }
-        }
-      }
+    int kinkESDIdx = TMath::Abs(indexkink)-1;
+    AliESDkink *kink = esd.GetKink(kinkESDIdx);
+       
+    // kink selection
+    if (!kink || (fKinkFilter && !fKinkFilter->IsSelected(kink)) ) continue;
+    
+    AliAODTrack * mother = NULL;
+    
+    if (!fUsedTrack[iTrack]) { // add mother track if not yet added, w/o check for the quality!
+      fUsedTrack[iTrack] = kTRUE;
+      UInt_t selectInfo = fTrackFilter ? fTrackFilter->IsSelected(esdTrack) : 0;
+      esdTrack->GetPxPyPz(p);
+      esdTrack->GetXYZ(motherPos);
+      esdTrack->GetCovarianceXYZPxPyPz(covTr);
+      esdTrack->GetTOFLabel(tofLabel);
+      if (fMChandler) fMChandler->SelectParticle( esdTrack->GetLabel() );
+      mother = new(Tracks()[fNumberOfTracks++]) AliAODTrack(esdTrack->GetID(),
+							    esdTrack->GetLabel(),
+							    p,
+							    kTRUE,
+							      motherPos,
+							    kFALSE,
+							    covTr,
+							    (Short_t)esdTrack->GetSign(),
+							    esdTrack->GetITSClusterMap(),
+							    fPrimaryVertex,
+							    kTRUE, // check if this is right
+							    vtx->UsesTrack(esdTrack->GetID()),
+							    AliAODTrack::kPrimary,
+							    selectInfo);
+      mother->SetITSSharedMap(esdTrack->GetITSSharedMap());
+      mother->SetITSchi2(esdTrack->GetITSchi2());
+      mother->SetPIDForTracking(esdTrack->GetPIDForTracking());
+      mother->SetTPCFitMap(esdTrack->GetTPCFitMap());
+      mother->SetTPCClusterMap(esdTrack->GetTPCClusterMap());
+      mother->SetTPCSharedMap (esdTrack->GetTPCSharedMap());
+      mother->SetChi2perNDF(Chi2perNDF(esdTrack));
+      mother->SetTPCPointsF(esdTrack->GetTPCNclsF());
+      mother->SetTPCNCrossedRows(UShort_t(esdTrack->GetTPCCrossedRows()));
+      mother->SetIntegratedLength(esdTrack->GetIntegratedLength());
+      mother->SetTOFLabel(tofLabel);
+      CopyChi2TPCConstrainedVsGlobal(esdTrack, mother);
+      CopyCaloProps(esdTrack,mother);
+      fAODTrackRefs->AddAt(mother, iTrack);
+      if (esdTrack->GetSign() > 0) ++fNumberOfPositiveTracks;
+      mother->SetFlags(esdTrack->GetStatus());
+      mother->ConvertAliPIDtoAODPID();
+      fPrimaryVertex->AddDaughter(mother);
+      mother->ConvertAliPIDtoAODPID();
+      SetAODPID(esdTrack,mother,detpid);
     }
-  }
+    else {
+      mother = static_cast<AliAODTrack*>(fAODTrackRefs->At(iTrack));
+    }
+    
+    // add kink to AOD
+    const TVector3 vposKink(kink->GetPosition()); //reco kink vtx position
+    for (Int_t j=0; j<3; j++) pos[j]=vposKink[j];
+    AliAODVertex * vkink = new(Vertices()[fNumberOfVertices++]) AliAODVertex(pos,
+									     NULL,
+									     0.,
+									     mother,
+									     kinkESDIdx,  // ID of ESD kink
+									     AliAODVertex::kKink);
+    fPrimaryVertex->AddDaughter(vkink);
+    
+    Float_t kinkAngle = TMath::RadToDeg()*kink->GetAngle(2);
+    Double_t radius = kink->GetR();
+    Float_t qT = kink->GetQt();
+    const TVector3 motherMfromKink(kink->GetMotherP());
+    const TVector3 daughterMKink(kink->GetDaughterP());
+
+    AliAODkink* aodkink = new(Kinks()[fNumberOfKinks++]) AliAODkink(vkink,
+								    kinkAngle,
+								    radius,
+								    qT,
+								    motherMfromKink,
+								    daughterMKink);
+       
+  } // loop over tracks
+
 }
 
 //______________________________________________________________________________

--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.h
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.h
@@ -125,6 +125,7 @@ private:
 
   TClonesArray& Tracks();
   TClonesArray& V0s();
+  TClonesArray& Kinks();
   TClonesArray& Vertices();
   TClonesArray& Cascades();
   

--- a/STEER/AOD/AODLinkDef.h
+++ b/STEER/AOD/AODLinkDef.h
@@ -73,6 +73,7 @@
 #pragma link C++ class AliAODTrdTracklet+;
 #pragma link C++ class AliNanoAODStorage+;
 #pragma link C++ class AliNanoAODHeader+;
+#pragma link C++ class AliAODkink+;
 
 #pragma link C++ method AliAODTrack::SetPosition<double>(double const*, bool);
 

--- a/STEER/AOD/AliAODEvent.cxx
+++ b/STEER/AOD/AliAODEvent.cxx
@@ -36,6 +36,7 @@ ClassImp(AliAODEvent)
 						      "tracks",
 						      "vertices",
 						      "v0s",
+						      "kinks",
 						      "cascades",
 						      "tracklets",
 						      "jets",
@@ -67,6 +68,7 @@ AliAODEvent::AliAODEvent() :
   fTracks(0),
   fVertices(0),
   fV0s(0),
+  fKinks(0),
   fCascades(0),
   fTracklets(0),
   fJets(0),
@@ -103,6 +105,7 @@ AliAODEvent::AliAODEvent(const AliAODEvent& aod):
   fTracks(new TClonesArray(*aod.fTracks)),
   fVertices(new TClonesArray(*aod.fVertices)),
   fV0s(new TClonesArray(*aod.fV0s)),
+  fKinks(new TClonesArray(*aod.fKinks)),
   fCascades(new TClonesArray(*aod.fCascades)),
   fTracklets(new AliAODTracklets(*aod.fTracklets)),
   fJets(new TClonesArray(*aod.fJets)),
@@ -129,6 +132,7 @@ AliAODEvent::AliAODEvent(const AliAODEvent& aod):
   AddObject(fTracks);
   AddObject(fVertices);
   AddObject(fV0s);
+  AddObject(fKinks);
   AddObject(fCascades);
   AddObject(fTracklets);
   AddObject(fJets);
@@ -317,6 +321,7 @@ void AliAODEvent::CreateStdContent()
   AddObject(new TClonesArray("AliAODTrack", 0));
   AddObject(new TClonesArray("AliAODVertex", 0));
   AddObject(new TClonesArray("AliAODv0", 0));
+  AddObject(new TClonesArray("AliAODkink", 0));
   AddObject(new TClonesArray("AliAODcascade", 0));
   AddObject(new AliAODTracklets());
   AddObject(new TClonesArray("AliAODJet", 0));
@@ -411,6 +416,7 @@ void AliAODEvent::GetStdContent()
   fTracks        = (TClonesArray*)fAODObjects->FindObject("tracks");
   fVertices      = (TClonesArray*)fAODObjects->FindObject("vertices");
   fV0s           = (TClonesArray*)fAODObjects->FindObject("v0s");
+  fKinks         = (TClonesArray*)fAODObjects->FindObject("kinks");
   fCascades      = (TClonesArray*)fAODObjects->FindObject("cascades");
   fTracklets     = (AliAODTracklets*)fAODObjects->FindObject("tracklets");
   fJets          = (TClonesArray*)fAODObjects->FindObject("jets");
@@ -435,6 +441,7 @@ void AliAODEvent::GetStdContent()
 void AliAODEvent::ResetStd(Int_t trkArrSize, 
             Int_t vtxArrSize, 
             Int_t v0ArrSize,
+	    Int_t kinkArrSize,
             Int_t cascadeArrSize,
             Int_t jetSize, 
             Int_t caloClusSize, 
@@ -462,6 +469,11 @@ void AliAODEvent::ResetStd(Int_t trkArrSize,
     fV0s->Delete();
     if (v0ArrSize > fV0s->GetSize()) 
       fV0s->Expand(v0ArrSize);
+  }
+  if (fKinks) {
+    fKinks->Delete();
+    if (kinkArrSize > fKinks->GetSize()) 
+      fKinks->Expand(kinkArrSize);
   }
   if (fCascades) {
     fCascades->Delete();
@@ -544,6 +556,8 @@ void AliAODEvent::ClearStd()
     fVertices      ->Delete();
   if (fV0s)
     fV0s           ->Delete();
+  if (fKinks)
+    fKinks         ->Delete();
   if (fCascades)
     fCascades      ->Delete();
   if (fTracklets)

--- a/STEER/AOD/AliAODEvent.h
+++ b/STEER/AOD/AliAODEvent.h
@@ -24,6 +24,7 @@
 #include "AliAODTrack.h"
 #include "AliAODVertex.h"
 #include "AliAODv0.h"
+#include "AliAODkink.h"
 #include "AliAODcascade.h"
 #include "AliAODTracklets.h"
 #include "AliAODJet.h"
@@ -52,6 +53,7 @@ public:
 		       kAODTracks,
 		       kAODVertices,
 		       kAODv0,
+		       kAODkink,
 		       kAODcascade,
 		       kAODTracklets,
 		       kAODJets,
@@ -206,6 +208,15 @@ public:
   Int_t         AddV0(const AliAODv0* v0)
   {new((*fV0s)[fV0s->GetEntriesFast()]) AliAODv0(*v0); return fV0s->GetEntriesFast()-1;}
 
+  // Kinks
+  TClonesArray *GetKinks()                 const { return fKinks; }
+  Int_t         GetNumberOfKinks()         const { return fKinks ? fKinks->GetEntriesFast() : 0; }
+  //using AliVEvent::GetKink;
+  AliAODkink     *GetAODkink(Int_t nkink)    const { return fKinks ? (AliAODkink*)fKinks->UncheckedAt(nkink) : 0; }
+  Int_t         AddKink(const AliAODkink* kink)
+  {new((*fKinks)[fKinks->GetEntriesFast()]) AliAODkink(*kink); return fKinks->GetEntriesFast()-1;}
+
+  
   // Cascades
   TClonesArray  *GetCascades(){
     FixCascades();
@@ -301,6 +312,7 @@ public:
   void    ResetStd(Int_t trkArrSize = 0,
 		   Int_t vtxArrSize = 0,
 		   Int_t v0ArrSize = 0,
+		   Int_t kinkArrSize = 0,
 		   Int_t cascadeArrSize = 0,
 		   Int_t jetSize = 0,
 		   Int_t caloClusSize = 0,
@@ -361,6 +373,7 @@ private:
   TClonesArray    *fTracks;       //!<! charged tracks
   TClonesArray    *fVertices;     //!<! vertices
   TClonesArray    *fV0s;          //!<! V0s
+  TClonesArray    *fKinks;       //!<!  kinks
   TClonesArray    *fCascades;     //!<! Cascades
   AliAODTracklets *fTracklets;    //!<! SPD tracklets
   TClonesArray    *fJets;         //!<! jets
@@ -385,7 +398,7 @@ private:
 
   static const char* fAODListName[kAODListN]; //!<!
 
-  ClassDef(AliAODEvent,94);
+  ClassDef(AliAODEvent,95);
 };
 
 #endif

--- a/STEER/AOD/AliAODkink.cxx
+++ b/STEER/AOD/AliAODkink.cxx
@@ -1,0 +1,117 @@
+/**************************************************************************
+ * Copyright(c) 1998-2007, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: The ALICE Off-line Project.                                    *
+ * Contributors are mentioned in the code where appropriate.              *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+#include "AliAODkink.h"
+#include "AliAODTrack.h"
+
+ClassImp(AliAODkink)
+
+AliAODkink::AliAODkink() : 
+AliAODRecoDecay(), fRadius(999), fkinkAngle(999), fQt(999)
+{
+}
+
+AliAODkink::AliAODkink(AliAODVertex* rAODVertex, Float_t rkinkAngle, Float_t rradius, Float_t qT, const TVector3& rmotherMfromKink, const TVector3& rdaughterMKink):
+  AliAODRecoDecay(), fRadius(rradius), fkinkAngle(rkinkAngle), fQt(qT)
+{
+  /// Constructor via setting each data member
+  SetSecondaryVtx(rAODVertex);
+  
+  fNProngs=1;
+
+  fPx = new Double_t[GetNProngs()];
+  fPy = new Double_t[GetNProngs()];
+  fPz = new Double_t[GetNProngs()];
+  fd0 = new Double32_t[GetNProngs()];
+  
+  fPx[0] = rdaughterMKink[0];
+  fPy[0] = rdaughterMKink[1];
+  fPz[0] = rdaughterMKink[2];
+  fd0[0] = 999.;
+  
+  fMotherMfromKink.SetXYZ(rmotherMfromKink.X(), rmotherMfromKink.Y(), rmotherMfromKink.Z());
+}
+
+AliAODkink::AliAODkink(const AliAODkink& src) :
+  AliAODRecoDecay(src), fRadius(src.fRadius), fkinkAngle(src.fkinkAngle), fQt(src.fQt)
+{
+  /// Copy constructor
+  fMotherMfromKink = src.fMotherMfromKink;
+}
+
+AliAODkink& AliAODkink::operator=(const AliAODkink& src){
+  /// Assignment overload
+
+  if(this!=&src) {
+    AliAODRecoDecay::operator=(src);
+    fRadius = src.fRadius;
+    fkinkAngle = src.fkinkAngle;
+    fQt = src.fQt;
+    fMotherMfromKink = src.fMotherMfromKink;
+  }
+  
+  return *this;
+}
+
+AliAODkink::~AliAODkink(){
+  /// Empty destructor
+
+}
+
+void AliAODkink::Fill(AliAODVertex *rAODVertex, Float_t rkinkAngle, Float_t rradius, Float_t qT, const TVector3& rmotherMfromKink, const TVector3& rdaughterMKink) {
+  /// Filling with all needed info
+
+  this->SetSecondaryVtx(rAODVertex);
+
+  fPx[0] = rdaughterMKink[0];
+  fPy[0] = rdaughterMKink[1];
+  fPz[0] = rdaughterMKink[2];
+
+  fRadius=rradius;
+  fkinkAngle=rkinkAngle;
+  fQt=qT;
+  fMotherMfromKink.SetXYZ(rmotherMfromKink.X(), rmotherMfromKink.Y(), rmotherMfromKink.Z());
+
+}
+
+void AliAODkink::ResetKink() {
+  /// Resetting all the info
+
+  GetSecondaryVtx()->SetChi2perNDF(999);
+  GetSecondaryVtx()->RemoveCovMatrix();
+  GetSecondaryVtx()->RemoveDaughters();
+  GetSecondaryVtx()->SetParent((TObject*) 0x0);
+  GetSecondaryVtx()->SetID(-1);
+  GetSecondaryVtx()->SetPosition(999,999,999);
+  GetSecondaryVtx()->SetType(AliAODVertex::kUndef);
+
+  fPx[0] = 999;
+  fPy[0] = 999;
+  fPz[0] = 999;
+
+  fRadius=999;
+  fkinkAngle=999;
+  fQt=999;
+  fMotherMfromKink(0);
+}
+
+void AliAODkink::Print(Option_t* /*option*/) const {
+  /// Print some information
+
+  AliAODRecoDecay::Print();
+  printf("AliAODkink: R=%e Angle=%e Qt=%e\n",fRadius, fkinkAngle, fQt);
+
+  return;
+}

--- a/STEER/AOD/AliAODkink.h
+++ b/STEER/AOD/AliAODkink.h
@@ -1,0 +1,85 @@
+#ifndef ALIAODKINK_H
+#define ALIAODKINK_H
+/* Copyright(c) 1998-2007, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/// \class AliAODkink
+/// \brief Analysis Oriented Data (AOD) V0 vertex class
+///
+/// G.Van Buren, BNL,  gene@bnl.gov      (original STAR MuDsts)
+///
+/// \author B.Hippolyte, IPHC, hippolyt@in2p3.fr
+
+#include "TVector3.h"
+#include "AliAODRecoDecay.h"
+
+
+class AliAODkink : public AliAODRecoDecay {
+
+public:
+
+  AliAODkink();
+  AliAODkink(AliAODVertex *rAODVertex, Float_t rkinkAngle, Float_t rradius, Float_t qT, const TVector3& rmotherMfromKink, const TVector3& rdaughterMKink);
+  virtual ~AliAODkink();
+
+  AliAODkink(const AliAODkink& rAliAODkink);
+  AliAODkink& operator=(const AliAODkink& rAliAODkink);
+
+  void     Fill(AliAODVertex *rAODVertex, Float_t rkinkAngle, Float_t rradius, Float_t qT, const TVector3& rmotherMfromKink, const TVector3& rdaughterMKink);
+  void     ResetKink();
+  void     Print(Option_t* option = "") const;
+
+  Double_t DecayVertexKinkX() const;
+  Double_t DecayVertexKinkY() const;
+  Double_t DecayVertexKinkZ() const;
+
+  Double_t RadiusKink() const;  
+  Float_t  KinkAngle()const; 
+  Float_t  KinkQt() const;
+
+  Double_t MomMotherX() const;
+  Double_t MomMotherY() const;
+  Double_t MomMotherZ() const;
+  Double_t MomDaughterX() const;
+  Double_t MomDaughterY() const;
+  Double_t MomDaughterZ() const;
+
+  Double_t PseudoRapMKink()    const;
+  
+  Int_t    GetLabel()       const {return -1;} // Dummy
+  Int_t    PdgCode()        const {return  0;} // Dummy
+  
+  virtual void     SetID(Short_t /*id*/) {;}
+  
+protected:
+
+  Double_t fRadius;
+  Float_t  fkinkAngle;
+  Float_t  fQt;
+  TVector3 fMotherMfromKink; 
+   
+  ClassDef(AliAODkink,1)
+};
+
+inline Double_t AliAODkink::DecayVertexKinkX() const {return this->GetSecVtxX();}
+inline Double_t AliAODkink::DecayVertexKinkY() const {return this->GetSecVtxY();}
+inline Double_t AliAODkink::DecayVertexKinkZ() const {return this->GetSecVtxZ();}
+
+inline Double_t AliAODkink::MomMotherX() const {return fMotherMfromKink[0];}
+inline Double_t AliAODkink::MomMotherY() const {return fMotherMfromKink[1];}
+inline Double_t AliAODkink::MomMotherZ() const {return fMotherMfromKink[2];}
+inline Double_t AliAODkink::MomDaughterX() const {return fPx[0];}
+inline Double_t AliAODkink::MomDaughterY() const {return fPy[0];}
+inline Double_t AliAODkink::MomDaughterZ() const {return fPz[0];}
+
+inline Double_t AliAODkink::RadiusKink() const {return fRadius;}  
+inline Float_t  AliAODkink::KinkAngle() const {return fkinkAngle;}
+inline Float_t  AliAODkink::KinkQt() const {return fQt;}
+
+inline Double_t AliAODkink::PseudoRapMKink() const {
+  return Eta();
+}
+
+//----------------------------------------------------------------------------
+
+#endif

--- a/STEER/AOD/CMakeLists.txt
+++ b/STEER/AOD/CMakeLists.txt
@@ -68,6 +68,7 @@ set(SRCS
     AliAODZDC.cxx
     AliNanoAODHeader.cxx
     AliNanoAODStorage.cxx
+    AliAODkink.cxx
    )
 
 # Sources from headers


### PR DESCRIPTION
Now apart from the Kink AliAODVertex also the AliAODkink object is stored, containing the
kink-specific info like kinematics of prongs at the kink point.
All mothers are stored (including those which did not get any filter bit).