### PR TITLE
Fix: restore AliAnalysisManager::Notify kTrueNotify actions

### DIFF
--- a/ANALYSIS/ANALYSIS/AliAnalysisManager.cxx
+++ b/ANALYSIS/ANALYSIS/AliAnalysisManager.cxx
@@ -631,7 +631,7 @@ Bool_t AliAnalysisManager::Notify()
 
    fIOTimer->Start(kTRUE); 
    if (!fTree) return kFALSE;
-   //PH   if (!TObject::TestBit(AliAnalysisManager::kTrueNotify)) return kFALSE;
+   if (!TObject::TestBit(AliAnalysisManager::kTrueNotify)) return kFALSE;
 
    fTable.Clear("nodelete"); // clearing the hash table may not be needed -> C.L.
    if (fMode == kProofAnalysis) fIsRemote = kTRUE;


### PR DESCRIPTION
On of the changes in fix 3756604e497e65ba327a7e7b2d8f69db7b91ac09 (intended to make AliAnalysisManager compatible
both with root5.. and root6-18-04, was in fact crashing analysis with all root versions. Reverting it.