### PR TITLE
Custom pile-up info in ESD and AOD

### DIFF
--- a/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
+++ b/ANALYSIS/ESDfilter/AliAnalysisTaskESDfilter.cxx
@@ -2036,12 +2036,23 @@ void AliAnalysisTaskESDfilter::ConvertPrimaryVertices(const AliESDEvent& esd)
   mVTPC->SetNContributors(vtxT->GetNContributors());
 
   // Add custom TPC and ITS pileup infos
-  AliAODHeader* header = dynamic_cast<AliAODHeader*>(AODEvent()->GetHeader());
   static TVectorF vtiTPC(10), vtiITS(8);
-  AliESDUtils::GetTPCPileupVertexInfo(&esd, vtiTPC);
-  AliESDUtils::GetITSPileupVertexInfo(&esd, vtiITS);
-  header->SetTPCPileUpInfo(&vtiTPC);
-  header->SetITSPileUpInfo(&vtiITS);
+  AliAODHeader* headAOD = dynamic_cast<AliAODHeader*>(AODEvent()->GetHeader());
+  AliESDHeader* headESD = esd.GetHeader();
+  if (headESD->GetTPCPileUpInfo()) {
+    headAOD->SetTPCPileUpInfo( headESD->GetTPCPileUpInfo() );
+  }
+  else {
+    AliESDUtils::GetTPCPileupVertexInfo(&esd, vtiTPC);
+    headAOD->SetTPCPileUpInfo(&vtiTPC);
+  }
+  if (headESD->GetITSPileUpInfo()) {
+    headAOD->SetITSPileUpInfo( headESD->GetITSPileUpInfo() );
+  }
+  else {
+    AliESDUtils::GetITSPileupVertexInfo(&esd, vtiITS);
+    headAOD->SetITSPileUpInfo(&vtiITS);
+  }  
   //
 }
 

--- a/STEER/AOD/AliAODHeader.cxx
+++ b/STEER/AOD/AliAODHeader.cxx
@@ -291,6 +291,8 @@ AliAODHeader::~AliAODHeader()
   delete fCentralityP;
   delete fEventplaneP;
   RemoveQTheta();
+  delete fTPCPileUpInfo;
+  delete fITSPileUpInfo;
 }
 
 //______________________________________________________________________________

--- a/STEER/ESD/AliESDHeader.cxx
+++ b/STEER/ESD/AliESDHeader.cxx
@@ -52,7 +52,9 @@ AliESDHeader::AliESDHeader() :
   fCTPConfig(NULL),
   fIRBufferArray(),
   fIRInt2InteractionsMap(0),
-  fIRInt1InteractionsMap(0)
+  fIRInt1InteractionsMap(0),
+  fTPCPileUpInfo(0),
+  fITSPileUpInfo(0)
 {
   // default constructor
 
@@ -69,6 +71,8 @@ AliESDHeader::~AliESDHeader()
   for(Int_t i=0;i<kNMaxIR;i++)if(fIRArray[i])delete fIRArray[i];
   delete fCTPConfig;
   //  fIRBufferArray.Delete();
+  delete fTPCPileUpInfo;
+  delete fITSPileUpInfo;
 }
 
 
@@ -94,7 +98,9 @@ AliESDHeader::AliESDHeader(const AliESDHeader &header) :
   fCTPConfig(header.fCTPConfig),
   fIRBufferArray(),
   fIRInt2InteractionsMap(header.fIRInt2InteractionsMap),
-  fIRInt1InteractionsMap(header.fIRInt1InteractionsMap)
+  fIRInt1InteractionsMap(header.fIRInt1InteractionsMap),
+  fTPCPileUpInfo(new TVectorF(*header.fTPCPileUpInfo)),
+  fITSPileUpInfo(new TVectorF(*header.fITSPileUpInfo))
 {
   // copy constructor
   for(Int_t i = 0; i<kNMaxIR ; i++) {
@@ -159,6 +165,12 @@ AliESDHeader& AliESDHeader::operator=(const AliESDHeader &header)
       if (ir) fIRBufferArray.Add(new AliTriggerIR(*ir));
     }
     for (Int_t itype=0; itype<3; itype++) fTPCNoiseFilterCounter[itype]=header.fTPCNoiseFilterCounter[itype];
+    
+    delete fTPCPileUpInfo;
+    fTPCPileUpInfo = header.fTPCPileUpInfo ? new TVectorF(*header.fTPCPileUpInfo) : 0;
+    delete fITSPileUpInfo;
+    fITSPileUpInfo = header.fITSPileUpInfo ? new TVectorF(*header.fITSPileUpInfo) : 0;
+    
   }
   return *this;
 }
@@ -650,4 +662,34 @@ Int_t  AliESDHeader::GetIRInt2LastInteractionMap() const
 
   Int_t last = lastPositive > TMath::Abs(lastNegative) ? lastPositive : TMath::Abs(lastNegative);
   return last;
+}
+
+void AliESDHeader::SetTPCPileUpInfo(const TVectorF* src)
+{
+  if (src) {
+    if (!fTPCPileUpInfo || !AreCompatible(*fTPCPileUpInfo, *src)) {
+      delete fTPCPileUpInfo;
+      fTPCPileUpInfo = new TVectorF(*src);
+    }
+    else *fTPCPileUpInfo = *src;
+  }
+  else {
+    delete fTPCPileUpInfo;
+    fTPCPileUpInfo = 0;
+  }
+}
+
+void AliESDHeader::SetITSPileUpInfo(const TVectorF* src)
+{
+  if (src) {
+    if (!fITSPileUpInfo || !AreCompatible(*fITSPileUpInfo, *src)) {
+      delete fITSPileUpInfo;
+      fITSPileUpInfo = new TVectorF(*src);
+    }
+    else *fITSPileUpInfo = *src;
+  }
+  else {
+    delete fITSPileUpInfo;
+    fITSPileUpInfo = 0;
+  }
 }

--- a/STEER/ESD/AliESDHeader.h
+++ b/STEER/ESD/AliESDHeader.h
@@ -15,6 +15,7 @@
 #include <TObjArray.h>
 #include <TClonesArray.h>
 #include <TBits.h>
+#include <TVectorF.h>
 #include "AliVHeader.h"
 #include "AliTriggerScalersESD.h"
 #include "AliTriggerScalersRecordESD.h"
@@ -93,6 +94,11 @@ public:
   Char_t GetTPCNoiseFilterCounter(UInt_t index) {return fTPCNoiseFilterCounter[index%3];};
   void SetTPCNoiseFilterCounter(UInt_t index,UChar_t value) {fTPCNoiseFilterCounter[index%3]=value;};
 
+  const TVectorF* GetTPCPileUpInfo() const {return fTPCPileUpInfo;}
+  const TVectorF* GetITSPileUpInfo() const {return fITSPileUpInfo;}
+  void SetTPCPileUpInfo(const TVectorF* src);
+  void SetITSPileUpInfo(const TVectorF* src);
+  
 private:
   void   SetIRInteractionMap() const;
 
@@ -124,8 +130,10 @@ private:
   mutable TBits   fIRInt1InteractionsMap;  // map of the Int1 events (normally V0A&V0C) near the event, that's Int1Id-EventId within -90 +90 BXs
   UChar_t fTPCNoiseFilterCounter[3];  // filter counter [0]=sector, [1]-timebin/sector, [2]-padrowsector 
 
-
-  ClassDef(AliESDHeader,14)
+  TVectorF* fTPCPileUpInfo;           ///< custom info about TPC pileup used by TPC PID
+  TVectorF* fITSPileUpInfo;           ///< custom info about TPC pileup used by TPC PID
+ 
+  ClassDef(AliESDHeader,15)
 };
 
 #endif

--- a/STEER/STEER/AliReconstruction.cxx
+++ b/STEER/STEER/AliReconstruction.cxx
@@ -157,6 +157,7 @@
 #include "AliESDpid.h"
 #include "AliESDtrack.h"
 #include "AliESDtrack.h"
+#include "AliESDUtils.h"
 #include "AliEventInfo.h"
 #include "AliGRPObject.h"
 #include "AliGRPRecoParam.h"
@@ -228,6 +229,7 @@ AliReconstruction::AliReconstruction(const char* gAliceFilename) :
   fRunV0Finder(kTRUE),
   fRunCascadeFinder(kTRUE),
   fRunMultFinder(kTRUE),
+  fRunCustomPileupFinders(kTRUE),
   fStopOnError(kTRUE),
   fStopOnMissingTriggerFile(kTRUE),
   fWriteAlignmentData(kFALSE),
@@ -379,6 +381,7 @@ AliReconstruction::AliReconstruction(const AliReconstruction& rec) :
   fRunV0Finder(rec.fRunV0Finder),
   fRunCascadeFinder(rec.fRunCascadeFinder),
   fRunMultFinder(rec.fRunMultFinder),
+  fRunCustomPileupFinders(rec.fRunCustomPileupFinders),
   fStopOnError(rec.fStopOnError),
   fStopOnMissingTriggerFile(rec.fStopOnMissingTriggerFile),
   fWriteAlignmentData(rec.fWriteAlignmentData),
@@ -548,6 +551,7 @@ AliReconstruction& AliReconstruction::operator = (const AliReconstruction& rec)
   fRunV0Finder           = rec.fRunV0Finder;
   fRunCascadeFinder      = rec.fRunCascadeFinder;
   fRunMultFinder         = rec.fRunMultFinder;
+  fRunCustomPileupFinders = rec.fRunCustomPileupFinders;
   fStopOnError           = rec.fStopOnError;
   fStopOnMissingTriggerFile = rec.fStopOnMissingTriggerFile;
   fWriteAlignmentData    = rec.fWriteAlignmentData;
@@ -2557,6 +2561,12 @@ Bool_t AliReconstruction::ProcessEvent(Int_t iEvent)
        if (fStopOnError) {CleanUp(); return kFALSE;}
     }
 
+    if (fRunCustomPileupFinders) {
+      if (RunCustomPileUpFinders(fesd)) {
+	if (fStopOnError) {CleanUp(); return kFALSE;}
+      }
+    }
+    
     AliSysInfo::AddStamp(Form("FillVaria_%d",iEvent), 0,0,iEvent); 
 
     // write ESD
@@ -5218,4 +5228,17 @@ void AliReconstruction::SetPIDforTrackingOptimisedForNuclei(Int_t val)
   // set/unset pid for tracking as in Run1
   AliInfoF("Impose PID for tracking optimised for nuclei, dE/dx threshold between 3He and pi: %i",val);
   AliESDpid::SetOnly3HeOrPi(val);
+}
+
+//___________________________________________________
+Bool_t AliReconstruction::RunCustomPileUpFinders(AliESDEvent*& esd)
+{
+  // put into the ESD header custom pile-up info
+  static TVectorF vtiTPC(10), vtiITS(8);
+  AliESDUtils::GetTPCPileupVertexInfo(esd, vtiTPC);
+  AliESDUtils::GetITSPileupVertexInfo(esd, vtiITS);
+  AliESDHeader* esdheader = esd->GetHeader();
+  esdheader->SetTPCPileUpInfo(&vtiTPC);
+  esdheader->SetITSPileUpInfo(&vtiITS);
+  return kTRUE;
 }

--- a/STEER/STEER/AliReconstruction.h
+++ b/STEER/STEER/AliReconstruction.h
@@ -118,6 +118,7 @@ public:
   void SetRunVertexFinder(Bool_t flag=kTRUE) {fRunVertexFinder=flag;};
   void SetRunVertexFinderTracks(Bool_t flag=kTRUE) {fRunVertexFinderTracks=flag;};
   void SetRunV0Finder(Bool_t flag=kTRUE) {fRunV0Finder=flag;};
+  void SetRunCustomPileupFinders(Bool_t flag=kTRUE) {fRunCustomPileupFinders=flag;}
   void SetRunCascadeFinder(Bool_t flag=kTRUE) {fRunCascadeFinder=flag;};
   void SetStopOnError(Bool_t flag=kTRUE) {fStopOnError=flag;}
   void SetStopOnMissingTriggerFile(Bool_t flag=kTRUE) {fStopOnMissingTriggerFile=flag;}
@@ -147,6 +148,7 @@ public:
   
   //
   Bool_t  IsRunMultFinder()   const {return fRunMultFinder;}
+  Bool_t  IsRunCustomPileupFinders() const {return fRunCustomPileupFinders;}
   
   // CDB storage activation
   void SetDefaultStorage(const char* uri);
@@ -267,6 +269,7 @@ private:
   Bool_t         RunSPDTrackleting(AliESDEvent*& esd);
   Bool_t         RunMultFinder(AliESDEvent*& esd);
   Bool_t         RunTracking(AliESDEvent*& esd, AliESDpid &PID);
+  Bool_t         RunCustomPileUpFinders(AliESDEvent*& esd);
   Bool_t         CleanESD(AliESDEvent *esd,const AliGRPRecoParam *grpRecoParam);
   Bool_t         FillESD(AliESDEvent*& esd, const TString& detectors);
   Bool_t         FillTriggerESD(AliESDEvent*& esd);
@@ -314,6 +317,7 @@ private:
   Bool_t         fRunV0Finder;        // run the ESD V0 finder
   Bool_t         fRunCascadeFinder;   // run the ESD cascade finder
   Bool_t         fRunMultFinder;      // run the trackleter for ITS clusters
+  Bool_t         fRunCustomPileupFinders; // run custom pile-up finders
   Bool_t         fStopOnError;        // stop or continue on errors
   Bool_t         fStopOnMissingTriggerFile; // stop if the simulated trigger file is absent
   Bool_t         fWriteAlignmentData; // write track space-points flag
@@ -459,7 +463,7 @@ private:
   Int_t                fNAbandonedEv;   //  number of abandoned events
   static const char*   fgkStopEvFName;  //  filename for stop.event stamp
   //
-  ClassDef(AliReconstruction, 53)      // class for running the reconstruction
+  ClassDef(AliReconstruction, 54)      // class for running the reconstruction
 };
 
 #endif


### PR DESCRIPTION
Run TPC and ITS pileup taggers from AliESDUtils in the reconstruction and fill AliESDHeader.
In the AOD filtering, either transfer pile-up info from AliESDHeader to AliAODHeader or run the taggers
directly in the filtering.