### PR TITLE
Prefer Clear over Delete for `AliESDTRDTracklet`s

### DIFF
--- a/STEER/ESD/AliESDEvent.cxx
+++ b/STEER/ESD/AliESDEvent.cxx
@@ -571,7 +571,7 @@ void AliESDEvent::ResetStdContent()
   if(fMuonGlobalTracks)fMuonGlobalTracks->Clear("C");     // AU
   if(fPmdTracks)fPmdTracks->Delete();
   if(fTrdTracks)fTrdTracks->Delete();
-  if(fTrdTracklets)fTrdTracklets->Clear("C");
+  if(fTrdTracklets)fTrdTracklets->Clear();
   if(fV0s)fV0s->Delete();
   if(fCascades)fCascades->Delete();
   if(fKinks)fKinks->Delete();

--- a/STEER/ESD/AliESDEvent.cxx
+++ b/STEER/ESD/AliESDEvent.cxx
@@ -571,7 +571,7 @@ void AliESDEvent::ResetStdContent()
   if(fMuonGlobalTracks)fMuonGlobalTracks->Clear("C");     // AU
   if(fPmdTracks)fPmdTracks->Delete();
   if(fTrdTracks)fTrdTracks->Delete();
-  if(fTrdTracklets)fTrdTracklets->Delete();
+  if(fTrdTracklets)fTrdTracklets->Clear("C");
   if(fV0s)fV0s->Delete();
   if(fCascades)fCascades->Delete();
   if(fKinks)fKinks->Delete();


### PR DESCRIPTION
This is where we spend 80% of the cost when iterating on an ESD collection.