### PR TITLE
Clear V0s rather than deleting them

### DIFF
--- a/STEER/ESD/AliESDEvent.cxx
+++ b/STEER/ESD/AliESDEvent.cxx
@@ -572,7 +572,7 @@ void AliESDEvent::ResetStdContent()
   if(fPmdTracks)fPmdTracks->Delete();
   if(fTrdTracks)fTrdTracks->Delete();
   if(fTrdTracklets)fTrdTracklets->Clear();
-  if(fV0s)fV0s->Delete();
+  if(fV0s)fV0s->Clear();
   if(fCascades)fCascades->Delete();
   if(fKinks)fKinks->Delete();
   if(fCaloClusters)fCaloClusters->Delete();


### PR DESCRIPTION
This is now 10% of running over ESDs.