### PR TITLE
Reset L0 time

### DIFF
--- a/EMCAL/EMCALsim/AliEMCALTriggerTRU.cxx
+++ b/EMCAL/EMCALsim/AliEMCALTriggerTRU.cxx
@@ -572,5 +572,7 @@ void AliEMCALTriggerTRU::Reset()
   ZeroRegion();
   
   for (Int_t i=0;i<96;i++) for (Int_t j=0;j<256;j++) fADC[i][j] = 0;
+
+  fL0Time = 0;
 }
 


### PR DESCRIPTION
After the event is done the L0 time has to be set
to 0, otherwise it is not re-evaluated for the next
event (check for L0 time != 0)