### PR TITLE
Fix in treatment of return value of RunCustomPileUpFinders

### DIFF
--- a/STEER/STEER/AliReconstruction.cxx
+++ b/STEER/STEER/AliReconstruction.cxx
@@ -2562,7 +2562,7 @@ Bool_t AliReconstruction::ProcessEvent(Int_t iEvent)
     }
 
     if (fRunCustomPileupFinders) {
-      if (RunCustomPileUpFinders(fesd)) {
+      if (!RunCustomPileUpFinders(fesd)) {
 	if (fStopOnError) {CleanUp(); return kFALSE;}
       }
     }


### PR DESCRIPTION
Returned false should be treated as a failure, while opposite was done.

@pzhristov thanks for spotting this. Fortunately, in the productions we use ``rec.SetStopOnError(kFALSE)``, so the bug did not affect any MC.