### PR TITLE
Correct use of decayer in AliGenPythiaPlus

### DIFF
--- a/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
@@ -68,7 +68,7 @@ AliGenPythiaPlus::AliGenPythiaPlus():
     fQuench(0),
     fPtKick(1.),
     fFullEvent(kTRUE),
-    fDecayer(new AliDecayerPythia()),
+    fDecayer(0),
     fDebugEventFirst(-1),
     fDebugEventLast(-1),
     fEtMinJet(0.),      
@@ -137,6 +137,7 @@ AliGenPythiaPlus::AliGenPythiaPlus():
 {
 // Default Constructor
   fEnergyCMS = 5500.;
+ 
   if (!AliPythiaRndm::GetPythiaRandom()) 
       AliPythiaRndm::SetPythiaRandom(GetRandom());
 }
@@ -172,7 +173,7 @@ AliGenPythiaPlus::AliGenPythiaPlus(AliPythiaBase* pythia)
      fQuench(kFALSE),
      fPtKick(1.),
      fFullEvent(kTRUE),
-     fDecayer(new AliDecayerPythia()),
+     fDecayer(0),
      fDebugEventFirst(-1),
      fDebugEventLast(-1),
      fEtMinJet(0.),      
@@ -246,6 +247,7 @@ AliGenPythiaPlus::AliGenPythiaPlus(AliPythiaBase* pythia)
     fEnergyCMS = 5500.;
     fName = "Pythia";
     fTitle= "Particle Generator using PYTHIA";
+    fDecayer = pythia->Decayer();
     SetForceDecay();
     // Set random number generator 
     if (!AliPythiaRndm::GetPythiaRandom()) 

--- a/PYTHIA6/AliPythia6/AliPythiaBase.h
+++ b/PYTHIA6/AliPythia6/AliPythiaBase.h
@@ -8,11 +8,13 @@
 #include <TObject.h>
 #include "AliStructFuncType.h"
 #include "PythiaProcesses.h"
+#include "AliDecayer.h"
 
 class AliFastGlauber;
 class AliQuenchingWeights;
 class AliStack;
 class TClonesArray;
+
 
 class AliPythiaBase : public AliRndm 
 {
@@ -28,6 +30,7 @@ class AliPythiaBase : public AliRndm
     virtual void  ProcInit (Process_t /*process*/, Float_t /*energy*/, StrucFunc_t /*strucfunc*/, Int_t /* tune */) {;}
     virtual void  SetSeed(UInt_t seed);
     virtual void  GenerateEvent() {;}
+    virtual AliDecayer* Decayer() {return 0;}
     virtual void  GenerateMIEvent() {;}
     virtual Int_t GetNumberOfParticles() {return -1;};
     virtual void  SetNumberOfParticles(Int_t /*i*/){;}

--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
@@ -125,7 +125,6 @@ void AliDecayerPythia8::ForceDecay()
     fPythia8->ReadString("HadronLevel:Decay = on");
     
     if (decay == kNoDecayHeavy) return;
-
 //
 // select mode    
     switch (decay) 

--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.h
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.h
@@ -10,7 +10,10 @@
 
 #include <ParticleData.h>
 #include <TVirtualMCDecayer.h>
-#include "AliDecayer.h"
+#include <AliDecayer.h>
+
+class AliDecayerPythia8;
+
 
 class AliDecayerPythia8 : public TVirtualMCDecayer {
  public:

--- a/PYTHIA8/AliPythia8/AliPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliPythia8.cxx
@@ -67,7 +67,9 @@ AliPythia8::AliPythia8():
     fPtScale(0.),
     fNJetMin(0),
     fNJetMax(0),
-    fDecayLonglived(kFALSE)
+    fDecayLonglived(kFALSE),
+    fDecayer(0)
+    
 {
 // Default Constructor
 //
@@ -91,10 +93,19 @@ AliPythia8::AliPythia8(const AliPythia8& pythia):
     fPtScale(0.),
     fNJetMin(0),
     fNJetMax(0),
-    fDecayLonglived(kFALSE)
+    fDecayLonglived(kFALSE),
+    fDecayer(0)
 {
     // Copy Constructor
     pythia.Copy(*this);
+}
+
+AliDecayer* AliPythia8::Decayer()
+{
+  printf("calling AliPythia8::Decayer \n");
+  if (!fDecayer) fDecayer = new AliDecayerPythia8();
+  printf("decayer is  %p \n", fDecayer);
+  return fDecayer;
 }
 
 void AliPythia8::ProcInit(Process_t process, Float_t energy, StrucFunc_t strucfunc, Int_t tune)
@@ -574,7 +585,7 @@ void AliPythia8::SetNuclei(Int_t /*a1*/, Int_t /*a2*/)
 
 AliPythia8* AliPythia8::Instance()
 { 
-// Set random number generator 
+// return singleton instance
     if (fgAliPythia8) {
 	return fgAliPythia8;
     } else {
@@ -597,6 +608,10 @@ void  AliPythia8::ResetDecayTable()
 //    for (i = 1; i < 2001; i++) SetMDME(i,1,fDefMDME[i]);
 }
 
+void  AliPythia8::PrintDecayTable()
+{
+  Pythia8()->particleData.listChanged(); 
+}
 void  AliPythia8::SetDecayTable()
 {
 //  Set default values for pythia decay switches

--- a/PYTHIA8/AliPythia8/AliPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliPythia8.cxx
@@ -102,7 +102,6 @@ AliPythia8::AliPythia8(const AliPythia8& pythia):
 
 AliDecayer* AliPythia8::Decayer()
 {
-  printf("calling AliPythia8::Decayer \n");
   if (!fDecayer) fDecayer = new AliDecayerPythia8();
   return fDecayer;
 }

--- a/PYTHIA8/AliPythia8/AliPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliPythia8.cxx
@@ -104,7 +104,6 @@ AliDecayer* AliPythia8::Decayer()
 {
   printf("calling AliPythia8::Decayer \n");
   if (!fDecayer) fDecayer = new AliDecayerPythia8();
-  printf("decayer is  %p \n", fDecayer);
   return fDecayer;
 }
 

--- a/PYTHIA8/AliPythia8/AliPythia8.h
+++ b/PYTHIA8/AliPythia8/AliPythia8.h
@@ -8,6 +8,8 @@
 #include "Pythia8/Analysis.h"
 #include "AliPythiaBase.h"
 #include "AliTPythia8.h"
+#include "AliDecayer.h"
+#include "AliDecayerPythia8.h"
 
 class AliStack;
 class AliPythia8 :public AliTPythia8, public AliPythiaBase
@@ -18,6 +20,7 @@ class AliPythia8 :public AliTPythia8, public AliPythiaBase
     AliPythia8(const AliPythia8& pythia);
     virtual ~AliPythia8() {;}
     virtual Int_t Version() {return (8);}
+    virtual AliDecayer* Decayer(); 
     // convert to compressed code and print result (for debugging only)
     virtual Int_t CheckedLuComp(Int_t /*kf*/) {return -1;}
     // Pythia initialisation for selected processes
@@ -38,6 +41,7 @@ class AliPythia8 :public AliTPythia8, public AliPythiaBase
     virtual void PrintParticles();
     // Reset the decay table
     virtual void ResetDecayTable();
+    virtual void PrintDecayTable();
     //
     // Common Physics Configuration
     virtual void SetPtHardRange(Float_t ptmin, Float_t ptmax);
@@ -130,7 +134,7 @@ class AliPythia8 :public AliTPythia8, public AliPythiaBase
     Int_t                 fNJetMax;           //  ! max. number of jets
     Bool_t                fDecayLonglived;	  ///<    Decay long-lived particles (see @ref SetDecayLonglived for list of supported particles)
     static AliPythia8*    fgAliPythia8;       //    Pointer to single instance
-
+    AliDecayerPythia8*    fDecayer;           //  !  Pointer to decayer
     ClassDef(AliPythia8, 2); //ALICE UI to PYTHIA8
 };
 

--- a/PYTHIA8/AliPythia8/AliTPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliTPythia8.cxx
@@ -111,6 +111,7 @@ AliTPythia8::AliTPythia8():
    } else {
      fPythia    = new Pythia8::Pythia();
    }
+   fgInstance = this; 
 }
 
 //___________________________________________________________________________

--- a/PYTHIA8/pythia8.C
+++ b/PYTHIA8/pythia8.C
@@ -1,15 +1,10 @@
+R__LOAD_LIBRARY(libpythia8243)
+R__LOAD_LIBRARY(libAliPythia8)
 AliGenerator*  CreateGenerator();
 
 void pythia8(Int_t nev = 1, char* filename = "galice.root")
 {
 //  Runloader
-    gSystem->Load("liblhapdf");
-    gSystem->Load("libEGPythia6");
-    gSystem->Load("libpythia6");
-    gSystem->Load("libAliPythia6");
-    gSystem->Load("libpythia8205");
-    gSystem->Load("libAliPythia8");
-    
     AliRunLoader* rl = AliRunLoader::Open("galice.root","FASTRUN","recreate");
     
     rl->SetCompressionLevel(2);
@@ -28,6 +23,7 @@ void pythia8(Int_t nev = 1, char* filename = "galice.root")
 //  Create and Initialize Generator
     AliGenerator *gener = CreateGenerator();
     gener->Init();
+    (AliPythia8::Instance())->PrintDecayTable();
     gener->SetStack(stack);
     
 //
@@ -83,9 +79,11 @@ void pythia8(Int_t nev = 1, char* filename = "galice.root")
 AliGenerator*  CreateGenerator()
 {
     AliGenPythiaPlus* gener = new AliGenPythiaPlus(AliPythia8::Instance());
+
 //
 //
-    gener->SetProcess(kPyMbDefault);
+    gener->SetProcess(kPyCharmppMNRwmi);
+    gener->SetForceDecay(kHadronicDWithout4Bodies);
 //   Centre of mass energy 
     gener->SetEnergyCMS(7000.);
 //   Initialize generator    


### PR DESCRIPTION
- AliPythia8 has a factory method that returns a AliDecayerPythia8 object
(implementing a method in the base class AliPythiaBase)
- this method is called by AliGenPythiaPlus to set fDecayer consistently
- modifications to the decay table can be performed via AliGenPythiaPlus ::SetForceDecay

+

some updates in pythia8.C to work with root6
