### PR TITLE
Fix: Stack::PushTrack must assign ntr<0 when rejecting particle

### DIFF
--- a/STEER/STEERBase/AliStack.cxx
+++ b/STEER/STEERBase/AliStack.cxx
@@ -179,6 +179,7 @@ void AliStack::PushTrack(Int_t done, Int_t parent, Int_t pdg, const Float_t *pmo
     } else {
 	AliWarning(Form("Particle type %d not defined in PDG Database !", pdg));
 	AliWarning("Particle skipped !");
+	ntr = -1;
     }
 }
 


### PR DESCRIPTION
If the PDG is not known to the TParticlePDG then the particle is not added to the stack, nevertheless
the ntr (position of the added particle on the stack) was not set to negative value. This was signalling
to the generator which called PushTrack that the particle is added to the Stack, leading to the wrong
count of primaries in the generator header. In case the stack was empty at this moment, the following
call of KeepTrack(ntr) would lead to segm.violation, since ntr initial value is 0.
Now, the ntr is >=0 only if the particle was actually added to the stack.

ping: @ffionda @miweberSMI 

