### PR TITLE
fPythia object made non-persistent to avoid default constructur being called …

### DIFF
--- a/PYTHIA6/AliPythia6/AliGenPythiaPlus.h
+++ b/PYTHIA6/AliPythia6/AliGenPythiaPlus.h
@@ -256,7 +256,7 @@ class AliGenPythiaPlus : public AliGenMC
     void     MakeHeader();    
     void     GeneratePileup();
     
-    AliPythiaBase *fPythia;         //Pythia 
+    AliPythiaBase *fPythia;         //!Pythia 
     Process_t   fProcess;           //Process type
     StrucFunc_t fStrucFunc;         //Structure Function
     Float_t     fKineBias;          //!Bias from kinematic selection


### PR DESCRIPTION
…when reading galice.root