### PR TITLE
Return kTRUE since kFALSE indicates to Root v6-18-04 real problems

### DIFF
--- a/ANALYSIS/ANALYSIS/AliAnalysisManager.cxx
+++ b/ANALYSIS/ANALYSIS/AliAnalysisManager.cxx
@@ -631,7 +631,7 @@ Bool_t AliAnalysisManager::Notify()
 
    fIOTimer->Start(kTRUE); 
    if (!fTree) return kFALSE;
-   if (!TObject::TestBit(AliAnalysisManager::kTrueNotify)) return kFALSE;
+   if (!TObject::TestBit(AliAnalysisManager::kTrueNotify)) return kTRUE;
 
    fTable.Clear("nodelete"); // clearing the hash table may not be needed -> C.L.
    if (fMode == kProofAnalysis) fIsRemote = kTRUE;


### PR DESCRIPTION
The line was commented by mistake in the previous set of modifications and this led to problems. In fact it is enough to return kTRUE, which indicates everything is OK, but the remaining part of the Notify() is omitted.