### PR TITLE
PWGPP-571: Bug fix in implementation of the missing cluster correction factor 

### DIFF
--- a/TPC/TPCrec/AliTPCseed.cxx
+++ b/TPC/TPCrec/AliTPCseed.cxx
@@ -1457,6 +1457,7 @@ Float_t  AliTPCseed::CookdEdxAnalytical(Double_t low, Double_t up, Int_t type, I
     amp[ncl]/=gainChamber;
     amp[ncl]/=corrDipAngle;
     amp[ncl]/=corrDipAngleAbs;
+    amp[ncl]/=corrTimeGain;
     //
     ncl++;
   }
@@ -1495,13 +1496,13 @@ Float_t  AliTPCseed::CookdEdxAnalytical(Double_t low, Double_t up, Int_t type, I
   Float_t sumD=0, sumD2=0, sumDN=0;
 
   Int_t iclN=TMath::Nint((ncl + nclBelowThr*(1-factor))*(up-low));
-  Int_t icl0=TMath::Nint((ncl + nclBelowThr*factor)*low+ nclBelowThr*factor);
+  Int_t icl0=TMath::Nint((ncl + nclBelowThr*(1-factor))*low+ nclBelowThr*factor);
   Int_t icl1=icl0+iclN;
   Int_t iclm=icl0+iclN/2;
   //
   for (Int_t icl=icl0; icl<icl1;icl++){
     if (ampWithBelow[icl]<0.1) continue;
-    Double_t camp=ampWithBelow[icl]/corrTimeGain;
+    Double_t camp=ampWithBelow[icl];  // CHANGE 02.12.2019 - make time gain correction together with other corrections
     if (mode==1) camp= TMath::Log(camp);
     if (icl<icl1){
       suma+=camp;
@@ -1555,8 +1556,16 @@ Float_t  AliTPCseed::CookdEdxAnalytical(Double_t low, Double_t up, Int_t type, I
   if (mode==1) meanD=TMath::Exp(meanD);  // lower truncation
   //
   //delete [] ampWithBelow; //return? // RS made on stack
-  
-
+  if ((AliTPCReconstructor::StreamLevel()&AliTPCtracker::kStreamSeeddEdx)) {
+    Float_t dEdx0=0,dEdx1=0, dEdxF=0;
+    if (1){ /// this is to check with debugger
+      dEdx0= TMath::Mean(TMath::Nint((ncl + nclBelowThr)*(up-low)),&ampWithBelow[TMath::Nint((ncl+nclBelowThr)*low)]);
+      dEdx1=TMath::Mean(TMath::Nint(ncl*(up-low)),&ampWithBelow[TMath::Nint(ncl*low+nclBelowThr)]);
+      dEdxF=TMath::Mean(iclN,&ampWithBelow[icl0]);
+      // if (gRandom->Rndm()<0.01 && nclBelowThr>2) printf("%f\t%f\t%f\t%d\n",dEdx0, dEdx1,dEdxF,nclBelowThr);
+    }
+    if (gRandom->Rndm() < 0.01 && nclBelowThr > 2) printf("dEdx %f\t%f\t%f\t%f\t%d\n", dEdx0, dEdx1, dEdxF, mean, nclBelowThr);   // to be transformed to the DebugStreamer
+  }
   //
   if(returnVec){
       (*returnVec)(0) = mean;

--- a/TPC/TPCrec/AliTPCseed.cxx
+++ b/TPC/TPCrec/AliTPCseed.cxx
@@ -1495,7 +1495,7 @@ Float_t  AliTPCseed::CookdEdxAnalytical(Double_t low, Double_t up, Int_t type, I
   Float_t sumD=0, sumD2=0, sumDN=0;
 
   Int_t iclN=TMath::Nint((ncl + nclBelowThr*(1-factor))*(up-low));
-  Int_t icl0=TMath::Nint((ncl + nclBelowThr*factor)*low);
+  Int_t icl0=TMath::Nint((ncl + nclBelowThr*factor)*low+ nclBelowThr*factor);
   Int_t icl1=icl0+iclN;
   Int_t iclm=icl0+iclN/2;
   //

--- a/TPC/TPCrec/AliTPCseed.cxx
+++ b/TPC/TPCrec/AliTPCseed.cxx
@@ -1494,9 +1494,10 @@ Float_t  AliTPCseed::CookdEdxAnalytical(Double_t low, Double_t up, Int_t type, I
   Float_t sumL=0, sumL2=0, sumLN=0;
   Float_t sumD=0, sumD2=0, sumDN=0;
 
-  Int_t icl0=TMath::Nint((ncl + nclBelowThr)*low + nclBelowThr*factor);
-  Int_t icl1=TMath::Nint((ncl + nclBelowThr)*up+nclBelowThr*factor);
-  Int_t iclm=TMath::Nint((ncl + nclBelowThr)*(low +(up+low)*0.5));
+  Int_t iclN=TMath::Nint((ncl + nclBelowThr*(1-factor))*(up-low));
+  Int_t icl0=TMath::Nint((ncl + nclBelowThr*factor)*low);
+  Int_t icl1=icl0+iclN;
+  Int_t iclm=icl0+iclN/2;
   //
   for (Int_t icl=icl0; icl<icl1;icl++){
     if (ampWithBelow[icl]<0.1) continue;

--- a/TPC/TPCrec/AliTPCtracker.cxx
+++ b/TPC/TPCrec/AliTPCtracker.cxx
@@ -322,6 +322,7 @@ Int_t AliTPCtracker::AcceptCluster(AliTPCseed * seed, AliTPCclusterMI * cluster)
     Float_t tanPhi2 = (snp2>0)? snp2/(1-snp2):0;
     Float_t tgl2 = seed->GetTgl(); tgl2 *= tgl2;
     if (seed->GetESD()) if (seed->GetESD()->GetTPCsignal()>0)  mdEdx=TMath::Min(kdEdxMIP / seed->GetESD()->GetTPCsignal(), 1.);
+    if (cluster->GetMax()<=1 ) cluster->SetMax(2); // it can happend that common mode shift cluster bellow 0 -rocover such cluster
     if (AliTPCReconstructor::GetRecoParam()->GetUseClusterErrordEdxMultCorrection()) {
       // error tuning in https://gitlab.cern.ch/alice-tpc-offline/alice-tpc-notes/blob/0e00a7739d6c3cf89438f48c107b7e530a780e80/JIRA/PWGPP-570/clusterPerfromanceDF.C
       //      tree->SetAlias("erry2LM", "(erry2+(0.2**2)*TanPhi2)*(0.5+mdEdx+0.3*mQ)*0.25");


### PR DESCRIPTION
##  PWGPP-570 - BUG FIX - calculation of upper threshold of truncated mean
    

###  Algorithm
    

* Non observed clusters are used in the calculation assuming there is a signal  below threshold.
* Missing cluster is defined, in case there is signal before and after +-2 rows
* Number of  non observed rows, (signal below threshold) are used in truncated mean.
    
* Threshold and baseline is not well defined, as baseline  fluctuates. Mean  of the lowest obsereved NCL Q are  used to estimate lower signal.
    
###  One tuning parameter *factor* used:

```    
  Int_t iclN=TMath::Nint((ncl + nclBelowThr*(1-factor))*(up-low));
  Int_t icl0=TMath::Nint((ncl + nclBelowThr*(1-factor))*low+ nclBelowThr*factor);
  ...
  dEdxF=TMath::Mean(iclN,&ampWithBelow[icl0]);
```   

### Extreme cases:
- if factor ==1  -> missing clusters are ignored (not good idea -biasing results)
- ifactor ==0  -> missing clusters are ignored (not good idea -biasing results)
