### PR TITLE
Fix index to have the CutOnChild selection working with Pythia8

### DIFF
--- a/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
@@ -978,7 +978,7 @@ Int_t  AliGenPythiaPlus::GenerateMB()
 	}
 
 	if(fCutOnChild && TMath::Abs(pdg) == fPdgCodeParticleforAcceptanceCut) {
-	  Int_t mi = partCheck->GetFirstMother() - 1;
+	  Int_t mi = (fPythia->Version() == 6) ? (partCheck->GetFirstMother() - 1) :(partCheck->GetFirstMother()) ;
 	  if(mi<0) continue;
 	  mother = (TParticle*)fParticles.At(mi);
 	  mpdg=TMath::Abs(mother->GetPdgCode());


### PR DESCRIPTION
Dear @amorsch ,

with Pythia8 the HF selection on the decay particles was not working (causing in an infinite loop).
It seems to me it was due to a fortran/c++ mismatch in the counting (from 0 or from 1).
The fix in this commit solves the issue: from local simulations I could get proper selection on the decay particles.

Cheers, Francesco
