### PR TITLE
PWGPP-566, PWGPP-426, PWGPP-571 - TOF tracking bug fix   -using 3D distance …

### DIFF
--- a/TOF/TOFrec/AliTOFtracker.cxx
+++ b/TOF/TOFrec/AliTOFtracker.cxx
@@ -871,8 +871,11 @@ void AliTOFtracker::MatchTracks( Int_t mLastStep){
     for (Int_t iclus= 0; iclus<nfound;iclus++) {
       AliTOFtrackPoint *matchableTOFcluster = (AliTOFtrackPoint*)fTOFtrackPoints->At(iclus);
       //if ( matchableTOFcluster->Distance()<mindist ) {
-      if ( TMath::Abs(matchableTOFcluster->DistanceX())<TMath::Abs(mindistX) &&
-	   TMath::Abs(matchableTOFcluster->DistanceX())<=stepSize ) {
+      //if ( TMath::Abs(matchableTOFcluster->DistanceX())<TMath::Abs(mindistX) &&
+	   //TMath::Abs(matchableTOFcluster->DistanceX())<=stepSize ) {
+        	   if ( TMath::Abs(matchableTOFcluster->Distance())<TMath::Abs(mindist) &&
+	    TMath::Abs(matchableTOFcluster->DistanceX())<=stepSize ) {                     /// MI - Temporary BUG FIX - use 3D distance instead of the localX (radial) distance
+
 	mindist = matchableTOFcluster->Distance();
 	mindistZ = matchableTOFcluster->DistanceZ(); // Z distance in the
 						     // RF of the hit pad


### PR DESCRIPTION
## PWGPP-566, PWGPP-426, PWGPP-571 - TOF tracking bug fix   

Using 3D distance instead of the   localX (radial) distance
The bug was affecting PbPb productions since 2011.

Next commit (more lines to change and benchmark)  which will follow soon:
*  prohibits cluster usage (cluster SetUse) - only for "gold matches" 
  * criteria  match in space and time
  * gold to be defined in scan
*  TRD/TOF causality information for best matches

