### PR TITLE
M<0 in AliV0HypSel will be interpreted as q=2 particle

### DIFF
--- a/GRP/MakeGRPRecoParam.C
+++ b/GRP/MakeGRPRecoParam.C
@@ -65,8 +65,10 @@ void MakeGRPRecoParam(Bool_t allowCleanup, AliRecoParam::EventSpecie_t default=A
       param->AddV0HypSel( AliV0HypSel("K0",139.570e-3, 139.570e-3, 497.7e-3, 0.003,20,0.07, 1.,0.5));
       param->AddV0HypSel( AliV0HypSel("Lambda",938.272e-3, 139.570e-3, 1115.683e-3, 0.001, 20, 0.07, 1.,0.5));
       param->AddV0HypSel( AliV0HypSel("antiLambda",139.570e-3, 938.272e-3, 1115.683e-3, 0.001, 20, 0.07, 1.,0.5));
-      param->AddV0HypSel( AliV0HypSel("HyperTriton",2.8092, 139.570e-3, 2.992, 0.0025, 14, 0.07, 1.,0.5));
-      param->AddV0HypSel( AliV0HypSel("antiHyperTriton",139.570e-3, 2.8092, 2.992, 0.0025, 14, 0.07, 1.,0.5));
+      // He3 with negative mass to signal q=2
+      param->AddV0HypSel( AliV0HypSel("HyperTriton",-2.8092, 139.570e-3, 2.992, 0.0025, 14, 0.07, 1.,0.5));
+      // He3 with negative mass to signal q=2
+      param->AddV0HypSel( AliV0HypSel("antiHyperTriton",139.570e-3, -2.8092, 2.992, 0.0025, 14, 0.07, 1.,0.5));
       
       param->SetFlagsNotToClean(AliESDtrack::kITSin | AliESDtrack::kTRDrefit |
 				AliESDtrack::kTOFout | AliESDtrack::kHMPIDout);

--- a/STEER/ESD/AliESDv0.cxx
+++ b/STEER/ESD/AliESDv0.cxx
@@ -891,6 +891,12 @@ Double_t AliESDv0::GetEffMassExplicit(Double_t m1, Double_t m2) const {
   Double_t pmom[3]={0}, nmom[3]={0};
   paramP->GetPxPyPz(pmom);
   paramN->GetPxPyPz(nmom);
+  if (m1<0) { // q=2
+    for (int i=3;i--;) pmom[i] *= 2;
+  }
+  if (m2<0) { // q=2
+    for (int i=3;i--;) nmom[i] *= 2;
+  }  
   Double_t e12   = m1*m1+pmom[0]*pmom[0]+pmom[1]*pmom[1]+pmom[2]*pmom[2];
   Double_t e22   = m2*m2+nmom[0]*nmom[0]+nmom[1]*nmom[1]+nmom[2]*nmom[2];
   Double_t cmass = TMath::Sqrt(TMath::Max(m1*m1+m2*m2

--- a/STEER/ESD/AliV0HypSel.cxx
+++ b/STEER/ESD/AliV0HypSel.cxx
@@ -71,10 +71,10 @@ AliV0HypSel::AliV0HypSel(const char *name, float m0,float m1, float mass, float 
 void AliV0HypSel::Validate()
 {
   // consistency check
-  if (fM0<0.0005 || fM1<0.0005) {
+  if (TMath::Abs(fM0)<0.0005 || TMath::Abs(fM1)<0.0005) {
     AliFatal("V0 decay product mass cannot be lighter than electron");
   }
-  if (fMass<fM0+fM1) {
+  if (fMass<TMath::Abs(fM0)+TMath::Abs(fM1)) {
     AliFatal("V0 mass is less than sum of product masses");
   }
   if ( (fSigmaM<=0 || fNSigma<=0) && fMarginAdd<=1e-3) {

--- a/STEER/ESD/AliV0HypSel.h
+++ b/STEER/ESD/AliV0HypSel.h
@@ -38,8 +38,8 @@ public:
   virtual void Print(const Option_t *) const;
   
 private:
-  Float_t fM0;         // mass of the 1st prong
-  Float_t fM1;         // mass of the 2nd prong
+  Float_t fM0;         // mass of the 1st prong, <0 means q=2
+  Float_t fM1;         // mass of the 2nd prong, <0 meand q=2
   Float_t fMass ;      // expected V0 mass
   Float_t fSigmaM;     // rough sigma estimate for sigmaMass = fSigmaM*(fCoef0Pt+fCoef1Pt*Pt) parameterization
   Float_t fCoef0Pt;    // offset of sigma_m pT dependence


### PR DESCRIPTION
Needed for correct treatment of the hypertriton mass evaluation.