### PR TITLE
Change to SoftQCD the process for HF generation

### DIFF
--- a/PYTHIA8/AliPythia8/AliPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliPythia8.cxx
@@ -684,7 +684,7 @@ void AliPythia8::ConfigHeavyFlavor()
     //
     // All QCD processes
     //
-    ReadString("HardQCD:all = on");
+    ReadString("SoftQCD:nonDiffractive = on");
 
     // No multiple interactions
     ReadString("PartonLevel:MPI = off");


### PR DESCRIPTION
From the checks discussed in ALIROOT-8371, it emerged that the SoftQCD:nonDiffactive setting provides a better description for the pt spectra of D mesons and the underlying event multiplicity.
Based on these checks, we change the configuration in the method AliPythia8::ConfgHeavyFlavor