### PR TITLE
Fix remaining usage of alien_find

### DIFF
--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -2815,7 +2815,8 @@ Bool_t AliAnalysisAlien::CheckMergedFiles(const char *filename, const char *alie
    //TGridResult *res = gGrid->Command(Form("find -x Stage_%d %s %s", stage, aliendir, pattern.Data()));
    //if (res) delete res;
    // Write standard output to file
-   gSystem->Exec(Form("alien_find -x Stage_%d %s %s > Stage_%d.xml 2>/dev/null", stage, aliendir, pattern.Data(), stage));
+   TGridCollection *tmp = gGrid->OpenCollectionQuery(gGrid->Command(Form("find %s %s", aliendir, pattern.Data())),kTRUE);
+  tmp->ExportXML(Form("file://Stage_%d.xml",stage),kFALSE,kFALSE,Form("Stage_%d",stage));
    //gROOT->ProcessLine(Form("gGrid->Stdout(); > %s", Form("Stage_%d.xml",stage)));
    // Count the number of files inside
    ifstream ifile;


### PR DESCRIPTION
With a local installation (on a mac) of the master the merging via JDL of an analysis outputs fails. The locally created Stage_1.xml fails. As I understand the  new alien_find command does not redirect the output to the standard output and thus redirection of it to a file ends up with an empty file.