### PR TITLE
Add HF selection case with c and b proportions as in Pythia

### DIFF
--- a/PYTHIA6/AliPythia6/AliGenPythia.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythia.cxx
@@ -525,6 +525,16 @@ void AliGenPythia::Init()
 	fParentSelect[6]= 5332;
 	fFlavorSelect   = 5;	
 	break;
+    case kPyHeavyFlavppMNRwmi:
+	fParentSelect[0]=  511;  //settings to selct decay products
+	fParentSelect[1]=  521;
+	fParentSelect[2]=  531;
+	fParentSelect[3]= 5122;
+	fParentSelect[4]= 5132;
+	fParentSelect[5]= 5232;
+	fParentSelect[6]= 5332;
+	fFlavorSelect    =  5;
+	break;
     case kPyBeautyUnforced:
 	fParentSelect[0] =  511;
 	fParentSelect[1] =  521;
@@ -799,6 +809,7 @@ void AliGenPythia::Generate()
             fProcess != kPyZgamma &&
 	    fProcess != kPyCharmppMNRwmi && 
 	    fProcess != kPyBeautyppMNRwmi &&
+	    fProcess != kPyHeavyFlavppMNRwmi &&
 	    fProcess != kPyBeautyJets &&
             fProcess != kPyWPWHG &&
             fProcess != kPyJetsPWHG &&
@@ -1131,7 +1142,7 @@ Int_t  AliGenPythia::GenerateMB()
     // Check if there is a ccbar or bbbar pair with at least one of the two
     // in fYMin < y < fYMax
 
-    if (fProcess == kPyCharmppMNRwmi || fProcess == kPyBeautyppMNRwmi || fProcess == kPyBeautyJets) {
+    if (fProcess == kPyCharmppMNRwmi || fProcess == kPyBeautyppMNRwmi || fProcess == kPyHeavyFlavppMNRwmi || fProcess == kPyBeautyJets) {
       TParticle *partCheck;
       TParticle *mother;
       Bool_t  theQ=kFALSE,theQbar=kFALSE,inYcut=kFALSE;
@@ -1145,8 +1156,11 @@ Int_t  AliGenPythia::GenerateMB()
 
       for(i = 0; i < np; i++) {
 	partCheck = (TParticle*)fParticles.At(i);
-	pdg = partCheck->GetPdgCode();  
-	if(TMath::Abs(pdg) == fFlavorSelect) { // quark  
+	pdg = partCheck->GetPdgCode();
+	Bool_t flavSel=kFALSE;
+	if(TMath::Abs(pdg) == fFlavorSelect) flavSel=kTRUE;
+	if(fProcess == kPyHeavyFlavppMNRwmi && (TMath::Abs(pdg) == 4 || TMath::Abs(pdg) == 5)) flavSel=kTRUE;
+	if(flavSel){ // quark  
 	  if(pdg>0) { theQ=kTRUE; } else { theQbar=kTRUE; }
 	  y = 0.5*TMath::Log((partCheck->Energy()+partCheck->Pz()+1.e-13)/
 			     (partCheck->Energy()-partCheck->Pz()+1.e-13));

--- a/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
@@ -451,6 +451,16 @@ void AliGenPythiaPlus::Init()
 	fParentSelect[6]= 5332;
 	fFlavorSelect   = 5;	
 	break;
+    case kPyHeavyFlavppMNRwmi:
+	fParentSelect[0]=  511;  //settings to selct decay products
+	fParentSelect[1]=  521;
+	fParentSelect[2]=  531;
+	fParentSelect[3]= 5122;
+	fParentSelect[4]= 5132;
+	fParentSelect[5]= 5232;
+	fParentSelect[6]= 5332;
+	fFlavorSelect    =  5;
+	break;
     case kPyBeautyUnforced:
 	fParentSelect[0] =  511;
 	fParentSelect[1] =  521;
@@ -682,6 +692,7 @@ void AliGenPythiaPlus::Generate()
       fProcess != kPyZgamma &&
 	    fProcess != kPyCharmppMNRwmi && 
 	    fProcess != kPyBeautyppMNRwmi &&
+	    fProcess != kPyHeavyFlavppMNRwmi &&
       fProcess != kPyWPWHG &&
 	    fProcess != kPyJetsPWHG &&
             fProcess != kPyCharmPWHG &&
@@ -993,7 +1004,7 @@ Int_t  AliGenPythiaPlus::GenerateMB()
 
     // Check if there is a ccbar or bbbar pair with at least one of the two
     // in fYMin < y < fYMax
-    if (fProcess == kPyCharmppMNRwmi || fProcess == kPyBeautyppMNRwmi) {
+    if (fProcess == kPyCharmppMNRwmi || fProcess == kPyBeautyppMNRwmi || fProcess == kPyHeavyFlavppMNRwmi ) {
       TParticle *partCheck;
       TParticle *mother;
       Bool_t  theQ=kFALSE,theQbar=kFALSE,inYcut=kFALSE;
@@ -1003,7 +1014,10 @@ Int_t  AliGenPythiaPlus::GenerateMB()
       for(i=0; i<np; i++) {
 	partCheck = (TParticle*)fParticles.At(i);
 	pdg = partCheck->GetPdgCode();  
-	if(TMath::Abs(pdg) == fFlavorSelect) { // quark  
+	Bool_t flavSel=kFALSE;
+	if(TMath::Abs(pdg) == fFlavorSelect) flavSel=kTRUE;
+	if(fProcess == kPyHeavyFlavppMNRwmi && (TMath::Abs(pdg) == 4 || TMath::Abs(pdg) == 5)) flavSel=kTRUE;
+	if(flavSel) { // quark  
 	  if(pdg>0) { theQ=kTRUE; } else { theQbar=kTRUE; }
 
       	if(partCheck->Energy()-TMath::Abs(partCheck->Pz()) > FLT_EPSILON) y = 0.5*TMath::Log((partCheck->Energy()+partCheck->Pz()+1.e-13)/

--- a/PYTHIA6/AliPythia6/AliPythia.cxx
+++ b/PYTHIA6/AliPythia6/AliPythia.cxx
@@ -578,6 +578,39 @@ void AliPythia::ProcInit(Process_t process, Float_t energy, StrucFunc_t strucfun
 
 	 AtlasTuning();
 	 break; 
+     case kPyHeavyFlavppMNRwmi:
+      // Tuning of Pythia parameters aimed to get a resonable agreement
+      // between with the NLO calculation by Mangano, Nason, Ridolfi for the
+      // b-bbar single inclusive and double differential distributions.
+      // This parameter settings are meant to work with pp collisions
+      // and with kCTEQ5L PDFs.
+      // Added multiple interactions according to ATLAS tune settings.
+      // To get a "reasonable" agreement with MNR results, events have to be 
+      // generated with the minimum ptHard (AliGenPythia::SetPtHard)
+      // set to 2.76 GeV.
+      // To get a "perfect" agreement with MNR results, events have to be 
+      // generated in four ptHard bins with the following relative 
+      // normalizations:
+      // 2.76-4 GeV:  5% 
+      //    4-6 GeV: 31%
+      //    6-8 GeV: 28%
+      //     >8 GeV: 36%
+	 ConfigHeavyFlavor();
+      // QCD scales
+	 SetPARP(67,1.0);
+	 SetPARP(71,1.0);
+	 
+	 // Intrinsic <kT>
+	 SetMSTP(91,1);
+	 SetPARP(91,1.);
+	 SetPARP(93,5.);
+
+      // Set c and b quark masses
+	 SetPMAS(4,1,1.2);
+	 SetPMAS(5,1,4.75);
+
+	 AtlasTuning();
+	 break; 
     case kPyW:
 
       //Inclusive production of W+/-

--- a/PYTHIA6/AliPythia6/AliPythia6.cxx
+++ b/PYTHIA6/AliPythia6/AliPythia6.cxx
@@ -566,6 +566,39 @@ void AliPythia6::ProcInit(Process_t process, Float_t energy, StrucFunc_t strucfu
 
 	 AtlasTuning();
 	 break; 
+    case kPyHeavyFlavppMNRwmi:
+      // Tuning of Pythia parameters aimed to get a resonable agreement
+      // between with the NLO calculation by Mangano, Nason, Ridolfi for the
+      // b-bbar single inclusive and double differential distributions.
+      // This parameter settings are meant to work with pp collisions
+      // and with kCTEQ5L PDFs.
+      // Added multiple interactions according to ATLAS tune settings.
+      // To get a "reasonable" agreement with MNR results, events have to be 
+      // generated with the minimum ptHard (AliGenPythia::SetPtHard)
+      // set to 2.76 GeV.
+      // To get a "perfect" agreement with MNR results, events have to be 
+      // generated in four ptHard bins with the following relative 
+      // normalizations:
+      // 2.76-4 GeV:  5% 
+      //    4-6 GeV: 31%
+      //    6-8 GeV: 28%
+      //     >8 GeV: 36%
+	 ConfigHeavyFlavor();
+      // QCD scales
+	 SetPARP(67,1.0);
+	 SetPARP(71,1.0);
+	 
+	 // Intrinsic <kT>
+	 SetMSTP(91,1);
+	 SetPARP(91,1.);
+	 SetPARP(93,5.);
+
+      // Set c and b quark masses
+	 SetPMAS(4,1,1.2);
+	 SetPMAS(5,1,4.75);
+
+	 AtlasTuning();
+	 break; 
     case kPyW:
 
       //Inclusive production of W+/-

--- a/PYTHIA6/AliPythia6/PythiaProcesses.h
+++ b/PYTHIA6/AliPythia6/PythiaProcesses.h
@@ -8,7 +8,7 @@ typedef enum
     kPyCharmPbPbMNR, kPyD0PbPbMNR, kPyDPlusPbPbMNR, kPyDPlusStrangePbPbMNR, kPyBeautyPbPbMNR,
     kPyCharmpPbMNR, kPyD0pPbMNR, kPyDPluspPbMNR, kPyDPlusStrangepPbMNR, kPyBeautypPbMNR,
     kPyCharmppMNR, kPyCharmppMNRwmi, kPyD0ppMNR, kPyDPlusppMNR, kPyDPlusStrangeppMNR, 
-    kPyBeautyppMNR, kPyBeautyppMNRwmi, kPyBeautyJets, kPyW, kPyZ, kPyLambdacppMNR, kPyMbMSEL1,
+    kPyBeautyppMNR, kPyBeautyppMNRwmi, kPyHeavyFlavppMNRwmi, kPyBeautyJets, kPyW, kPyZ, kPyLambdacppMNR, kPyMbMSEL1,
     kPyOldUEQ2ordered, kPyOldUEQ2ordered2, kPyOldPopcorn,
     kPyLhwgMb, kPyMbDefault, kPyMbAtlasTuneMC09, kPyMBRSingleDiffraction, kPyMBRDoubleDiffraction, kPyMBRCentralDiffraction, kPyJetsPWHG, kPyCharmPWHG, kPyBeautyPWHG, kPyWPWHG, kPyZgamma
 }

--- a/PYTHIA8/AliPythia8/AliPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliPythia8.cxx
@@ -502,6 +502,37 @@ void AliPythia8::ProcInit(Process_t process, Float_t energy, StrucFunc_t strucfu
 	ReadString("ParticleData:mbRun = 4.75");
 	AtlasTuning();
 	break; 
+     case kPyHeavyFlavppMNRwmi:
+      // Tuning of Pythia parameters aimed to get a resonable agreement
+      // between with the NLO calculation by Mangano, Nason, Ridolfi for the
+      // b-bbar single inclusive and double differential distributions.
+      // This parameter settings are meant to work with pp collisions
+      // and with kCTEQ5L PDFs.
+      // Added multiple interactions according to ATLAS tune settings.
+      // To get a "reasonable" agreement with MNR results, events have to be 
+      // generated with the minimum ptHard (AliGenPythia::SetPtHard)
+      // set to 2.76 GeV.
+      // To get a "perfect" agreement with MNR results, events have to be 
+      // generated in four ptHard bins with the following relative 
+      // normalizations:
+      // 2.76-4 GeV:  5% 
+      //    4-6 GeV: 31%
+      //    6-8 GeV: 28%
+      //     >8 GeV: 36%
+	 ConfigHeavyFlavor();
+	 // QCD scales
+	 ReadString("SigmaProcess:factorMultFac = 1.");
+	 // Intrinsic <kT>
+	ReadString("BeamRemnants:primordialKT = on");
+	ReadString("BeamRemnants:primordialKTsoft = 0.");
+	ReadString("BeamRemnants:primordialKThard = 1.0");
+	ReadString("BeamRemnants:halfScaleForKT = 0.");
+	ReadString("BeamRemnants:halfMassForKT = 0.");
+	// Set c and b quark masses
+	ReadString("ParticleData:mcRun = 1.20");
+	ReadString("ParticleData:mbRun = 4.75");
+	AtlasTuning();
+	break; 
     case kPyW:
 	//Inclusive production of W+/-
 	//f fbar -> W+ 


### PR DESCRIPTION
This feature allows to select generated events containing a charm or a beauty quark.
This allows to create samples enriched of HF with the c and b proportions given by PYTHIA, which could be practical for some studies (e.g. HF-lepton pairs).

