### PR TITLE
Account for BC dependent ALTRO/LHC clocks shift

### DIFF
--- a/STEER/ESD/AliTrackerBase.cxx
+++ b/STEER/ESD/AliTrackerBase.cxx
@@ -41,7 +41,11 @@ AliTrackerBase::AliTrackerBase():
   fZ(0),
   fSigmaX(0.005),
   fSigmaY(0.005),
-  fSigmaZ(0.010)
+  fSigmaZ(0.010),
+  fRun(0),
+  fOrbitNumber(0),
+  fPeriodNumber(0),
+  fBunchCrossNumber(0)
 {
   //--------------------------------------------------------------------
   // The default constructor.
@@ -58,7 +62,11 @@ AliTrackerBase::AliTrackerBase(const AliTrackerBase &atr):
   fZ(atr.fZ),
   fSigmaX(atr.fSigmaX),
   fSigmaY(atr.fSigmaY),
-  fSigmaZ(atr.fSigmaZ)
+  fSigmaZ(atr.fSigmaZ),
+  fRun(atr.fRun),
+  fOrbitNumber(atr.fOrbitNumber),
+  fPeriodNumber(atr.fPeriodNumber),
+  fBunchCrossNumber(atr.fBunchCrossNumber)
 {
   //--------------------------------------------------------------------
   // The default constructor.

--- a/STEER/ESD/AliTrackerBase.h
+++ b/STEER/ESD/AliTrackerBase.h
@@ -40,7 +40,16 @@ public:
   Int_t    GetRunNumber() const {return fRun;}
   void     SetTimeStamp(UInt_t t) {fTimeStamp = t;}
   void     SetRunNumber(int run)  {fRun = run;}
+  
+  void      SetBunchCrossNumber(UShort_t n) {fBunchCrossNumber=n;}
+  void      SetPeriodNumber(UInt_t n) {fPeriodNumber=n;}
+  void      SetOrbitNumber(UInt_t n) {fOrbitNumber=n;}
 
+  UShort_t  GetBunchCrossNumber() const {return fBunchCrossNumber;}
+  UInt_t    GetPeriodNumber() const {return fPeriodNumber;}
+  UInt_t    GetOrbitNumber() const {return fOrbitNumber;}
+
+  
   static Double_t GetTrackPredictedChi2(AliExternalTrackParam *track,
                                         Double_t mass, Double_t step, 
 			          const AliExternalTrackParam *backup);
@@ -101,7 +110,11 @@ private:
   UInt_t   fTimeStamp; // event time stamp
   Int_t    fRun;       //  run number
 
-  ClassDef(AliTrackerBase,2) //base tracker
+  UInt_t   fOrbitNumber;       // Orbit Number
+  UInt_t   fPeriodNumber;      // Period Number
+  UShort_t fBunchCrossNumber;  // Bunch Crossing Number
+
+  ClassDef(AliTrackerBase,3) //base tracker
 };
 
 //__________________________________________________________________________

--- a/STEER/STEER/AliReconstruction.cxx
+++ b/STEER/STEER/AliReconstruction.cxx
@@ -2256,7 +2256,10 @@ Bool_t AliReconstruction::ProcessEvent(Int_t iEvent)
     for (Int_t iDet = 0; iDet < kNDetectors; iDet++) {
       if (fTracker[iDet]) { // some trackers need details about the run/time
 	fTracker[iDet]->SetTimeStamp(fesd->GetTimeStamp());
-	fTracker[iDet]->SetRunNumber(fesd->GetRunNumber());
+	fTracker[iDet]->SetOrbitNumber(fesd->GetOrbitNumber());
+	fTracker[iDet]->SetPeriodNumber(fesd->GetPeriodNumber());
+	fTracker[iDet]->SetBunchCrossNumber(fesd->GetBunchCrossNumber());
+	fTracker[iDet]->SetRunNumber(fesd->GetRunNumber());	
       }
       //RS also some reconstructructors may need the time stamp
       if (fReconstructor[iDet]) fReconstructor[iDet]->SetTimeStamp(fesd->GetTimeStamp());

--- a/TPC/TPCbase/AliTPCTransform.cxx
+++ b/TPC/TPCbase/AliTPCTransform.cxx
@@ -102,6 +102,7 @@ AliTPCTransform::AliTPCTransform():
   fLumiGraphMap(0),
   fCurrentRun(0),             //! current run
   fCurrentTimeStamp(0),       //! current time stamp
+  fAltroLHCShift(0),
   fTimeDependentUpdated(kFALSE),
   fCorrMapMode(kTRUE),
   //
@@ -143,6 +144,7 @@ AliTPCTransform::AliTPCTransform(const AliTPCTransform& transform):
   fLumiGraphMap(transform.fLumiGraphMap ? new TGraph(*transform.fLumiGraphMap) : 0),
   fCurrentRun(transform.fCurrentRun),             //! current run
   fCurrentTimeStamp(transform.fCurrentTimeStamp),       //! current time stamp
+  fAltroLHCShift(transform.fAltroLHCShift),
   fTimeDependentUpdated(transform.fTimeDependentUpdated),
   fCorrMapMode(transform.fCorrMapMode),
   fDebugStreamer(0),
@@ -193,6 +195,7 @@ void AliTPCTransform::Transform(Double_t *x,Int_t *i,UInt_t /*time*/,
   /// line approximation
 
   if (!fCurrentRecoParam) return;
+  x[2] -= fAltroLHCShift; // account for the (BC%4)*100ns/200ns BC-dependent shift
   Int_t row=TMath::Nint(x[0]);
   Int_t pad=TMath::Nint(x[1]);
   Int_t sector=i[0];

--- a/TPC/TPCbase/AliTPCTransform.h
+++ b/TPC/TPCbase/AliTPCTransform.h
@@ -59,6 +59,7 @@ public:
   void SetCurrentRecoParam(AliTPCRecoParam* param){fCurrentRecoParam=param;}
   void SetCurrentRun(Int_t run){fCurrentRun=run;}
   void SetCurrentTimeStamp(time_t timeStamp);
+  void AccountCurrentBC(UShort_t bc);
   void ApplyTransformations(Double_t *xyz, Int_t volID);
   //
   // new correction maps
@@ -125,6 +126,7 @@ private:
   TGraph*  fLumiGraphMap;                    //!<! graph for current map luminosity (may be different from current run), owned by the class
   Int_t    fCurrentRun;                //!<! current run
   time_t   fCurrentTimeStamp;          //!<! current time stamp
+  Float_t  fAltroLHCShift;             //!<! current (BC%4)*25ns/100ns BC-dependent shift
   Bool_t   fTimeDependentUpdated;      //!<! flag successful update of time dependent stuff
   Bool_t   fCorrMapMode;               //!<! correction or distortion map mode
   //
@@ -150,7 +152,7 @@ private:
   
   AliHLTTPCReverseTransformInfoV1* fTmpReverseTransformInfo; //!
   //
-  ClassDef(AliTPCTransform,5)
+  ClassDef(AliTPCTransform,6)
   /// \endcond
 };
 
@@ -208,5 +210,10 @@ inline int AliTPCTransform::SectorDown(int idROC)
   return idROC + (((idROC%18)== 0) ?  17 : -1); // change to the lower sector
 }
 
+//_________________________________________________
+inline void AliTPCTransform::AccountCurrentBC(UShort_t bc)
+{
+  fAltroLHCShift = (bc%4)*0.25; // (bc%4)*25ns/100ns
+}
 
 #endif

--- a/TPC/TPCcalib/AliTPCcalibAlignInterpolation.cxx
+++ b/TPC/TPCcalib/AliTPCcalibAlignInterpolation.cxx
@@ -468,7 +468,8 @@ void  AliTPCcalibAlignInterpolation::Process(AliVEvent *eventV) {
   transform->GetCurrentRecoParamNonConst()->SetAccountDistortions(kFALSE);
 
   transform->SetCurrentTimeStamp(esdEvent->GetTimeStamp()); // to be independent from the time set by other tasks
-
+  transform->AccountCurrentBC( esdEvent->GetBunchCrossNumber() );
+  
   for (Int_t iTrack=0;iTrack<nTracks;iTrack++){ // Track loop
     // 0.) For each track in each event, get the AliESDfriendTrack
     AliESDtrack *esdTrack = esdEvent->GetTrack(iTrack);

--- a/TPC/TPCcalib/AliTPCcalibBase.cxx
+++ b/TPC/TPCcalib/AliTPCcalibBase.cxx
@@ -68,6 +68,9 @@ AliTPCcalibBase::AliTPCcalibBase():
     fRun(0),                  //!  current Run number
     fEvent(0),                //!  current Event number
     fTime(0),                 //!  current Time
+    fOrbitNumber(0),
+    fPeriodNumber(0),
+    fBunchCrossNumber(0),
     fTrigger(0),              //! current trigger type
     fMagF(0),                 //! current magnetic field
     fTriggerMaskReject(-1),   //trigger mask - reject trigger
@@ -93,6 +96,9 @@ AliTPCcalibBase::AliTPCcalibBase(const char * name, const char * title):
   fRun(0),                  //!  current Run number
   fEvent(0),                //!  current Event number
   fTime(0),                 //!  current Time
+  fOrbitNumber(0),
+  fPeriodNumber(0),
+  fBunchCrossNumber(0),
   fTrigger(0),              //! current trigger type
   fMagF(0),                 //! current magnetic field
   fTriggerMaskReject(-1),   //trigger mask - reject trigger
@@ -118,6 +124,9 @@ AliTPCcalibBase::AliTPCcalibBase(const AliTPCcalibBase&calib):
   fRun(0),                  //!  current Run number
   fEvent(0),                //!  current Event number
   fTime(0),                 //!  current Time
+  fOrbitNumber(0),
+  fPeriodNumber(0),
+  fBunchCrossNumber(0),
   fTrigger(0),              //! current trigger type
   fMagF(0),                 //! current magnetic field
   fTriggerMaskReject(calib.fTriggerMaskReject),   //trigger mask - reject trigger
@@ -192,6 +201,10 @@ void    AliTPCcalibBase::UpdateEventInfo(AliVEvent * event){
   fRun     = event->GetRunNumber();
   fEvent   = event->GetEventNumberInFile();
   fTime    = event->GetTimeStamp();
+  fOrbitNumber = event->GetOrbitNumber();
+  fPeriodNumber = event->GetPeriodNumber();
+  fBunchCrossNumber = event->GetBunchCrossNumber();
+  
   fTrigger = event->GetTriggerMask();
   fMagF    = event->GetMagneticField();
   fTriggerClass = event->GetFiredTriggerClasses().Data();

--- a/TPC/TPCcalib/AliTPCcalibBase.h
+++ b/TPC/TPCcalib/AliTPCcalibBase.h
@@ -66,6 +66,11 @@ protected:
   Int_t  fRun;                          //!  current Run number
   Int_t  fEvent;                        //! current Event number
   Int_t  fTime;                         //!  current Time
+  UInt_t   fOrbitNumber;                //! Orbit Number
+  UInt_t   fPeriodNumber;               //! Period Number
+  UShort_t fBunchCrossNumber;           //! Bunch Crossing Number
+
+  
   ULong64_t  fTrigger;                  //! current trigger mask
   Float_t fMagF;                        // current magnetic field 
   Int_t   fTriggerMaskReject;           //trigger mask - non accept trigger
@@ -80,7 +85,7 @@ protected:
 private:
   Int_t  fDebugLevel;                   //  debug level
 
-  ClassDef(AliTPCcalibBase,3)
+  ClassDef(AliTPCcalibBase,4)
 };
 
 #endif

--- a/TPC/TPCcalib/AliTPCcalibCalib.cxx
+++ b/TPC/TPCcalib/AliTPCcalibCalib.cxx
@@ -207,6 +207,7 @@ Bool_t  AliTPCcalibCalib::RefitTrack(AliVTrack * track, AliTPCseed *seed, Float_
   AliTPCParam     *param     = AliTPCcalibDB::Instance()->GetParameters();
   transform->SetCurrentRun(fRun);
   transform->SetCurrentTimeStamp((UInt_t)fTime);
+  transform->AccountCurrentBC( fBunchCrossNumber );
   if(!fApplyExBCorrection) { // disable ExB correction in transform
     if(transform->GetCurrentRecoParam())
       transform->GetCurrentRecoParamNonConst()->SetUseExBCorrection(0);

--- a/TPC/TPCcalib/AliTPCcalibGainMult.cxx
+++ b/TPC/TPCcalib/AliTPCcalibGainMult.cxx
@@ -381,7 +381,8 @@ void AliTPCcalibGainMult::Process(AliVEvent *event) {
   AliTPCTransform *transform = AliTPCcalibDB::Instance()->GetTransform() ;
   transform->SetCurrentRun(fRun);
   transform->SetCurrentTimeStamp((UInt_t)fTime);
-
+  transform->AccountCurrentBC( fBunchCrossNumber );
+  
   const Int_t row0 = param->GetNRowLow();
   const Int_t row1 = row0+param->GetNRowUp1();
   const Int_t row2 = row1+param->GetNRowUp2();

--- a/TPC/TPCcalib/AliTPCcalibTimeGain.cxx
+++ b/TPC/TPCcalib/AliTPCcalibTimeGain.cxx
@@ -332,7 +332,8 @@ void AliTPCcalibTimeGain::Process(AliVEvent *event) {
   AliTPCTransform *transform = AliTPCcalibDB::Instance()->GetTransform() ;
   transform->SetCurrentRun(fRun);
   transform->SetCurrentTimeStamp((UInt_t)fTime);
-
+  transform->AccountCurrentBC( fBunchCrossNumber );
+  
   if (fIsCosmic) { // this should be removed at some point based on trigger mask !?
     ProcessCosmicEvent(event);
   } else {

--- a/TPC/TPCrec/AliTPCclusterer.cxx
+++ b/TPC/TPCrec/AliTPCclusterer.cxx
@@ -639,6 +639,7 @@ void AliTPCclusterer::AddCluster(AliTPCclusterMI &c, bool addtoarray, Float_t * 
     if (transform->GetCurrentTimeStamp()!=fTimeStamp) {
       transform->SetCurrentTimeStamp(fTimeStamp);
     }
+    transform->AccountCurrentBC( fBunchCrossNumber );
     Double_t x[3]={static_cast<Double_t>(c.GetRow()),static_cast<Double_t>(c.GetPad()),static_cast<Double_t>(c.GetTimeBin())};
     Int_t i[1]={fSector};
     transform->Transform(x,i,0,1);

--- a/TPC/TPCrec/AliTPCtracker.cxx
+++ b/TPC/TPCrec/AliTPCtracker.cxx
@@ -1484,6 +1484,7 @@ Int_t  AliTPCtracker::LoadClusters(const TObjArray *arr)
   transform->SetCurrentRecoParam((AliTPCRecoParam*)AliTPCReconstructor::GetRecoParam());
   transform->SetCurrentTimeStamp( GetTimeStamp());
   transform->SetCurrentRun( GetRunNumber() );
+  transform->AccountCurrentBC( GetBunchCrossNumber() );
 
   AliWarning("Sector Change ins not checked in LoadClusters(const TObjArray *arr)");
 


### PR DESCRIPTION
See discussion at https://alice.its.cern.ch/jira/browse/ALIROOT-8260?focusedCommentId=242160&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-242160
for details.

@miranov25 please cross-check, I've tested it on a few 10 events of 1 LHC18q chunk, and I see that depending on the BC the cluster time in the ``AliTPCTransform->Transform(...)`` gets shifted by 0, 0.25 or 0.75, as we want.