### PR TITLE
Missing settings for altro clock fix (#1106)

### DIFF
--- a/TPC/TPCrec/AliTPCclusterer.cxx
+++ b/TPC/TPCrec/AliTPCclusterer.cxx
@@ -917,6 +917,7 @@ void AliTPCclusterer::ProcessSectorData(){
             Double_t x[]={static_cast<Double_t>(iRow),static_cast<Double_t>(iPad-3),static_cast<Double_t>(iTimeBin-3)};
             Int_t i[]={fSector};
             AliTPCTransform trafo;
+	    trafo.AccountCurrentBC( fBunchCrossNumber );
             trafo.Transform(x,i,0,1);
             Double_t gx[3]={x[0],x[1],x[2]};
             trafo.RotatedGlobal2Global(fSector,gx);

--- a/TPC/TPCrec/AliTPCtracker.cxx
+++ b/TPC/TPCrec/AliTPCtracker.cxx
@@ -1549,6 +1549,7 @@ Int_t  AliTPCtracker::LoadClusters(const TClonesArray *arr)
   transform->SetCurrentRecoParam((AliTPCRecoParam*)AliTPCReconstructor::GetRecoParam());
   transform->SetCurrentTimeStamp( GetTimeStamp());
   transform->SetCurrentRun( GetRunNumber() );
+  transform->AccountCurrentBC( GetBunchCrossNumber() );
   //
   AliTPCclusterMI *clust=0;
   Int_t count[72][96] = { {0} , {0} }; 
@@ -1613,6 +1614,7 @@ Int_t  AliTPCtracker::LoadClusters()
   transform->SetCurrentRecoParam((AliTPCRecoParam*)AliTPCReconstructor::GetRecoParam());
   transform->SetCurrentTimeStamp( GetTimeStamp());
   transform->SetCurrentRun( GetRunNumber() );
+  transform->AccountCurrentBC( GetBunchCrossNumber() );
 
   //  TTree * tree = fClustersArray.GetTree();
   AliInfo("LoadClusters()\n");
@@ -8484,6 +8486,7 @@ Int_t AliTPCtracker::Clusters2TracksHLT (AliESDEvent *const esd, const AliESDEve
   transform->SetCurrentRecoParam((AliTPCRecoParam*)AliTPCReconstructor::GetRecoParam());
   transform->SetCurrentTimeStamp( GetTimeStamp());
   transform->SetCurrentRun( GetRunNumber());
+  transform->AccountCurrentBC( GetBunchCrossNumber() );
 
   //transform->SetCurrentTimeStamp( esd->GetTimeStamp());
   //transform->SetCurrentRun(esd->GetRunNumber());


### PR DESCRIPTION
Previous patch was working for clusters produced in the reconstruction, but was failing
when clusters were extracted beforehand