### PR TITLE
PWGPP-529 -TStatToolkit::MakePDFMap()- adding new fit option LTMFitRange

### DIFF
--- a/STAT/TStatToolkit.cxx
+++ b/STAT/TStatToolkit.cxx
@@ -3331,6 +3331,10 @@ void TStatToolkit::MakePDFMap(THnBase *histo, TTreeSRedirector *pcstream, TMatri
       }
     }
     (*pcstream)<<tname<<"\n";
+    delete graphHisto;
+    delete graphCumulative;
+    graphHisto=NULL;
+    graphCumulative=NULL;
     if (hDump)	{
       (*pcstream)<<TString::Format("%sDump", tname).Data()<<"\n";
       hfit->GetListOfFunctions()->RemoveLast();


### PR DESCRIPTION
## PWGPP-529 -TStatToolkit::MakePDFMap()- adding new fit option LTMFitRange
* Default: if case option not specified - fits performed in full range
* if option specified fit is performed in range parameterized by LTM estimator
  * example option:  options["LTMFitRange"]="0.6:5:1";
    * Range center: LTM 0.6 used
    * Range:  (LTM0.6 -6 LTM sigma-1, LTM0.6 +6 LTM sigma+1 ) range

##  PWGPP-571, PWGPP-529 -TStatToolkit::MakePDFMap() - memory leak fix
