### PR TITLE
switch ON pi0 decay in pythia8 decayer

### DIFF
--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
@@ -93,17 +93,11 @@ void AliDecayerPythia8::Init()
 	    fPythia8->ReadString(Form("%d:onMode = on", heavy[j]));
 	}
     }
+ 
+    fPythia8->ReadString("111:onMode = on");
     
-
-//...Switch off decay of pi0, K0S, Lambda, Sigma+-, Xi0-, Omega-.
-    
-    if (fDecay != kNeutralPion) {
-	fPythia8->ReadString("111:onMode = off");
-    } else {
-	fPythia8->ReadString("111:onMode = on");
-    }
-
-    fPythia8->ReadString("310:onMode = off");
+//...Switch off decay of K0S, Lambda, Sigma+-, Xi0-, Omega-.
+    fPythia8->ReadString("310:onMode  = off");
     fPythia8->ReadString("3122:onMode = off");
     fPythia8->ReadString("3112:onMode = off");
     fPythia8->ReadString("3222:onMode = off");


### PR DESCRIPTION
Since AliDecayerPythia8 is correctly called from AliPythia8 the decay of pions was switched off.
With this change the pi0 decays are ON again. 