### PR TITLE
PWGPP-584   recursive TTree, TBranch  dump and formatted printing/sorting

### DIFF
--- a/STEER/STEERBase/AliSysInfo.cxx
+++ b/STEER/STEERBase/AliSysInfo.cxx
@@ -546,7 +546,10 @@ void AliSysInfo::printTreeTable(const char *inputLog, const char *mask,  Int_t n
   TString query = TString::Format("cat %s|egrep %s|sed s_dumpTreeSize::__|", inputLog, mask);
   query += TString::Format("sort -r -k %d| head -n %d", sortCol, nrows);
   //if (isJira) query+=TString::Format("|gawk '{print }'")
-  if (isJIRA) query += "|gawk '{print \"|\"$1\"|\"$2\"|\"$3\"|\"$4\"|\"$5\"|\"$6\"|\"$7\"|\"}'";
+  if (isJIRA) {
+    query += "|gawk '{print \"|\"$1\"|\"$2\"|\"$3\"|\"$4\"|\"$5\"|\"$6\"|\"$7\"|\"}'";
+    printf("|BranchName|Self size|Self Zip size|Full Total size|Full zip|Compression|Fraction|\n");
+  }
   if (verbose) printf("%s\n", query.Data());
   gSystem->Exec(query.Data());
 }

--- a/STEER/STEERBase/AliSysInfo.cxx
+++ b/STEER/STEERBase/AliSysInfo.cxx
@@ -472,3 +472,83 @@ TTree * AliSysInfo::MakeDUTree(const char *lname, const char * fout){
     tree=(TTree*)ftout->Get("du");
   return tree;  
 }
+
+
+/// recursive dumpBrachSize to outout file (or STDOUT)
+/// \param pFile         - output file (or STDOUT)
+/// \param branch        - branch to dump recursivele
+/// \param dumpName      - dump ID
+/// \param totBytes      - total bytes
+/// \param zipBytes      - zip butes
+/// \param zipBytesNorm  - overal normalization factor (full tree size)
+/// \return
+void AliSysInfo::dumpBranchSize(FILE *pFile,  TBranch * branch, const char *dumpName, Float_t &totBytes, Float_t &zipBytes, Float_t zipBytesNorm){
+  Int_t nBranches = branch->GetListOfBranches()->GetSize();
+  zipBytes=branch->GetZipBytes();
+  totBytes=branch->GetTotBytes();
+  for (Int_t iBranch=0; iBranch<nBranches; iBranch++){
+    TBranch * br = (TBranch*)branch->GetListOfBranches()->At(iBranch);
+    if (br== NULL) continue;
+    Float_t totBytesSelf=branch->GetTotBytes();
+    Float_t zipBytesSelf=branch->GetZipBytes();
+    Float_t totBytesL=branch->GetTotBytes();
+    Float_t zipBytesL=branch->GetZipBytes();
+    if (branch->GetListOfBranches()){
+      TString dumpNameLocal=TString::Format("%s",dumpName);
+      dumpBranchSize(pFile, br, dumpNameLocal, totBytesL, zipBytesL, zipBytesNorm);
+    }
+    zipBytes+=zipBytesL;
+    totBytes+=totBytesL;
+    fprintf(pFile, "dumpTreeSize::%s.%s\t%0.0f\t%0.0f\t%0.0f\t%0.0f\t%0.2f\t%0.4f\n", dumpName, br->GetName(), totBytesSelf,zipBytesSelf, totBytesL, zipBytesL,  zipBytesL/totBytesL, zipBytesL/zipBytesNorm);
+  }
+}
+
+/// recursie dumpTreeSize to ouput file or STDOUT
+/// \param tree            - input tree
+/// \param dumpName        - ID to dump
+/// \param outName         - out file to dump - defaut to STDOUT
+void AliSysInfo::dumpTreeSize(TTree * tree, const char *dumpName, const char * outName){
+  FILE * pFile;
+  if (outName!=0) {
+    pFile = fopen(outName, "w");
+  }else{
+    pFile=stdout;
+  }
+  Int_t nBranches = tree->GetListOfBranches()->GetSize();
+  Float_t nZipBytes=tree->GetZipBytes();
+  Float_t nTotBytes=tree->GetTotBytes();
+  fprintf(pFile,"dumpTreeSize::%s.%s\t%s\t%s\t%s\t%s\t%s\n", "Name", "BranchName", "Self Total", "Self Zip", "Full Total", "Full zip" , "Fraction");
+  fprintf(pFile,"dumpTreeSize::%s.base\t%0.0f\t%0.0f\t%0.0f\t%0.0f\t%0.2f\t%0.4f\n", dumpName, nTotBytes, nZipBytes, nTotBytes, nZipBytes, nZipBytes/nTotBytes,1.);
+  for (Int_t iBranch=0; iBranch<nBranches; iBranch++){
+    TBranch * branch = (TBranch*)tree->GetListOfBranches()->At(iBranch);
+    if (branch== NULL) continue;
+    Float_t totBytesSelf=branch->GetTotBytes();
+    Float_t zipBytesSelf=branch->GetZipBytes();
+    Float_t totBytes=branch->GetTotBytes();
+    Float_t zipBytes=branch->GetZipBytes();
+    if (branch->GetListOfBranches() && branch->GetListOfBranches()->GetSize()>0){
+      TString dumpNameLocal=TString::Format("%s",dumpName);
+      AliSysInfo::dumpBranchSize(pFile, branch, dumpNameLocal, totBytes, zipBytes,nZipBytes);
+    }
+    fprintf(pFile,"dumpTreeSize::%s.%s\t%0.0f\t%0.0f\t%0.0f\t%0.0f\t%0.2f\t%0.4f\n", dumpName, branch->GetName(), totBytesSelf, zipBytesSelf, totBytes, zipBytes,  zipBytes/totBytes, zipBytes/nZipBytes);
+  }
+  fflush(pFile);
+}
+
+/// print Tree memory and disk usage table  parsing dumpTreeSize log
+/// \param inputLog     - input log file
+/// \param mask         - mask to dump
+/// \param nrows        - number of raws to dump
+/// \param sortCol      - column to sort
+/// \param isJIRA       - flag - JIRA format
+/// \param verbose
+void AliSysInfo::printTreeTable(const char *inputLog, const char *mask,  Int_t nrows, Int_t sortCol, Bool_t isJIRA, Bool_t verbose) {
+  TString query = TString::Format("cat %s|egrep %s|sed s_dumpTreeSize::__|", inputLog, mask);
+  query += TString::Format("sort -r -k %d| head -n %d", sortCol, nrows);
+  //if (isJira) query+=TString::Format("|gawk '{print }'")
+  if (isJIRA) query += "|gawk '{print \"|\"$1\"|\"$2\"|\"$3\"|\"$4\"|\"$5\"|\"$6\"|\"$7\"|\"}'";
+  if (verbose) printf("%s\n", query.Data());
+  gSystem->Exec(query.Data());
+}
+
+

--- a/STEER/STEERBase/AliSysInfo.h
+++ b/STEER/STEERBase/AliSysInfo.h
@@ -7,6 +7,7 @@
 #include <TObject.h>
 class TStopwatch;
 class TTree;
+class TBranch;
 class TMemStatManager;
 using std::fstream;
 
@@ -32,6 +33,10 @@ public:
   static void SetDisabled(Bool_t v=kTRUE)   {fgDisabled = v; fgVerbose=kFALSE;}
   static Bool_t IsDisabled()               {return fgDisabled;}
   static void PrintJiraTable(TTree * tree, const char *var, const char *cut, const char *format, const char *output="syswatch.table");
+  //
+  static void dumpBranchSize(FILE *pFile,  TBranch * branch, const char *dumpName, Float_t &totBytes, Float_t &zipBytes, Float_t zipBytesNorm);
+  static void dumpTreeSize(TTree * tree, const char *dumpName, const char * outName=0);
+  static void printTreeTable(const char *inputLog, const char *mask,  Int_t nrows, Int_t sortCol=7, Bool_t isJIRA=1, Bool_t verbose=1);
 private:
   AliSysInfo(const AliSysInfo& source);
   AliSysInfo& operator= (const AliSysInfo& rec);

--- a/STEER/STEERBase/AliSysInfo.h
+++ b/STEER/STEERBase/AliSysInfo.h
@@ -36,7 +36,7 @@ public:
   //
   static void dumpBranchSize(FILE *pFile,  TBranch * branch, const char *dumpName, Float_t &totBytes, Float_t &zipBytes, Float_t zipBytesNorm);
   static void dumpTreeSize(TTree * tree, const char *dumpName, const char * outName=0);
-  static void printTreeTable(const char *inputLog, const char *mask,  Int_t nrows, Int_t sortCol=7, Bool_t isJIRA=1, Bool_t verbose=1);
+  static void printTreeTable(const char *inputLog, const char *mask,  Int_t nrows, Int_t sortCol=7, Bool_t isJIRA=1, Bool_t verbose=0);
 private:
   AliSysInfo(const AliSysInfo& source);
   AliSysInfo& operator= (const AliSysInfo& rec);


### PR DESCRIPTION
## PWGPP-584   recursive TTree, TBranch  dump and formatted printing/sorting


```
 static void dumpBranchSize(FILE *pFile,  TBranch * branch, const char *dumpName, Float_t &totBytes, Float_t &zipBytes, Float_t zipBytesNorm);
 static void dumpTreeSize(TTree * tree, const char *dumpName, const char * outName=0);
 static void printTreeTable(const char *inputLog, const char *mask,  Int_t nrows, Int_t sortCol=7, Bool_t isJIRA=1, Bool_t verbose=1);
````
### Example usage:
```
 for (Int_t i=0;i<3; i++){
    TFile * f = TFile::Open(fnames[i]);
    TTree * tree = (TTree*)f->Get(tnames[i]);
    AliSysInfo::dumpTreeSize(tree, tnames[i],"dump.list");
    AliSysInfo::printTreeTable("dump.list",tnames[i],nrows,7,1);
  }
````
### Example output:
|branch|sel.fsize|zip.self size|size|zipsize|compression|fraction|
| ------------- | ------------- |--|--|--|--|--|
|V0s.base|1729879|1081357|1729879|1081357|0.63|1.0000|
|V0s.track0.|0|0|263316|233339|0.89|0.2158|
|V0s.track1.|0|0|262842|232370|0.88|0.2149|
|V0s.friendTrack0.|0|0|521578|225249|0.43|0.2083|
|V0s.friendTrack1.|0|0|456127|202960|0.44|0.1877|
|V0s.friendTrack0.fCalibContainer|0|0|326988|133732|0.41|0.1237|
|V0s.friendTrack1.fCalibContainer|0|0|299673|121821|0.41|0.1127|
|V0s.v0.|0|0|85479|82314|0.96|0.0761|
|V0s.friendTrack0.fPoints|0|0|145565|54392|0.37|0.0503|
|V0s.kf.AliKFParticleBase|0|0|60006|54283|0.90|0.0502|
|V0s.kf.|0|0|60006|54283|0.90|0.0502|
|V0s.friendTrack1.fPoints|0|0|113549|46085|0.41|0.0426|
|V0s.kf.AliKFParticleBase.fC[36]|0|0|26436|21892|0.83|0.0202|
|V0s.track1.AliExternalTrackParam|0|0|19212|19042|0.99|0.0176|
|V0s.track0.AliExternalTrackParam|0|0|19212|19041|0.99|0.0176|

