### PR TITLE
Elastic scattering between N-N pairs switched off to avoid frequent crashes

### DIFF
--- a/THijing/AliGenHijing.cxx
+++ b/THijing/AliGenHijing.cxx
@@ -78,7 +78,7 @@ AliGenHijing::AliGenHijing()
      fNoHeavyQuarks(kFALSE),
      fHeader(AliGenHijingEventHeader("Hijing")),
      fSigmaNN(-1),
-     fNoElas(0),
+     fNoElas(1),
      fDataFragmentation(kTRUE),
      fFreeProjSpecn(0),
      fFreeProjSpecp(0),
@@ -135,7 +135,7 @@ AliGenHijing::AliGenHijing(Int_t npart)
      fNoHeavyQuarks(kFALSE),
      fHeader(AliGenHijingEventHeader("Hijing")),
      fSigmaNN(-1),
-     fNoElas(0),
+     fNoElas(1),
      fDataFragmentation(kTRUE),
      fFreeProjSpecn(0),
      fFreeProjSpecp(0),
@@ -196,8 +196,11 @@ void AliGenHijing::Init()
     fHijing->SetHIPR1(50, fSimpleJet);
     //
     // Switching off elastic scattering
-    if (fNoElas)
+    // By deafult it is off
+    if (fNoElas) {
       fHijing->SetIHPR2(14, 0);
+      printf("\n Elastic scattering between N-N pairs is switched off. \n");
+    }
 //
 //  Quenching
 //


### PR DESCRIPTION
The crashes are due to a numerical instabilities in the elastic scattering routine at specific settings of the center of mass energy. In these cases for some nucleons E < |pz|. This is checked by HIJING and the program stops.
No significant effects from elastic scattering on physics expected at LHC energies.
With 
hijing->SetNoElas(kFALSE);   
one can switch elastic scattering on.
