### PR TITLE
ATO-493 - MakeCacheTree (file mode option), AliTreePlayer::NextPad

### DIFF
--- a/STAT/AliTreePlayer.cxx
+++ b/STAT/AliTreePlayer.cxx
@@ -1580,8 +1580,8 @@ TPad *  AliTreePlayer::DrawHistograms(TPad  * pad, TObjArray * hisArray, TString
 /// \param selection    - tree selection
 /// \param firstEntry   - first entry to export
 /// \param nEntries     - number of nEntries to export
-void AliTreePlayer::MakeCacheTree(TTree * tree, TString varList, TString outFile, TString outTree, TCut selection, Int_t nEntries, Int_t firstEntry){
-  TTreeSRedirector *pcstream = new TTreeSRedirector(outFile,"recreate");
+void AliTreePlayer::MakeCacheTree(TTree * tree, TString varList, TString outFile, TString outTree, TCut selection, Int_t nEntries, Int_t firstEntry, const char *fileMode){
+  TTreeSRedirector *pcstream = new TTreeSRedirector(outFile,fileMode);
   if (tree->GetEstimate()<tree->GetEntries()) tree->SetEstimate(tree->GetEntries());
   Int_t estimate=tree->GetEstimate();
   Int_t entries=0;
@@ -1791,4 +1791,18 @@ TNamed* AliTreePlayer::GetMetadata(TTree* tree, const char *varTagName, TString 
   named = (TNamed*)metaData->FindObject(metaName.Data());
   return named;
 
+}
+/// change to next pad in canvas - used in TTree::Draw()
+/// Example:
+///   draw histogram fulfilling criteria
+///   tree->Draw("histCM.Draw(\"colz\"):histCM.GetXaxis()->SetRangeUser(130,170)","!T0_isOK&&abs(peakPosition-150)<20&&AliTreePlayer::nextPad()","goffpara",100,0);
+Int_t AliTreePlayer::nextPad(){
+  /// used for Tree draw queries
+  static int counter=0;
+  if (!gPad) return kFALSE;
+  counter++;
+  gPad->GetMother()->cd(counter);
+  if (gPad->GetNumber()<counter) counter=0;
+  gPad->Update();
+  return counter;
 }

--- a/STAT/AliTreePlayer.cxx
+++ b/STAT/AliTreePlayer.cxx
@@ -1800,6 +1800,7 @@ Int_t AliTreePlayer::nextPad(){
   /// used for Tree draw queries
   static int counter=0;
   if (!gPad) return kFALSE;
+  gPad->Update();
   counter++;
   gPad->GetMother()->cd(counter);
   if (gPad->GetNumber()<counter) counter=0;

--- a/STAT/AliTreePlayer.h
+++ b/STAT/AliTreePlayer.h
@@ -101,7 +101,8 @@ public:
   static TString  printSelectedTreeInfo(TTree*tree, TString infoType,  TString regExpFriend, TString regExpTag, Int_t verbose);
   static TObjArray  * MakeHistograms(TTree * tree, TString hisString, TString defaultCut, Int_t firstEntry, Int_t lastEntry, Int_t chunkSize=-1, Int_t verbose=1);
   static TPad *  DrawHistograms(TPad  * pad, TObjArray * hisArray, TString drawExpression, TObjArray *keepArray=0, Int_t verbose=0);
-  static void MakeCacheTree(TTree * tree, TString varList, TString outFile, TString outTree, TCut selection,   Int_t nEntries=-1, Int_t firstEntry=0);
+  static void MakeCacheTree(TTree * tree, TString varList, TString outFile, TString outTree, TCut selection,   Int_t nEntries=-1, Int_t firstEntry=0, const char *fileMode="recreate");
+  static Int_t nextPad();
 
   template <typename T> static Long64_t BinarySearchSmaller(Long64_t n, const T *array, T value);
   enum TStatType {kUndef=-1,kEntries, kSum, kMean, kRMS, kMedian, kLTM, kLTMRMS, kMedianLeft,kMedianRight,kMax,kMin};


### PR DESCRIPTION
# MakeCacheTree - possibility to specify file opneing mode
* before only "recreate mode" supported

# AliTreePlayer::NextPad
* change to next pad in canvas - used in TTree::Draw()
  *  Example  - query draw histogram fulfilling criteria to sequence of pads
     * visualizing histogram where fits failed "!T0_isOK"
````
   tree->Draw("histCM.Draw(\"colz\"):histCM.GetXaxis()->SetRangeUser(130,170)","!T0_isOK&&abs(peakPosition-150)<20&&AliTreePlayer::nextPad()","goffpara",100,0);
````