### PR TITLE
[EMCAL 510] Fix TRU L0 version selection

### DIFF
--- a/EMCAL/EMCALsim/AliEMCALTriggerTRU.cxx
+++ b/EMCAL/EMCALsim/AliEMCALTriggerTRU.cxx
@@ -173,6 +173,7 @@ Int_t AliEMCALTriggerTRU::L0()
   ma = (ma >> 8) & 0x7f;
   
   AliDebug(999,Form("=== TRU fw version %x ===",fDCSConfig->GetFw()));
+  AliDebug(999,Form("=== TRU Segmentation %x ===",fDCSConfig->GetSegmentation()));
   AliDebug(999,Form("=== TRU L0 THR = %d ===",fDCSConfig->GetGTHRL0()));
   
   if (fDCSConfig->GetGTHRL0() <= 1) { // Checking for the null threshold
@@ -180,7 +181,8 @@ Int_t AliEMCALTriggerTRU::L0()
     return 0; // Don't use trigger if threshold is 0 or 1.
   }
 
-  if (fDCSConfig->GetFw() < 0x4d) {
+//  if (fDCSConfig->GetFw() < 0x4d) { // FW information not saved in OCDB
+  if (fDCSConfig->GetSegmentation() == 1) {
     return L0v0(nb, ma);
   } else {
     return L0v1(nb, ma);


### PR DESCRIPTION
[EMCAL 510] The TRU firmware version was not saved properly and should not
be used for determine which L0 version to use. Decision is now made based
on the L0 Sel variable, via AliEMCALTriggerTRUDCSConfig::GetSegmentation().
This corrects issue where simulations used L0v0 instead of L0v1