### PR TITLE
ATO-496, PWGPP-6, PWGPP-538 - interpolated momentum for the ITS BetheBloch (for nuclei PID)

### DIFF
--- a/STEER/STEERBase/AliITSPIDResponse.cxx
+++ b/STEER/STEERBase/AliITSPIDResponse.cxx
@@ -25,6 +25,7 @@
 #include "AliVTrack.h"
 #include "AliITSPIDResponse.h"
 #include "AliITSPidParams.h"
+#include "AliPIDResponse.h"
 #include "AliExternalTrackParam.h"
 
 ClassImp(AliITSPIDResponse)
@@ -476,7 +477,10 @@ Double_t AliITSPIDResponse::GetNumberOfSigmas( const AliVTrack* track, AliPID::E
   //TODO: in case of the electron, use the SA parametrisation,
   //      this needs to be changed if ITS provides a parametrisation
   //      for electrons also for ITS+TPC tracks
-  return GetNumberOfSigmas(mom,dEdx,type,nPointsForPid,isSA || (type==AliPID::kElectron));
+  const Float_t kInterpolPosition=0.75;
+  Double_t momInner = (track->GetInnerParam()) ? track->GetInnerParam()->P():track->P();
+  Double_t momITS=AliPIDResponse::interpolateP(track->P(),momInner,AliPID::ParticleMass(type),kInterpolPosition, AliPID::ParticleCharge(type));
+  return GetNumberOfSigmas(momITS,dEdx,type,nPointsForPid,isSA || (type==AliPID::kElectron));
 }
 
 //_________________________________________________________________________
@@ -497,8 +501,10 @@ Double_t AliITSPIDResponse::GetSignalDelta( const AliVTrack* track, AliPID::EPar
   //TODO: in case of the electron, use the SA parametrisation,
   //      this needs to be changed if ITS provides a parametrisation
   //      for electrons also for ITS+TPC tracks
-
-  const Float_t bethe = Bethe(mom,type, isSA || (type==AliPID::kElectron))*chargeFactor;
+  const Float_t kInterpolPosition=0.75;
+  Double_t momInner = (track->GetInnerParam()) ? track->GetInnerParam()->P():track->P();
+  Double_t momITS=AliPIDResponse::interpolateP(track->P(),momInner,AliPID::ParticleMass(type),kInterpolPosition, AliPID::ParticleCharge(type));
+  const Float_t bethe = Bethe(momITS,type, isSA || (type==AliPID::kElectron))*chargeFactor;
 
   Double_t delta=-9999.;
   if (!ratio) delta=dEdx-bethe;

--- a/STEER/STEERBase/AliPIDResponse.cxx
+++ b/STEER/STEERBase/AliPIDResponse.cxx
@@ -52,6 +52,7 @@
 #include "AliDetectorPID.h"
 
 #include "AliMultSelectionBase.h"
+#include "AliExternalTrackParam.h"
 
 ClassImp(AliPIDResponse);
 
@@ -2762,7 +2763,7 @@ AliPIDResponse::EDetPidStatus AliPIDResponse::GetComputeITSProbability  (const A
   //
   // Compute PID response for the ITS
   //
-
+  const Float_t kInterpolPosition=0.75;
   // set flat distribution (no decision)
   for (Int_t j=0; j<nSpecies; j++) p[j]=1./nSpecies;
 
@@ -2782,7 +2783,9 @@ AliPIDResponse::EDetPidStatus AliPIDResponse::GetComputeITSProbability  (const A
   if (fTuneMConData && ((fTuneMConDataMask & kDetITS) == kDetITS)) dedx = GetITSsignalTunedOnData(track);
   (void) dedx;//mark as used to avoid warning
 
-  Double_t momITS=mom;
+  // Double_t momITS=mom; MI change use inteoploated momentum between ITS and TPC  -species dependent
+
+
   UChar_t clumap=track->GetITSClusterMap();
   Int_t nPointsForPid=0;
   for(Int_t i=2; i<6; i++){
@@ -2792,16 +2795,21 @@ AliPIDResponse::EDetPidStatus AliPIDResponse::GetComputeITSProbability  (const A
   Bool_t mismatch=kTRUE/*, heavy=kTRUE*/;
   for (Int_t j=0; j<nSpecies; j++) {
     const Double_t chargeFactor = TMath::Power(AliPID::ParticleCharge(j),2.);
+    Double_t momInner = (track->GetInnerParam()) ? track->GetInnerParam()->P():track->P();
+    Double_t momITS=interpolateP(track->P(),momInner,AliPID::ParticleMass(j),kInterpolPosition, AliPID::ParticleCharge(j));
     //TODO: in case of the electron, use the SA parametrisation,
     //      this needs to be changed if ITS provides a parametrisation
     //      for electrons also for ITS+TPC tracks
     Double_t bethe=fITSResponse.Bethe(momITS,(AliPID::EParticleType)j,isSA || (j==(Int_t)AliPID::kElectron))*chargeFactor;
+    AliDebug(10, Form("%f\t%f\t%f\n",mom, momITS, momInner));
     Double_t sigma=fITSResponse.GetResolution(bethe,nPointsForPid,isSA || (j==(Int_t)AliPID::kElectron));
     Double_t nSigma=fITSResponse.GetNumberOfSigmas(track, (AliPID::EParticleType)j);
     if (TMath::Abs(nSigma) > fRange) {
-      p[j]=TMath::Exp(-0.5*fRange*fRange)/sigma;
+      // p[j]=TMath::Exp(-0.5*fRange*fRange)/sigma; // BUG fix
+      p[j]=TMath::Exp(-0.5*fRange*fRange);
     } else {
-      p[j]=TMath::Exp(-0.5*nSigma*nSigma)/sigma;
+      //p[j]=TMath::Exp(-0.5*nSigma*nSigma)/sigma; // BUG fix
+      p[j]=TMath::Exp(-0.5*nSigma*nSigma);
       mismatch=kFALSE;
     }
   }
@@ -2840,9 +2848,11 @@ AliPIDResponse::EDetPidStatus AliPIDResponse::GetComputeTPCProbability  (const A
     sigma=fTPCResponse.GetExpectedSigma(track, type, AliTPCPIDResponse::kdEdxDefault, fUseTPCEtaCorrection, fUseTPCMultiplicityCorrection, fUseTPCPileupCorrection);
 
     if (TMath::Abs(dedx-bethe) > fRange*sigma) {
-      p[j]=TMath::Exp(-0.5*fRange*fRange)/sigma;
+      // p[j]=TMath::Exp(-0.5*fRange*fRange)/sigma;   // BUG fix
+      p[j]=TMath::Exp(-0.5*fRange*fRange);
     } else {
-      p[j]=TMath::Exp(-0.5*(dedx-bethe)*(dedx-bethe)/(sigma*sigma))/sigma;
+      // p[j]=TMath::Exp(-0.5*(dedx-bethe)*(dedx-bethe)/(sigma*sigma))/sigma;  //BUG fix
+      p[j]=TMath::Exp(-0.5*(dedx-bethe)*(dedx-bethe)/(sigma*sigma));
       mismatch=kFALSE;
     }
   }
@@ -3333,4 +3343,27 @@ void AliPIDResponse::SetEventPileupProperties(const AliVEvent* /*vevent*/)
     AliWarning("==========================================================");
   }
   warned = kTRUE;
+}
+
+/// parabolic interpolation  of the momenta between tow reference layers 0 and 1
+/// assuming mometum loss model AliExternalTrackParam::BetheBlochSolid
+/// \param p0             - momentum at layer 0
+/// \param p1             - momentum at layer 1
+/// \param mass           - mass of particle
+/// \param X              - reference X position - should be in inteval (0,1) - not extrapolation
+/// \param z              - charge of particle
+/// \return               - interpolated momentum at layer X
+Float_t AliPIDResponse::interpolateP(Float_t p0, Float_t p1, Float_t mass, Float_t X, Float_t z){
+  if (X>1 || X<0) return 0;
+  Float_t mass2=mass*mass;
+  Float_t E0=sqrt(p0*p0+mass2);
+  Float_t E1=sqrt(p1*p1+mass2);
+  Float_t dEdx0=-z*z*AliExternalTrackParam::BetheBlochSolid(z*p0/mass);
+  Float_t dEdx1=-z*z*AliExternalTrackParam::BetheBlochSolid(z*p1/mass);
+  Float_t k= 2*(E1-E0)/(dEdx0+dEdx1);
+  Float_t c0=k*dEdx0;
+  Float_t c1=k*(dEdx1-dEdx0)*0.5;
+  Float_t EX=E0+c0*X+c1*X*X;                  // interpolated Energy at layer X
+  Float_t pX=sqrt((EX*EX-mass2));          // interpolated momentum at layer X
+  return pX;
 }

--- a/STEER/STEERBase/AliPIDResponse.h
+++ b/STEER/STEERBase/AliPIDResponse.h
@@ -217,7 +217,7 @@ public:
 
   void    SetProbabilityRangeNsigma(Float_t range) { fRange = range; }
   Float_t GetProbabilityRangeNsigma() const        { return fRange;  }
-
+  static Float_t interpolateP(Float_t p0, Float_t p1, Float_t mass, Float_t X, Float_t z=1);
 protected:
   AliITSPIDResponse   fITSResponse;    //PID response function of the ITS
   AliTPCPIDResponse   fTPCResponse;    //PID response function of the TPC


### PR DESCRIPTION
## ATO-496, PWGPP-6, PWGPP-538 - interpolated momentum for the ITS BetheBloch (for nuclei PID)

Solving problem of imperfect ITS dedx parametrization for highly ionizing particles using 
AliPIDResponse::interpolateP

* Interpolate  momenta at ITS dEdx layers  -   taking into account energy loss in ITS
* static calculation to interpolate momentum between 2 layers
  * mass and Z used and momenta in outer(TPCin) and inner(vertex) layer used
```C++
/// parabolic interpolation  of the momenta between tow reference layers 0 and 1
/// assuming mometum loss model AliExternalTrackParam::BetheBlochSolid
/// \param p0             - momentum at layer 0
/// \param p1             - momentum at layer 1
/// \param mass           - mass of particle
/// \param X              - reference X position - should be in inteval (0,1) - not extrapolation
/// \param z              - charge of particle
/// \return               - interpolated momentum at layer X
Float_t AliPIDResponse::interpolateP(Float_t p0, Float_t p1, Float_t mass, Float_t X, Float_t z){
```

### Using interpolated momenta instead of vertex momenta in following functions:
* AliPIDResponse::EDetPidStatus AliPIDResponse::GetComputeITSProbability
* Double_t AliITSPIDResponse::GetNumberOfSigmas
* Double_t AliITSPIDResponse::GetSignalDelta

