### PR TITLE
Option to swicth off Ds->K*K decays

### DIFF
--- a/EVGEN/AliDecayer.h
+++ b/EVGEN/AliDecayer.h
@@ -24,7 +24,7 @@ typedef enum
     kHadronicDWithV0,kHadronicDWithout4BodiesWithV0,kAllEM,
     kLcpKpi, kLcpK0S, kHFYellowReport, kHadronicDPionicD0, kHadronicDWithV0PionicD0, kHadronicDWithout4BodiesPionicD0, 
     kHadronicDWithout4BodiesWithV0PionicD0,kHadronicDPionicD0pure,kHadronicDPionicD0K,kHadronicDPionicD0pi, kLcpK0SBDTsig, kEtaPrime,
-    kXic0Semileptonic
+    kXic0Semileptonic,kHadronicDWithout4BodiesDsPhiPi
 } Decay_t;
 #endif
 

--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
@@ -572,25 +572,27 @@ void AliDecayerPythia8::ForceDecay()
 	fPythia8->ReadString("23:onIfAll = 11 11");
 	break;
     case kHadronicD:
-    ForceHadronicD(1,0,0,0);
+      ForceHadronicD(1,0,0,0,0);
     break;
     case kHadronicDWithV0:
-    ForceHadronicD(1,1,0,0);
+      ForceHadronicD(1,1,0,0,0);
     break;
     case kHadronicDWithout4Bodies:
-    ForceHadronicD(0,0,0,0);
+      ForceHadronicD(0,0,0,0,0);
     break;
     case kHadronicDWithout4BodiesWithV0:
-    ForceHadronicD(0,1,0,0);
+      ForceHadronicD(0,1,0,0,0);
     break;
     case kLcpKpi:
-    ForceHadronicD(0,0,1,0);  // Lc -> p K pi
+      ForceHadronicD(0,0,1,0,0);  // Lc -> p K pi
     break;
     case kLcpK0S:
-    ForceHadronicD(0,0,2,0);  // Lc -> p K0S
+      ForceHadronicD(0,0,2,0,0);  // Lc -> p K0S
     break;
     case kXic0Semileptonic:
-    ForceHadronicD(0,0,0,1);  // Xic0 -> Xi e nu
+      ForceHadronicD(0,0,0,1,0);  // Xic0 -> Xi e nu
+    case kHadronicDWithout4BodiesDsPhiPi:
+      ForceHadronicD(0,0,0,0,1);
     break;
       
     case kPhiKK:
@@ -695,12 +697,12 @@ void AliDecayerPythia8::ForceBeautyUpgrade(){
   fPythia8->ReadString("521:onMode = off");
   fPythia8->ReadString("521:onIfMatch = 421 211");
 
-  ForceHadronicD(0,0,0,0);
+  ForceHadronicD(0,0,0,0,0);
 
 }
 
 
-void AliDecayerPythia8::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, Int_t optForceLcChannel, Int_t optForceXicChannel)
+void AliDecayerPythia8::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, Int_t optForceLcChannel, Int_t optForceXicChannel, Int_t optForceDsChannel)
 {
 //
 // Force golden D decay modes
@@ -786,7 +788,7 @@ void AliDecayerPythia8::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, I
 
 
     // D_s -> K K*
-    fPythia8->ReadString("431:onIfMatch = 321 313");
+    if(optForceDsChannel==0) fPythia8->ReadString("431:onIfMatch = 321 313");
     // D_s -> Phi pi
     fPythia8->ReadString("431:onIfMatch = 333 211");
 

--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.h
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.h
@@ -39,7 +39,7 @@ class AliDecayerPythia8 : public TVirtualMCDecayer {
   AliDecayerPythia8(const AliDecayerPythia8&);
   AliDecayerPythia8 operator=(const AliDecayerPythia8&);
   void     SwitchOffHeavyFlavour();
-  void     ForceHadronicD(Int_t optUser4Bodies = 1,Int_t optUseDtoV0 =1, Int_t optForceLcChannel = 0, Int_t optForceXicChannel = 0);
+  void     ForceHadronicD(Int_t optUser4Bodies = 1,Int_t optUseDtoV0 =1, Int_t optForceLcChannel = 0, Int_t optForceXicChannel = 0, Int_t optForceDsChannel = 0);
   void  ForceBeautyUpgrade();
   AliTPythia8*  fPythia8;          // Pointer to pythia8
   Int_t         fDebug;            // Debug level


### PR DESCRIPTION
This option is added to increase the statistics of Ds->phi+pi decays in MC productions, see ALIROOT-8502