### PR TITLE
Backportings for HF productions

### DIFF
--- a/EVGEN/AliDecayer.h
+++ b/EVGEN/AliDecayer.h
@@ -24,7 +24,7 @@ typedef enum
     kHadronicDWithV0,kHadronicDWithout4BodiesWithV0,kAllEM,
     kLcpKpi, kLcpK0S, kHFYellowReport, kHadronicDPionicD0, kHadronicDWithV0PionicD0, kHadronicDWithout4BodiesPionicD0, 
     kHadronicDWithout4BodiesWithV0PionicD0,kHadronicDPionicD0pure,kHadronicDPionicD0K,kHadronicDPionicD0pi, kLcpK0SBDTsig, kEtaPrime,
-    kXic0Hadronic, kXic0Semileptonic
+    kXic0Semileptonic
 } Decay_t;
 #endif
 

--- a/EVGEN/AliDecayer.h
+++ b/EVGEN/AliDecayer.h
@@ -24,7 +24,7 @@ typedef enum
     kHadronicDWithV0,kHadronicDWithout4BodiesWithV0,kAllEM,
     kLcpKpi, kLcpK0S, kHFYellowReport, kHadronicDPionicD0, kHadronicDWithV0PionicD0, kHadronicDWithout4BodiesPionicD0, 
     kHadronicDWithout4BodiesWithV0PionicD0,kHadronicDPionicD0pure,kHadronicDPionicD0K,kHadronicDPionicD0pi, kLcpK0SBDTsig, kEtaPrime,
-    kXic0Semileptonic
+    kXic0Semileptonic,kHadronicDWithout4BodiesDsPhiPi
 } Decay_t;
 #endif
 

--- a/EVGEN/AliDecayer.h
+++ b/EVGEN/AliDecayer.h
@@ -22,8 +22,9 @@ typedef enum
     kChiToJpsiGammaToMuonMuon, kChiToJpsiGammaToElectronElectron, kNoDecayBeauty, kPsiPrimeJpsiDiElectron,
     kElectronEM, kGammaEM, kDiElectronEM, kBeautyUpgrade,
     kHadronicDWithV0,kHadronicDWithout4BodiesWithV0,kAllEM,
-    kLcpKpi, kLcpK0S, kHFYellowReport, kHadronicDPionicD0, kHadronicDWithV0PionicD0, kHadronicDWithout4BodiesPionicD0,
-    kHadronicDWithout4BodiesWithV0PionicD0,kHadronicDPionicD0pure,kHadronicDPionicD0K,kHadronicDPionicD0pi, kLcpK0SBDTsig, kEtaPrime
+    kLcpKpi, kLcpK0S, kHFYellowReport, kHadronicDPionicD0, kHadronicDWithV0PionicD0, kHadronicDWithout4BodiesPionicD0, 
+    kHadronicDWithout4BodiesWithV0PionicD0,kHadronicDPionicD0pure,kHadronicDPionicD0K,kHadronicDPionicD0pi, kLcpK0SBDTsig, kEtaPrime,
+    kXic0Hadronic, kXic0Semileptonic
 } Decay_t;
 #endif
 

--- a/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
@@ -704,6 +704,8 @@ void AliGenPythiaPlus::Generate()
 	Int_t nParents = 0;  // Selected parents
 	Int_t nTkbles = 0;   // Trackable particles
 	Bool_t trigPartOK = (fTriggerParticle==0) ? kTRUE : kFALSE;
+	Bool_t hqYrangeOK = fUseYCutHQ ? kFALSE : kTRUE;
+
 	if (fProcess != kPyMbDefault && 
 	    fProcess != kPyMb && 
 	    fProcess != kPyMbWithDirectPhoton && 
@@ -737,6 +739,13 @@ void AliGenPythiaPlus::Generate()
 //
 		// quark ?
 		kf = TMath::Abs(kf);
+		// Heavy quark Y range cut
+		if(kf==fFlavorSelect && fUseYCutHQ){
+		  Double_t y = 9999.;
+		  if(iparticle->Energy()-TMath::Abs(iparticle->Pz()) > FLT_EPSILON) y = 0.5*TMath::Log((iparticle->Energy()+iparticle->Pz()+1.e-13)/(iparticle->Energy()-iparticle->Pz()+1.e-13));
+		  if(y>fYMinHQ && y<fYMaxHQ) hqYrangeOK=kTRUE;
+		}
+
 		Int_t kfl = kf;
 		// Resonance
 
@@ -861,6 +870,7 @@ void AliGenPythiaPlus::Generate()
 
   	    } // particle selection loop
 	    if(!trigPartOK) nc=0;
+	    if(fUseYCutHQ && !hqYrangeOK) nc=0;
 	    if (nc > 0) {
 		for (i = 0; i < np; i++) {
 		    if (!pSelected[i]) continue;

--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
@@ -572,23 +572,30 @@ void AliDecayerPythia8::ForceDecay()
 	fPythia8->ReadString("23:onIfAll = 11 11");
 	break;
     case kHadronicD:
-      ForceHadronicD(1,0,0);
-	break;
+    ForceHadronicD(1,0,0,0);
+    break;
     case kHadronicDWithV0:
-        ForceHadronicD(1,1,0);
-        break;
+    ForceHadronicD(1,1,0,0);
+    break;
     case kHadronicDWithout4Bodies:
-        ForceHadronicD(0,0,0);
-        break;
+    ForceHadronicD(0,0,0,0);
+    break;
     case kHadronicDWithout4BodiesWithV0:
-        ForceHadronicD(0,1,0);
-        break;
+    ForceHadronicD(0,1,0,0);
+    break;
     case kLcpKpi:
-      ForceHadronicD(0,0,1);  // Lc -> p K pi
-      break;
+    ForceHadronicD(0,0,1,0);  // Lc -> p K pi
+    break;
     case kLcpK0S:
-      ForceHadronicD(0,0,2);  // Lc -> p K0S
-      break;
+    ForceHadronicD(0,0,2,0);  // Lc -> p K0S
+    break;
+    case kXic0Hadronic:
+    ForceHadronicD(0,0,2,0);  // Xic0 -> Xi pi
+    break;
+    case kXic0Semileptonic:
+    ForceHadronicD(0,0,2,1);  // Xic0 -> Xi e nu
+    break;
+      
     case kPhiKK:
 	// Phi-> K+ K-
 	fPythia8->ReadString("333:onMode = off");
@@ -691,12 +698,12 @@ void AliDecayerPythia8::ForceBeautyUpgrade(){
   fPythia8->ReadString("521:onMode = off");
   fPythia8->ReadString("521:onIfMatch = 421 211");
 
-  ForceHadronicD(0,0,0);
+  ForceHadronicD(0,0,0,0);
 
 }
 
 
-void AliDecayerPythia8::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, Int_t optForceLcChannel)
+void AliDecayerPythia8::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, Int_t optForceLcChannel, Int_t optForceXicChannel)
 {
 //
 // Force golden D decay modes
@@ -816,8 +823,12 @@ void AliDecayerPythia8::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, I
     fPythia8->ReadString("4232:onIfMatch = 3312 211 211");
     
     // Xic0 -> Xi- pi+
-    fPythia8->ReadString("4132:onIfMatch = 3312 211");
-       
+    if (optForceXicChannel == 0) { // hadronic decay
+        fPythia8->ReadString("4132:onIfMatch = 3312 211");
+    }       
+    else if (optForceXicChannel == 1) { // semileptonic decay
+        fPythia8->ReadString("4132:onIfMatch = 3312 -11 12");
+    }       
     
 }
 

--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
@@ -589,11 +589,8 @@ void AliDecayerPythia8::ForceDecay()
     case kLcpK0S:
     ForceHadronicD(0,0,2,0);  // Lc -> p K0S
     break;
-    case kXic0Hadronic:
-    ForceHadronicD(0,0,2,0);  // Xic0 -> Xi pi
-    break;
     case kXic0Semileptonic:
-    ForceHadronicD(0,0,2,1);  // Xic0 -> Xi e nu
+    ForceHadronicD(0,0,0,1);  // Xic0 -> Xi e nu
     break;
       
     case kPhiKK:

--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
@@ -572,25 +572,27 @@ void AliDecayerPythia8::ForceDecay()
 	fPythia8->ReadString("23:onIfAll = 11 11");
 	break;
     case kHadronicD:
-    ForceHadronicD(1,0,0,0);
+      ForceHadronicD(1,0,0,0,0);
     break;
     case kHadronicDWithV0:
-    ForceHadronicD(1,1,0,0);
+      ForceHadronicD(1,1,0,0,0);
     break;
     case kHadronicDWithout4Bodies:
-    ForceHadronicD(0,0,0,0);
+      ForceHadronicD(0,0,0,0,0);
     break;
     case kHadronicDWithout4BodiesWithV0:
-    ForceHadronicD(0,1,0,0);
+      ForceHadronicD(0,1,0,0,0);
     break;
     case kLcpKpi:
-    ForceHadronicD(0,0,1,0);  // Lc -> p K pi
+      ForceHadronicD(0,0,1,0,0);  // Lc -> p K pi
     break;
     case kLcpK0S:
-    ForceHadronicD(0,0,2,0);  // Lc -> p K0S
+      ForceHadronicD(0,0,2,0,0);  // Lc -> p K0S
     break;
     case kXic0Semileptonic:
-    ForceHadronicD(0,0,0,1);  // Xic0 -> Xi e nu
+      ForceHadronicD(0,0,0,1,0);  // Xic0 -> Xi e nu
+    case kHadronicDWithout4BodiesDsPhiPi:
+      ForceHadronicD(0,0,0,0,1);
     break;
       
     case kPhiKK:
@@ -695,12 +697,12 @@ void AliDecayerPythia8::ForceBeautyUpgrade(){
   fPythia8->ReadString("521:onMode = off");
   fPythia8->ReadString("521:onIfMatch = 421 211");
 
-  ForceHadronicD(0,0,0,0);
+  ForceHadronicD(0,0,0,0,0);
 
 }
 
 
-void AliDecayerPythia8::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, Int_t optForceLcChannel, Int_t optForceXicChannel)
+void AliDecayerPythia8::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, Int_t optForceLcChannel, Int_t optForceXicChannel, Int_t optForceDsChannel)
 {
 //
 // Force golden D decay modes
@@ -783,7 +785,7 @@ void AliDecayerPythia8::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, I
 
 
     // D_s -> K K*
-    fPythia8->ReadString("431:onIfMatch = 321 313");
+    if(optForceDsChannel==0) fPythia8->ReadString("431:onIfMatch = 321 313");
     // D_s -> Phi pi
     fPythia8->ReadString("431:onIfMatch = 333 211");
 

--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.h
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.h
@@ -39,7 +39,7 @@ class AliDecayerPythia8 : public TVirtualMCDecayer {
   AliDecayerPythia8(const AliDecayerPythia8&);
   AliDecayerPythia8 operator=(const AliDecayerPythia8&);
   void     SwitchOffHeavyFlavour();
-  void     ForceHadronicD(Int_t optUser4Bodies = 1,Int_t optUseDtoV0 =1, Int_t optForceLcChannel = 0, Int_t optForceXicChannel = 0);
+  void     ForceHadronicD(Int_t optUser4Bodies = 1,Int_t optUseDtoV0 =1, Int_t optForceLcChannel = 0, Int_t optForceXicChannel = 0, Int_t optForceDsChannel = 0);
   void  ForceBeautyUpgrade();
   AliTPythia8*  fPythia8;          // Pointer to pythia8
   Int_t         fDebug;            // Debug level

--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.h
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.h
@@ -39,7 +39,7 @@ class AliDecayerPythia8 : public TVirtualMCDecayer {
   AliDecayerPythia8(const AliDecayerPythia8&);
   AliDecayerPythia8 operator=(const AliDecayerPythia8&);
   void     SwitchOffHeavyFlavour();
-  void     ForceHadronicD(Int_t optUser4Bodies = 1,Int_t optUseDtoV0 =1, Int_t optForceLcChannel = 0);
+  void     ForceHadronicD(Int_t optUser4Bodies = 1,Int_t optUseDtoV0 =1, Int_t optForceLcChannel = 0, Int_t optForceXicChannel = 0);
   void  ForceBeautyUpgrade();
   AliTPythia8*  fPythia8;          // Pointer to pythia8
   Int_t         fDebug;            // Debug level


### PR DESCRIPTION
This is to backport to v5-09-54 two modifications needed for the HF productions anchored to Pb-Pb pass3:
- Apply selection on heavy-quark rapidity for kPyCharm and kPyBeauty
- Option to switch off Ds->K*K decays
