### PR TITLE
Possibility to select pt and y for trigger particles

### DIFF
--- a/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
@@ -100,6 +100,9 @@ AliGenPythiaPlus::AliGenPythiaPlus():
     fHFoff(kFALSE),    
     fTriggerParticle(0),
     fTriggerEta(0.9),
+    fTriggerY(999.),
+    fTriggerMinPt(-1),
+    fTriggerMaxPt(1000),
     fTriggerMultiplicity(0),
     fTriggerMultiplicityEta(0),
     fTriggerMultiplicityEtaMin(0),
@@ -213,6 +216,9 @@ AliGenPythiaPlus::AliGenPythiaPlus(AliPythiaBase* pythia)
      fHFoff(kFALSE),    
      fTriggerParticle(0),
      fTriggerEta(0.9),     
+     fTriggerY(999.),
+     fTriggerMinPt(-1),
+     fTriggerMaxPt(1000),
      fTriggerMultiplicity(0),
      fTriggerMultiplicityEta(0),
      fTriggerMultiplicityEtaMin(0),
@@ -733,7 +739,7 @@ void AliGenPythiaPlus::Generate()
 //
 // Trigger particle selection
 //
-		if(fTriggerParticle!=0 && kf == fTriggerParticle && TMath::Abs(iparticle->Eta()) < fTriggerEta) trigPartOK=kTRUE;
+		if(fTriggerParticle!=0 && kf == fTriggerParticle && TMath::Abs(iparticle->Eta()) < fTriggerEta && TMath::Abs(iparticle->Y())<fTriggerY && iparticle->Pt()>fTriggerMinPt && iparticle->Pt()<fTriggerMaxPt) trigPartOK=kTRUE;
 //
 // Heavy Flavor Selection
 //
@@ -1032,7 +1038,9 @@ Int_t  AliGenPythiaPlus::GenerateMB()
 	    kf = CheckPDGCode(iparticle->GetPdgCode());
 	    if (kf != fTriggerParticle) continue;
 	    if (iparticle->Pt() == 0.) continue;
+	    if (TMath::Abs(iparticle->Y()) > fTriggerY) continue;
 	    if (TMath::Abs(iparticle->Eta()) > fTriggerEta) continue;
+	    if ( iparticle->Pt() > fTriggerMaxPt || iparticle->Pt() < fTriggerMinPt ) continue;
 	    triggered = kTRUE;
 	    break;
 	}

--- a/PYTHIA6/AliPythia6/AliGenPythiaPlus.h
+++ b/PYTHIA6/AliPythia6/AliGenPythiaPlus.h
@@ -187,8 +187,9 @@ class AliGenPythiaPlus : public AliGenMC
       fTriggerMultiplicityPtMin = ptmin;}
 
     // Trigger on a single particle (not related to calorimeter trigger above)
-    virtual void    SetTriggerParticle(Int_t particle = 0, Float_t etamax = 0.9) 
-	{fTriggerParticle = particle; fTriggerEta = etamax;}
+    virtual void    SetTriggerParticle(Int_t particle = 0, Float_t etamax = 0.9, Float_t ptmin = -1, Float_t ptmax = 1000)
+	{fTriggerParticle = particle; fTriggerEta = etamax; fTriggerMinPt = ptmin; fTriggerMaxPt = ptmax;}
+    virtual void  SetTriggerY(Float_t dy) {fTriggerY = dy;}
     //
     // Heavy flavor options
     //
@@ -336,6 +337,9 @@ class AliGenPythiaPlus : public AliGenMC
     Bool_t  fHFoff;                 // Flag for switching heafy flavor production off
     Int_t   fTriggerParticle;       // Trigger on this particle ...
     Float_t fTriggerEta;            // .. within |eta| < fTriggerEta
+    Float_t fTriggerY;              // .. within |y|   < fTriggerY
+    Float_t fTriggerMinPt;          // .. within pt > fTriggerMinPt
+    Float_t fTriggerMaxPt;          // .. within pt < fTriggerMaxPt
     Int_t       fTriggerMultiplicity;       // Trigger on events with a minimum charged multiplicity
     Float_t     fTriggerMultiplicityEta;    // in a given eta range
     Float_t     fTriggerMultiplicityEtaMin;    // in a given eta min
@@ -393,7 +397,7 @@ class AliGenPythiaPlus : public AliGenMC
     AliGenPythiaPlus(const AliGenPythiaPlus &Pythia);
     AliGenPythiaPlus & operator=(const AliGenPythiaPlus & rhs);
 
-    ClassDef(AliGenPythiaPlus, 7)
+    ClassDef(AliGenPythiaPlus, 8)
 
 };
 #endif


### PR DESCRIPTION
This commit adds a feature that will be useful for future HF productions, see e.g. the case in ALIROOT-8281.
The modification adds the possibility to select the rapidity and pt of trigger particles, which was there in AliGenPythia (PYTHIA6), but not in AliGenPythiaPlus.