### PR TITLE
Propagate number of MC events to generate to alien plugin in case of …

### DIFF
--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -4348,8 +4348,10 @@ void AliAnalysisAlien::WriteAnalysisMacro(Long64_t nentries, Long64_t firstentry
             out << "   plugin->SetFriendChainName(\"" << fFriendChainName << "\",\"" << fFriendLibs << "\");" << endl;
          if (IsUseMCchain())
             out << "   plugin->SetUseMCchain();" << endl;
-         if (fMCLoop)
+         if (fMCLoop) {
             out << "   plugin->SetMCLoop(kTRUE);" << endl;  
+            out << "   plugin->SetNMCevents(" << GetNMCevents() << ");" << std::endl;
+         }  
          out << "   mgr->SetGridHandler(plugin);" << endl;
          if (AliAnalysisManager::GetAnalysisManager()) {
             out << "   mgr->SetDebugLevel(" << AliAnalysisManager::GetAnalysisManager()->GetDebugLevel() << ");" << endl;


### PR DESCRIPTION
…MC loop

Propagating the number of MC events allows that
add macros for generators can make use of this
information. This is particularly of relevance for
generators which are running as external processes
not steered by the event loop. Adding this information
does not impose any problem on existing
implementations