### PR TITLE
Using decayer in Init, when set

### DIFF
--- a/EVGEN/AliGenParam.cxx
+++ b/EVGEN/AliGenParam.cxx
@@ -489,7 +489,12 @@ void AliGenParam::Init()
 {
   // Initialisation
 
-  if (TVirtualMC::GetMC()) fDecayer = TVirtualMC::GetMC()->GetDecayer();
+  if (!fDecayer && TVirtualMC::GetMC()) fDecayer = TVirtualMC::GetMC()->GetDecayer();
+  if (!fDecayer){
+	Fatal("AliGenParam",
+              "No decayer attached");
+  }
+
   //Begin_Html
   /*
     <img src="picts/AliGenParam.gif">


### PR DESCRIPTION
- if not set, use external decayer from TVirtualMC::GetMC() (as before)
- if no decayer available, return Fatal
- needed for adding Exodus decayer for single AliGenParam sources in cocktail