### PR TITLE
Bug fix in copy constructor for AliAOD/ESDCaloCells

### DIFF
--- a/STEER/AOD/AliAODCaloCells.cxx
+++ b/STEER/AOD/AliAODCaloCells.cxx
@@ -103,7 +103,7 @@ AliAODCaloCells& AliAODCaloCells::operator=(const AliAODCaloCells& source)
     }
     
     if(source.fHGLG)
-      memcpy(fCellNumber,source.fHGLG,fNCells*sizeof(Bool_t));
+      memcpy(fHGLG,source.fHGLG,fNCells*sizeof(Bool_t));
     memcpy(fCellNumber,source.fCellNumber, fNCells*sizeof(Short_t));
     memcpy(fAmplitude, source.fAmplitude,  fNCells*sizeof(Double32_t));
     if(source.fTime      && fTime)      memcpy(fTime,      source.fTime,      fNCells*sizeof(Double32_t));

--- a/STEER/ESD/AliESDCaloCells.cxx
+++ b/STEER/ESD/AliESDCaloCells.cxx
@@ -107,7 +107,7 @@ AliESDCaloCells & AliESDCaloCells::operator =(const AliESDCaloCells& source)
     }
     
     if(source.fHGLG)
-      memcpy(fCellNumber,source.fHGLG,fNCells*sizeof(Bool_t));
+      memcpy(fHGLG,source.fHGLG,fNCells*sizeof(Bool_t));
     memcpy(fCellNumber,source.fCellNumber,fNCells*sizeof(Short_t));
     memcpy(fAmplitude, source.fAmplitude, fNCells*sizeof(Double32_t));
     memcpy(fTime,      source.fTime,      fNCells*sizeof(Double32_t));


### PR DESCRIPTION
- this bug fix is needed for skimming data sets, otherwise part of the information is lost and the skimmed AODs aren't useful any longer