### PR TITLE
Adds a rescaling of the EMCAl trigger digits in MC

### DIFF
--- a/EMCAL/EMCALsim/AliEMCALTriggerElectronics.cxx
+++ b/EMCAL/EMCALsim/AliEMCALTriggerElectronics.cxx
@@ -43,6 +43,7 @@ ClassImp(AliEMCALTriggerElectronics) ;
 /// Constructor
 //__________________
 AliEMCALTriggerElectronics::AliEMCALTriggerElectronics(const AliEMCALTriggerDCSConfig *dcsConf) : TObject(),
+fADCscaleMC(1.239958),
 fTRU(new TClonesArray("AliEMCALTriggerTRU",52)),
 fSTU(0x0),
 fGeometry(0)
@@ -314,7 +315,7 @@ void AliEMCALTriggerElectronics::Digits2Trigger(TClonesArray* digits, const Int_
           if (data->GetMode())
             etr->SetADC(iADC, time, 4 * amp);
           else
-            etr->SetADC(iADC, time,     amp);
+            etr->SetADC(iADC, time, (Int_t) (fADCscaleMC * amp));
         }
       }
     }
@@ -418,7 +419,7 @@ void AliEMCALTriggerElectronics::Digits2Trigger(TClonesArray* digits, const Int_
             
             // 14b to 12b STU time sums
             reg[j][k] >>= 2; 
-            
+
             dig->SetL1TimeSum(reg[j][k]);
           }
         }

--- a/EMCAL/EMCALsim/AliEMCALTriggerElectronics.h
+++ b/EMCAL/EMCALsim/AliEMCALTriggerElectronics.h
@@ -36,6 +36,9 @@ public:
   
   virtual void   Digits2Trigger(TClonesArray* digits, const Int_t V0M[], AliEMCALTriggerData* data);	
   virtual void   Reset();  
+
+  Float_t GetADCscaleMC() { return fADCscaleMC; }
+  void SetADCscaleMC(Float_t input) { fADCscaleMC = input; }
   
   virtual AliEMCALTriggerTRU* GetTRU( Int_t iTRU ) {return (AliEMCALTriggerTRU*)fTRU->At(iTRU);}
   virtual AliEMCALTriggerSTU* GetSTU( Bool_t isDCAL = false ) {return isDCAL ? fSTUDCAL : fSTU;}
@@ -51,6 +54,7 @@ private:
   AliEMCALGeometry     *fGeometry; ///< EMCal geometry
  
   Int_t                fMedianMode; // 0 for no median subtraction, 1 for median sub.
+  Float_t              fADCscaleMC; //< Scaling up MC raw digits so samples match total energy
   TClonesArray*        fTRUDCAL;  //< 14 TRU
   AliEMCALTriggerSTU*  fSTUDCAL;  //< 1 STU for DCAL
  


### PR DESCRIPTION
Adds a rescaling of the digits in MC so trigger signal energies match total deposited energy, as done in data.
Necessary for simulated trigger thresholds to be accurate.