### PR TITLE
Usage of TF1 for Ndimensioal AliTPCPIDResponse error parameterization - https://alice.its.cern.ch/jira/browse/ATO-525

### DIFF
--- a/STEER/STEERBase/AliTPCPIDResponse.cxx
+++ b/STEER/STEERBase/AliTPCPIDResponse.cxx
@@ -2315,13 +2315,18 @@ void AliTPCPIDResponse::GetTF1ParametrizationValues(Double_t values[7], const Al
 }
 
 
-
+/// This is the empirical ALEPH parameterization of the Bethe-Bloch formula.
+/// Compared to the  AliExternalTrackParam::BetheBlochAleph here it is save version not failing in minimization
+/// \param bg    - beta gamma
+/// \param kp1
+/// \param kp2
+/// \param kp3
+/// \param kp4
+/// \param kp5
+/// \return
 Double_t  AliTPCPIDResponse::BetheBlochAleph(Double_t bg, Double_t kp1, Double_t kp2, Double_t kp3, Double_t kp4, Double_t kp5){
-   // This is the empirical ALEPH parameterization of the Bethe-Bloch formula.
+  //
   // It is normalized to 1 at the minimum.
-  // bg - beta*gamma
-  // The default values for the kp* parameters are for ALICE TPC.
-  // The returned value is in MIP units
   //
   if (bg<0) return 0;
   const Double_t kEpsilon=1e-12;

--- a/STEER/STEERBase/AliTPCPIDResponse.h
+++ b/STEER/STEERBase/AliTPCPIDResponse.h
@@ -308,7 +308,9 @@ public:
   //===| Helpers |==============================================================
   static TString GetChecksum(const TObject* obj);
   static TObjArray* GetMultiplicityCorrectionArrayFromString(const TString& corrections);
-
+  //
+  static Double_t BetheBlochAleph(Double_t bg, Double_t kp1, Double_t kp2, Double_t kp3, Double_t kp4, Double_t kp5);
+  static double   sigmadEdxPt(double p, double PID, double resol=0.01 );
 protected:
   Double_t GetExpectedSignal(const AliVTrack* track,
                              AliPID::EParticleType species,

--- a/STEER/STEERBase/AliTPCPIDResponse.h
+++ b/STEER/STEERBase/AliTPCPIDResponse.h
@@ -276,6 +276,23 @@ public:
 
   Double_t GetTrackdEdx(const AliVTrack* track) const;
 
+  //===| New resolution parametrization |=======================================
+  void SetResolutionParametrization(TF1* fun) { fSigmaParametrization = fun; }
+  TF1* GetResolutionParametrization() const { return fSigmaParametrization; }
+
+  void SetMultiplicityNormalization(Double_t norm) { fMultiplicityNormalization = norm; }
+  Double_t GetMultiplicityNormalization() const { return fMultiplicityNormalization; }
+
+  /// index PID estimator as in AliTPCdEdxInfo: 0-IROC, 1-OROCmedium, 2-OROClong, 3-OROCall, 4-FullTrack
+  Double_t GetExpectedSigmaTF1(const AliVTrack* track,
+                               AliPID::EParticleType species,
+                               Int_t dEdxType = 4) const;
+
+  void GetTF1ParametrizationValues(Double_t values[7],
+                                   const AliVTrack* track,
+                                   AliPID::EParticleType species,
+                                   Int_t dEdxType = 4) const;
+
   //===| Initialisation |=======================================================
   Bool_t InitFromOADB(const Int_t run, Int_t pass, TString passName,
                       const char* oadbFile="$ALICE_PHYSICS/OADB/COMMON/PID/data/TPCPIDResponseOADB.root",
@@ -368,6 +385,10 @@ private:
 
   ETPCPileupCorrectionStrategy fPileupCorrectionStrategy; // Pileup correction strategy
   Bool_t fPileupCorrectionRequested; // If pileup correction was configured in the OADB object
+
+  //===| New resolution parametrization |=======================================
+  TF1*     fSigmaParametrization;      // Resolution parametrization
+  Double_t fMultiplicityNormalization; // Value for the multiplicity normalisation in the sigma parametrization
 
   // Information on reconstruction data used
   TString fRecoPassNameUsed;          //! Name or number of the actually used reconstruction pass


### PR DESCRIPTION
## Goal:
Generic TF1 functional representation should be (optionaly) used to describe TPC dEdx properties in AliTPCPIDResponse
TF1 can represent  arbitrary number of variables and parameters.

`Double_t TF1::EvalPar(const Double_t* x, const Double_t* params = 0)`

## Important links
* https://alice.its.cern.ch/jira/browse/ATO-525
* https://alice.its.cern.ch/jira/browse/ATO-525?focusedCommentId=258929&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-258929
