### PR TITLE
Fixes for EMCAL unit tests

### DIFF
--- a/EMCAL/EMCALbase/CMakeLists.txt
+++ b/EMCAL/EMCALbase/CMakeLists.txt
@@ -133,14 +133,22 @@ install(FILES ${HDRS} DESTINATION include)
 add_executable(testemcaltrudcsconfig TestsAliEMCALTriggerTRUDCSConfig.cxx)
 target_link_libraries(testemcaltrudcsconfig ${MODULE} ${LIBDEPS})
 add_test(func_EMCALbase_AliEMCALTriggerTRUDCSConfig 
-    testemcaltrudcsconfig)
+    ENV
+    PATH=$ENV{PATH}
+    LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{LD_LIBRARY_PATH}
+    DYLD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{DYLD_LIBRARY_PATH}
+    ${CMAKE_INSTALL_PREFIX}/bin/testemcaltrudcsconfig)
 install(TARGETS testemcaltrudcsconfig RUNTIME DESTINATION bin)
 
 # STU DCS config unit test
 add_executable(testemcalstudcsconfig TestsAliEMCALTriggerSTUDCSConfig.cxx)
 target_link_libraries(testemcalstudcsconfig ${MODULE} ${LIBDEPS})
 add_test(func_EMCALbase_AliEMCALTriggerSTUDCSConfig 
-    testemcalstudcsconfig)
+    ENV
+    PATH=$ENV{PATH}
+    LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{LD_LIBRARY_PATH}
+    DYLD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{DYLD_LIBRARY_PATH}
+    ${CMAKE_INSTALL_PREFIX}/bin/testemcalstudcsconfig)
 install(TARGETS testemcalstudcsconfig RUNTIME DESTINATION bin)
 
 # Static version if DA enabled

--- a/EMCAL/EMCALbase/TestsAliEMCALTriggerSTUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/TestsAliEMCALTriggerSTUDCSConfig.cxx
@@ -26,6 +26,7 @@
  ************************************************************************************/
 #include <cstdlib>
 #include <bitset>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -165,14 +166,15 @@ namespace EMCAL {
          * @return false Test failed (operator<< to string produces different string)
          */
         bool TestStream() {
-          std::string reference = std::string("Gamma High: (0, 0, 115)\nGamma Low:  (0, 0, 51)\nJet High:   (0, 0, 255)\nJet Low:    (0, 0, 204)\n")
-                                + std::string("GetRawData: 1, Region: -1, Median: 0Firmware: 2a012, PHOS Scale: (0, 0, 0, 0)\n");
+          std::stringstream reference;
+          reference << "Gamma High: (0, 0, 115)\nGamma Low:  (0, 0, 51)\nJet High:   (0, 0, 255)\nJet Low:    (0, 0, 204)\n"
+                    << "GetRawData: 1, Region: " << std::hex << -1 << std::dec << "(" << std::bitset<32>(-1) << "), Median: 0, Firmware: 2a012, PHOS Scale: (0, 0, 0, 0)\n";
           
           AliEMCALTriggerSTUDCSConfig test;
           ConfigureReference(test);
           std::stringstream testmaker;
           testmaker << test;
-          return testmaker.str() == reference;
+          return testmaker.str() == reference.str();
         }
       }
     }

--- a/EMCAL/EMCALbase/TestsAliEMCALTriggerTRUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/TestsAliEMCALTriggerTRUDCSConfig.cxx
@@ -166,9 +166,9 @@ namespace EMCAL {
          */
         bool TestStream(){
           std::string reference = std::string("SELPF: 1e1f, L0SEL: 1, L0COSM: 100, GTHRL0: 132, RLBKSTU: 0, FW: 21\n")
-                                + std::string("Reg0: 00000000000000000000010000000000\nReg1: 00000000000000000000000000000000\n")
-                                + std::string("Reg2: 00000000000000000000001000000000\nReg3: 00000000000000000111110011110001\n")
-                                + std::string("Reg4: 00000000000000000000000000000000\nReg5: 00000000000000000000000000000000\n");
+                                + std::string("Reg0: 00000000000000000000010000000000 (1024)\nReg1: 00000000000000000000000000000000 (0)\n")
+                                + std::string("Reg2: 00000000000000000000001000000000 (512)\nReg3: 00000000000000000111110011110001 (31985)\n")
+                                + std::string("Reg4: 00000000000000000000000000000000 (0)\nReg5: 00000000000000000000000000000000 (0)\n");
           
           AliEMCALTriggerTRUDCSConfig test;
           ConfigureReference(test);


### PR DESCRIPTION
- Adding environment and CMAKE_INSTALL_PREFIX
  in test definition
- Adapt reference for stream operators to latest
  implementation