### PR TITLE
Avoid opening friend files in analysis, done anyway by TChain::GetEntries

### DIFF
--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -4457,6 +4457,7 @@ void AliAnalysisAlien::WriteAnalysisMacro(Long64_t nentries, Long64_t firstentry
             out << "      while ((cfriend=(TChain*)nextfriend())) {" << endl;
             out << "         fileFriend = bpath;" << endl;
             out << "         fileFriend += cfriend->GetTitle();" << endl;
+#if ROOT_VERSION_CODE < ROOT_VERSION(5,99,99)
             out << "         TFile *file = TFile::Open(fileFriend);" << endl;
             out << "         if (file) {" << endl;
             out << "            file->Close();" << endl;
@@ -4465,6 +4466,11 @@ void AliAnalysisAlien::WriteAnalysisMacro(Long64_t nentries, Long64_t firstentry
             out << "            ::Fatal(\"CreateChain\", \"Cannot open friend file: %s\", fileFriend.Data());" << endl;
             out << "            return 0;" << endl;
             out << "         }" << endl;
+#else
+            // No need to check the friend chain files individually, we can use later-on in ROOT6
+            // the open status stored in each chain after calling TChain::GetEntries
+            out << "         cfriend->Add(fileFriend.Data());" << endl;
+#endif
             out << "      }" << endl;
          }
          out << "   }" << endl;
@@ -4474,7 +4480,7 @@ void AliAnalysisAlien::WriteAnalysisMacro(Long64_t nentries, Long64_t firstentry
          out << "   }" << endl;
          out << "   return chain;" << endl;
          out << "}" << endl << endl;
-      }   
+      }
       if (hasANALYSISalice) {
          out <<"//________________________________________________________________________________" << endl;
          out << "Bool_t SetupPar(const char *package) {" << endl;

--- a/STEER/AOD/AliAODInputHandler.cxx
+++ b/STEER/AOD/AliAODInputHandler.cxx
@@ -106,7 +106,8 @@ Bool_t AliAODInputHandler::Init(TTree* tree, Option_t* opt)
 
     fTree = tree;
     if (!fTree) return kFALSE;
-    fTree->GetEntries();
+    GetEntries();
+
     ConnectFriends();
 
     SwitchOffBranches();

--- a/STEER/ESD/AliESDInputHandler.cxx
+++ b/STEER/ESD/AliESDInputHandler.cxx
@@ -99,7 +99,7 @@ Bool_t AliESDInputHandler::Init(TTree* tree,  Option_t* opt)
 
     if (!fEvent) fEvent = new AliESDEvent();
     fEvent->ReadFromTree(fTree);
-    fNEvents = fTree->GetEntries();
+    fNEvents = GetEntries();
     if (fReadFriends) ConnectFriends();
 
     if (fMixingHandler) fMixingHandler->Init(tree,  opt);

--- a/STEER/STEERBase/AliInputEventHandler.h
+++ b/STEER/STEERBase/AliInputEventHandler.h
@@ -85,6 +85,7 @@ class AliInputEventHandler : public AliVEventHandler {
     virtual void CreatePIDResponse(Bool_t /*isMC*/=kFALSE) {;}
 
  protected:
+    Long64_t GetEntries();
     void SwitchOffBranches() const;
     void SwitchOnBranches()  const;
  private:


### PR DESCRIPTION
This PR addresses ALIROOT-8652. The open status for friend files can be read directly from the chain, after TChain::GetEntries gets called in AliAnalysisManager::Init. This will reduce the number of file open requests in the analysis using friend files.