### PR TITLE
Add kLcLpi forced decay option to AliDecayer

### DIFF
--- a/EVGEN/AliDecayer.h
+++ b/EVGEN/AliDecayer.h
@@ -24,7 +24,7 @@ typedef enum
     kHadronicDWithV0,kHadronicDWithout4BodiesWithV0,kAllEM,
     kLcpKpi, kLcpK0S, kHFYellowReport, kHadronicDPionicD0, kHadronicDWithV0PionicD0, kHadronicDWithout4BodiesPionicD0, 
     kHadronicDWithout4BodiesWithV0PionicD0,kHadronicDPionicD0pure,kHadronicDPionicD0K,kHadronicDPionicD0pi, kLcpK0SBDTsig, kEtaPrime,
-    kXic0Semileptonic,kHadronicDWithout4BodiesDsPhiPi
+    kXic0Semileptonic,kHadronicDWithout4BodiesDsPhiPi, kLcLpi
 } Decay_t;
 #endif
 

--- a/PYTHIA6/AliPythia6/AliDecayerPythia.cxx
+++ b/PYTHIA6/AliPythia6/AliDecayerPythia.cxx
@@ -941,6 +941,8 @@ void AliDecayerPythia::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, In
    Int_t multLcLambdaPiPlPi0[3] = {1,1,1};
    
    Int_t prodLcLambdaPi[2] = {3122, 211};
+   Int_t multLcLambdaPi[2] = {1,1};
+   
     if (optForceLcChannel == 1) { //pKpi
       ForceParticleDecay(4122,prodLcpKpi,multLcpKpi,3,1);
     }

--- a/PYTHIA6/AliPythia6/AliDecayerPythia.cxx
+++ b/PYTHIA6/AliPythia6/AliDecayerPythia.cxx
@@ -594,6 +594,8 @@ void AliDecayerPythia::ForceDecay()
      case kLcpK0SBDTsig:
         ForceHadronicD(0,0,4);
         break;
+     case kLcLpi:
+        ForceHadronicD(0,0,5);
      case kEtaPrime:
 	if(gRandom->Rndm()<0.5) {
 		products1[0]=211;
@@ -937,6 +939,8 @@ void AliDecayerPythia::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, In
 
    Int_t prodLcLambdaPiPlPi0[3] = {iLambda, kPiPlus, kPi0};
    Int_t multLcLambdaPiPlPi0[3] = {1,1,1};
+   
+   Int_t prodLcLambdaPi[2] = {3122, 211};
     if (optForceLcChannel == 1) { //pKpi
       ForceParticleDecay(4122,prodLcpKpi,multLcpKpi,3,1);
     }
@@ -952,6 +956,10 @@ void AliDecayerPythia::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, In
       ForceParticleDecay(311,310,1); // K0 -> K0S
       ForceParticleDecay(310,211,2); // K0S -> pi+ pi-
     }
+    if(optForceLcChannel == 5) { // Lc -> Lambda Pi+
+      ForceParticleDecay(4122,prodLcLambdaPi,multLcLambdaPi,2,1);
+    }
+    
 
   
 

--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
@@ -589,6 +589,9 @@ void AliDecayerPythia8::ForceDecay()
     case kLcpK0S:
       ForceHadronicD(0,0,2,0,0);  // Lc -> p K0S
     break;
+    case kLcLpi:
+      ForceHadronicD(0,0,5,0,0);  // Lc -> Lambda pi
+    break;
     case kXic0Semileptonic:
       ForceHadronicD(0,0,0,1,0);  // Xic0 -> Xi e nu
     break;
@@ -827,6 +830,10 @@ void AliDecayerPythia8::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, I
       // for K0s -> pi+pi-
       fPythia8->ReadString("310:onMode = off");
       fPythia8->ReadString("310:onIfAll = 211 211");
+    }
+    
+    if (optForceLcChannel == 5) { // force only Lc -> Lambda pi+
+       fPythia8->ReadString("4122:onIfMatch = 3122 211");     
     }
 
     // Xic+ -> pK*0


### PR DESCRIPTION
Adds option to AliDecayerPythia and AliDecayerPythia8 to force Lambda_c to decay in the Lambda pion channel (3122 211), for use in dedicated MC productions.