### PR TITLE
Enable more than one file in chain for local analysis

### DIFF
--- a/STEER/AOD/AliAODEvent.cxx
+++ b/STEER/AOD/AliAODEvent.cxx
@@ -741,7 +741,7 @@ void AliAODEvent::ReadFromTree(TTree *tree, Option_t* opt /*= ""*/)
       // Check if already connected to tree
     TList* connectedList = (TList*) (tree->GetUserInfo()->FindObject("AODObjectsConnectedToTree"));
     if (connectedList && (!strcmp(opt, "reconnect"))) {
-		
+
         // If connected use the connected list of objects
         if (fAODObjects != connectedList) {
            delete fAODObjects;
@@ -749,29 +749,28 @@ void AliAODEvent::ReadFromTree(TTree *tree, Option_t* opt /*= ""*/)
         }   
         
         friendL = tree->GetTree()->GetListOfFriends();
-		if (friendL) 
-		{
-		  // set the branch addresses
-		TIter next(fAODObjects);
-		TNamed *el;
-		while((el=(TNamed*)next())){
-		  TString bname(el->GetName());
-			// check if branch exists under this Name
-		  TBranch *br = tree->GetTree()->GetBranch(bname.Data());
-		  if(br){
-			tree->SetBranchAddress(bname.Data(),fAODObjects->GetObjectRef(el));
-		  } else {
-			br = tree->GetBranch(Form("%s.",bname.Data()));
-			if(br){
-			  tree->SetBranchAddress(Form("%s.",bname.Data()),fAODObjects->GetObjectRef(el));
-			}
-			else{
-			  printf("%s %d AliAODEvent::ReadFromTree() No Branch found with Name %s. \n",
-					 (char*)__FILE__,__LINE__,bname.Data());
-			}	
-		  }
-		}
-	}
+        if (friendL) 
+        {
+          // set the branch addresses
+        TIter next(fAODObjects);
+        TNamed *el;
+        while((el=(TNamed*)next())){
+          TString bname(el->GetName());
+            // check if branch exists under this Name
+          TBranch *br = tree->GetTree()->GetBranch(bname.Data());
+          if(br){
+            tree->SetBranchAddress(bname.Data(),fAODObjects->GetObjectRef(el));
+          } else {
+            br = tree->GetBranch(Form("%s.",bname.Data()));
+            if(br){
+              tree->SetBranchAddress(Form("%s.",bname.Data()),fAODObjects->GetObjectRef(el));
+            }
+            else{
+              printf("%s %d AliAODEvent::ReadFromTree() No Branch found with Name %s. \n", (char*)__FILE__,__LINE__,bname.Data());
+            }	
+          }
+        }
+    }
         
         GetStdContent(); 
         fConnected = kTRUE;

--- a/STEER/AOD/AliAODInputHandler.cxx
+++ b/STEER/AOD/AliAODInputHandler.cxx
@@ -106,7 +106,8 @@ Bool_t AliAODInputHandler::Init(TTree* tree, Option_t* opt)
 
     fTree = tree;
     if (!fTree) return kFALSE;
-    GetEntries();
+    //GetEntries();
+    if(!fTree->GetTree())fTree->LoadTree(0);
 
     ConnectFriends();
 


### PR DESCRIPTION
When running a PCM analysis locally on a chain containing more than one AOD file, apparently no AOD Conversion Photons are extracted and, consequently, all histograms containing properties of the Conversion Photons remain empty. This error, however, does not occur when there is only one file in the chain. Introducing some modifications to the AliAODInputHandler::Init() and AliAODEvent::ReadFromTree() methods in AliRoot seems to fix this issue. In AliAODInputHandler::Init(), this is loading the first tree in the chain at the beginning. In AliAODEvent::ReadFromTree(), this is setting the branch addresses for every tree anew.