### PR TITLE
Fix: add protection against too small likelihoods container

### DIFF
--- a/ANALYSIS/ANALYSISalice/AliAnalysisTaskPIDqa.cxx
+++ b/ANALYSIS/ANALYSISalice/AliAnalysisTaskPIDqa.cxx
@@ -1452,8 +1452,8 @@ void AliAnalysisTaskPIDqa::FillTRDHistogramsLikelihood(TList *sublistTRD, Int_t 
 
   nSigmaTPCele=fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, AliPID::kElectron);
   const Int_t countSpecies=nSpecies;
-  Double_t likelihoods[countSpecies];
-
+  Double_t likelihoods[AliPID::kSPECIESCN]; //countSpecies];
+ 
   for(Int_t itl = 0; itl < ntracklets; itl++){
       // - Beginn: Likelihood & Nsigma vs. p before/after TRD PID
       for (Int_t ispecie=0; ispecie<numberSpecies; ++ispecie){


### PR DESCRIPTION
@chiarazampolli this is a brute-force protection: depending on the options, the `countSpecies` can be as small as 3, while the https://github.com/shahor02/AliRoot/blob/9d935c6602778cdbf833c95d00eea23f50f47cc2/ANALYSIS/ANALYSISalice/AliAnalysisTaskPIDqa.cxx#L1514 is called with kSPECIES=5, overflowing the `likelihoods`.
This bug dates back to 2016, strange that it fired only now. The logics should be checked by the authors (Yvonne? did not find hew on the git)