### PR TITLE
EMCal trigger fix and PYTHIA weights recovery to V5 09 56 patches

### DIFF
--- a/EMCAL/EMCALbase/AliEMCALSimParam.cxx
+++ b/EMCAL/EMCALbase/AliEMCALSimParam.cxx
@@ -19,6 +19,8 @@
 #include "AliEMCALSimParam.h"
 #include "AliLog.h"
 
+#include <iostream>
+
 /// \cond CLASSIMP
 ClassImp(AliEMCALSimParam);
 /// \endcond
@@ -42,7 +44,8 @@ fTimeResolutionPar1(0),
 fNADCEC(0),//Digitizer
 fA(0.),
 fB(0.),
-fECPrimThreshold(0.) //SDigitizer   
+fECPrimThreshold(0.), //SDigitizer
+fL1ADCNoise(0.0)//TriggerElectronics
 {
   // Parameters in Digitizer
   fMeanPhotonElectron = 4400;    // electrons per GeV 
@@ -61,12 +64,13 @@ fECPrimThreshold(0.) //SDigitizer
   fA                  = 0;
   fB                  = 1.e+6; // Dynamic range now 2 TeV
   fECPrimThreshold    = 0.05;  // GeV	// threshold for deposit energy of hit
+
 }
 
 ///
 /// Copy constructor.
 //-----------------------------------------------------------------------------
-AliEMCALSimParam::AliEMCALSimParam(const AliEMCALSimParam& ):
+/*AliEMCALSimParam::AliEMCALSimParam(const AliEMCALSimParam& ):
 TNamed(),
 fDigitThreshold(0),
 fMeanPhotonElectron(0),
@@ -80,12 +84,13 @@ fTimeResolutionPar1(0),
 fNADCEC(0),
 fA(0.),
 fB(0.),
-fECPrimThreshold(0.)//SDigitizer
+fECPrimThreshold(0.),//SDigitizer
+fL1ADCNoise(0)//TriggerElectronics
 {
   AliError("Should not use copy constructor for singleton") ;
   
   fgSimParam = this ;
-}
+}*/
 
 ///
 /// Get Instance
@@ -101,35 +106,55 @@ AliEMCALSimParam * AliEMCALSimParam::GetInstance()
 ///
 /// Assignment operator.
 //-----------------------------------------------------------------------------
-AliEMCALSimParam& AliEMCALSimParam::operator = (const AliEMCALSimParam& simParam)
+/*AliEMCALSimParam& AliEMCALSimParam::operator = (const AliEMCALSimParam& simParam)
 {
   if(this != &simParam) 
     AliError("Should not use operator= for singleton\n") ;
   
   return *this;
-}
+}*/
 
 ///
 /// Print simulation parameters to stdout
 //-----------------------------------------------------------------------------
 void AliEMCALSimParam::Print(Option_t *) const
 { 
-  printf("=== Parameters in Digitizer === \n");
-  printf("\t Electronics noise in EMC (fPinNoise)       = %f, (fTimeNoise) = %e\n", fPinNoise, fTimeNoise) ;
-  printf("\t Threshold  in EMC  (fDigitThreshold)       = %d\n", fDigitThreshold)  ;
-  printf("\t Time Resolution (fTimeResolutionPar0)      = %g\n", fTimeResolutionPar0) ;
-  printf("\t Time Resolution (fTimeResolutionPar1)      = %g\n", fTimeResolutionPar1) ;
-  printf("\t Time Delay (fTimeDelay)                    = %g\n", fTimeDelay) ;
-  printf("\t Time Delay OCDB (fTimeDelayFromOCDB)       = %d\n", fTimeDelayFromOCDB) ;
-  printf("\t Mean Photon-Electron (fMeanPhotonElectron) = %d, Gain Fluc. (fGainFluctuations) %2.1f\n", 
-         fMeanPhotonElectron,fGainFluctuations)  ;
-  printf("\t N channels in EC section ADC (fNADCEC)     = %d\n", fNADCEC) ;
-
-  printf("\n");
-
-  printf("=== Parameters in SDigitizer === \n");
-  printf("\t sdigitization parameters       A = %f\n",     fA);
-  printf("\t                                B = %f\n",     fB);
-  printf("\t Threshold for EC Primary assignment  = %f\n", fECPrimThreshold);
+  AliInfoStream() << *this << std::endl;
+  return;
 }
 
+
+
+///
+/// Print simulation parameters to stream
+//-----------------------------------------------------------------------------
+void AliEMCALSimParam::PrintStream(std::ostream &stream) const {
+  stream << "=== Sim Params ===" << std::endl;
+
+
+  stream << "=== Parameters in Digitizer === " << std::endl;
+  stream << "\t Electronics noise in EMC (fPinNoise)       = "<<fPinNoise<<", (fTimeNoise) = "<<fTimeNoise ;
+  stream << "\t Threshold  in EMC  (fDigitThreshold)       = "<<fDigitThreshold<<std::endl ;
+  stream << "\t Time Resolution (fTimeResolutionPar0)      = "<<fTimeResolutionPar0<<std::endl ;
+  stream << "\t Time Resolution (fTimeResolutionPar1)      = "<<fTimeResolutionPar1<<std::endl;
+  stream << "\t Time Delay (fTimeDelay)                    = "<<fTimeDelay<<std::endl ;
+  stream << "\t Time Delay OCDB (fTimeDelayFromOCDB)       = "<<fTimeDelayFromOCDB<<std::endl ;
+  stream << "\t Mean Photon-Electron (fMeanPhotonElectron) = "<<fMeanPhotonElectron<<", Gain Fluc. (fGainFluctuations) "<<fGainFluctuations<<std::endl;
+  stream << "\t N channels in EC section ADC (fNADCEC)     = "<<fNADCEC<<std::endl ;
+
+  stream << std::endl;
+
+  stream << "=== Parameters in SDigitizer === "<<std::endl;
+  stream << "\t sdigitization parameters       A = "<<fA<<std::endl;
+  stream << "\t                                B = "<<fB<<std::endl;
+  stream << "\t Threshold for EC Primary assignment  = "<<fECPrimThreshold<<std::endl;
+
+  stream << "=== Parameters in TriggerElectronics === "<<std::endl;
+  stream << "\t L1 FastOR timesum noise (fL1ADCNoise) = "<<fL1ADCNoise<<std::endl;
+
+}
+
+std::ostream &operator<<(std::ostream &stream, const AliEMCALSimParam &param) {
+  param.PrintStream(stream);
+  return stream;
+}

--- a/EMCAL/EMCALbase/AliEMCALSimParam.h
+++ b/EMCAL/EMCALbase/AliEMCALSimParam.h
@@ -18,6 +18,7 @@
 //-----------------------------------------------------------------------------
 
 #include "TNamed.h"
+#include <iosfwd>
 
 class AliEMCALSimParam : public TNamed 
 {
@@ -25,9 +26,9 @@ class AliEMCALSimParam : public TNamed
 public:
 
   AliEMCALSimParam();
-  AliEMCALSimParam(const AliEMCALSimParam& recoParam);
-  AliEMCALSimParam& operator = (const AliEMCALSimParam& recoParam);
   virtual ~AliEMCALSimParam() {}
+  void PrintStream(std::ostream &stream) const;
+
 
   static AliEMCALSimParam * GetInstance() ;
   virtual void Print(Option_t * option="") const ;
@@ -52,6 +53,7 @@ public:
   void     SetTimeResolutionPar0(Double_t val){ fTimeResolutionPar0  = val ; }
   void     SetTimeResolutionPar1(Double_t val){ fTimeResolutionPar1  = val ; }
   void     SetNADCED(Int_t val)               { fNADCEC              = val ; }
+
   void     SetMeanPhotonElectron(Int_t val)   { fMeanPhotonElectron  = val ; }
   void     SetGainFluctuations(Float_t val)   { fGainFluctuations    = val ; }
 
@@ -64,7 +66,17 @@ public:
   void     SetB(Float_t val)                  { fB                   = val ; }
   void     SetECPrimaryThreshold(Float_t val) { fECPrimThreshold     = val ; }
 
+  // Parameters used in TriggerElectronics for simulations
+  Float_t GetL1ADCNoise()              const { return fL1ADCNoise         ; }
+
+  void     SetL1ADCNoise(Float_t val)        { fL1ADCNoise          = val ; }
+
+
+
 private:
+
+  AliEMCALSimParam(const AliEMCALSimParam& recoParam);
+  AliEMCALSimParam& operator = (const AliEMCALSimParam& recoParam);
 
   static AliEMCALSimParam * fgSimParam ; // pointer to the unique instance of the class
 
@@ -84,12 +96,22 @@ private:
   Float_t fA ;                     ///< Pedestal parameter
   Float_t fB ;                     ///< Slope Digitizition parameters
   Float_t fECPrimThreshold ;       ///< To store primary if EC Shower Elos > threshold
+
+  // TriggerElectronics (simulation)
+  Float_t fL1ADCNoise ;          ///< Noise in FastOR Timesums for L1
 		
   /// \cond CLASSIMP
-  ClassDef(AliEMCALSimParam,7) ;
+  ClassDef(AliEMCALSimParam,8) ;
   /// \endcond
 
 };
+
+/// \brief Output stream operator for AliEMCALSimParams
+/// \param stream Stream where to print the params on
+/// \param param SimParams object to be printed
+/// \return Stream after printing the params
+std::ostream &operator<<(std::ostream &stream, const AliEMCALSimParam &param);
+
 
 #endif // ALIEMCALSIMPARAM_H
 

--- a/EMCAL/EMCALbase/CMakeLists.txt
+++ b/EMCAL/EMCALbase/CMakeLists.txt
@@ -133,14 +133,22 @@ install(FILES ${HDRS} DESTINATION include)
 add_executable(testemcaltrudcsconfig TestsAliEMCALTriggerTRUDCSConfig.cxx)
 target_link_libraries(testemcaltrudcsconfig ${MODULE} ${LIBDEPS})
 add_test(func_EMCALbase_AliEMCALTriggerTRUDCSConfig 
-    testemcaltrudcsconfig)
+    ENV
+    PATH=$ENV{PATH}
+    LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{LD_LIBRARY_PATH}
+    DYLD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{DYLD_LIBRARY_PATH}
+    ${CMAKE_INSTALL_PREFIX}/bin/testemcaltrudcsconfig)
 install(TARGETS testemcaltrudcsconfig RUNTIME DESTINATION bin)
 
 # STU DCS config unit test
 add_executable(testemcalstudcsconfig TestsAliEMCALTriggerSTUDCSConfig.cxx)
 target_link_libraries(testemcalstudcsconfig ${MODULE} ${LIBDEPS})
 add_test(func_EMCALbase_AliEMCALTriggerSTUDCSConfig 
-    testemcalstudcsconfig)
+    ENV
+    PATH=$ENV{PATH}
+    LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{LD_LIBRARY_PATH}
+    DYLD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{DYLD_LIBRARY_PATH}
+    ${CMAKE_INSTALL_PREFIX}/bin/testemcalstudcsconfig)
 install(TARGETS testemcalstudcsconfig RUNTIME DESTINATION bin)
 
 # Static version if DA enabled

--- a/EMCAL/EMCALbase/TestsAliEMCALTriggerSTUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/TestsAliEMCALTriggerSTUDCSConfig.cxx
@@ -26,6 +26,7 @@
  ************************************************************************************/
 #include <cstdlib>
 #include <bitset>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -165,14 +166,15 @@ namespace EMCAL {
          * @return false Test failed (operator<< to string produces different string)
          */
         bool TestStream() {
-          std::string reference = std::string("Gamma High: (0, 0, 115)\nGamma Low:  (0, 0, 51)\nJet High:   (0, 0, 255)\nJet Low:    (0, 0, 204)\n")
-                                + std::string("GetRawData: 1, Region: -1, Median: 0Firmware: 2a012, PHOS Scale: (0, 0, 0, 0)\n");
+          std::stringstream reference;
+          reference << "Gamma High: (0, 0, 115)\nGamma Low:  (0, 0, 51)\nJet High:   (0, 0, 255)\nJet Low:    (0, 0, 204)\n"
+                    << "GetRawData: 1, Region: " << std::hex << -1 << std::dec << "(" << std::bitset<32>(-1) << "), Median: 0, Firmware: 2a012, PHOS Scale: (0, 0, 0, 0)\n";
           
           AliEMCALTriggerSTUDCSConfig test;
           ConfigureReference(test);
           std::stringstream testmaker;
           testmaker << test;
-          return testmaker.str() == reference;
+          return testmaker.str() == reference.str();
         }
       }
     }

--- a/EMCAL/EMCALbase/TestsAliEMCALTriggerTRUDCSConfig.cxx
+++ b/EMCAL/EMCALbase/TestsAliEMCALTriggerTRUDCSConfig.cxx
@@ -166,9 +166,9 @@ namespace EMCAL {
          */
         bool TestStream(){
           std::string reference = std::string("SELPF: 1e1f, L0SEL: 1, L0COSM: 100, GTHRL0: 132, RLBKSTU: 0, FW: 21\n")
-                                + std::string("Reg0: 00000000000000000000010000000000\nReg1: 00000000000000000000000000000000\n")
-                                + std::string("Reg2: 00000000000000000000001000000000\nReg3: 00000000000000000111110011110001\n")
-                                + std::string("Reg4: 00000000000000000000000000000000\nReg5: 00000000000000000000000000000000\n");
+                                + std::string("Reg0: 00000000000000000000010000000000 (1024)\nReg1: 00000000000000000000000000000000 (0)\n")
+                                + std::string("Reg2: 00000000000000000000001000000000 (512)\nReg3: 00000000000000000111110011110001 (31985)\n")
+                                + std::string("Reg4: 00000000000000000000000000000000 (0)\nReg5: 00000000000000000000000000000000 (0)\n");
           
           AliEMCALTriggerTRUDCSConfig test;
           ConfigureReference(test);

--- a/EMCAL/EMCALsim/AliEMCALTriggerElectronics.cxx
+++ b/EMCAL/EMCALsim/AliEMCALTriggerElectronics.cxx
@@ -43,6 +43,7 @@ ClassImp(AliEMCALTriggerElectronics) ;
 /// Constructor
 //__________________
 AliEMCALTriggerElectronics::AliEMCALTriggerElectronics(const AliEMCALTriggerDCSConfig *dcsConf) : TObject(),
+fADCscaleMC(1.239958),
 fTRU(new TClonesArray("AliEMCALTriggerTRU",52)),
 fSTU(0x0),
 fGeometry(0)
@@ -314,7 +315,7 @@ void AliEMCALTriggerElectronics::Digits2Trigger(TClonesArray* digits, const Int_
           if (data->GetMode())
             etr->SetADC(iADC, time, 4 * amp);
           else
-            etr->SetADC(iADC, time,     amp);
+            etr->SetADC(iADC, time, (Int_t) (fADCscaleMC * amp));
         }
       }
     }
@@ -418,7 +419,7 @@ void AliEMCALTriggerElectronics::Digits2Trigger(TClonesArray* digits, const Int_
             
             // 14b to 12b STU time sums
             reg[j][k] >>= 2; 
-            
+
             dig->SetL1TimeSum(reg[j][k]);
           }
         }

--- a/EMCAL/EMCALsim/AliEMCALTriggerElectronics.cxx
+++ b/EMCAL/EMCALsim/AliEMCALTriggerElectronics.cxx
@@ -478,7 +478,13 @@ void AliEMCALTriggerElectronics::Digits2Trigger(TClonesArray* digits, const Int_
 //              posMap[px + j % sizeX][py + j / sizeX] = digits->GetEntriesFast();
               posMap[px + j / sizeX][py + j % sizeX] = digits->GetEntriesFast();
 
-              new((*digits)[digits->GetEntriesFast()]) AliEMCALTriggerRawDigit(id, 0x0, 0);
+              // Previously this created digits only with the upper left fastOR id
+              //new((*digits)[digits->GetEntriesFast()]) AliEMCALTriggerRawDigit(id, 0x0, 0);
+              // Now use the proper FastOR ID
+              Int_t newID = -1;
+              fGeometry->GetAbsFastORIndexFromPositionInEMCAL(py + j % sizeX,px + j / sizeX, newID);
+              new((*digits)[digits->GetEntriesFast()]) AliEMCALTriggerRawDigit(newID, 0x0, 0);
+
                 
               dig = (AliEMCALTriggerRawDigit*)digits->At(digits->GetEntriesFast() - 1);							
             } else {

--- a/EMCAL/EMCALsim/AliEMCALTriggerElectronics.h
+++ b/EMCAL/EMCALsim/AliEMCALTriggerElectronics.h
@@ -36,6 +36,9 @@ public:
   
   virtual void   Digits2Trigger(TClonesArray* digits, const Int_t V0M[], AliEMCALTriggerData* data);	
   virtual void   Reset();  
+
+  Float_t GetADCscaleMC() { return fADCscaleMC; }
+  void SetADCscaleMC(Float_t input) { fADCscaleMC = input; }
   
   virtual AliEMCALTriggerTRU* GetTRU( Int_t iTRU ) {return (AliEMCALTriggerTRU*)fTRU->At(iTRU);}
   virtual AliEMCALTriggerSTU* GetSTU( Bool_t isDCAL = false ) {return isDCAL ? fSTUDCAL : fSTU;}
@@ -51,6 +54,7 @@ private:
   AliEMCALGeometry     *fGeometry; ///< EMCal geometry
  
   Int_t                fMedianMode; // 0 for no median subtraction, 1 for median sub.
+  Float_t              fADCscaleMC; //< Scaling up MC raw digits so samples match total energy
   TClonesArray*        fTRUDCAL;  //< 14 TRU
   AliEMCALTriggerSTU*  fSTUDCAL;  //< 1 STU for DCAL
  

--- a/EMCAL/EMCALsim/AliEMCALTriggerElectronics.h
+++ b/EMCAL/EMCALsim/AliEMCALTriggerElectronics.h
@@ -55,6 +55,7 @@ private:
  
   Int_t                fMedianMode; // 0 for no median subtraction, 1 for median sub.
   Float_t              fADCscaleMC; //< Scaling up MC raw digits so samples match total energy
+  Float_t              fL1ADCNoise; //< Sigma of noise added to the L1 Timesums in MC
   TClonesArray*        fTRUDCAL;  //< 14 TRU
   AliEMCALTriggerSTU*  fSTUDCAL;  //< 1 STU for DCAL
  

--- a/EMCAL/EMCALsim/CMakeLists.txt
+++ b/EMCAL/EMCALsim/CMakeLists.txt
@@ -23,6 +23,7 @@ include_directories(${AliRoot_SOURCE_DIR}/EMCAL/${MODULE})
 # Additional include folders in alphabetical order except ROOT
 include_directories(SYSTEM ${ROOT_INCLUDE_DIR})
 include_directories(${AliRoot_SOURCE_DIR}/EMCAL/EMCALbase
+                    ${AliRoot_SOURCE_DIR}/EMCAL/EMCALTriggerBase
                     ${AliRoot_SOURCE_DIR}/EMCAL/EMCALUtils
                     ${AliRoot_SOURCE_DIR}/RAW/RAWDatarec
                     ${AliRoot_SOURCE_DIR}/STEER/CDB

--- a/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
@@ -1327,6 +1327,9 @@ void AliGenPythiaPlus::MakeHeader()
     ((AliGenPythiaEventHeader*) fHeader)->SetPtHard(fPythia->GetPtHard());
     ((AliGenPythiaEventHeader*) fHeader)->SetXsection(fPythia->GetXSection());
 
+// Store Event weight
+    ((AliGenPythiaEventHeader*) fHeader)->SetEventWeight(fPythia->GetEventWeight());
+
 //
 //  Pass header
 //

--- a/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
@@ -56,6 +56,7 @@ AliGenPythiaPlus::AliGenPythiaPlus():
     fNev(0),
     fFlavorSelect(0),
     fXsection(0.),
+    fWeightPower(0.),
     fPtHardMin(0.),
     fPtHardMax(1.e4),
     fYHardMin(-1.e10),
@@ -172,6 +173,7 @@ AliGenPythiaPlus::AliGenPythiaPlus(AliPythiaBase* pythia)
      fNev(0),
      fFlavorSelect(0),
      fXsection(0.),
+     fWeightPower(0.),
      fPtHardMin(0.),
      fPtHardMax(1.e4),
      fYHardMin(-1.e10),
@@ -369,7 +371,8 @@ void AliGenPythiaPlus::Init()
 //
     fParentWeight=1./Float_t(fNpart);
 //
-
+    if (fWeightPower != 0)
+      fPythia->SetWeightPower(fWeightPower);
     
     fPythia->SetPtHardRange(fPtHardMin, fPtHardMax);
     fPythia->SetYHardRange(fYHardMin, fYHardMax);

--- a/PYTHIA6/AliPythia6/AliGenPythiaPlus.h
+++ b/PYTHIA6/AliPythia6/AliGenPythiaPlus.h
@@ -50,6 +50,8 @@ class AliGenPythiaPlus : public AliGenMC
     virtual void    SetProcess(Process_t proc = kPyCharm) {fProcess = proc;}
     // Select structure function
     virtual void    SetStrucFunc(StrucFunc_t func =  kCTEQ5L) {fStrucFunc = func;}
+    // Rewieght pt, hard spectrum with pT/p0^n, set power n
+    virtual void    SetWeightPower(Float_t power = 0.) { fWeightPower = power; }
     // Select pt of hard scattering 
     virtual void    SetPtHard(Float_t ptmin = 0, Float_t ptmax = 1.e10)
 	{fPtHardMin = ptmin; fPtHardMax = ptmax; }
@@ -290,6 +292,7 @@ class AliGenPythiaPlus : public AliGenMC
     Int_t       fNev;               //Number of events 
     Int_t       fFlavorSelect;      //Heavy Flavor Selection
     Float_t     fXsection;          //Cross-section
+    Float_t     fWeightPower;       //power for cross section weights; 0 means no reweighting
     Float_t     fPtHardMin;         //lower pT-hard cut 
     Float_t     fPtHardMax;         //higher pT-hard cut
     Float_t     fYHardMin;          //lower  y-hard cut 

--- a/PYTHIA6/AliPythia6/AliPythia6.cxx
+++ b/PYTHIA6/AliPythia6/AliPythia6.cxx
@@ -1660,6 +1660,11 @@ Float_t AliPythia6::GetPtHard()
     return GetVINT(47);
 }
 
+Float_t AliPythia6::GetEventWeight()
+{
+	return GetVINT(97);
+}
+
 Int_t AliPythia6::ProcessCode()
 {
     // Get the subprocess code

--- a/PYTHIA6/AliPythia6/AliPythia6.h
+++ b/PYTHIA6/AliPythia6/AliPythia6.h
@@ -59,6 +59,12 @@ class AliPythia6 : public TPythia6, public AliPythiaBase
     // Common Getters
     virtual void    GetXandQ(Float_t& x1, Float_t& x2, Float_t& q);
     virtual Float_t GetXSection();
+
+    /**
+     * @brief Get the event weight from the underlying pythia process 
+     * @return Event weight 
+     */
+    virtual Float_t GetEventWeight();
     virtual Int_t   ProcessCode();
     virtual Float_t GetPtHard();
     virtual Int_t   GetNMPI();

--- a/PYTHIA6/AliPythia6/AliPythiaBase.h
+++ b/PYTHIA6/AliPythia6/AliPythiaBase.h
@@ -39,6 +39,11 @@ class AliPythiaBase : public AliRndm
     virtual Int_t GetParticles(TClonesArray */*particles*/){return -1;}
     virtual void  PrintStatistics() {;}
     virtual void  EventListing() {;}
+    /**
+     * @brief Use weighted cross sections
+     * @param pow Weight power
+     */
+    virtual void SetWeightPower(Double_t pow) {;}
     // Treat protons as inside nuclei
     virtual void  SetNuclei(Int_t /*a1*/, Int_t /*a2*/) {;}
     // Print particle properties

--- a/PYTHIA6/AliPythia6/AliPythiaBase.h
+++ b/PYTHIA6/AliPythia6/AliPythiaBase.h
@@ -71,6 +71,12 @@ class AliPythiaBase : public AliRndm
     virtual Float_t GetPtHard() {return -1.;}
     virtual Int_t   GetNMPI() {return -1;}
     virtual Int_t   GetNSuperpositions() { return 1; }
+
+    /**
+     * @brief Get the event weight from the underlying pythia process 
+     * @return Event weight 
+     */
+    virtual Float_t GetEventWeight() { return 1; }
     //
     //
     virtual void SetDecayTable() {;}

--- a/PYTHIA8/AliPythia8/AliPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliPythia8.cxx
@@ -892,7 +892,10 @@ Float_t AliPythia8::GetPtHard()
     return Pythia8()->info.pTHat();
 }
 
-
+Float_t AliPythia8::GetEventWeight()
+{
+    return Pythia8()->info.weight();
+}
 
 
 AliPythia8& AliPythia8::operator=(const  AliPythia8& rhs)

--- a/PYTHIA8/AliPythia8/AliPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliPythia8.cxx
@@ -771,6 +771,10 @@ void AliPythia8::SetYHardRange(Float_t /*ymin*/, Float_t /*ymax*/)
     
 }
 
+void AliPythia8::SetWeightPower(Double_t pow){
+    ReadString("PhaseSpace:bias2Selection = on");
+    ReadString(Form("PhaseSpace:bias2SelectionPow = %13.3f", pow));
+}
 
 void AliPythia8::SetFragmentation(Int_t flag)
 {

--- a/PYTHIA8/AliPythia8/AliPythia8.h
+++ b/PYTHIA8/AliPythia8/AliPythia8.h
@@ -84,6 +84,12 @@ class AliPythia8 :public AliTPythia8, public AliPythiaBase
     virtual void    GetXandQ(Float_t& x1, Float_t& x2, Float_t& q);
     virtual Float_t GetXSection();
     virtual Float_t GetPtHard();
+    
+    /**
+     * @brief Get the event weight from the underlying pythia process 
+     * @return Event weight 
+     */
+    virtual Float_t GetEventWeight();
     virtual Int_t GetNMPI() { return fLastNMPI; }
     virtual Int_t GetNSuperpositions() { return fLastNSuperposition; }
 

--- a/PYTHIA8/AliPythia8/AliPythia8.h
+++ b/PYTHIA8/AliPythia8/AliPythia8.h
@@ -37,6 +37,11 @@ class AliPythia8 :public AliTPythia8, public AliPythiaBase
     virtual Int_t GetParticles(TClonesArray *particles) {return ImportParticles(particles, "All");}
     // Treat protons as inside nuclei
     virtual void  SetNuclei(Int_t a1, Int_t a2);
+    /**
+     * @brief Use weighted cross sections
+     * @param pow Weight power
+     */
+    virtual void SetWeightPower(Double_t pow);
     // Print particle properties
     virtual void PrintParticles();
     // Reset the decay table


### PR DESCRIPTION
* Restore option to generate weighted events in AliGenPythiaPlus and add setting for AliPythia8

https://github.com/alisw/AliRoot/commit/a98c7f7bd8c9a9ff850d8684b26c37eda7d58c56#diff-6b966b6d0aa9f7582026d951afaecbe3ed80074d087b3f7140884f7deeac848f

* [ALIROOT-8649] Restore porting the event weight to the pythia header

https://github.com/alisw/AliRoot/commit/80c212d58b667e42dc37f7fa137ac38c56e66485#diff-6b966b6d0aa9f7582026d951afaecbe3ed80074d087b3f7140884f7deeac848f

* Adds a rescaling of the digits in MC so trigger signal energies match total deposited energy, as done in data

https://github.com/alisw/AliRoot/commit/471256c6415ece265f350b8671e667c88f2552a5#diff-8d4f87477168201a3bd96e6814ab0e0afe3dead85b882cf21105e9f220a2c97d

* Fixes an error where new L0 patch digits would be created with the wrong fastOR id.
https://github.com/alisw/AliRoot/commit/2eff45883e13d4a16158c2a98aa6ec04aa962cb9#diff-8d4f87477168201a3bd96e6814ab0e0afe3dead85b882cf21105e9f220a2c97d

* updates SimParams, adding L1ADCNoise param Adds noise to L1 trigger timesums based on param in SimParam OCDB

https://github.com/alisw/AliRoot/commit/09d39a9c7bbd464bece6b836e8d3fd7734b1ede7#diff-8d4f87477168201a3bd96e6814ab0e0afe3dead85b882cf21105e9f220a2c97d

* Fixes for EMCAL unit tests
   - Adding environment and CMAKE_INSTALL_PREFIX
     in test definition
   - Adapt reference for stream operators to latest
     implementation

https://github.com/alisw/AliRoot/commit/4c710e548623de213b9a4362ed2a21e0055065fe#diff-8d4f87477168201a3bd96e6814ab0e0afe3dead85b882cf21105e9f220a2c97d