### PR TITLE
protection against -1 index

### DIFF
--- a/STEER/STEER/AliMC.cxx
+++ b/STEER/STEER/AliMC.cxx
@@ -1345,8 +1345,12 @@ void AliMC::Stepping()
   // Called at every step during transport
   //
   //verbose.Stepping();
-
-  Int_t id = DetFromMate(fMC->CurrentMedium());
+  Int_t curmed = fMC->CurrentMedium();
+  if (curmed<0||curmed>=fImedia->fN) {
+    AliError(Form("Index for medium would be out-of-bounds: %d\n", curmed));
+    return;
+  }
+  Int_t id = DetFromMate(curmed);
   if (id < 0) return;
 
 


### PR DESCRIPTION
, which means that the particle made it outside the
defined geometry, ie gGeoManager->IsOutside() == kTRUE