### PR TITLE
Explicitly specify pythia6 dependency for AliPythia6

### DIFF
--- a/PYTHIA6/AliPythia6/CMakeLists.txt
+++ b/PYTHIA6/AliPythia6/CMakeLists.txt
@@ -62,7 +62,7 @@ generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS STEERBase STEER EVGEN FASTSIM EGPythia6 microcern lhapdfbase)
+set(LIBDEPS STEERBase STEER EVGEN FASTSIM EGPythia6 pythia6 microcern lhapdfbase)
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 


### PR DESCRIPTION
Previously, analysis trains relied on the pythia6 library being pre-loaded, but that pre-loading is a ROOT5-ism. Instead, make sure libAliPythia6 is linked properly against pythia6.

This should solve the `libAliPythia6.so: undefined symbol: pyqpar_` error seen by analysers.

This seems to fix the problem in the one instance I reproduced locally based on the run at:
http://alitrain.cern.ch/train-workdir/PWGGA/GA_pp_MC/3980_20221018-2243/test/__BASELINE__

While I did not reproduce the full run with all *.root files, I managed to reproduce the crash (without this patch), which did not occur with this patch applied.