### PR TITLE
Fix floating point exception in Linux guntest

### DIFF
--- a/ITS/ITSbase/AliITStrackerMI.cxx
+++ b/ITS/ITSbase/AliITStrackerMI.cxx
@@ -751,6 +751,10 @@ Int_t AliITStrackerMI::PropagateBack(AliESDEvent *event) {
        dst2 = dxs*dxs + dys*dys;
        double dxy = TMath::Sqrt(dst2), arg = crvh*dxy;
        if (arg > kWatchStep) { // correct circular part for arc/segment factor
+         if (arg > 1.0) {
+           // Clamp "arg" to be <=1.0, to avoid errors from TMath::Asin below.
+           arg = 1.0;
+         }
 	 double dst = 1./crvh*TMath::ASin(arg);
 	 dst2 *= dst*dst;
        }

--- a/test/gun/runtest.sh
+++ b/test/gun/runtest.sh
@@ -6,7 +6,10 @@ aliroot -b -q sim.C      2>&1 | tee sim.log
 mv syswatch.log simwatch.log
 aliroot -b -q rec.C      2>&1 | tee rec.log
 mv syswatch.log recwatch.log
-aliroot -b -q ${ALICE_ROOT}/STEER/macros/CheckESD.C 2>&1 | tee check.log
+if [ -n "$ALICE_PHYSICS" ]; then
+  # For this macro, we need OADB, which is part of AliPhysics.
+  aliroot -b -q "$ALICE_ROOT/STEER/macros/CheckESD.C" 2>&1 | tee check.log
+fi
 aliroot -b -q aod.C 2>&1 | tee aod.log
 
 cd recraw

--- a/test/gun/runtest.sh
+++ b/test/gun/runtest.sh
@@ -7,10 +7,10 @@ mv syswatch.log simwatch.log
 aliroot -b -q rec.C      2>&1 | tee rec.log
 mv syswatch.log recwatch.log
 if [ -n "$ALICE_PHYSICS" ]; then
-  # For this macro, we need OADB, which is part of AliPhysics.
+  # These macros need AliPhysics to work.
   aliroot -b -q "$ALICE_ROOT/STEER/macros/CheckESD.C" 2>&1 | tee check.log
+  aliroot -b -q aod.C 2>&1 | tee aod.log
 fi
-aliroot -b -q aod.C 2>&1 | tee aod.log
 
 cd recraw
 ln -s ../raw.root

--- a/test/gun/runtest.sh
+++ b/test/gun/runtest.sh
@@ -15,5 +15,7 @@ fi
 cd recraw
 ln -s ../raw.root
 aliroot -b -q rec.C      2>&1 | tee rec.log
-aliroot -b -q  2>&1 aod.C | tee aod.log
-
+if [ -n "$ALICE_PHYSICS" ]; then
+  # This macro needs AliPhysics to work.
+  aliroot -b -q  2>&1 aod.C | tee aod.log
+fi

--- a/test/vmctest/gun/runtest.sh
+++ b/test/vmctest/gun/runtest.sh
@@ -22,7 +22,10 @@ if [ "$RUNG3" = "1" ]; then
   rm -rf *.root *.dat *.log fort* hlt hough raw* recraw/*.root recraw/*.log
   aliroot -b -q  sim.C\($NEVENTS,\""$G3CONFIG"\"\)  2>&1 | tee sim.log
   aliroot -b -q rec.C      2>&1 | tee rec.log
-  aliroot -b -q ${ALICE_ROOT}/STEER/macros/CheckESD.C  2>&1 | tee check.log
+  if [ -n "$ALICE_PHYSICS" ]; then
+    # This macro needs AliPhysics to work.
+    aliroot -b -q "$ALICE_ROOT/STEER/macros/CheckESD.C" 2>&1 | tee check.log
+  fi
   rm -fr $G3OUTDIR
   mkdir $G3OUTDIR
   mv *.root *.log GRP $G3OUTDIR
@@ -33,7 +36,10 @@ if [ "$RUNG4" = "1" ]; then
   rm -rf *.root *.dat *.log fort* hlt hough raw* recraw/*.root recraw/*.log
   aliroot -b -q  simG4.C\($NEVENTS,\""$G4CONFIG"\"\)  2>&1 | tee sim.log
   aliroot -b -q rec.C      2>&1 | tee rec.log
-  aliroot -b -q ${ALICE_ROOT}/STEER/macros/CheckESD.C  2>&1 | tee check.log
+  if [ -n "$ALICE_PHYSICS" ]; then
+    # This macro needs AliPhysics to work.
+    aliroot -b -q "$ALICE_ROOT/STEER/macros/CheckESD.C" 2>&1 | tee check.log
+  fi
   rm -fr $G4OUTDIR
   mkdir $G4OUTDIR
   mv *.root *.log *.rndm GRP $G4OUTDIR


### PR DESCRIPTION
Since moving to `o2` defaults, the Linux CI check has been failing in AliRoot-guntest with a floating point exception. Peter tracked this down to a value `> 1.0` being passed to `asin` and provided this fix.

Written-by: Peter Hristov (@pzhristov)