### PR TITLE
Get the generated vertex position of trigger event in case of pileup

### DIFF
--- a/STEER/STEERBase/AliMCEvent.cxx
+++ b/STEER/STEERBase/AliMCEvent.cxx
@@ -919,7 +919,18 @@ const AliVVertex * AliMCEvent::GetPrimaryVertex() const
 {
     // Create a MCVertex object from the MCHeader information
     TArrayF v;
-    GenEventHeader()->PrimaryVertex(v) ;
+    AliGenEventHeader* gh =  GenEventHeader();
+    gh->PrimaryVertex(v) ;
+    
+    // Special treatment for AODs from productions with pileup generation
+    TString gname=gh->GetName();
+    gname.ToLower();
+    if(fAODMCHeader && gname.Contains("pileup") && gh->InheritsFrom(AliGenCocktailEventHeader::Class())){
+      v[0]=fAODMCHeader->GetVtxX();
+      v[1]=fAODMCHeader->GetVtxY();
+      v[2]=fAODMCHeader->GetVtxZ();
+    }
+    
     if (!fVertex) {
 	fVertex = new AliMCVertex(v[0], v[1], v[2]);
     } else {

--- a/STEER/STEERBase/AliVHeader.h
+++ b/STEER/STEERBase/AliVHeader.h
@@ -29,6 +29,11 @@ class AliVHeader : public TNamed {
   virtual ULong64_t GetTriggerMaskNext50()  const = 0;
   virtual UChar_t   GetTriggerCluster()     const = 0;
   virtual UInt_t    GetEventType()          const = 0;
+  
+  virtual Double_t GetVtxX() const {return 0;}
+  virtual Double_t GetVtxY() const {return 0;}
+  virtual Double_t GetVtxZ() const {return 0;}
+
   virtual TList*    GetCocktailHeaders()    {return 0;}
   ULong64_t GetEventIdAsLong() const;
   virtual Bool_t    IsTriggerInputFired(const char* /*name*/) const {return kFALSE;}


### PR DESCRIPTION
This modification to AliMCEvent::GetPrimaryVertex allows one to retrieve the generated vertex position for the trigger collision in case of AODs of MC productions with generated pileup.

This method was already returning the position of the trigger event for ESDs.
This is due to the fact that the vertex position of the trigger event is properly set in the "highest level" header of the cocktail  generator and it is thus correctly retrieved in AliMCEvent::GetPrimaryVertex.

However, this does not hold in the case of AODs, for which the "highest level" cocktail header is not made available in AliAODMCHeader (and therefore in AliMCEvent), due to the different structure of the event headers of the cocktail generator it was returning (0,0,0).
Nevertheless, the manipulations done in AliAODHandler::StoreMCParticles store the vertex position (taken from the highest level cocktail header, hence the same source used for ESDs) into the data member fVertex of AliAODMCHeader.
With this modification the proper vertex position in case of AODs with pileup generation is retrieved by using AliAODMCHeader::GetVtxX,Y,Z.


