### PR TITLE
Tune `find` commands that generate XML collections

### DIFF
--- a/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
+++ b/ANALYSIS/ANALYSISaliceBase/AliAnalysisAlien.cxx
@@ -1257,7 +1257,7 @@ Bool_t AliAnalysisAlien::CreateDataset(const char *pattern)
    delimiter.Strip();
    if (delimiter.Contains(" ")) delimiter = "";
    else delimiter = " ";
-   TString options = " ";
+   TString options = "-f ";
    if (TestBit(AliAnalysisGrid::kTest)) options += Form("-l %d ", fNtestFiles);
    else options += Form("-l %d ", gMaxEntries);  // Protection for the find command
    TString conditions = "";
@@ -2816,7 +2816,7 @@ Bool_t AliAnalysisAlien::CheckMergedFiles(const char *filename, const char *alie
    //TGridResult *res = gGrid->Command(Form("find -x Stage_%d %s %s", stage, aliendir, pattern.Data()));
    //if (res) delete res;
    // Write standard output to file
-   TGridCollection *tmp = gGrid->OpenCollectionQuery(gGrid->Command(Form("find %s %s", aliendir, pattern.Data())),kTRUE);
+   TGridCollection *tmp = gGrid->OpenCollectionQuery(gGrid->Command(Form("find -f %s %s", aliendir, pattern.Data())),kTRUE);
   tmp->ExportXML(Form("file://Stage_%d.xml",stage),kFALSE,kFALSE,Form("Stage_%d",stage));
    //gROOT->ProcessLine(Form("gGrid->Stdout(); > %s", Form("Stage_%d.xml",stage)));
    // Count the number of files inside


### PR DESCRIPTION
Add a `-f` argument to the `find` commands that are used to produce collections. The new argument makes `find` return a full set of metadata about the files, generating XML files with the same content as the ones produced by the central services.