### PR TITLE
Updating the mass of exotic bound states

### DIFF
--- a/STEER/STEERBase/AliPDG.cxx
+++ b/STEER/STEERBase/AliPDG.cxx
@@ -335,13 +335,13 @@ void AliPDG::AddParticlesToPdgDataBase()
 
   ionCode = 1010010021;
   if(!pdgDB->GetParticle(ionCode)){
-    pdgDB->AddParticle("Lambda1405Proton","Lambda1405Proton", 2.295, kFALSE,
+    pdgDB->AddParticle("Lambda1405Proton","Lambda1405Proton", 2.37, kFALSE,
 		       0.05, 3, "Special", ionCode);
   }
 
   ionCode = -1010010021;
   if(!pdgDB->GetParticle(ionCode)){
-    pdgDB->AddParticle("AntiLambda1405Proton","AntiLambda1405Proton", 2.295, kFALSE,
+    pdgDB->AddParticle("AntiLambda1405Proton","AntiLambda1405Proton", 2.37, kFALSE,
 		       0.05, 3, "Special", ionCode);
   }
 


### PR DESCRIPTION
The new value is from the 3-body decay channel: anti-p anti-p K^+
The total mass of the decay products is 0.938+0.938+0.493 = 2.37 GeV.