### PR TITLE
allowing pythia8 decay longlived part for fast sim

### DIFF
--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
@@ -36,6 +36,7 @@ AliDecayerPythia8::AliDecayerPythia8():
   fPythia8(AliTPythia8::Instance()),
   fDebug(0),
   fDecay(kAll),
+  fEnableLongLivedDecay(kFALSE),
   fHeavyFlavour(kTRUE)
 {
     // Constructor
@@ -97,13 +98,15 @@ void AliDecayerPythia8::Init()
     fPythia8->ReadString("111:onMode = on");
     
 //...Switch off decay of K0S, Lambda, Sigma+-, Xi0-, Omega-.
-    fPythia8->ReadString("310:onMode  = off");
-    fPythia8->ReadString("3122:onMode = off");
-    fPythia8->ReadString("3112:onMode = off");
-    fPythia8->ReadString("3222:onMode = off");
-    fPythia8->ReadString("3312:onMode = off");
-    fPythia8->ReadString("3322:onMode = off");
-    fPythia8->ReadString("3334:onMode = off");
+    if(!fEnableLongLivedDecay) {
+      fPythia8->ReadString("310:onMode  = off");
+      fPythia8->ReadString("3122:onMode = off");
+      fPythia8->ReadString("3112:onMode = off");
+      fPythia8->ReadString("3222:onMode = off");
+      fPythia8->ReadString("3312:onMode = off");
+      fPythia8->ReadString("3322:onMode = off");
+      fPythia8->ReadString("3334:onMode = off");
+    }
 // .. Force decay channels
     ForceDecay();
 }

--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.h
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.h
@@ -24,6 +24,7 @@ class AliDecayerPythia8 : public TVirtualMCDecayer {
   virtual Int_t   ImportParticles(TClonesArray *particles);
   virtual void    SetForceDecay(Decay_t decay) {fDecay=decay;}
   virtual void    SetForceDecay(Int_t decay)   {SetForceDecay((Decay_t) decay);}
+  virtual void    SetLongLivedDecay(bool val = true) { fEnableLongLivedDecay = val; }
   virtual void    ForceDecay();
   virtual Float_t GetPartialBranchingRatio(Int_t ipart);
   virtual void    HeavyFlavourOff() {fHeavyFlavour = kFALSE;}
@@ -41,13 +42,14 @@ class AliDecayerPythia8 : public TVirtualMCDecayer {
   void     SwitchOffHeavyFlavour();
   void     ForceHadronicD(Int_t optUser4Bodies = 1,Int_t optUseDtoV0 =1, Int_t optForceLcChannel = 0, Int_t optForceXicChannel = 0, Int_t optForceDsChannel = 0, Int_t optForceOmegacChannel = 0);
   void  ForceBeautyUpgrade();
-  AliTPythia8*  fPythia8;          // Pointer to pythia8
-  Int_t         fDebug;            // Debug level
+  AliTPythia8*  fPythia8;               // Pointer to pythia8
+  Int_t         fDebug;                 // Debug level
  
-  Decay_t       fDecay;            //  Forced decay mode
-  Bool_t        fHeavyFlavour;     //! Flag for heavy flavors
-  static Bool_t fgInit;            //! initialization flag 
-  ClassDef(AliDecayerPythia8, 2) // Particle Decayer using Pythia8
+  Decay_t       fDecay;                 //  Forced decay mode
+  bool          fEnableLongLivedDecay;  // To enable long lived particle decay
+  Bool_t        fHeavyFlavour;          //! Flag for heavy flavors
+  static Bool_t fgInit;                 //! initialization flag 
+  ClassDef(AliDecayerPythia8, 3)        // Particle Decayer using Pythia8
 };
 #endif
 

--- a/PYTHIA8/AliPythia8/AliPythia8.h
+++ b/PYTHIA8/AliPythia8/AliPythia8.h
@@ -77,7 +77,7 @@ class AliPythia8 :public AliTPythia8, public AliPythiaBase
      *
      * @param doDecay If true the particles listed here are decayed
      */
-    void SetDecayLonglived(Bool_t doDecay = kTRUE) { fDecayLonglived = doDecay; }
+    void SetDecayLonglived(Bool_t doDecay = kTRUE) { fDecayLonglived = doDecay; ((AliDecayerPythia8*) Decayer())->SetLongLivedDecay(doDecay); }
 
     //
     // Common Getters


### PR DESCRIPTION
This is to allow for setting decay of longlived particles in pythia8 (fast sim).

It is currently not allowed because of a setting in AliDecayerPythia8 (default is still no decay for those particles)