### PR TITLE
Forcing Ds-reso decay and fixing track transport

### DIFF
--- a/EVGEN/AliDecayer.h
+++ b/EVGEN/AliDecayer.h
@@ -24,7 +24,7 @@ typedef enum
     kHadronicDWithV0,kHadronicDWithout4BodiesWithV0,kAllEM,
     kLcpKpi, kLcpK0S, kHFYellowReport, kHadronicDPionicD0, kHadronicDWithV0PionicD0, kHadronicDWithout4BodiesPionicD0, 
     kHadronicDWithout4BodiesWithV0PionicD0,kHadronicDPionicD0pure,kHadronicDPionicD0K,kHadronicDPionicD0pi, kLcpK0SBDTsig, kEtaPrime,kEtaPrimeGammaGamma,
-    kXic0Semileptonic,kHadronicDWithout4BodiesDsPhiPi, kLcLpi, kOmegac0Semileptonic, kOmegac0ToXiPi, kF0F1K0s, kF1K0sK
+    kXic0Semileptonic,kHadronicDWithout4BodiesDsPhiPi, kLcLpi, kOmegac0Semileptonic, kOmegac0ToXiPi, kF0F1K0s, kF1K0sK, kDsResonances
 } Decay_t;
 #endif
 

--- a/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
+++ b/PYTHIA6/AliPythia6/AliGenPythiaPlus.cxx
@@ -1277,8 +1277,12 @@ Int_t  AliGenPythiaPlus::GenerateMB()
             iparent_reso = iparent + p->GetFirstMother(); // set parent
           }
           Int_t trackIt = 0;
-          if (TMath::Abs(p->GetPdgCode()) == 310 || TMath::Abs(p->GetPdgCode()) == 130) trackIt = 1; // K0s and K0l are stable in pythia
           Int_t ks = p->GetStatusCode();
+          kf = CheckPDGCode(p->GetPdgCode());
+          if ((ks == 1) || fDecayer->GetLifetime(kf) > fMaxLifeTime) {
+            trackIt = 1;
+          }
+
           PushTrack(fTrackIt*trackIt, iparent_reso, CheckPDGCode(p->GetPdgCode()), 
                     p->Px(), p->Py(), p->Pz(), p->Energy(), 
                     originDauX, originDauY, originDauZ, tof, 

--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.cxx
@@ -604,6 +604,9 @@ void AliDecayerPythia8::ForceDecay()
     case kOmegac0ToXiPi:
       ForceHadronicD(0,0,0,0,0,2); //Omegac0 -> Xi Pi
     break;
+	case kDsResonances:
+      ForceHadronicD(0,0,0,0,0,0,1); //Ds -> Resonances
+	break;
     case kPhiKK:
 	// Phi-> K+ K-
 	fPythia8->ReadString("333:onMode = off");
@@ -711,7 +714,7 @@ void AliDecayerPythia8::ForceBeautyUpgrade(){
 }
 
 
-void AliDecayerPythia8::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, Int_t optForceLcChannel, Int_t optForceXicChannel, Int_t optForceDsChannel, Int_t optForceOmegacChannel)
+void AliDecayerPythia8::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, Int_t optForceLcChannel, Int_t optForceXicChannel, Int_t optForceDsChannel, Int_t optForceOmegacChannel, Int_t optForceDsResonances)
 {
 //
 // Force golden D decay modes
@@ -880,7 +883,19 @@ void AliDecayerPythia8::ForceHadronicD(Int_t optUse4Bodies, Int_t optUseDtoV0, I
         fPythia8->ReadString("3324:onMode = off");
         fPythia8->ReadString("3314:onIfMatch = 3312 111");
         fPythia8->ReadString("3324:onIfMatch = 3312 211");
-    }       
+    }
+
+	if (optForceDsResonances == 1){
+		// for K0 -> K0s
+        fPythia8->ReadString("311:onMode = off");
+        fPythia8->ReadString("311:onIfAll = 310");
+		// for Ds1+ -> D*+ K0s
+		fPythia8->ReadString("10433:onMode = off");
+		fPythia8->ReadString("10433:onIfAll = 413 311");
+		// for Ds2+ -> D+ K0s
+		fPythia8->ReadString("435:onMode = off");
+		fPythia8->ReadString("435:onIfAll = 411 311");
+	}
     
 }
 

--- a/PYTHIA8/AliPythia8/AliDecayerPythia8.h
+++ b/PYTHIA8/AliPythia8/AliDecayerPythia8.h
@@ -39,7 +39,7 @@ class AliDecayerPythia8 : public TVirtualMCDecayer {
   AliDecayerPythia8(const AliDecayerPythia8&);
   AliDecayerPythia8 operator=(const AliDecayerPythia8&);
   void     SwitchOffHeavyFlavour();
-  void     ForceHadronicD(Int_t optUser4Bodies = 1,Int_t optUseDtoV0 =1, Int_t optForceLcChannel = 0, Int_t optForceXicChannel = 0, Int_t optForceDsChannel = 0, Int_t optForceOmegacChannel = 0);
+  void     ForceHadronicD(Int_t optUser4Bodies = 1,Int_t optUseDtoV0 =1, Int_t optForceLcChannel = 0, Int_t optForceXicChannel = 0, Int_t optForceDsChannel = 0, Int_t optForceOmegacChannel = 0, Int_t optForceDsResonances=0);
   void  ForceBeautyUpgrade();
   AliTPythia8*  fPythia8;          // Pointer to pythia8
   Int_t         fDebug;            // Debug level


### PR DESCRIPTION
This PR implements forced decay for D-meson resonances and resolves issues with their decay product track transport.
It is in response to the discussion documented here: https://alice.its.cern.ch/jira/browse/ALIROOT-8847.