### PR TITLE
Updaet f0 f1 particle decay mode via AliMC

### DIFF
--- a/STEER/STEER/AliMC.cxx
+++ b/STEER/STEER/AliMC.cxx
@@ -1184,7 +1184,7 @@ void  AliMC::AddParticles()
   }
   bratio[0] = 100.;
   mode[0][0] = 310; // K0s
-  mode[0][1] = -310; // K0s
+  mode[0][1] = 310; // K0s
 
   TVirtualMC::GetMC()->SetDecayMode(9030221,bratio,mode); // f0(1500)
   TVirtualMC::GetMC()->SetDecayMode(335,bratio,mode); // f2(1525)

--- a/STEER/STEER/AliMC.cxx
+++ b/STEER/STEER/AliMC.cxx
@@ -1175,7 +1175,7 @@ void  AliMC::AddParticles()
 
   TVirtualMC::GetMC()->SetDecayMode(225,bratio,mode);
 
-  // Define the 2-body phase space decay for the resonances: f0(1500), f2(1525)
+  // Define the 2-body phase space decay for the resonances: f0(1500), f2(1525), f0(1710
   for (Int_t kz = 0; kz < 6; kz++) {
     bratio[kz] = 0.;
     mode[kz][0] = 0;
@@ -1188,6 +1188,7 @@ void  AliMC::AddParticles()
 
   TVirtualMC::GetMC()->SetDecayMode(9030221,bratio,mode); // f0(1500)
   TVirtualMC::GetMC()->SetDecayMode(335,bratio,mode); // f2(1525)
+  TVirtualMC::GetMC()->SetDecayMode(10331,bratio,mode); // f0(1710)
   // TVirtualMC::GetMC()->SetDecayMode(10221,bratio,mode); // f0(1370)
 
   // Define the 2-body phase space decay for the resonances: f1(1285), f1(1420)

--- a/STEER/STEER/AliMC.cxx
+++ b/STEER/STEER/AliMC.cxx
@@ -1175,7 +1175,7 @@ void  AliMC::AddParticles()
 
   TVirtualMC::GetMC()->SetDecayMode(225,bratio,mode);
 
-  // Define the 2-body phase space decay for the resonances: f0(1500), f2(1525), f0(1370)
+  // Define the 2-body phase space decay for the resonances: f0(1500), f2(1525)
   for (Int_t kz = 0; kz < 6; kz++) {
     bratio[kz] = 0.;
     mode[kz][0] = 0;
@@ -1188,7 +1188,7 @@ void  AliMC::AddParticles()
 
   TVirtualMC::GetMC()->SetDecayMode(9030221,bratio,mode); // f0(1500)
   TVirtualMC::GetMC()->SetDecayMode(335,bratio,mode); // f2(1525)
-  TVirtualMC::GetMC()->SetDecayMode(10221,bratio,mode); // f0(1370)
+  // TVirtualMC::GetMC()->SetDecayMode(10221,bratio,mode); // f0(1370)
 
   // Define the 2-body phase space decay for the resonances: f1(1285), f1(1420)
   for (Int_t kz = 0; kz < 6; kz++) {

--- a/STEER/STEER/AliMC.cxx
+++ b/STEER/STEER/AliMC.cxx
@@ -1175,6 +1175,42 @@ void  AliMC::AddParticles()
 
   TVirtualMC::GetMC()->SetDecayMode(225,bratio,mode);
 
+  // Define the 2-body phase space decay for the resonances: f0(1500), f2(1525), f0(1370)
+  for (Int_t kz = 0; kz < 6; kz++) {
+    bratio[kz] = 0.;
+    mode[kz][0] = 0;
+    mode[kz][1] = 0;
+    mode[kz][2] = 0;
+  }
+  bratio[0] = 100.;
+  mode[0][0] = 310; // pion
+  mode[0][1] = -310; // pion
+
+  TVirtualMC::GetMC()->SetDecayMode(9030221,bratio,mode); // f0(1500)
+  TVirtualMC::GetMC()->SetDecayMode(335,bratio,mode); // f2(1525)
+  TVirtualMC::GetMC()->SetDecayMode(10221,bratio,mode); // f0(1370)
+
+  // Define the 2-body phase space decay for the resonances: f1(1285), f1(1420)
+  for (Int_t kz = 0; kz < 6; kz++) {
+    bratio[kz] = 0.;
+    mode[kz][0] = 0;
+    mode[kz][1] = 0;
+    mode[kz][2] = 0;
+  }
+
+  bratio2[0] = 50.;
+  mode[0][0] = 310;
+  mode[0][1] = -321;
+  mode[0][2] = 211;
+
+  bratio2[1] = 50.;
+  mode[1][0] = 310;
+  mode[1][1] = 321;
+  mode[1][2] = -211;
+
+  TVirtualMC::GetMC()->SetDecayMode(20223,bratio2,mode); // f1(1285)
+  TVirtualMC::GetMC()->SetDecayMode(20333,bratio2,mode); // f1(1420)
+  
   // Lambda1520/Lambda1520bar
 
   TVirtualMC::GetMC()->DefineParticle(3124, "Lambda1520", kPTNeutron, 1.5195 , 0.0, 4.22e-23,"Hadron", 0.0156, 3, -1, 0, 0, 0, 0, 0, 1, kTRUE);

--- a/STEER/STEER/AliMC.cxx
+++ b/STEER/STEER/AliMC.cxx
@@ -1183,8 +1183,8 @@ void  AliMC::AddParticles()
     mode[kz][2] = 0;
   }
   bratio[0] = 100.;
-  mode[0][0] = 310; // pion
-  mode[0][1] = -310; // pion
+  mode[0][0] = 310; // K0s
+  mode[0][1] = -310; // K0s
 
   TVirtualMC::GetMC()->SetDecayMode(9030221,bratio,mode); // f0(1500)
   TVirtualMC::GetMC()->SetDecayMode(335,bratio,mode); // f2(1525)
@@ -1199,14 +1199,14 @@ void  AliMC::AddParticles()
   }
 
   bratio2[0] = 50.;
-  mode[0][0] = 310;
-  mode[0][1] = -321;
-  mode[0][2] = 211;
+  mode[0][0] = 310; // K0s
+  mode[0][1] = -321; // anti-K
+  mode[0][2] = 211; // pion+
 
   bratio2[1] = 50.;
-  mode[1][0] = 310;
-  mode[1][1] = 321;
-  mode[1][2] = -211;
+  mode[1][0] = 310; // K0s
+  mode[1][1] = 321; // K
+  mode[1][2] = -211; // pion-
 
   TVirtualMC::GetMC()->SetDecayMode(20223,bratio2,mode); // f1(1285)
   TVirtualMC::GetMC()->SetDecayMode(20333,bratio2,mode); // f1(1420)


### PR DESCRIPTION
Suggested by @mpuccio , Sourav.

`f2(1270)` is missing due to the conflict of the previous force decay mode/